### PR TITLE
Support parquet file for log_table

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2368,7 +2368,7 @@ class MlflowClient:
         import pandas as pd
 
         self._check_artifact_file_string(artifact_file)
-        if not artifact_file.endswith(".json") and not artifact_file.endswith(".parquet"):
+        if not artifact_file.endswith((".json", ".parquet")):
             raise ValueError(
                 f"The provided artifact file '{artifact_file}' does not have "
                 "the required '.json' or '.parquet' extension. Please ensure the file you are "

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2293,6 +2293,7 @@ class MlflowClient:
             return pd.read_json(artifact_path, orient="split")
         if artifact_path.endswith(".parquet"):
             return pd.read_parquet(artifact_path)
+        raise ValueError(f"Unsupported file type in {artifact_path}. Expected .json or .parquet")
 
     @experimental
     def log_table(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2371,9 +2371,9 @@ class MlflowClient:
         self._check_artifact_file_string(artifact_file)
         if not artifact_file.endswith((".json", ".parquet")):
             raise ValueError(
-                f"The provided artifact file '{artifact_file}' does not have "
-                "the required '.json' or '.parquet' extension. Please ensure the file you are "
-                "trying to log as a table is valid with either '.json' or '.parquet' extension."
+                f"Invalid artifact file path '{artifact_file}'. Please ensure the file you are "
+                "trying to log as a table has a file name with either '.json' "
+                "or '.parquet' extension."
             )
 
         if not isinstance(data, (pd.DataFrame, dict)):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2286,6 +2286,14 @@ class MlflowClient:
             if char in artifact_file:
                 raise ValueError(f"The artifact_file contains forbidden character: {char}")
 
+    def _read_from_file(self, artifact_path):
+        import pandas as pd
+
+        if artifact_path.endswith(".json"):
+            return pd.read_json(artifact_path, orient="split")
+        if artifact_path.endswith(".parquet"):
+            return pd.read_parquet(artifact_path)
+
     @experimental
     def log_table(
         self,
@@ -2360,11 +2368,11 @@ class MlflowClient:
         import pandas as pd
 
         self._check_artifact_file_string(artifact_file)
-        if not artifact_file.endswith(".json"):
+        if not artifact_file.endswith(".json") and not artifact_file.endswith(".parquet"):
             raise ValueError(
                 f"The provided artifact file '{artifact_file}' does not have "
-                "the required '.json' extension. Please ensure the file you are trying "
-                "to log as a table is a JSON file with the '.json' extension. "
+                "the required '.json' or '.parquet' extension. Please ensure the file you are "
+                "trying to log as a table is valid with either '.json' or '.parquet' extension."
             )
 
         if not isinstance(data, (pd.DataFrame, dict)):
@@ -2427,6 +2435,12 @@ class MlflowClient:
                     # Save files to artifact storage
                     data[column] = data[column].map(lambda x: process_image(x))
 
+        def write_to_file(data, artifact_path):
+            if artifact_path.endswith(".json"):
+                data.to_json(artifact_path, orient="split", index=False, date_format="iso")
+            elif artifact_path.endswith(".parquet"):
+                data.to_parquet(artifact_path, index=False)
+
         norm_path = posixpath.normpath(artifact_file)
         artifact_dir = posixpath.dirname(norm_path)
         artifact_dir = None if artifact_dir == "" else artifact_dir
@@ -2436,7 +2450,7 @@ class MlflowClient:
                 downloaded_artifact_path = mlflow.artifacts.download_artifacts(
                     run_id=run_id, artifact_path=artifact_file, dst_path=tmpdir
                 )
-                existing_predictions = pd.read_json(downloaded_artifact_path, orient="split")
+                existing_predictions = self._read_from_file(downloaded_artifact_path)
             data = pd.concat([existing_predictions, data], ignore_index=True)
             _logger.info(
                 "Appending new table to already existing artifact "
@@ -2445,7 +2459,7 @@ class MlflowClient:
 
         with self._log_artifact_helper(run_id, artifact_file) as artifact_path:
             try:
-                data.to_json(artifact_path, orient="split", index=False, date_format="iso")
+                write_to_file(data, artifact_path)
             except Exception as e:
                 raise MlflowException(
                     f"Failed to save {data} as table as the data is not JSON serializable. "
@@ -2579,7 +2593,7 @@ class MlflowClient:
                         artifact_path=artifact_file,
                         dst_path=tmpdir,
                     )
-                    existing_predictions = pd.read_json(downloaded_artifact_path, orient="split")
+                    existing_predictions = self._read_from_file(downloaded_artifact_path)
                     if extra_columns is not None:
                         for column in extra_columns:
                             if column in existing_predictions:

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -857,6 +857,7 @@ def read_data(artifact_path):
         return pd.read_json(artifact_path, orient="split")
     if artifact_path.endswith(".parquet"):
         return pd.read_parquet(artifact_path)
+    raise ValueError(f"Unsupported file type in {artifact_path}. Expected .json or .parquet")
 
 
 @pytest.mark.skipif(

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -850,11 +850,21 @@ def test_search_runs_multiple_experiments():
     assert len(MlflowClient().search_runs(experiment_ids, "metrics.m_3 < 4", ViewType.ALL)) == 1
 
 
+def read_data(artifact_path):
+    import pandas as pd
+
+    if artifact_path.endswith("json"):
+        return pd.read_json(artifact_path, orient="split")
+    if artifact_path.endswith("parquet"):
+        return pd.read_parquet(artifact_path)
+
+
 @pytest.mark.skipif(
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny client does not support the np or pandas dependencies",
 )
-def test_log_table():
+@pytest.mark.parametrize("file_type", ["json", "parquet"])
+def test_log_table(file_type):
     import pandas as pd
 
     table_dict = {
@@ -862,7 +872,7 @@ def test_log_table():
         "outputs": ["MLflow is ...", "Databricks is ..."],
         "toxicity": [0.0, 0.0],
     }
-    artifact_file = "qabot_eval_results.json"
+    artifact_file = f"qabot_eval_results.{file_type}"
     TAG_NAME = "mlflow.loggedArtifacts"
     run_id = None
 
@@ -881,7 +891,7 @@ def test_log_table():
 
     run = mlflow.get_run(run_id)
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    table_data = pd.read_json(artifact_path, orient="split")
+    table_data = read_data(artifact_path)
     assert table_data.shape[0] == 2
     assert table_data.shape[1] == 3
 
@@ -897,7 +907,7 @@ def test_log_table():
 
     run = mlflow.get_run(run_id)
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    table_data = pd.read_json(artifact_path, orient="split")
+    table_data = read_data(artifact_path)
     assert table_data.shape[0] == 4
     assert table_data.shape[1] == 3
     # Get the current value of the tag
@@ -905,7 +915,7 @@ def test_log_table():
     assert {"path": artifact_file, "type": "table"} in current_tag_value
     assert len(current_tag_value) == 1
 
-    artifact_file_new = "qabot_eval_results_new.json"
+    artifact_file_new = f"qabot_eval_results_new.{file_type}"
     with mlflow.start_run(run_id=run_id):
         # Log the dataframe as a table to new artifact file
         mlflow.log_table(data=table_df, artifact_file=artifact_file_new)
@@ -914,7 +924,7 @@ def test_log_table():
     artifact_path = mlflow.artifacts.download_artifacts(
         run_id=run_id, artifact_path=artifact_file_new
     )
-    table_data = pd.read_json(artifact_path, orient="split")
+    table_data = read_data(artifact_path)
     assert table_data.shape[0] == 2
     assert table_data.shape[1] == 3
     # Get the current value of the tag
@@ -927,7 +937,8 @@ def test_log_table():
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny client does not support the np or pandas dependencies",
 )
-def test_log_table_with_subdirectory():
+@pytest.mark.parametrize("file_type", ["json", "parquet"])
+def test_log_table_with_subdirectory(file_type):
     import pandas as pd
 
     table_dict = {
@@ -935,7 +946,7 @@ def test_log_table_with_subdirectory():
         "outputs": ["MLflow is ...", "Databricks is ..."],
         "toxicity": [0.0, 0.0],
     }
-    artifact_file = "dir/foo.json"
+    artifact_file = f"dir/foo.{file_type}"
     TAG_NAME = "mlflow.loggedArtifacts"
     run_id = None
 
@@ -946,7 +957,7 @@ def test_log_table_with_subdirectory():
 
     run = mlflow.get_run(run_id)
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    table_data = pd.read_json(artifact_path, orient="split")
+    table_data = read_data(artifact_path)
     assert table_data.shape[0] == 2
     assert table_data.shape[1] == 3
 
@@ -962,7 +973,7 @@ def test_log_table_with_subdirectory():
 
     run = mlflow.get_run(run_id)
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    table_data = pd.read_json(artifact_path, orient="split")
+    table_data = read_data(artifact_path)
     assert table_data.shape[0] == 4
     assert table_data.shape[1] == 3
     # Get the current value of the tag
@@ -975,14 +986,15 @@ def test_log_table_with_subdirectory():
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny client does not support the np or pandas dependencies",
 )
-def test_load_table():
+@pytest.mark.parametrize("file_type", ["json", "parquet"])
+def test_load_table(file_type):
     table_dict = {
         "inputs": ["What is MLflow?", "What is Databricks?"],
         "outputs": ["MLflow is ...", "Databricks is ..."],
         "toxicity": [0.0, 0.0],
     }
-    artifact_file = "qabot_eval_results.json"
-    artifact_file_2 = "qabot_eval_results_2.json"
+    artifact_file = f"qabot_eval_results.{file_type}"
+    artifact_file_2 = f"qabot_eval_results_2.{file_type}"
     run_id_2 = None
 
     with mlflow.start_run() as run:
@@ -1046,7 +1058,7 @@ def test_load_table():
     with pytest.raises(
         MlflowException, match="No runs found with the corresponding table artifact"
     ):
-        mlflow.load_table(artifact_file="error_case.json")
+        mlflow.load_table(artifact_file=f"error_case.{file_type}")
 
     # test 7: load table with no matching extra_column found. Error case
     with pytest.raises(KeyError, match="error_column"):
@@ -1057,7 +1069,8 @@ def test_load_table():
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny client does not support the np or pandas dependencies",
 )
-def test_log_table_with_datetime_columns():
+@pytest.mark.parametrize("file_type", ["json", "parquet"])
+def test_log_table_with_datetime_columns(file_type):
     import pandas as pd
 
     start_time = str(datetime.now(timezone.utc))
@@ -1066,7 +1079,7 @@ def test_log_table_with_datetime_columns():
         "outputs": ["MLflow is ...", "Databricks is ..."],
         "start_time": [start_time, start_time],
     }
-    artifact_file = "test_time.json"
+    artifact_file = f"test_time.{file_type}"
 
     with mlflow.start_run() as run:
         # Log the dictionary as a table
@@ -1074,13 +1087,19 @@ def test_log_table_with_datetime_columns():
         run_id = run.info.run_id
 
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    table_data = pd.read_json(artifact_path, orient="split", convert_dates=False)
+    if file_type == "parquet":
+        table_data = pd.read_parquet(artifact_path)
+    else:
+        table_data = pd.read_json(artifact_path, orient="split", convert_dates=False)
     assert table_data["start_time"][0] == start_time
 
     # append the same table to the same artifact file
     mlflow.log_table(data=table_dict, artifact_file=artifact_file, run_id=run_id)
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    df = pd.read_json(artifact_path, orient="split", convert_dates=False)
+    if file_type == "parquet":
+        df = pd.read_parquet(artifact_path)
+    else:
+        df = pd.read_json(artifact_path, orient="split", convert_dates=False)
     assert df["start_time"][2] == start_time
 
 
@@ -1088,9 +1107,9 @@ def test_log_table_with_datetime_columns():
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny client does not support the np or pandas dependencies",
 )
-def test_log_table_with_image_columns():
+@pytest.mark.parametrize("file_type", ["json", "parquet"])
+def test_log_table_with_image_columns(file_type):
     import numpy as np
-    import pandas as pd
     from PIL import Image
 
     image = mlflow.Image([[1, 2, 3]])
@@ -1099,7 +1118,7 @@ def test_log_table_with_image_columns():
         "outputs": ["MLflow is ...", "Databricks is ..."],
         "image": [image, image],
     }
-    artifact_file = "test_time.json"
+    artifact_file = f"test_time.{file_type}"
 
     with mlflow.start_run() as run:
         # Log the dictionary as a table
@@ -1107,7 +1126,7 @@ def test_log_table_with_image_columns():
         run_id = run.info.run_id
 
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    table_data = pd.read_json(artifact_path, orient="split")
+    table_data = read_data(artifact_path)
     assert table_data["image"][0]["type"] == "image"
     image_path = mlflow.artifacts.download_artifacts(
         run_id=run_id, artifact_path=table_data["image"][0]["filepath"]
@@ -1118,7 +1137,7 @@ def test_log_table_with_image_columns():
     # append the same table to the same artifact file
     mlflow.log_table(data=table_dict, artifact_file=artifact_file, run_id=run_id)
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    df = pd.read_json(artifact_path, orient="split")
+    df = read_data(artifact_path)
     assert df["image"][2]["type"] == "image"
 
 
@@ -1126,9 +1145,9 @@ def test_log_table_with_image_columns():
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny client does not support the np or pandas dependencies",
 )
-def test_log_table_with_pil_image_columns():
+@pytest.mark.parametrize("file_type", ["json", "parquet"])
+def test_log_table_with_pil_image_columns(file_type):
     import numpy as np
-    import pandas as pd
     from PIL import Image
 
     image = Image.fromarray(np.array([[1.0, 2.0, 3.0]]))
@@ -1139,7 +1158,7 @@ def test_log_table_with_pil_image_columns():
         "outputs": ["MLflow is ...", "Databricks is ..."],
         "image": [image, image],
     }
-    artifact_file = "test_time.json"
+    artifact_file = f"test_time.{file_type}"
 
     with mlflow.start_run() as run:
         # Log the dictionary as a table
@@ -1147,7 +1166,7 @@ def test_log_table_with_pil_image_columns():
         run_id = run.info.run_id
 
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    table_data = pd.read_json(artifact_path, orient="split")
+    table_data = read_data(artifact_path)
     assert table_data["image"][0]["type"] == "image"
     image_path = mlflow.artifacts.download_artifacts(
         run_id=run_id, artifact_path=table_data["image"][0]["filepath"]
@@ -1158,7 +1177,7 @@ def test_log_table_with_pil_image_columns():
     # append the same table to the same artifact file
     mlflow.log_table(data=table_dict, artifact_file=artifact_file, run_id=run_id)
     artifact_path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=artifact_file)
-    df = pd.read_json(artifact_path, orient="split")
+    df = read_data(artifact_path)
     assert df["image"][2]["type"] == "image"
 
 
@@ -1166,14 +1185,15 @@ def test_log_table_with_pil_image_columns():
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny client does not support the np or pandas dependencies",
 )
-def test_log_table_with_invalid_image_columns():
+@pytest.mark.parametrize("file_type", ["json", "parquet"])
+def test_log_table_with_invalid_image_columns(file_type):
     image = mlflow.Image([[1, 2, 3]])
     table_dict = {
         "inputs": ["What is MLflow?", "What is Databricks?"],
         "outputs": ["MLflow is ...", "Databricks is ..."],
         "image": [image, "text"],
     }
-    artifact_file = "test_time.json"
+    artifact_file = f"test_time.{file_type}"
     with pytest.raises(ValueError, match="Column `image` contains a mix of images and non-images"):
         with mlflow.start_run():
             # Log the dictionary as a table
@@ -1184,7 +1204,8 @@ def test_log_table_with_invalid_image_columns():
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny client does not support the np or pandas dependencies",
 )
-def test_log_table_with_valid_image_columns():
+@pytest.mark.parametrize("file_type", ["json", "parquet"])
+def test_log_table_with_valid_image_columns(file_type):
     class ImageObj:
         def __init__(self):
             self.size = (1, 1)
@@ -1205,7 +1226,7 @@ def test_log_table_with_valid_image_columns():
         "image": [image, image_obj],
     }
     # No error should be raised
-    artifact_file = "test_time.json"
+    artifact_file = f"test_time.{file_type}"
     with mlflow.start_run():
         # Log the dictionary as a table
         mlflow.log_table(data=table_dict, artifact_file=artifact_file)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -853,9 +853,9 @@ def test_search_runs_multiple_experiments():
 def read_data(artifact_path):
     import pandas as pd
 
-    if artifact_path.endswith("json"):
+    if artifact_path.endswith(".json"):
         return pd.read_json(artifact_path, orient="split")
-    if artifact_path.endswith("parquet"):
+    if artifact_path.endswith(".parquet"):
         return pd.read_parquet(artifact_path)
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11922?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11922/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11922
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support log_table to parquet file

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
