### PR TITLE
Add start run by name

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -149,6 +149,7 @@ from mlflow.tracking.fluent import (
     set_tag,
     set_tags,
     start_run,
+    start_run_by_name,
 )
 from mlflow.tracking.multimedia import Image
 from mlflow.utils.async_logging.run_operations import RunOperations  # noqa: F401
@@ -213,6 +214,7 @@ __all__ = [
     "set_tags",
     "set_tracking_uri",
     "start_run",
+    "start_run_by_name",
     "Image",
 ]
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -212,9 +212,11 @@ def start_run_by_name(
     will be logged. The return value can be used as a context manager within a ``with`` block;
     otherwise, you must call ``end_run()`` to terminate the current run.
 
-    ``start_run_by_name`` attempts to resume a run with the specified run name and
-    other parameters are ignored.
-
+    When you pass a ``run_name``, ``start_run_by_name`` attempts to resume a run with the specified run name and
+    other parameters (except ``tags`` and ``description``) are ignored.
+    ``run_name`` takes precedence over ``MLFLOW_RUN_ID``.
+    If resuming an existing run, the run status is set to ``RunStatus.RUNNING``.
+    In case there are no runs with the specified run_name a new run is started.
     Throws an exception if there are multiple runs with the specified run_name
 
     Args:
@@ -223,7 +225,7 @@ def start_run_by_name(
             is set to running, but the run's other attributes (``source_version``,
             ``source_type``, etc.) are not changed.
         experiment_id: ID of the experiment under which to create the current run (applicable
-            only when ``run_id`` is not specified). If ``experiment_id`` argument
+            only when run is being resumed. If ``experiment_id`` argument
             is unspecified, will look for valid experiment in the following order:
             activated using ``set_experiment``, ``MLFLOW_EXPERIMENT_NAME``
             environment variable, ``MLFLOW_EXPERIMENT_ID`` environment variable,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -244,6 +244,34 @@ def start_run_by_name(
         :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping the
         run's state.
 
+    .. code-block:: python
+        :test:
+        :caption: Example
+
+        import mlflow
+
+        # Resume an existing run
+        experiment_id = mlflow.create_experiment("experiment1")
+        old_run  = mlflow.start_named_run(run_name="My Test Run")
+        mlflow.end_run()
+
+        resumed_run = mlflow.start_named_run(run_name="My Test Run")
+
+        print("old run:")
+        print(f"run_id: {old_run.info.run_id}")
+
+        print("resumed run:")
+        print(f"run_id: {resumed_run.info.run_id}")
+
+    .. code-block:: text
+        :caption: Output
+
+        old run:
+        run_id: 8979459433a24a52ab3be87a229a9cdf
+        resumed run:
+        run_id: 8979459433a24a52ab3be87a229a9cdf
+
+
     """
     runs = search_runs(filter_string=f"attributes.run_name='{run_name}'", output_format="list")
     if len(runs) == 0:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -213,8 +213,8 @@ def start_run_by_name(
     will be logged. The return value can be used as a context manager within a ``with`` block;
     otherwise, you must call ``end_run()`` to terminate the current run.
 
-    When you pass a ``run_name``, ``start_run_by_name`` attempts to resume a run with the specified run name
-    other parameters (except ``tags`` and ``description``) are ignored.
+    When you pass a ``run_name``, ``start_run_by_name`` attempts to resume a run.
+    When run is found, other parameters (except ``tags`` and ``description``) are ignored.
     ``run_name`` takes precedence over ``MLFLOW_RUN_ID``.
     If resuming an existing run, the run status is set to ``RunStatus.RUNNING``.
     In case there are no runs with the specified run_name a new run is started.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2,6 +2,7 @@
 Internal module implementing the fluent API, allowing management of an active
 MLflow run. This module is exposed to users at the top-level :py:mod:`mlflow` module.
 """
+
 import atexit
 import contextlib
 import importlib
@@ -212,7 +213,7 @@ def start_run_by_name(
     will be logged. The return value can be used as a context manager within a ``with`` block;
     otherwise, you must call ``end_run()`` to terminate the current run.
 
-    When you pass a ``run_name``, ``start_run_by_name`` attempts to resume a run with the specified run name and
+    When you pass a ``run_name``, ``start_run_by_name`` attempts to resume a run with the specified run name
     other parameters (except ``tags`` and ``description``) are ignored.
     ``run_name`` takes precedence over ``MLFLOW_RUN_ID``.
     If resuming an existing run, the run status is set to ``RunStatus.RUNNING``.
@@ -254,7 +255,7 @@ def start_run_by_name(
 
         # Resume an existing run
         experiment_id = mlflow.create_experiment("experiment1")
-        old_run  = mlflow.start_run_by_name(run_name="My Test Run")
+        old_run = mlflow.start_run_by_name(run_name="My Test Run")
         mlflow.end_run()
 
         resumed_run = mlflow.start_run_by_name(run_name="My Test Run")
@@ -290,8 +291,9 @@ def start_run_by_name(
         return start_run(run_id=runs[0].info.run_id, tags=tags, description=description)
     else:
         raise MlflowException(
-            message="More than one run_id with {} run_name. "
-                    "start_run_by_name can only be used for runs with unique run_names".format(run_name))
+            message=f"More than one run_id with {run_name} run_name. "
+            "start_run_by_name can only be used for runs with unique run_names"
+        )
 
 
 def start_run(

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -254,10 +254,11 @@ def start_run_by_name(
 
         # Resume an existing run
         experiment_id = mlflow.create_experiment("experiment1")
-        old_run  = mlflow.start_named_run(run_name="My Test Run")
+        old_run  = mlflow.start_run_by_name(run_name="My Test Run")
         mlflow.end_run()
 
-        resumed_run = mlflow.start_named_run(run_name="My Test Run")
+        resumed_run = mlflow.start_run_by_name(run_name="My Test Run")
+        mlflow.end_run()
 
         print("old run:")
         print(f"run_id: {old_run.info.run_id}")

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -919,6 +919,44 @@ def test_get_run():
         run = get_run(run_id)
         assert run.info.user_id == "my_user_id"
 
+@pytest.mark.usefixtures(empty_active_run_stack.__name__)
+def test_start_run_by_name_run_resume():
+    run = mlflow.start_run()
+    mlflow.end_run()
+    restarted_run = mlflow.start_run_by_name(run.info.run_name)
+    assert run.info.run_id == restarted_run.info.run_id
+    assert run.info.run_name == restarted_run.info.run_name
+
+@pytest.mark.usefixtures(empty_active_run_stack.__name__)
+def test_start_run_by_name_run_resume_add_description():
+    run = mlflow.start_run()
+    mlflow.end_run()
+    description = "Description"
+    restarted_run = mlflow.start_run_by_name(run.info.run_name, description=description)
+    assert run.info.run_id == restarted_run.info.run_id
+    assert run.info.run_name == restarted_run.info.run_name
+    assert mlflow_tags.MLFLOW_RUN_NOTE in restarted_run.data.tags
+
+
+@pytest.mark.usefixtures(empty_active_run_stack.__name__)
+def test_start_run_by_name_new_run():
+    run_name = "Test Run"
+    run = mlflow.start_run_by_name(run_name)
+    assert run.info.run_name == run_name
+
+
+@pytest.mark.usefixtures(empty_active_run_stack.__name__)
+def test_start_run_by_name_duplicated_runs():
+    run_name = "Test Run"
+    mlflow.start_run(run_name=run_name)
+    mlflow.end_run()
+    mlflow.start_run(run_name=run_name)
+    mlflow.end_run()
+    match = ("More than one run_id with {} run_name. "
+             "start_run_by_name can only be used for runs with unique run_names").format(run_name)
+    with pytest.raises(MlflowException, match=match):
+        mlflow.start_run_by_name(run_name=run_name)
+
 
 def validate_search_runs(results, data, output_format):
     if output_format == "list":

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -919,6 +919,7 @@ def test_get_run():
         run = get_run(run_id)
         assert run.info.user_id == "my_user_id"
 
+
 @pytest.mark.usefixtures(empty_active_run_stack.__name__)
 def test_start_run_by_name_run_resume():
     run = mlflow.start_run()
@@ -926,6 +927,7 @@ def test_start_run_by_name_run_resume():
     restarted_run = mlflow.start_run_by_name(run.info.run_name)
     assert run.info.run_id == restarted_run.info.run_id
     assert run.info.run_name == restarted_run.info.run_name
+
 
 @pytest.mark.usefixtures(empty_active_run_stack.__name__)
 def test_start_run_by_name_run_resume_add_description():
@@ -952,8 +954,10 @@ def test_start_run_by_name_duplicated_runs():
     mlflow.end_run()
     mlflow.start_run(run_name=run_name)
     mlflow.end_run()
-    match = ("More than one run_id with {} run_name. "
-             "start_run_by_name can only be used for runs with unique run_names").format(run_name)
+    match = (
+        f"More than one run_id with {run_name} run_name. "
+        "start_run_by_name can only be used for runs with unique run_names"
+    )
     with pytest.raises(MlflowException, match=match):
         mlflow.start_run_by_name(run_name=run_name)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/m-blasiak/mlflow/pull/11896?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11896/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11896
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve  https://github.com/mlflow/mlflow/issues/11783

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Creates new function to start an mlflow run `start_run_by_name`.
Similarly to `start_run` this will attempt to resume a run (by performing an exact name lookup), if no runs exist with the specified name, a new run will be created.

In case lookup returns multiple runs with the specified name, an exception is raised

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [X] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Adds `start_run_by_name` function to make it easier to resume existing runs.
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
