### PR TITLE
Add parameter for system prompt in make_genai_metric, add metric metadata to EvaluationMetric

### DIFF
--- a/mlflow/metrics/genai/base.py
+++ b/mlflow/metrics/genai/base.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Union
 
 from mlflow.metrics.genai.prompt_template import PromptTemplate
-from mlflow.models import EvaluationMetric
 from mlflow.utils.annotations import experimental
 
 
@@ -70,7 +69,10 @@ class EvaluationExample:
     def _format_grading_context(self):
         if isinstance(self.grading_context, dict):
             return "\n".join(
-                [f"key: {key}\nvalue:\n{value}" for key, value in self.grading_context.items()]
+                [
+                    f"key: {key}\nvalue:\n{value}"
+                    for key, value in self.grading_context.items()
+                ]
             )
         else:
             return self.grading_context

--- a/mlflow/metrics/genai/base.py
+++ b/mlflow/metrics/genai/base.py
@@ -69,10 +69,7 @@ class EvaluationExample:
     def _format_grading_context(self):
         if isinstance(self.grading_context, dict):
             return "\n".join(
-                [
-                    f"key: {key}\nvalue:\n{value}"
-                    for key, value in self.grading_context.items()
-                ]
+                [f"key: {key}\nvalue:\n{value}" for key, value in self.grading_context.items()]
             )
         else:
             return self.grading_context

--- a/mlflow/metrics/genai/base.py
+++ b/mlflow/metrics/genai/base.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Union
 
 from mlflow.metrics.genai.prompt_template import PromptTemplate
+from mlflow.models import EvaluationMetric
 from mlflow.utils.annotations import experimental
 
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -85,10 +85,7 @@ def _extract_score_and_justification(text):
                 justification = f"Failed to extract score and justification. Raw output: {text}"
 
         if not isinstance(score, (int, float)) or not isinstance(justification, str):
-            return (
-                None,
-                f"Failed to extract score and justification. Raw output: {text}",
-            )
+            return None, f"Failed to extract score and justification. Raw output: {text}"
 
         return score, justification
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -35,9 +35,7 @@ justification: Your reasoning for giving this score
 Do not add additional new lines. Do not add any other fields."""
 
 
-def _format_args_string(
-    grading_context_columns: Optional[List[str]], eval_values, indx
-) -> str:
+def _format_args_string(grading_context_columns: Optional[List[str]], eval_values, indx) -> str:
     import pandas as pd
 
     args_dict = {}
@@ -59,10 +57,7 @@ def _format_args_string(
         else (
             "Additional information used by the model:\n"
             + "\n".join(
-                [
-                    f"key: {arg}\nvalue:\n{arg_value}"
-                    for arg, arg_value in args_dict.items()
-                ]
+                [f"key: {arg}\nvalue:\n{arg_value}" for arg, arg_value in args_dict.items()]
             )
         )
     )
@@ -81,17 +76,13 @@ def _extract_score_and_justification(text):
         except json.JSONDecodeError:
             # If parsing fails, use regex
             if (match := re.search(r"score: (\d+),?\s*justification: (.+)", text)) or (
-                match := re.search(
-                    r"\s*score:\s*(\d+)\s*justification:\s*(.+)", text, re.DOTALL
-                )
+                match := re.search(r"\s*score:\s*(\d+)\s*justification:\s*(.+)", text, re.DOTALL)
             ):
                 score = int(match.group(1))
                 justification = match.group(2)
             else:
                 score = None
-                justification = (
-                    f"Failed to extract score and justification. Raw output: {text}"
-                )
+                justification = f"Failed to extract score and justification. Raw output: {text}"
 
         if not isinstance(score, (int, float)) or not isinstance(justification, str):
             return (
@@ -185,10 +176,7 @@ def _get_aggregate_results(scores, aggregations):
     scores_for_aggregation = [score for score in scores if score is not None]
 
     return (
-        {
-            option: aggregate_function(option, scores_for_aggregation)
-            for option in aggregations
-        }
+        {option: aggregate_function(option, scores_for_aggregation) for option in aggregations}
         if aggregations is not None
         else {}
     )
@@ -219,9 +207,7 @@ def _make_custom_genai_metric(
                 error_code=INVALID_PARAMETER_VALUE,
             )
         grading_payloads = pd.DataFrame(kwargs).to_dict(orient="records")
-        arg_strings = [
-            prompt_template.format(**payload) for payload in grading_payloads
-        ]
+        arg_strings = [prompt_template.format(**payload) for payload in grading_payloads]
         scores, justifications = _score_model_on_payloads(
             arg_strings, model, parameters, max_workers
         )
@@ -468,9 +454,7 @@ def make_genai_metric(
         grading_payloads = []
         for indx, (input, output) in enumerate(zip(inputs, outputs)):
             try:
-                arg_string = _format_args_string(
-                    grading_context_columns, eval_values, indx
-                )
+                arg_string = _format_args_string(grading_context_columns, eval_values, indx)
             except Exception as e:
                 raise MlflowException(
                     f"Values for grading_context_columns are malformed and cannot be "
@@ -524,9 +508,7 @@ def make_genai_metric(
         return MetricValue(scores, justifications, aggregate_results)
 
     signature_parameters = [
-        Parameter(
-            "predictions", Parameter.POSITIONAL_OR_KEYWORD, annotation="pd.Series"
-        ),
+        Parameter("predictions", Parameter.POSITIONAL_OR_KEYWORD, annotation="pd.Series"),
         Parameter(
             "metrics",
             Parameter.POSITIONAL_OR_KEYWORD,

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -330,7 +330,15 @@ def make_genai_metric(
         )
     """
     if judge_prompt is not None:
-        return _make_custom_genai_metric()
+        return _make_custom_genai_metric(
+            name=name,
+            judge_prompt=judge_prompt,
+            model=model,
+            parameters=parameters,
+            aggregations=aggregations,
+            greater_is_better=greater_is_better,
+            max_workers=max_workers,
+        )
 
     if definition is None or grading_prompt is None:
         raise MlflowException(

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -546,11 +546,7 @@ def make_genai_metric(
 
     signature_parameters = [
         Parameter("predictions", Parameter.POSITIONAL_OR_KEYWORD, annotation="pd.Series"),
-        Parameter(
-            "metrics",
-            Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=Dict[str, MetricValue],
-        ),
+        Parameter("metrics", Parameter.POSITIONAL_OR_KEYWORD, annotation=Dict[str, MetricValue]),
         Parameter("inputs", Parameter.POSITIONAL_OR_KEYWORD, annotation="pd.Series"),
     ]
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -187,6 +187,7 @@ def _make_custom_genai_metric(
     aggregations: Optional[List[str]] = ["mean", "variance", "p90"],  # noqa: B006
     greater_is_better: bool = True,
     max_workers: int = 10,
+    metric_metadata: Optional[Dict[str, Any]] = None,
 ) -> EvaluationMetric:
 
     def eval_fn(
@@ -209,6 +210,7 @@ def _make_custom_genai_metric(
         eval_fn=eval_fn,
         greater_is_better=greater_is_better,
         name=name,
+        metric_metadata=metric_metadata,
     )
 
 
@@ -227,6 +229,7 @@ def make_genai_metric(
     aggregations: Optional[List[str]] = ["mean", "variance", "p90"],  # noqa: B006
     greater_is_better: bool = True,
     max_workers: int = 10,
+    metric_metadata: Optional[Dict[str, Any]] = None,
 ) -> EvaluationMetric:
     """
     Create a genai metric used to evaluate LLM using LLM as a judge in MLflow. The full grading
@@ -238,7 +241,7 @@ def make_genai_metric(
         grading_prompt: Grading criteria of the metric.
         judge_prompt: (Optional) The entire prompt to be used for the judge model. This is useful for including
             use cases or system prompts that are not covered by the full grading prompt in any ``EvaluationMetric``
-            object. If used,  
+            object. If used, examples, definition, and grading_prompt will be ignored.
         examples: (Optional) Examples of the metric.
         version: (Optional) Version of the metric. Currently supported versions are: v1.
         model: (Optional) Model uri of an openai, gateway, or deployments judge model in the
@@ -263,6 +266,7 @@ def make_genai_metric(
         greater_is_better: (Optional) Whether the metric is better when it is greater.
         max_workers: (Optional) The maximum number of workers to use for judge scoring.
             Defaults to 10 workers.
+        metric_metadata: Optional dictionary of metadata to be attached to the EvaluationMetric object.
 
     Returns:
         A metric object.
@@ -337,6 +341,7 @@ def make_genai_metric(
             aggregations=aggregations,
             greater_is_better=greater_is_better,
             max_workers=max_workers,
+            metric_metadata=metric_metadata,
         )
 
     if definition is None or grading_prompt is None:
@@ -504,6 +509,7 @@ def make_genai_metric(
         name=name,
         version=version,
         metric_details=evaluation_context["eval_prompt"].__str__(),
+        metric_metadata=metric_metadata,
     )
 
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import pandas as pd
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from inspect import Parameter, Signature
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Tuple
@@ -22,8 +23,6 @@ from mlflow.protos.databricks_pb2 import (
 from mlflow.utils.annotations import experimental
 from mlflow.utils.class_utils import _get_class_from_string
 
-if TYPE_CHECKING:
-    import pandas as pd
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/metrics/genai/prompt_template.py
+++ b/mlflow/metrics/genai/prompt_template.py
@@ -29,6 +29,10 @@ class PromptTemplate:
     def __init__(self, template_str: Union[str, List[str]]):
         self.template_strs = [template_str] if isinstance(template_str, str) else template_str
 
+    @property
+    def variables(self):
+        return {fname for template_str in self.template_strs for _, fname, _, _ in string.Formatter().parse(template_str) if fname}
+
     def format(self, **kwargs: Any) -> str:
         safe_kwargs = {k: v for k, v in kwargs.items() if v is not None}
         formatted_strs = []

--- a/mlflow/metrics/genai/prompt_template.py
+++ b/mlflow/metrics/genai/prompt_template.py
@@ -27,9 +27,7 @@ class PromptTemplate:
     """
 
     def __init__(self, template_str: Union[str, List[str]]):
-        self.template_strs = (
-            [template_str] if isinstance(template_str, str) else template_str
-        )
+        self.template_strs = [template_str] if isinstance(template_str, str) else template_str
 
     @property
     def variables(self):
@@ -45,9 +43,7 @@ class PromptTemplate:
         formatted_strs = []
         for template_str in self.template_strs:
             extracted_variables = [
-                fname
-                for _, fname, _, _ in string.Formatter().parse(template_str)
-                if fname
+                fname for _, fname, _, _ in string.Formatter().parse(template_str) if fname
             ]
             if all(item in safe_kwargs.keys() for item in extracted_variables):
                 formatted_strs.append(template_str.format(**safe_kwargs))
@@ -59,9 +55,7 @@ class PromptTemplate:
         new_template_strs = []
         for template_str in self.template_strs:
             extracted_variables = [
-                fname
-                for _, fname, _, _ in string.Formatter().parse(template_str)
-                if fname
+                fname for _, fname, _, _ in string.Formatter().parse(template_str) if fname
             ]
             safe_available_kwargs = {
                 k: safe_kwargs.get(k, "{" + k + "}") for k in extracted_variables

--- a/mlflow/metrics/genai/prompt_template.py
+++ b/mlflow/metrics/genai/prompt_template.py
@@ -27,18 +27,27 @@ class PromptTemplate:
     """
 
     def __init__(self, template_str: Union[str, List[str]]):
-        self.template_strs = [template_str] if isinstance(template_str, str) else template_str
+        self.template_strs = (
+            [template_str] if isinstance(template_str, str) else template_str
+        )
 
     @property
     def variables(self):
-        return {fname for template_str in self.template_strs for _, fname, _, _ in string.Formatter().parse(template_str) if fname}
+        return {
+            fname
+            for template_str in self.template_strs
+            for _, fname, _, _ in string.Formatter().parse(template_str)
+            if fname
+        }
 
     def format(self, **kwargs: Any) -> str:
         safe_kwargs = {k: v for k, v in kwargs.items() if v is not None}
         formatted_strs = []
         for template_str in self.template_strs:
             extracted_variables = [
-                fname for _, fname, _, _ in string.Formatter().parse(template_str) if fname
+                fname
+                for _, fname, _, _ in string.Formatter().parse(template_str)
+                if fname
             ]
             if all(item in safe_kwargs.keys() for item in extracted_variables):
                 formatted_strs.append(template_str.format(**safe_kwargs))
@@ -50,7 +59,9 @@ class PromptTemplate:
         new_template_strs = []
         for template_str in self.template_strs:
             extracted_variables = [
-                fname for _, fname, _, _ in string.Formatter().parse(template_str) if fname
+                fname
+                for _, fname, _, _ in string.Formatter().parse(template_str)
+                if fname
             ]
             safe_available_kwargs = {
                 k: safe_kwargs.get(k, "{" + k + "}") for k in extracted_variables

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -115,6 +115,7 @@ class EvaluationMetric:
             ``"root_mean_squared_error"`` for ``"mse"``.
         version: (Optional) The metric version. For example ``v1``.
         metric_details: (Optional) A description of the metric and how it is calculated.
+        metric_metadata: (Optional) A dictionary containing metadata for the metric.
     '''
 
     def __init__(
@@ -125,6 +126,7 @@ class EvaluationMetric:
         long_name=None,
         version=None,
         metric_details=None,
+        metric_metadata=None,
     ):
         self.eval_fn = eval_fn
         self.name = name
@@ -132,6 +134,7 @@ class EvaluationMetric:
         self.long_name = long_name or name
         self.version = version
         self.metric_details = metric_details
+        self.metric_metadata = metric_metadata
 
     def __str__(self):
         parts = [f"name={self.name}, greater_is_better={self.greater_is_better}"]
@@ -142,6 +145,8 @@ class EvaluationMetric:
             parts.append(f"version={self.version}")
         if self.metric_details:
             parts.append(f"metric_details={self.metric_details}")
+        if self.metric_metadata:
+            parts.append(f"metric_metadata={self.metric_metadata}")
 
         return "EvaluationMetric(" + ", ".join(parts) + ")"
 
@@ -154,6 +159,7 @@ def make_metric(
     long_name=None,
     version=None,
     metric_details=None,
+    metric_metadata=None,
 ):
     '''
     A factory function to create an :py:class:`EvaluationMetric` object.
@@ -201,6 +207,7 @@ def make_metric(
             for ``"mse"``.
         version: (Optional) The metric version. For example ``v1``.
         metric_details: (Optional) A description of the metric and how it is calculated.
+        metric_metadata: (Optional) A dictionary containing metadata for the metric.
 
     .. seealso::
 
@@ -247,7 +254,7 @@ def make_metric(
             "name to enable creation of derived metrics that use the given metric."
         )
 
-    return EvaluationMetric(eval_fn, name, greater_is_better, long_name, version, metric_details)
+    return EvaluationMetric(eval_fn, name, greater_is_better, long_name, version, metric_details, metric_metadata)
 
 
 @developer_stable

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -331,17 +331,11 @@ class EvaluationResult:
     def __init__(self, metrics, artifacts, baseline_model_metrics=None, run_id=None):
         self._metrics = metrics
         self._artifacts = artifacts
-        self._baseline_model_metrics = (
-            baseline_model_metrics if baseline_model_metrics else {}
-        )
+        self._baseline_model_metrics = baseline_model_metrics if baseline_model_metrics else {}
         self._run_id = (
             run_id
             if run_id is not None
-            else (
-                mlflow.active_run().info.run_id
-                if mlflow.active_run() is not None
-                else None
-            )
+            else (mlflow.active_run().info.run_id if mlflow.active_run() is not None else None)
         )
 
     @classmethod
@@ -421,18 +415,14 @@ class EvaluationResult:
         """
         eval_tables = {}
         if self._run_id is None:
-            _logger.warning(
-                "Cannot load eval_results_table because run_id is not specified."
-            )
+            _logger.warning("Cannot load eval_results_table because run_id is not specified.")
             return eval_tables
 
         for table_name, table_path in self._artifacts.items():
             path = urllib.parse.urlparse(table_path.uri).path
             table_fileName = os.path.basename(path)
             try:
-                eval_tables[table_name] = mlflow.load_table(
-                    table_fileName, run_ids=[self._run_id]
-                )
+                eval_tables[table_name] = mlflow.load_table(table_fileName, run_ids=[self._run_id])
             except Exception:
                 pass  # Swallow the exception since we assume its not a table.
 
@@ -548,11 +538,7 @@ def _hash_array_like_obj_as_bytes(data):
         # because lists are not hashable
         hashable = np.array(str(val) for val in data)
         return _hash_ndarray_as_bytes(hashable)
-    elif (
-        isinstance(data, np.ndarray)
-        and len(data) > 0
-        and isinstance(data[0], np.ndarray)
-    ):
+    elif isinstance(data, np.ndarray) and len(data) > 0 and isinstance(data[0], np.ndarray):
         # convert numpy array of numpy arrays into 2d numpy arrays
         # because numpy array of numpy arrays are not hashable
         hashable = np.array(data.tolist())
@@ -640,9 +626,7 @@ class EvaluationDataset:
         except ImportError:
             pass
 
-        if feature_names is not None and len(set(feature_names)) < len(
-            list(feature_names)
-        ):
+        if feature_names is not None and len(set(feature_names)) < len(list(feature_names)):
             raise MlflowException(
                 message="`feature_names` argument must be a list containing unique feature names.",
                 error_code=INVALID_PARAMETER_VALUE,
@@ -750,14 +734,11 @@ class EvaluationDataset:
                     features_data = features_data.drop(targets, axis=1, inplace=False)
 
                 if self._has_predictions:
-                    features_data = features_data.drop(
-                        predictions, axis=1, inplace=False
-                    )
+                    features_data = features_data.drop(predictions, axis=1, inplace=False)
 
                 self._features_data = features_data
                 self._feature_names = [
-                    generate_feature_name_if_not_string(c)
-                    for c in self._features_data.columns
+                    generate_feature_name_if_not_string(c) for c in self._features_data.columns
                 ]
         else:
             raise MlflowException(
@@ -836,11 +817,7 @@ class EvaluationDataset:
         Dataset name, which is specified dataset name or the dataset hash if user don't specify
         name.
         """
-        return (
-            self._user_specified_name
-            if self._user_specified_name is not None
-            else self.hash
-        )
+        return self._user_specified_name if self._user_specified_name is not None else self.hash
 
     @property
     def path(self):
@@ -903,9 +880,7 @@ class EvaluationDataset:
             return False
 
         if isinstance(self._features_data, np.ndarray):
-            is_features_data_equal = np.array_equal(
-                self._features_data, other._features_data
-            )
+            is_features_data_equal = np.array_equal(self._features_data, other._features_data)
         else:
             is_features_data_equal = self._features_data.equals(other._features_data)
 
@@ -1097,8 +1072,7 @@ def _model_validation_contains_model_comparison(validation_thresholds):
         return False
     thresholds = validation_thresholds.values()
     return any(
-        threshold.min_relative_change or threshold.min_absolute_change
-        for threshold in thresholds
+        threshold.min_relative_change or threshold.min_absolute_change for threshold in thresholds
     )
 
 
@@ -1155,12 +1129,8 @@ def _validate(validation_thresholds, candidate_metrics, baseline_metrics=None):
 
         # If metric is higher is better, >= is used, otherwise <= is used
         # for thresholding metric value and model comparsion
-        comparator_fn = (
-            operator.__ge__ if metric_threshold.greater_is_better else operator.__le__
-        )
-        operator_fn = (
-            operator.add if metric_threshold.greater_is_better else operator.sub
-        )
+        comparator_fn = operator.__ge__ if metric_threshold.greater_is_better else operator.__le__
+        operator_fn = operator.add if metric_threshold.greater_is_better else operator.sub
 
         if metric_threshold.threshold is not None:
             # metric threshold fails
@@ -1182,11 +1152,7 @@ def _validate(validation_thresholds, candidate_metrics, baseline_metrics=None):
             # - if not (metric_value <= baseline - min_absolute_change) for lower is better
             validation_result.min_absolute_change_failed = not comparator_fn(
                 Decimal(candidate_metric_value),
-                Decimal(
-                    operator_fn(
-                        baseline_metric_value, metric_threshold.min_absolute_change
-                    )
-                ),
+                Decimal(operator_fn(baseline_metric_value, metric_threshold.min_absolute_change)),
             )
 
         if metric_threshold.min_relative_change is not None:
@@ -1254,9 +1220,7 @@ def _convert_data_to_mlflow_dataset(data, targets=None, predictions=None):
     elif isinstance(data, np.ndarray):
         return mlflow.data.from_numpy(data, targets=targets)
     elif isinstance(data, pd.DataFrame):
-        return mlflow.data.from_pandas(
-            df=data, targets=targets, predictions=predictions
-        )
+        return mlflow.data.from_pandas(df=data, targets=targets, predictions=predictions)
     elif "pyspark" in sys.modules and isinstance(data, SparkDataFrame):
         return mlflow.data.from_spark(df=data, targets=targets, predictions=predictions)
     else:
@@ -1268,9 +1232,7 @@ def _convert_data_to_mlflow_dataset(data, targets=None, predictions=None):
         return data
 
 
-def _validate_dataset_type_supports_predictions(
-    data, supported_predictions_dataset_types
-):
+def _validate_dataset_type_supports_predictions(data, supported_predictions_dataset_types):
     """
     Validate that the dataset type supports a user-specified "predictions" column.
     """
@@ -1360,9 +1322,7 @@ def _evaluate(
         merged_eval_result.metrics.update(eval_result.metrics)
         merged_eval_result.artifacts.update(eval_result.artifacts)
         if baseline_model and eval_result.baseline_model_metrics:
-            merged_eval_result.baseline_model_metrics.update(
-                eval_result.baseline_model_metrics
-            )
+            merged_eval_result.baseline_model_metrics.update(eval_result.baseline_model_metrics)
 
     return merged_eval_result
 
@@ -2132,22 +2092,14 @@ def evaluate(
 
         from mlflow.data.pyfunc_dataset_mixin import PyFuncConvertibleDatasetMixin
 
-        if isinstance(data, Dataset) and issubclass(
-            data.__class__, PyFuncConvertibleDatasetMixin
-        ):
+        if isinstance(data, Dataset) and issubclass(data.__class__, PyFuncConvertibleDatasetMixin):
             dataset = data.to_evaluation_dataset(dataset_path, feature_names)
-            if evaluator_name_to_conf_map and evaluator_name_to_conf_map.get(
-                "default", None
-            ):
-                context = evaluator_name_to_conf_map["default"].get(
-                    "metric_prefix", None
-                )
+            if evaluator_name_to_conf_map and evaluator_name_to_conf_map.get("default", None):
+                context = evaluator_name_to_conf_map["default"].get("metric_prefix", None)
             else:
                 context = None
             client = MlflowClient()
-            tags = (
-                [InputTag(key=MLFLOW_DATASET_CONTEXT, value=context)] if context else []
-            )
+            tags = [InputTag(key=MLFLOW_DATASET_CONTEXT, value=context)] if context else []
             dataset_input = DatasetInput(dataset=data._to_mlflow_entity(), tags=tags)
             client.log_inputs(run_id, [dataset_input])
         else:
@@ -2158,9 +2110,7 @@ def evaluate(
                 feature_names=feature_names,
                 predictions=predictions,
             )
-        predictions_expected_in_model_output = (
-            predictions if model is not None else None
-        )
+        predictions_expected_in_model_output = predictions if model is not None else None
 
         try:
             evaluate_result = _evaluate(

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -254,7 +254,15 @@ def make_metric(
             "name to enable creation of derived metrics that use the given metric."
         )
 
-    return EvaluationMetric(eval_fn, name, greater_is_better, long_name, version, metric_details, metric_metadata)
+    return EvaluationMetric(
+        eval_fn,
+        name,
+        greater_is_better,
+        long_name,
+        version,
+        metric_details,
+        metric_metadata,
+    )
 
 
 @developer_stable
@@ -323,11 +331,17 @@ class EvaluationResult:
     def __init__(self, metrics, artifacts, baseline_model_metrics=None, run_id=None):
         self._metrics = metrics
         self._artifacts = artifacts
-        self._baseline_model_metrics = baseline_model_metrics if baseline_model_metrics else {}
+        self._baseline_model_metrics = (
+            baseline_model_metrics if baseline_model_metrics else {}
+        )
         self._run_id = (
             run_id
             if run_id is not None
-            else (mlflow.active_run().info.run_id if mlflow.active_run() is not None else None)
+            else (
+                mlflow.active_run().info.run_id
+                if mlflow.active_run() is not None
+                else None
+            )
         )
 
     @classmethod
@@ -407,14 +421,18 @@ class EvaluationResult:
         """
         eval_tables = {}
         if self._run_id is None:
-            _logger.warning("Cannot load eval_results_table because run_id is not specified.")
+            _logger.warning(
+                "Cannot load eval_results_table because run_id is not specified."
+            )
             return eval_tables
 
         for table_name, table_path in self._artifacts.items():
             path = urllib.parse.urlparse(table_path.uri).path
             table_fileName = os.path.basename(path)
             try:
-                eval_tables[table_name] = mlflow.load_table(table_fileName, run_ids=[self._run_id])
+                eval_tables[table_name] = mlflow.load_table(
+                    table_fileName, run_ids=[self._run_id]
+                )
             except Exception:
                 pass  # Swallow the exception since we assume its not a table.
 
@@ -530,7 +548,11 @@ def _hash_array_like_obj_as_bytes(data):
         # because lists are not hashable
         hashable = np.array(str(val) for val in data)
         return _hash_ndarray_as_bytes(hashable)
-    elif isinstance(data, np.ndarray) and len(data) > 0 and isinstance(data[0], np.ndarray):
+    elif (
+        isinstance(data, np.ndarray)
+        and len(data) > 0
+        and isinstance(data[0], np.ndarray)
+    ):
         # convert numpy array of numpy arrays into 2d numpy arrays
         # because numpy array of numpy arrays are not hashable
         hashable = np.array(data.tolist())
@@ -618,7 +640,9 @@ class EvaluationDataset:
         except ImportError:
             pass
 
-        if feature_names is not None and len(set(feature_names)) < len(list(feature_names)):
+        if feature_names is not None and len(set(feature_names)) < len(
+            list(feature_names)
+        ):
             raise MlflowException(
                 message="`feature_names` argument must be a list containing unique feature names.",
                 error_code=INVALID_PARAMETER_VALUE,
@@ -626,7 +650,8 @@ class EvaluationDataset:
 
         if self._has_predictions:
             _validate_dataset_type_supports_predictions(
-                data=data, supported_predictions_dataset_types=self._supported_dataframe_types
+                data=data,
+                supported_predictions_dataset_types=self._supported_dataframe_types,
             )
 
         has_targets = targets is not None
@@ -725,11 +750,14 @@ class EvaluationDataset:
                     features_data = features_data.drop(targets, axis=1, inplace=False)
 
                 if self._has_predictions:
-                    features_data = features_data.drop(predictions, axis=1, inplace=False)
+                    features_data = features_data.drop(
+                        predictions, axis=1, inplace=False
+                    )
 
                 self._features_data = features_data
                 self._feature_names = [
-                    generate_feature_name_if_not_string(c) for c in self._features_data.columns
+                    generate_feature_name_if_not_string(c)
+                    for c in self._features_data.columns
                 ]
         else:
             raise MlflowException(
@@ -808,7 +836,11 @@ class EvaluationDataset:
         Dataset name, which is specified dataset name or the dataset hash if user don't specify
         name.
         """
-        return self._user_specified_name if self._user_specified_name is not None else self.hash
+        return (
+            self._user_specified_name
+            if self._user_specified_name is not None
+            else self.hash
+        )
 
     @property
     def path(self):
@@ -871,7 +903,9 @@ class EvaluationDataset:
             return False
 
         if isinstance(self._features_data, np.ndarray):
-            is_features_data_equal = np.array_equal(self._features_data, other._features_data)
+            is_features_data_equal = np.array_equal(
+                self._features_data, other._features_data
+            )
         else:
             is_features_data_equal = self._features_data.equals(other._features_data)
 
@@ -1063,7 +1097,8 @@ def _model_validation_contains_model_comparison(validation_thresholds):
         return False
     thresholds = validation_thresholds.values()
     return any(
-        threshold.min_relative_change or threshold.min_absolute_change for threshold in thresholds
+        threshold.min_relative_change or threshold.min_absolute_change
+        for threshold in thresholds
     )
 
 
@@ -1120,8 +1155,12 @@ def _validate(validation_thresholds, candidate_metrics, baseline_metrics=None):
 
         # If metric is higher is better, >= is used, otherwise <= is used
         # for thresholding metric value and model comparsion
-        comparator_fn = operator.__ge__ if metric_threshold.greater_is_better else operator.__le__
-        operator_fn = operator.add if metric_threshold.greater_is_better else operator.sub
+        comparator_fn = (
+            operator.__ge__ if metric_threshold.greater_is_better else operator.__le__
+        )
+        operator_fn = (
+            operator.add if metric_threshold.greater_is_better else operator.sub
+        )
 
         if metric_threshold.threshold is not None:
             # metric threshold fails
@@ -1143,7 +1182,11 @@ def _validate(validation_thresholds, candidate_metrics, baseline_metrics=None):
             # - if not (metric_value <= baseline - min_absolute_change) for lower is better
             validation_result.min_absolute_change_failed = not comparator_fn(
                 Decimal(candidate_metric_value),
-                Decimal(operator_fn(baseline_metric_value, metric_threshold.min_absolute_change)),
+                Decimal(
+                    operator_fn(
+                        baseline_metric_value, metric_threshold.min_absolute_change
+                    )
+                ),
             )
 
         if metric_threshold.min_relative_change is not None:
@@ -1211,7 +1254,9 @@ def _convert_data_to_mlflow_dataset(data, targets=None, predictions=None):
     elif isinstance(data, np.ndarray):
         return mlflow.data.from_numpy(data, targets=targets)
     elif isinstance(data, pd.DataFrame):
-        return mlflow.data.from_pandas(df=data, targets=targets, predictions=predictions)
+        return mlflow.data.from_pandas(
+            df=data, targets=targets, predictions=predictions
+        )
     elif "pyspark" in sys.modules and isinstance(data, SparkDataFrame):
         return mlflow.data.from_spark(df=data, targets=targets, predictions=predictions)
     else:
@@ -1223,7 +1268,9 @@ def _convert_data_to_mlflow_dataset(data, targets=None, predictions=None):
         return data
 
 
-def _validate_dataset_type_supports_predictions(data, supported_predictions_dataset_types):
+def _validate_dataset_type_supports_predictions(
+    data, supported_predictions_dataset_types
+):
     """
     Validate that the dataset type supports a user-specified "predictions" column.
     """
@@ -1313,7 +1360,9 @@ def _evaluate(
         merged_eval_result.metrics.update(eval_result.metrics)
         merged_eval_result.artifacts.update(eval_result.artifacts)
         if baseline_model and eval_result.baseline_model_metrics:
-            merged_eval_result.baseline_model_metrics.update(eval_result.baseline_model_metrics)
+            merged_eval_result.baseline_model_metrics.update(
+                eval_result.baseline_model_metrics
+            )
 
     return merged_eval_result
 
@@ -2083,14 +2132,22 @@ def evaluate(
 
         from mlflow.data.pyfunc_dataset_mixin import PyFuncConvertibleDatasetMixin
 
-        if isinstance(data, Dataset) and issubclass(data.__class__, PyFuncConvertibleDatasetMixin):
+        if isinstance(data, Dataset) and issubclass(
+            data.__class__, PyFuncConvertibleDatasetMixin
+        ):
             dataset = data.to_evaluation_dataset(dataset_path, feature_names)
-            if evaluator_name_to_conf_map and evaluator_name_to_conf_map.get("default", None):
-                context = evaluator_name_to_conf_map["default"].get("metric_prefix", None)
+            if evaluator_name_to_conf_map and evaluator_name_to_conf_map.get(
+                "default", None
+            ):
+                context = evaluator_name_to_conf_map["default"].get(
+                    "metric_prefix", None
+                )
             else:
                 context = None
             client = MlflowClient()
-            tags = [InputTag(key=MLFLOW_DATASET_CONTEXT, value=context)] if context else []
+            tags = (
+                [InputTag(key=MLFLOW_DATASET_CONTEXT, value=context)] if context else []
+            )
             dataset_input = DatasetInput(dataset=data._to_mlflow_entity(), tags=tags)
             client.log_inputs(run_id, [dataset_input])
         else:
@@ -2101,7 +2158,9 @@ def evaluate(
                 feature_names=feature_names,
                 predictions=predictions,
             )
-        predictions_expected_in_model_output = predictions if model is not None else None
+        predictions_expected_in_model_output = (
+            predictions if model is not None else None
+        )
 
         try:
             evaluate_result = _evaluate(

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -1120,7 +1120,7 @@ def test_make_custom_judge_prompt_genai_metric():
 def test_make_custom_prompt_genai_metric_validates_input_kwargs():
     custom_judge_prompt = "This is a custom judge prompt that uses {input} and {output}"
 
-    custom_judge_prompt_metric = make_genai_metric(
+    custom_judge_prompt_metric = make_custom_genai_metric(
         name="custom",
         judge_prompt=custom_judge_prompt,
     )

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -11,6 +11,7 @@ from mlflow.metrics.genai import EvaluationExample, model_utils
 from mlflow.metrics.genai.genai_metric import (
     _extract_score_and_justification,
     _format_args_string,
+    make_custom_genai_metric,
     make_genai_metric,
 )
 from mlflow.metrics.genai.metric_definitions import (
@@ -1054,6 +1055,8 @@ def test_make_genai_metric_without_example():
 
 
 def test_make_genai_metric_metric_metadata():
+    expected_metric_metadata = {"metadata_field": "metadata_value"}
+
     custom_metric = make_genai_metric(
         name="correctness",
         version="v1",
@@ -1065,16 +1068,14 @@ def test_make_genai_metric_metric_metadata():
         parameters={"temperature": 0.0},
         greater_is_better=True,
         aggregations=["mean", "variance", "p90"],
-        metric_metadata={"metadata_field": "metadata_value"},
+        metric_metadata=expected_metric_metadata,
     )
-    expected_metric_details = "\nTask:\nYou must return the following fields in your response in two lines, one below the other:\nscore: Your numerical score for the model's correctness based on the rubric\njustification: Your reasoning about the model's correctness score\n\nYou are an impartial judge. You will be given an input that was sent to a machine\nlearning model, and you will be given an output that the model produced. You\nmay also be given additional information that was used by the model to generate the output.\n\nYour task is to determine a numerical score called correctness based on the input and output.\nA definition of correctness and a grading rubric are provided below.\nYou must use the grading rubric to determine your score. You must also justify your score.\n\nExamples could be included below for reference. Make sure to use them as references and to\nunderstand them before completing the task.\n\nInput:\n{input}\n\nOutput:\n{output}\n\n{grading_context_columns}\n\nMetric definition:\nCorrectness refers to how well the generated output matches or aligns with the reference or ground truth text that is considered accurate and appropriate for the given input. The ground truth serves as a benchmark against which the provided output is compared to determine the level of accuracy and fidelity.\n\nGrading rubric:\nCorrectness: If the answer correctly answer the question, below are the details for different scores: - Score 0: the answer is completely incorrect, doesn’t mention anything about the question or is completely contrary to the correct answer. - Score 1: the answer provides some relevance to the question and answer one aspect of the question correctly. - Score 2: the answer mostly answer the question but is missing or hallucinating on one critical aspect. - Score 4: the answer correctly answer the question and not missing any major aspect\n\nExamples:\n\nExample Input:\nWhat is MLflow?\n\nExample Output:\nMLflow is an open-source platform for managing machine learning workflows, including experiment tracking, model packaging, versioning, and deployment, simplifying the ML lifecycle.\n\nAdditional information used by the model:\nkey: targets\nvalue:\nMLflow is an open-source platform for managing the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, a company that specializes in big data and machine learning solutions. MLflow is designed to address the challenges that data scientists and machine learning engineers face when developing, training, and deploying machine learning models.\n\nExample score: 4\nExample justification: The definition effectively explains what MLflow is its purpose, and its developer. It could be more concise for a 5-score.\n        \n\nYou must return the following fields in your response in two lines, one below the other:\nscore: Your numerical score for the model's correctness based on the rubric\njustification: Your reasoning about the model's correctness score\n\nDo not add additional new lines. Do not add any other fields.\n    "  # noqa: E501
-    expected_metric_metadata = {"metadata_field": "metadata_value"}
 
     assert custom_metric.metric_metadata == expected_metric_metadata
 
     assert custom_metric.__str__() == (
         f"EvaluationMetric(name=correctness, greater_is_better=True, long_name=correctness, "
-        f"version=v1, metric_details={expected_metric_details}, "
+        f"version=v1, metric_details={custom_metric.metric_details}, "
         f"metric_metadata={expected_metric_metadata})"
     )
 
@@ -1082,7 +1083,7 @@ def test_make_genai_metric_metric_metadata():
 def test_make_custom_judge_prompt_genai_metric():
     custom_judge_prompt = "This is a custom judge prompt that uses {input} and {output}"
 
-    custom_judge_prompt_metric = make_genai_metric(
+    custom_judge_prompt_metric = make_custom_genai_metric(
         name="custom",
         judge_prompt=custom_judge_prompt,
         metric_metadata={"metadata_field": "metadata_value"},

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -154,8 +154,7 @@ def test_make_genai_metric_correct_response():
     )
 
     assert [
-        param.name
-        for param in inspect.signature(custom_metric.eval_fn).parameters.values()
+        param.name for param in inspect.signature(custom_metric.eval_fn).parameters.values()
     ] == ["predictions", "metrics", "inputs", "targets"]
 
     with mock.patch.object(
@@ -274,8 +273,7 @@ def test_make_genai_metric_supports_string_value_for_grading_context_columns():
     )
 
     assert [
-        param.name
-        for param in inspect.signature(custom_metric.eval_fn).parameters.values()
+        param.name for param in inspect.signature(custom_metric.eval_fn).parameters.values()
     ] == ["predictions", "metrics", "inputs", "targets"]
 
     with mock.patch.object(
@@ -546,9 +544,7 @@ def test_make_genai_metric_failure():
         (None, ["column_a"]),
     ],
 )
-def test_make_genai_metric_throws_if_grading_context_cols_wrong(
-    grading_cols, example_context_cols
-):
+def test_make_genai_metric_throws_if_grading_context_cols_wrong(grading_cols, example_context_cols):
     with pytest.raises(
         MlflowException,
         match="Example grading context does not contain required columns",
@@ -575,9 +571,7 @@ def test_make_genai_metric_throws_if_grading_context_cols_wrong(
 
 
 def test_format_args_string():
-    variable_string = _format_args_string(
-        ["foo", "bar"], {"foo": ["foo"], "bar": ["bar"]}, 0
-    )
+    variable_string = _format_args_string(["foo", "bar"], {"foo": ["foo"], "bar": ["bar"]}, 0)
 
     assert variable_string == (
         "Additional information used by the model:\nkey: foo\nvalue:\nfoo\nkey: bar\nvalue:\nbar"
@@ -587,9 +581,7 @@ def test_format_args_string():
         MlflowException,
         match=re.escape("bar does not exist in the eval function ['foo']."),
     ):
-        variable_string = _format_args_string(
-            ["foo", "bar"], pd.DataFrame({"foo": ["foo"]}), 0
-        )
+        variable_string = _format_args_string(["foo", "bar"], pd.DataFrame({"foo": ["foo"]}), 0)
 
 
 def test_extract_score_and_justification():
@@ -607,9 +599,7 @@ def test_extract_score_and_justification():
     assert score2 == 2
     assert justification2 == "This is a justification"
 
-    score3, justification3 = _extract_score_and_justification(
-        properly_formatted_openai_response1
-    )
+    score3, justification3 = _extract_score_and_justification(properly_formatted_openai_response1)
     assert score3 == 3
     assert justification3 == (
         "The provided output mostly answers the question, but it is missing or hallucinating on "
@@ -810,9 +800,7 @@ def test_faithfulness_metric():
 def test_answer_correctness_metric():
     answer_correctness_metric = answer_correctness()
     input = "What is MLflow?"
-    examples = "\n".join(
-        [str(example) for example in AnswerCorrectnessMetric.default_examples]
-    )
+    examples = "\n".join([str(example) for example in AnswerCorrectnessMetric.default_examples])
 
     with mock.patch.object(
         model_utils,
@@ -879,9 +867,7 @@ def test_answer_correctness_metric():
 
 
 def test_answer_relevance_metric():
-    answer_relevance_metric = answer_relevance(
-        model="gateway:/gpt-3.5-turbo", examples=[]
-    )
+    answer_relevance_metric = answer_relevance(model="gateway:/gpt-3.5-turbo", examples=[])
     input = "What is MLflow?"
 
     with mock.patch.object(

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -154,7 +154,8 @@ def test_make_genai_metric_correct_response():
     )
 
     assert [
-        param.name for param in inspect.signature(custom_metric.eval_fn).parameters.values()
+        param.name
+        for param in inspect.signature(custom_metric.eval_fn).parameters.values()
     ] == ["predictions", "metrics", "inputs", "targets"]
 
     with mock.patch.object(
@@ -245,7 +246,11 @@ def test_make_genai_metric_correct_response():
         }
         assert metric_value.scores == [3]
         assert metric_value.justifications == [openai_justification1]
-        assert metric_value.aggregate_results == {"mean": 3.0, "p90": 3.0, "variance": 0.0}
+        assert metric_value.aggregate_results == {
+            "mean": 3.0,
+            "p90": 3.0,
+            "variance": 0.0,
+        }
 
 
 def test_make_genai_metric_supports_string_value_for_grading_context_columns():
@@ -269,7 +274,8 @@ def test_make_genai_metric_supports_string_value_for_grading_context_columns():
     )
 
     assert [
-        param.name for param in inspect.signature(custom_metric.eval_fn).parameters.values()
+        param.name
+        for param in inspect.signature(custom_metric.eval_fn).parameters.values()
     ] == ["predictions", "metrics", "inputs", "targets"]
 
     with mock.patch.object(
@@ -321,7 +327,11 @@ def test_make_genai_metric_supports_string_value_for_grading_context_columns():
         }
         assert metric_value.scores == [3]
         assert metric_value.justifications == [openai_justification1]
-        assert metric_value.aggregate_results == {"mean": 3.0, "p90": 3.0, "variance": 0.0}
+        assert metric_value.aggregate_results == {
+            "mean": 3.0,
+            "p90": 3.0,
+            "variance": 0.0,
+        }
 
 
 def test_make_genai_metric_incorrect_response():
@@ -416,7 +426,10 @@ def test_make_genai_metric_multiple():
     with mock.patch.object(
         model_utils,
         "score_model_on_payload",
-        side_effect=[properly_formatted_openai_response1, properly_formatted_openai_response2],
+        side_effect=[
+            properly_formatted_openai_response1,
+            properly_formatted_openai_response2,
+        ],
     ):
         metric_value = custom_metric.eval_fn(
             pd.Series(
@@ -533,9 +546,12 @@ def test_make_genai_metric_failure():
         (None, ["column_a"]),
     ],
 )
-def test_make_genai_metric_throws_if_grading_context_cols_wrong(grading_cols, example_context_cols):
+def test_make_genai_metric_throws_if_grading_context_cols_wrong(
+    grading_cols, example_context_cols
+):
     with pytest.raises(
-        MlflowException, match="Example grading context does not contain required columns"
+        MlflowException,
+        match="Example grading context does not contain required columns",
     ):
         make_genai_metric(
             name="correctness",
@@ -559,7 +575,9 @@ def test_make_genai_metric_throws_if_grading_context_cols_wrong(grading_cols, ex
 
 
 def test_format_args_string():
-    variable_string = _format_args_string(["foo", "bar"], {"foo": ["foo"], "bar": ["bar"]}, 0)
+    variable_string = _format_args_string(
+        ["foo", "bar"], {"foo": ["foo"], "bar": ["bar"]}, 0
+    )
 
     assert variable_string == (
         "Additional information used by the model:\nkey: foo\nvalue:\nfoo\nkey: bar\nvalue:\nbar"
@@ -569,7 +587,9 @@ def test_format_args_string():
         MlflowException,
         match=re.escape("bar does not exist in the eval function ['foo']."),
     ):
-        variable_string = _format_args_string(["foo", "bar"], pd.DataFrame({"foo": ["foo"]}), 0)
+        variable_string = _format_args_string(
+            ["foo", "bar"], pd.DataFrame({"foo": ["foo"]}), 0
+        )
 
 
 def test_extract_score_and_justification():
@@ -587,7 +607,9 @@ def test_extract_score_and_justification():
     assert score2 == 2
     assert justification2 == "This is a justification"
 
-    score3, justification3 = _extract_score_and_justification(properly_formatted_openai_response1)
+    score3, justification3 = _extract_score_and_justification(
+        properly_formatted_openai_response1
+    )
     assert score3 == 3
     assert justification3 == (
         "The provided output mostly answers the question, but it is missing or hallucinating on "
@@ -641,7 +663,10 @@ def test_similarity_metric():
         return_value=properly_formatted_openai_response1,
     ) as mock_predict_function:
         metric_value = similarity_metric.eval_fn(
-            pd.Series([mlflow_prediction]), {}, pd.Series([input]), pd.Series([mlflow_ground_truth])
+            pd.Series([mlflow_prediction]),
+            {},
+            pd.Series([input]),
+            pd.Series([mlflow_ground_truth]),
         )
 
         assert mock_predict_function.call_count == 1
@@ -764,7 +789,8 @@ def test_faithfulness_metric():
     }
 
     with pytest.raises(
-        MlflowException, match="Failed to find faithfulness metric for version non-existent-version"
+        MlflowException,
+        match="Failed to find faithfulness metric for version non-existent-version",
     ):
         faithfulness_metric = faithfulness(
             model="gateway:/gpt-3.5-turbo",
@@ -784,7 +810,9 @@ def test_faithfulness_metric():
 def test_answer_correctness_metric():
     answer_correctness_metric = answer_correctness()
     input = "What is MLflow?"
-    examples = "\n".join([str(example) for example in AnswerCorrectnessMetric.default_examples])
+    examples = "\n".join(
+        [str(example) for example in AnswerCorrectnessMetric.default_examples]
+    )
 
     with mock.patch.object(
         model_utils,
@@ -851,7 +879,9 @@ def test_answer_correctness_metric():
 
 
 def test_answer_relevance_metric():
-    answer_relevance_metric = answer_relevance(model="gateway:/gpt-3.5-turbo", examples=[])
+    answer_relevance_metric = answer_relevance(
+        model="gateway:/gpt-3.5-turbo", examples=[]
+    )
     input = "What is MLflow?"
 
     with mock.patch.object(
@@ -989,7 +1019,8 @@ def test_relevance_metric():
     }
 
     with pytest.raises(
-        MlflowException, match="Failed to find relevance metric for version non-existent-version"
+        MlflowException,
+        match="Failed to find relevance metric for version non-existent-version",
     ):
         relevance_metric = relevance(
             model="gateway:/gpt-3.5-turbo",
@@ -1057,7 +1088,8 @@ def test_make_genai_metric_metric_metadata():
 
     assert custom_metric.__str__() == (
         f"EvaluationMetric(name=correctness, greater_is_better=True, long_name=correctness, "
-        f"version=v1, metric_details={expected_metric_details}, metric_metadata={expected_metric_metadata})"
+        f"version=v1, metric_details={expected_metric_details}, "
+        f"metric_metadata={expected_metric_metadata})"
     )
 
 
@@ -1071,12 +1103,15 @@ def test_make_custom_judge_prompt_genai_metric():
     )
 
     inputs = ["What is MLflow?", "What is Spark?"]
-    outputs = ["MLflow is an open-source platform", "Apache Spark is an open-source distributed framework"]
+    outputs = [
+        "MLflow is an open-source platform",
+        "Apache Spark is an open-source distributed framework",
+    ]
 
     with mock.patch.object(
-            model_utils,
-            "score_model_on_payload",
-            return_value=properly_formatted_openai_response1,
+        model_utils,
+        "score_model_on_payload",
+        return_value=properly_formatted_openai_response1,
     ) as mock_predict_function:
         metric_value = custom_judge_prompt_metric.eval_fn(
             input=pd.Series(inputs),
@@ -1084,15 +1119,19 @@ def test_make_custom_judge_prompt_genai_metric():
         )
         assert mock_predict_function.call_count == 2
         assert mock_predict_function.call_args_list[0][0][1] == (
-            "This is a custom judge prompt that uses What is MLflow? and MLflow is an open-source platform"
-            "\n\nYou must return the following fields in your response in two lines, one below the other:"
+            "This is a custom judge prompt that uses What is MLflow? and "
+            "MLflow is an open-source platform"
+            "\n\nYou must return the following fields in your response in two "
+            "lines, one below the other:"
             "\nscore: Your numerical score based on the rubric"
             "\njustification: Your reasoning for giving this score"
             "\n\nDo not add additional new lines. Do not add any other fields."
         )
         assert mock_predict_function.call_args_list[1][0][1] == (
-            "This is a custom judge prompt that uses What is Spark? and Apache Spark is an open-source distributed framework"
-            "\n\nYou must return the following fields in your response in two lines, one below the other:"
+            "This is a custom judge prompt that uses What is Spark? and "
+            "Apache Spark is an open-source distributed framework"
+            "\n\nYou must return the following fields in your response in two "
+            "lines, one below the other:"
             "\nscore: Your numerical score based on the rubric"
             "\njustification: Your reasoning for giving this score"
             "\n\nDo not add additional new lines. Do not add any other fields."

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -246,11 +246,7 @@ def test_make_genai_metric_correct_response():
         }
         assert metric_value.scores == [3]
         assert metric_value.justifications == [openai_justification1]
-        assert metric_value.aggregate_results == {
-            "mean": 3.0,
-            "p90": 3.0,
-            "variance": 0.0,
-        }
+        assert metric_value.aggregate_results == {"mean": 3.0, "p90": 3.0, "variance": 0.0}
 
 
 def test_make_genai_metric_supports_string_value_for_grading_context_columns():
@@ -326,11 +322,7 @@ def test_make_genai_metric_supports_string_value_for_grading_context_columns():
         }
         assert metric_value.scores == [3]
         assert metric_value.justifications == [openai_justification1]
-        assert metric_value.aggregate_results == {
-            "mean": 3.0,
-            "p90": 3.0,
-            "variance": 0.0,
-        }
+        assert metric_value.aggregate_results == {"mean": 3.0, "p90": 3.0, "variance": 0.0}
 
 
 def test_make_genai_metric_incorrect_response():
@@ -425,10 +417,7 @@ def test_make_genai_metric_multiple():
     with mock.patch.object(
         model_utils,
         "score_model_on_payload",
-        side_effect=[
-            properly_formatted_openai_response1,
-            properly_formatted_openai_response2,
-        ],
+        side_effect=[properly_formatted_openai_response1, properly_formatted_openai_response2],
     ):
         metric_value = custom_metric.eval_fn(
             pd.Series(
@@ -547,8 +536,7 @@ def test_make_genai_metric_failure():
 )
 def test_make_genai_metric_throws_if_grading_context_cols_wrong(grading_cols, example_context_cols):
     with pytest.raises(
-        MlflowException,
-        match="Example grading context does not contain required columns",
+        MlflowException, match="Example grading context does not contain required columns"
     ):
         make_genai_metric(
             name="correctness",
@@ -654,10 +642,7 @@ def test_similarity_metric():
         return_value=properly_formatted_openai_response1,
     ) as mock_predict_function:
         metric_value = similarity_metric.eval_fn(
-            pd.Series([mlflow_prediction]),
-            {},
-            pd.Series([input]),
-            pd.Series([mlflow_ground_truth]),
+            pd.Series([mlflow_prediction]), {}, pd.Series([input]), pd.Series([mlflow_ground_truth])
         )
 
         assert mock_predict_function.call_count == 1
@@ -780,8 +765,7 @@ def test_faithfulness_metric():
     }
 
     with pytest.raises(
-        MlflowException,
-        match="Failed to find faithfulness metric for version non-existent-version",
+        MlflowException, match="Failed to find faithfulness metric for version non-existent-version"
     ):
         faithfulness_metric = faithfulness(
             model="gateway:/gpt-3.5-turbo",
@@ -1006,8 +990,7 @@ def test_relevance_metric():
     }
 
     with pytest.raises(
-        MlflowException,
-        match="Failed to find relevance metric for version non-existent-version",
+        MlflowException, match="Failed to find relevance metric for version non-existent-version"
     ):
         relevance_metric = relevance(
             model="gateway:/gpt-3.5-turbo",


### PR DESCRIPTION
### What changes are proposed in this pull request?
- Add a `judge_prompt` argument to `make_genai_metric` that allows control over the entire prompt sent to the LLM. This is useful in situations where users may want to override the preamble that normally is constructed with the prompt in `make_genai_metric`. If this argument is passed in, metric definition, examples and grading criteria will be ignored.
- Adds an optional `metric_metadata` to `EvaluationMetric` that can be used to store arbitrary metadata along with the EvaluationMetric. This can be useful for certain evaluators if additional metadata is needed to determine how to evaluate a given metric.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="2175" alt="image" src="https://github.com/mlflow/mlflow/assets/51172624/2db1ab84-8e33-4e14-a080-0944b461db28">

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes
- Add a `judge_prompt` argument to `make_genai_metric` to allow control over the entire prompt sent to the LLM during evaluation.
- Add optional `metric_metadata` to `EvaluationMetric`.

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
