### PR TITLE
Add source tags to traces in MlflowSpanProcessor

### DIFF
--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -83,6 +83,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                 "your environment using `mlflow.set_experiment()` API."
             )
         metadata = {}
+        default_tags = resolve_tags()
 
         # If the span is started within an active MLflow run, we should record it as a trace tag
         if run := mlflow.active_run():
@@ -92,7 +93,13 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         # ID from the prediction context. Otherwise, we create a new trace info by calling the
         # backend API.
         if request_id := maybe_get_evaluation_request_id():
-            trace_info = self._create_trace_info(request_id, span, experiment_id, metadata)
+            trace_info = self._create_trace_info(
+                request_id,
+                span,
+                experiment_id,
+                metadata,
+                tags=default_tags,
+            )
         else:
             try:
                 trace_info = self._client._start_tracked_trace(
@@ -103,6 +110,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                     #   updating the trace start time.
                     timestamp_ms=span.start_time // 1_000_000,  # nanosecond to millisecond
                     request_metadata=metadata,
+                    tags=default_tags,
                 )
 
             # TODO: This catches all exceptions from the tracking server so the in-memory tracing
@@ -115,9 +123,14 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                     exc_info=True,
                 )
                 request_id = encode_trace_id(span.context.trace_id)
-                trace_info = self._create_trace_info(request_id, span, experiment_id, metadata)
+                trace_info = self._create_trace_info(
+                    request_id,
+                    span,
+                    experiment_id,
+                    metadata,
+                    tags=default_tags,
+                )
 
-        trace_info.tags.update(resolve_tags())
         return trace_info
 
     def on_end(self, span: OTelReadableSpan) -> None:
@@ -180,6 +193,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         span: OTelSpan,
         experiment_id: Optional[str] = None,
         request_metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[Dict[str, str]] = None,
     ) -> TraceInfo:
         return TraceInfo(
             request_id=request_id,
@@ -188,4 +202,5 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             execution_time_ms=None,
             status=TraceStatus.IN_PROGRESS,
             request_metadata=request_metadata or {},
+            tags=tags or {},
         )

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -117,6 +117,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                 request_id = encode_trace_id(span.context.trace_id)
                 trace_info = self._create_trace_info(request_id, span, experiment_id, metadata)
 
+        trace_info.tags.update(resolve_tags())
         return trace_info
 
     def on_end(self, span: OTelReadableSpan) -> None:
@@ -162,7 +163,6 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                 TraceTagKey.TRACE_NAME: root_span.name,
             }
         )
-        trace.info.tags.update(resolve_tags())
 
     def _truncate_metadata(self, value: Optional[str]) -> str:
         """Get truncated value of the attribute if it exceeds the maximum length."""

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -117,6 +117,8 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                 request_id = encode_trace_id(span.context.trace_id)
                 trace_info = self._create_trace_info(request_id, span, experiment_id, metadata)
 
+        trace_info.tags.update(resolve_tags())
+
         return trace_info
 
     def on_end(self, span: OTelReadableSpan) -> None:
@@ -180,7 +182,6 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         experiment_id: Optional[str] = None,
         request_metadata: Optional[Dict[str, Any]] = None,
     ) -> TraceInfo:
-        tags = resolve_tags()
         return TraceInfo(
             request_id=request_id,
             experiment_id=experiment_id,
@@ -188,5 +189,4 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             execution_time_ms=None,
             status=TraceStatus.IN_PROGRESS,
             request_metadata=request_metadata or {},
-            tags=tags,
         )

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -27,6 +27,7 @@ from mlflow.tracing.utils import (
     maybe_get_evaluation_request_id,
 )
 from mlflow.tracking.client import MlflowClient
+from mlflow.tracking.context.registry import resolve_tags
 from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 from mlflow.tracking.fluent import _get_experiment_id
 
@@ -179,6 +180,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         experiment_id: Optional[str] = None,
         request_metadata: Optional[Dict[str, Any]] = None,
     ) -> TraceInfo:
+        tags = resolve_tags()
         return TraceInfo(
             request_id=request_id,
             experiment_id=experiment_id,
@@ -186,4 +188,5 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             execution_time_ms=None,
             status=TraceStatus.IN_PROGRESS,
             request_metadata=request_metadata or {},
+            tags=tags,
         )

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -117,8 +117,6 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                 request_id = encode_trace_id(span.context.trace_id)
                 trace_info = self._create_trace_info(request_id, span, experiment_id, metadata)
 
-        trace_info.tags.update(resolve_tags())
-
         return trace_info
 
     def on_end(self, span: OTelReadableSpan) -> None:
@@ -164,6 +162,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                 TraceTagKey.TRACE_NAME: root_span.name,
             }
         )
+        trace.info.tags.update(resolve_tags())
 
     def _truncate_metadata(self, value: Optional[str]) -> str:
         """Get truncated value of the attribute if it exceeds the maximum length."""

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 import mlflow
 from mlflow.entities import SpanType
 from mlflow.tracing.utils import TraceJSONEncoder
+from mlflow.tracking.context import registry
 
 from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.helper import get_traces
@@ -43,8 +44,7 @@ def test_json_deserialization(clear_singleton):
     trace_json = trace.to_json()
 
     trace_json_as_dict = json.loads(trace_json)
-
-    assert trace_json_as_dict == {
+    expected_dict = {
         "info": {
             "request_id": trace.info.request_id,
             "experiment_id": "0",
@@ -109,6 +109,8 @@ def test_json_deserialization(clear_singleton):
             ],
         },
     }
+    expected_dict["info"]["tags"].update(registry.resolve_tags())
+    assert trace_json_as_dict == expected_dict
 
 
 @pytest.mark.skipif(

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -62,7 +62,6 @@ def test_json_deserialization(clear_singleton, monkeypatch):
                 "mlflow.traceName": "predict",
                 "mlflow.source.name": "test",
                 "mlflow.source.type": "LOCAL",
-                "mlflow.user": "bob",
             },
         },
         "data": {

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -35,7 +35,10 @@ def test_on_start(clear_singleton):
     processor.on_start(span)
 
     mock_client._start_tracked_trace.assert_called_once_with(
-        experiment_id="0", timestamp_ms=5, request_metadata={}
+        experiment_id="0",
+        timestamp_ms=5,
+        request_metadata={},
+        tags={"mlflow.user": "bob", "mlflow.source.name": "test", "mlflow.source.type": "LOCAL"},
     )
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces
@@ -91,6 +94,7 @@ def test_on_start_with_experiment_id(clear_singleton):
         experiment_id=experiment_id,
         timestamp_ms=5,
         request_metadata={},
+        tags={"mlflow.user": "bob", "mlflow.source.name": "test", "mlflow.source.type": "LOCAL"},
     )
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -21,7 +21,10 @@ _TRACE_ID = 12345
 _REQUEST_ID = f"tr-{_TRACE_ID}"
 
 
-def test_on_start(clear_singleton):
+def test_on_start(clear_singleton, monkeypatch):
+    monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
+    monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
+
     # Root span should create a new trace on start
     span = create_mock_otel_span(
         trace_id=_TRACE_ID, span_id=1, parent_id=None, start_time=5_000_000
@@ -76,7 +79,10 @@ def test_on_start_adjust_span_timestamp_to_exclude_backend_latency(clear_singlet
     assert time.time_ns() - span.start_time < 100_000_000  # 0.1 second
 
 
-def test_on_start_with_experiment_id(clear_singleton):
+def test_on_start_with_experiment_id(clear_singleton, monkeypatch):
+    monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
+    monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
+
     experiment_id = "test_experiment_id"
     span = create_mock_otel_span(
         trace_id=_TRACE_ID, span_id=1, parent_id=None, start_time=5_000_000

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -11,11 +11,11 @@ from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_status import TraceStatus
+from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
 from mlflow.pyfunc.context import Context, set_prediction_context
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing.constant import TRACE_SCHEMA_VERSION_KEY, TraceMetadataKey
-from mlflow.tracking.context import registry
 
 from tests.tracing.helper import create_test_trace_info, get_traces
 
@@ -111,7 +111,9 @@ def test_trace_with_databricks_tracking_uri(
     databricks_tracking_uri, clear_singleton, mock_store, monkeypatch
 ):
     monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "test")
-    monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "bob")
+    monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
+    monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
+
     mock_experiment = mock.MagicMock()
     mock_experiment.experiment_id = "test_experiment_id"
     monkeypatch.setattr(
@@ -150,14 +152,13 @@ def test_trace_with_databricks_tracking_uri(
     assert trace_info.status == TraceStatus.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "64"
-
-    expected_tags = {
+    assert trace_info.tags == {
         "mlflow.traceName": "predict",
         "mlflow.artifactLocation": "test",
+        "mlflow.source.name": "test",
+        "mlflow.source.type": "LOCAL",
         "mlflow.user": "bob",
     }
-    expected_tags.update(registry.resolve_tags())
-    assert trace_info.tags == expected_tags
 
     trace_data = traces[0].data
     assert trace_data.request == '{"x": 2, "y": 5}'
@@ -281,7 +282,10 @@ def test_trace_in_databricks_model_serving(clear_singleton, monkeypatch):
     assert len(traces) == 0
 
 
-def test_trace_in_model_evaluation(clear_singleton, mock_store):
+def test_trace_in_model_evaluation(clear_singleton, mock_store, monkeypatch):
+    monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
+    monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
+
     class TestModel:
         @mlflow.trace()
         def predict(self, x, y):
@@ -299,8 +303,12 @@ def test_trace_in_model_evaluation(clear_singleton, mock_store):
         with set_prediction_context(Context(request_id=request_id_2, is_evaluate=True)):
             model.predict(3, 4)
 
-    expected_tags = {"mlflow.traceName": "predict"}
-    expected_tags.update(registry.resolve_tags())
+    expected_tags = {
+        "mlflow.traceName": "predict",
+        "mlflow.source.name": "test",
+        "mlflow.source.type": "LOCAL",
+        "mlflow.user": "bob",
+    }
 
     trace = mlflow.get_trace(request_id_1)
     assert trace.info.request_id == request_id_1

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -157,6 +157,7 @@ def test_trace_with_databricks_tracking_uri(
         "mlflow.artifactLocation": "test",
         "mlflow.source.name": "test",
         "mlflow.source.type": "LOCAL",
+        "mlflow.user": "bob",
     }
 
     trace_data = traces[0].data
@@ -306,6 +307,7 @@ def test_trace_in_model_evaluation(clear_singleton, mock_store, monkeypatch):
         "mlflow.traceName": "predict",
         "mlflow.source.name": "test",
         "mlflow.source.type": "LOCAL",
+        "mlflow.user": "bob",
     }
 
     trace = mlflow.get_trace(request_id_1)

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -157,7 +157,6 @@ def test_trace_with_databricks_tracking_uri(
         "mlflow.artifactLocation": "test",
         "mlflow.source.name": "test",
         "mlflow.source.type": "LOCAL",
-        "mlflow.user": "bob",
     }
 
     trace_data = traces[0].data
@@ -307,7 +306,6 @@ def test_trace_in_model_evaluation(clear_singleton, mock_store, monkeypatch):
         "mlflow.traceName": "predict",
         "mlflow.source.name": "test",
         "mlflow.source.type": "LOCAL",
-        "mlflow.user": "bob",
     }
 
     trace = mlflow.get_trace(request_id_1)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -609,7 +609,6 @@ def test_set_and_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
         "foo": "bar",
         "mlflow.source.name": "test",
         "mlflow.source.type": "LOCAL",
-        "mlflow.user": "bob",
     }
 
 
@@ -634,7 +633,6 @@ def test_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
         "mlflow.traceName": "test",  # Added by MLflow
         "mlflow.source.name": "test",
         "mlflow.source.type": "LOCAL",
-        "mlflow.user": "bob",
     }
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -601,9 +601,8 @@ def test_set_and_delete_trace_tag_on_active_trace(clear_singleton):
     client.end_trace(request_id)
 
     trace = get_traces()[0]
-    resolved_tags = registry.resolve_tags()
     expected_tags = {"mlflow.traceName": "test", "foo": "bar"}
-    expected_tags.update(resolved_tags)
+    expected_tags.update(registry.resolve_tags())
     assert trace.info.tags == expected_tags
 
 
@@ -620,12 +619,11 @@ def test_delete_trace_tag_on_active_trace(clear_singleton):
     client.end_trace(request_id)
 
     trace = get_traces()[0]
-    resolved_tags = registry.resolve_tags()
     expected_tags = {
         "baz": "qux",
         "mlflow.traceName": "test",  # Added by MLflow
     }
-    expected_tags.update(resolved_tags)
+    expected_tags.update(registry.resolve_tags())
     assert trace.info.tags == expected_tags
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -544,6 +544,8 @@ def test_log_trace_with_databricks_tracking_uri(
         "mlflow.traceName": "predict",
         "mlflow.artifactLocation": "test",
         "mlflow.user": "bob",
+        "mlflow.source.name": "test",
+        "mlflow.source.type": "LOCAL",
         "tag": "tag_value",
     }
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR adds databricks-specific tags to traces when the destination is the MLflow backend (i.e. not inference tables). The purpose of this is to enable linking traces to their source notebooks.

This is pretty much the same thing we do for runs:

https://github.com/mlflow/mlflow/blob/e0cf3a451cda02c52eec60280ce0682f434dfc1b/mlflow/tracking/fluent.py#L380-L386

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested in a Databricks notebook and verified that the tags are set.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
