### PR TITLE
Address very noisy deprecation warnings from pandas applymap

### DIFF
--- a/mlflow/data/digest_utils.py
+++ b/mlflow/data/digest_utils.py
@@ -1,5 +1,7 @@
 from typing import Any, List
 
+from packaging.version import Version
+
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils import insecure_hash
@@ -23,7 +25,10 @@ def compute_pandas_digest(df) -> str:
     trimmed_df = df.head(MAX_ROWS)
 
     # keep string and number columns, drop other column types
-    string_columns = trimmed_df.columns[(df.applymap(type) == str).all(0)]
+    if Version(pd.__version__) >= Version("2.1.0"):
+        string_columns = trimmed_df.columns[(df.map(type) == str).all(0)]
+    else:
+        string_columns = trimmed_df.columns[(df.applymap(type) == str).all(0)]
     numeric_columns = trimmed_df.select_dtypes(include=[np.number]).columns
 
     desired_columns = string_columns.union(numeric_columns)

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -17,6 +17,8 @@ from decimal import Decimal
 from types import FunctionType
 from typing import Any, Dict, Optional
 
+from packaging.version import Version
+
 import mlflow
 from mlflow.data.dataset import Dataset
 from mlflow.entities import RunTag
@@ -516,7 +518,10 @@ def _hash_array_like_obj_as_bytes(data):
                 return _hash_data_as_bytes(v)
             return v
 
-        data = data.applymap(_hash_array_like_element_as_bytes)
+        if Version(pd.__version__) >= Version("2.1.0"):
+            data = data.map(_hash_array_like_element_as_bytes)
+        else:
+            data = data.applymap(_hash_array_like_element_as_bytes)
         return _hash_uint64_ndarray_as_bytes(pd.util.hash_pandas_object(data))
     elif isinstance(data, np.ndarray) and len(data) > 0 and isinstance(data[0], list):
         # convert numpy array of lists into numpy array of the string representation of the lists

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -395,6 +395,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 import numpy as np
 import pandas
 import yaml
+from packaging.version import Version
 
 import mlflow
 import mlflow.pyfunc.loaders
@@ -1844,7 +1845,10 @@ Compound types:
             )
 
         if type(elem_type) == StringType:
-            result = result.applymap(str)
+            if Version(pandas.__version__) >= Version("2.1.0"):
+                result = result.map(str)
+            else:
+                result = result.applymap(str)
 
         if type(result_type) == ArrayType:
             return pandas.Series(result.to_numpy().tolist())

--- a/mlflow/recipes/cards/__init__.py
+++ b/mlflow/recipes/cards/__init__.py
@@ -263,6 +263,8 @@ class BaseCard:
         import pandas as pd
         from pandas.io.formats.style import Styler
 
+        pandas_version = Version(pd.__version__)
+
         if not isinstance(table, Styler):
             table = pd.DataFrame(table, columns=columns)
             # Escape specific characters in HTML to prevent
@@ -276,10 +278,11 @@ class BaseCard:
             if hasattr(table, "map"):
                 table = table.map(escape_value)
             else:
-                table = table.applymap(escape_value)
+                if pandas_version >= Version("2.1.0"):
+                    table = table.map(escape_value)
+                else:
+                    table = table.applymap(escape_value)
             table = table.style
-
-        pandas_version = Version(pd.__version__)
 
         styler = table.set_table_attributes('style="border-collapse:collapse"').set_table_styles(
             [

--- a/mlflow/recipes/steps/split.py
+++ b/mlflow/recipes/steps/split.py
@@ -9,6 +9,7 @@ from multiprocessing.pool import Pool, ThreadPool
 
 import numpy as np
 import pandas as pd
+from packaging.version import Version
 
 from mlflow.exceptions import BAD_REQUEST, INVALID_PARAMETER_VALUE, MlflowException
 from mlflow.recipes.artifacts import DataframeArtifact
@@ -130,6 +131,8 @@ def _parallelize(data, func, n_jobs=-1):
 
 
 def _run_on_subset(func, data_subset):
+    if Version(pd.__version__) >= Version("2.1.0"):
+        return data_subset.map(func)
     return data_subset.applymap(func)
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11910?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11910/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11910
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
