### PR TITLE
Only exclude tags for RestStore

### DIFF
--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -12,6 +12,7 @@ import mlflow
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
+from mlflow.environment_variables import _MLFLOW_TESTING
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
     TRUNCATION_SUFFIX,
@@ -113,6 +114,8 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                     "backend APIs are not available. Fallback to client-side generation",
                     exc_info=True,
                 )
+                if _MLFLOW_TESTING.get():
+                    raise
                 request_id = encode_trace_id(span.context.trace_id)
                 trace_info = self._create_trace_info(request_id, span, experiment_id, metadata)
 

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -12,7 +12,6 @@ import mlflow
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
-from mlflow.environment_variables import _MLFLOW_TESTING
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
     TRUNCATION_SUFFIX,
@@ -123,8 +122,6 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                     "backend APIs are not available. Fallback to client-side generation",
                     exc_info=True,
                 )
-                if _MLFLOW_TESTING.get():
-                    raise
                 request_id = encode_trace_id(span.context.trace_id)
                 trace_info = self._create_trace_info(
                     request_id,

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -178,6 +178,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         span: OTelSpan,
         experiment_id: Optional[str] = None,
         request_metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[Dict[str, str]] = None,
     ) -> TraceInfo:
         return TraceInfo(
             request_id=request_id,
@@ -186,4 +187,5 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             execution_time_ms=None,
             status=TraceStatus.IN_PROGRESS,
             request_metadata=request_metadata or {},
+            tags=tags or {},
         )

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -72,6 +72,20 @@ class InMemoryTraceManager:
             self._traces[trace_info.request_id] = _Trace(trace_info)
             self._trace_id_to_request_id[trace_id] = trace_info.request_id
 
+    def update_trace_info(self, trace_info: TraceInfo):
+        """
+        Update the trace info object in the in-memory trace registry.
+
+        Args:
+            trace_id: The trace ID for the existing trace.
+            trace_info: The updated trace info object to be stored.
+        """
+        with self._lock:
+            if trace_info.request_id not in self._traces:
+                _logger.warning(f"Trace data with request ID {trace_info.request_id} not found.")
+                return
+            self._traces[trace_info.request_id].info = trace_info
+
     def register_span(self, span: LiveSpan):
         """
         Store the given span in the in-memory trace data.
@@ -88,7 +102,7 @@ class InMemoryTraceManager:
             trace_data_dict[span.span_id] = span
 
     @contextlib.contextmanager
-    def get_trace(self, request_id: str) -> Generator[Optional[Trace], None, None]:
+    def get_trace(self, request_id: str) -> Generator[Optional[_Trace], None, None]:
         """
         Yield the trace info for the given request_id.
         This is designed to be used as a context manager to ensure the trace info is accessed

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -77,7 +77,6 @@ class InMemoryTraceManager:
         Update the trace info object in the in-memory trace registry.
 
         Args:
-            trace_id: The trace ID for the existing trace.
             trace_info: The updated trace info object to be stored.
         """
         with self._lock:

--- a/mlflow/tracing/utils.py
+++ b/mlflow/tracing/utils.py
@@ -11,6 +11,7 @@ from opentelemetry import trace as trace_api
 from packaging.version import Version
 
 from mlflow.exceptions import BAD_REQUEST, MlflowException
+from mlflow.utils.mlflow_tags import IMMUTABLE_TAGS
 
 _logger = logging.getLogger(__name__)
 
@@ -173,3 +174,8 @@ def maybe_get_evaluation_request_id() -> Optional[str]:
         )
 
     return context.request_id
+
+
+def exclude_immutable_tags(tags: Dict[str, str]) -> Dict[str, str]:
+    """Exclude immutable tags e.g. "mlflow.user" from the given tags."""
+    return {k: v for k, v in tags.items() if k not in IMMUTABLE_TAGS}

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -236,6 +236,18 @@ class TrackingServiceClient:
             request_ids=request_ids,
         )
 
+    def get_trace_info(self, request_id) -> TraceInfo:
+        """
+        Get the trace info matching the ``request_id``.
+
+        Args:
+            request_id: String id of the trace to fetch.
+
+        Returns:
+            TraceInfo object, of type ``mlflow.entities.trace_info.TraceInfo``.
+        """
+        return self.store.get_trace_info(request_id)
+
     def get_trace(self, request_id) -> Trace:
         """
         Get the trace matching the ``request_id``.
@@ -246,7 +258,7 @@ class TrackingServiceClient:
         Returns:
             The fetched Trace object, of type ``mlflow.entities.Trace``.
         """
-        trace_info = self.store.get_trace_info(request_id)
+        trace_info = self.get_trace_info(request_id)
         try:
             trace_data = self._download_trace_data(trace_info)
         except MlflowTraceDataNotFound:
@@ -328,6 +340,17 @@ class TrackingServiceClient:
                 next_max_results = max_results - len(traces)
 
         return PagedList(traces, next_token)
+
+    def set_trace_tags(self, request_id, tags):
+        """
+        Set tags on the trace with the given request_id.
+
+        Args:
+            request_id: The ID of the trace.
+            tags: A dictionary of key-value pairs.
+        """
+        for k, v in tags.items():
+            self.set_trace_tag(request_id, k, v)
 
     def set_trace_tag(self, request_id, key, value):
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -73,7 +73,6 @@ from mlflow.utils.async_logging.run_operations import RunOperations
 from mlflow.utils.databricks_utils import get_databricks_run_url
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.mlflow_tags import (
-    IMMUTABLE_TAGS,
     MLFLOW_LOGGED_ARTIFACTS,
     MLFLOW_LOGGED_IMAGES,
     MLFLOW_PARENT_RUN_ID,
@@ -571,15 +570,17 @@ class MlflowClient:
             if attributes:
                 mlflow_span.set_attributes(attributes)
             trace_manager = InMemoryTraceManager.get_instance()
-            with trace_manager.get_trace(request_id) as trace:
-                trace.info.tags.update(self._exclude_immutable_tags(tags or {}))
+            # Update trace tags both in store and in-memory trace manager
+            for k, v in tags.items():
+                self._tracking_client.set_trace_tag(request_id, k, v)
+            trace_info = self._tracking_client.get_trace(request_id).info
+            trace_manager.update_trace_info(trace_info)
             # Register new span in the in-memory trace manager
             trace_manager.register_span(mlflow_span)
 
             return mlflow_span
         except Exception as e:
             _logger.warning(f"Failed to start span {name}: {e}")
-            raise e
             return NoOpSpan()
 
     def end_trace(
@@ -840,7 +841,7 @@ class MlflowClient:
             experiment_id=experiment_id,
             timestamp_ms=timestamp_ms,
             request_metadata=request_metadata or {},
-            tags=self._exclude_immutable_tags(tags or {}),
+            tags=tags or {},
         )
 
     def _upload_ended_trace_info(
@@ -872,12 +873,8 @@ class MlflowClient:
             timestamp_ms=timestamp_ms,
             status=status,
             request_metadata=request_metadata or {},
-            tags=self._exclude_immutable_tags(tags or {}),
+            tags=tags or {},
         )
-
-    def _exclude_immutable_tags(self, tags: Dict[str, str]) -> Dict[str, str]:
-        """Exclude immutable tags e.g. "mlflow.user" from the given tags."""
-        return {k: v for k, v in tags.items() if k not in IMMUTABLE_TAGS}
 
     def set_trace_tag(self, request_id: str, key: str, value: str):
         """

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -62,6 +62,7 @@ def test_json_deserialization(clear_singleton, monkeypatch):
                 "mlflow.traceName": "predict",
                 "mlflow.source.name": "test",
                 "mlflow.source.type": "LOCAL",
+                "mlflow.user": "bob",  # only exclude this tag for rest store
             },
         },
         "data": {

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -50,7 +50,8 @@ def test_on_start(clear_singleton):
 
 
 @pytest.mark.skipif(is_windows(), reason="Timestamp is not precise enough on Windows")
-def test_on_start_adjust_span_timestamp_to_exclude_backend_latency(clear_singleton):
+def test_on_start_adjust_span_timestamp_to_exclude_backend_latency(clear_singleton, monkeypatch):
+    monkeypatch.setenv("MLFLOW_TESTING", "false")
     trace_info = create_test_trace_info(_REQUEST_ID, 0)
     mock_client = mock.MagicMock()
 
@@ -94,7 +95,8 @@ def test_on_start_with_experiment_id(clear_singleton):
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces
 
 
-def test_on_start_fallback_to_client_side_request_id(clear_singleton):
+def test_on_start_fallback_to_client_side_request_id(clear_singleton, monkeypatch):
+    monkeypatch.setenv("MLFLOW_TESTING", "false")
     span = create_mock_otel_span(
         trace_id=_TRACE_ID, span_id=1, parent_id=None, start_time=5_000_000
     )

--- a/tests/tracking/_tracking_service/test_tracking_service_client.py
+++ b/tests/tracking/_tracking_service/test_tracking_service_client.py
@@ -136,9 +136,8 @@ def test_upload_trace_data(tmp_path, mock_store):
         client = TrackingServiceClient(tmp_path.as_uri())
         client._upload_trace_data(trace_info=trace_info, trace_data=trace_data)
         mock_upload_trace_data.assert_called_once_with(trace_data_json)
-        # The TraceInfo is already fetched prior to the upload_trace_data call,
-        # so we should not call _get_trace_info again
-        mock_store.get_trace_info.assert_not_called()
+        # get_trace_info is called after tags are set
+        mock_store.get_trace_info.assert_called_once()
 
 
 def test_search_traces(tmp_path):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -618,12 +618,10 @@ def test_set_and_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
     client.end_trace(request_id)
 
     trace = get_traces()[0]
-    assert trace.info.tags == {
-        "mlflow.traceName": "test",
-        "foo": "bar",
-        "mlflow.source.name": "test",
-        "mlflow.source.type": "LOCAL",
-    }
+    assert trace.info.tags["mlflow.traceName"] == "test"
+    assert trace.info.tags["foo"] == "bar"
+    assert trace.info.tags["mlflow.source.name"] == "test"
+    assert trace.info.tags["mlflow.source.type"] == "LOCAL"
 
 
 def test_set_trace_tag_on_logged_trace(mock_store, clear_singleton):
@@ -642,12 +640,10 @@ def test_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
     client.end_trace(request_id)
 
     trace = get_traces()[0]
-    assert trace.info.tags == {
-        "baz": "qux",
-        "mlflow.traceName": "test",  # Added by MLflow
-        "mlflow.source.name": "test",
-        "mlflow.source.type": "LOCAL",
-    }
+    assert trace.info.tags["baz"] == "qux"
+    assert trace.info.tags["mlflow.traceName"] == "test"
+    assert trace.info.tags["mlflow.source.name"] == "test"
+    assert trace.info.tags["mlflow.source.type"] == "LOCAL"
 
 
 def test_delete_trace_tag_on_logged_trace(mock_store, clear_singleton):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11924?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11924/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11924
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Databricks backend set these immutable tags, but for other backend we should keep them and store them.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
