### PR TITLE
Display traces via post-run hook

### DIFF
--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -56,6 +56,10 @@ class IPythonTraceDisplayHandler:
                 return
 
             traces_to_display = list(self.traces_to_display.values())[:MAX_TRACES_TO_DISPLAY]
+            if len(traces_to_display) == 0:
+                self.traces_to_display = {}
+                return
+
             display(
                 self.get_mimebundle(traces_to_display),
                 display_id=True,

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -46,7 +46,7 @@ class IPythonTraceDisplayHandler:
             # the core functionality if the display fails.
             _logger.debug("Failed to register post-run cell display hook", exc_info=True)
 
-    def _display_traces_post_run(self):
+    def _display_traces_post_run(self, result):
         # this should do nothing if not in an IPython environment
         try:
             from IPython import get_ipython

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -29,9 +29,47 @@ class IPythonTraceDisplayHandler:
         return cls._instance
 
     def __init__(self):
-        self._prev_execution_count = -1
-        self.display_handle = None
         self.traces_to_display = {}
+        try:
+            from IPython import get_ipython
+
+            if get_ipython() is None:
+                return
+
+            # Register a post-run cell display hook to display traces
+            # after the cell has executed.
+            get_ipython().events.register("post_run_cell", self.display_traces_post_run)
+        except Exception:
+            # swallow exceptions. this function is called as
+            # a side-effect in a few other functions (e.g. log_trace,
+            # get_traces, search_traces), and we don't want to block
+            # the core functionality if the display fails.
+            _logger.debug("Failed to register post-run cell display hook", exc_info=True)
+
+    def display_traces_post_run(self):
+        # this should do nothing if not in an IPython environment
+        try:
+            from IPython import get_ipython
+            from IPython.display import display
+
+            if get_ipython() is None:
+                return
+
+            traces_to_display = list(self.traces_to_display.values())[:MAX_TRACES_TO_DISPLAY]
+            display(
+                self.get_mimebundle(traces_to_display),
+                display_id=True,
+                raw=True,
+            )
+
+            # reset state
+            self.traces_to_display = {}
+        except Exception:
+            # swallow exceptions. this function is called as
+            # a side-effect in a few other functions (e.g. log_trace,
+            # get_traces, search_traces), and we don't want to block
+            # the core functionality if the display fails.
+            _logger.debug("Failed to display traces", exc_info=True)
 
     def get_mimebundle(self, traces: List[Trace]):
         if len(traces) == 1:
@@ -46,40 +84,11 @@ class IPythonTraceDisplayHandler:
         # this should do nothing if not in an IPython environment
         try:
             from IPython import get_ipython
-            from IPython.display import display
 
             if len(traces) == 0 or get_ipython() is None:
                 return
 
-            traces = traces[:MAX_TRACES_TO_DISPLAY]
             traces_dict = {trace.info.request_id: trace for trace in traces}
-
-            # if the current ipython exec count has changed, then
-            # we're in a different cell (or rerendering the current
-            # cell), so we should create a new display handle.
-            current_exec_count = get_ipython().execution_count
-            if self._prev_execution_count != current_exec_count:
-                self._prev_execution_count = current_exec_count
-                self.traces_to_display = traces_dict
-                self.display_handle = None
-            else:
-                self.traces_to_display.update(traces_dict)
-
-            deduped_trace_list = list(self.traces_to_display.values())
-            if self.display_handle:
-                self.display_handle.update(
-                    self.get_mimebundle(deduped_trace_list),
-                    raw=True,
-                )
-            else:
-                self.display_handle = display(
-                    self.get_mimebundle(deduped_trace_list),
-                    display_id=True,
-                    raw=True,
-                )
+            self.traces_to_display.update(traces_dict)
         except Exception:
-            # swallow exceptions. this function is called as
-            # a side-effect in a few other functions (e.g. log_trace,
-            # get_traces, search_traces), and we don't want to block
-            # the core functionality if the display fails.
-            _logger.debug("Failed to display traces", exc_info=True)
+            _logger.debug("Failed to update traces", exc_info=True)

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -38,7 +38,7 @@ class IPythonTraceDisplayHandler:
 
             # Register a post-run cell display hook to display traces
             # after the cell has executed.
-            get_ipython().events.register("post_run_cell", self.display_traces_post_run)
+            get_ipython().events.register("post_run_cell", self._display_traces_post_run)
         except Exception:
             # swallow exceptions. this function is called as
             # a side-effect in a few other functions (e.g. log_trace,
@@ -46,7 +46,7 @@ class IPythonTraceDisplayHandler:
             # the core functionality if the display fails.
             _logger.debug("Failed to register post-run cell display hook", exc_info=True)
 
-    def display_traces_post_run(self):
+    def _display_traces_post_run(self):
         # this should do nothing if not in an IPython environment
         try:
             from IPython import get_ipython

--- a/tests/tracing/display/test_ipython.py
+++ b/tests/tracing/display/test_ipython.py
@@ -1,18 +1,31 @@
 import json
+from collections import defaultdict
 from unittest.mock import Mock
 
 import mlflow
-from mlflow.tracing.display import get_display_handler
+from mlflow.tracing.display import IPythonTraceDisplayHandler, get_display_handler
 
 from tests.tracing.helper import create_trace
 
 
+class MockEventRegistry:
+    def __init__(self):
+        self.events = defaultdict(list)
+
+    def register(self, event, callback):
+        self.events[event].append(callback)
+
+    def trigger(self, event):
+        for callback in self.events[event]:
+            callback()
+
+
 class MockIPython:
     def __init__(self):
-        self.execution_count = 0
+        self.events = MockEventRegistry()
 
     def mock_run_cell(self):
-        self.execution_count += 1
+        self.events.trigger("post_run_cell")
 
 
 def test_display_is_not_called_without_ipython(monkeypatch):
@@ -26,12 +39,22 @@ def test_display_is_not_called_without_ipython(monkeypatch):
     handler.display_traces([create_trace("a")])
     assert mock_display.call_count == 0
 
-    monkeypatch.setattr("IPython.get_ipython", lambda: MockIPython())
+    mock_ipython = MockIPython()
+    monkeypatch.setattr("IPython.get_ipython", lambda: mock_ipython)
+
+    # reset the singleton so the handler
+    # can register the post-display hook
+    IPythonTraceDisplayHandler._instance = None
+    handler = get_display_handler()
     handler.display_traces([create_trace("b")])
+
+    # simulate cell execution
+    mock_ipython.mock_run_cell()
+
     assert mock_display.call_count == 1
 
 
-def test_ipython_client_only_logs_once_per_execution(monkeypatch):
+def test_ipython_client_clears_display_after_execution(monkeypatch):
     mock_ipython = MockIPython()
     monkeypatch.setattr("IPython.get_ipython", lambda: mock_ipython)
     handler = get_display_handler()
@@ -43,27 +66,31 @@ def test_ipython_client_only_logs_once_per_execution(monkeypatch):
     handler.display_traces([create_trace("b")])
     handler.display_traces([create_trace("c")])
 
-    # there should be one display and two updates
-    assert mock_display.call_count == 1
-    assert mock_display_handle.update.call_count == 2
-
-    # after incrementing the execution count,
-    # the next log should call display again
     mock_ipython.mock_run_cell()
-    handler.display_traces([create_trace("a")])
-    assert mock_display.call_count == 2
+    # despite many calls to `display_traces`,
+    # there should only be one call to `display`
+    assert mock_display.call_count == 1
+
+    mock_ipython.mock_run_cell()
+    # expect that display is not called,
+    # since no traces should be present
+    assert mock_display.call_count == 1
 
 
 def test_display_is_called_in_correct_functions(monkeypatch):
     mock_ipython = MockIPython()
     monkeypatch.setattr("IPython.get_ipython", lambda: mock_ipython)
-    handler = get_display_handler()
-
     mock_display_handle = Mock()
     mock_display = Mock(return_value=mock_display_handle)
     monkeypatch.setattr("IPython.display.display", mock_display)
-    trace = create_trace("a")
-    handler.display_traces([trace])
+
+    @mlflow.trace
+    def foo():
+        return 3
+
+    # display should be called after trace creation
+    foo()
+    mock_ipython.mock_run_cell()
     assert mock_display.call_count == 1
 
     class MockMlflowClient:
@@ -71,9 +98,9 @@ def test_display_is_called_in_correct_functions(monkeypatch):
             return [create_trace("a"), create_trace("b"), create_trace("c")]
 
     monkeypatch.setattr("mlflow.tracing.fluent.MlflowClient", MockMlflowClient)
-
-    mock_ipython.mock_run_cell()
     mlflow.search_traces(["123"])
+    mock_ipython.mock_run_cell()
+
     assert mock_display.call_count == 2
 
 
@@ -82,8 +109,7 @@ def test_display_deduplicates_traces(monkeypatch):
     monkeypatch.setattr("IPython.get_ipython", lambda: mock_ipython)
     handler = get_display_handler()
 
-    mock_display_handle = Mock()
-    mock_display = Mock(return_value=mock_display_handle)
+    mock_display = Mock()
     monkeypatch.setattr("IPython.display.display", mock_display)
 
     trace_a = create_trace("a")
@@ -95,12 +121,12 @@ def test_display_deduplicates_traces(monkeypatch):
     handler.display_traces([trace_b])
     handler.display_traces([trace_c])
     handler.display_traces([trace_a, trace_b, trace_c])
+    mock_ipython.mock_run_cell()
 
     expected = [trace_a, trace_b, trace_c]
 
     assert mock_display.call_count == 1
-    assert mock_display_handle.update.call_count == 3
-    assert mock_display_handle.update.call_args[0][0] == {
+    assert mock_display.call_args[0][0] == {
         "application/databricks.mlflow.trace": json.dumps(
             [json.loads(t.to_json()) for t in expected]
         ),

--- a/tests/tracing/display/test_ipython.py
+++ b/tests/tracing/display/test_ipython.py
@@ -17,7 +17,7 @@ class MockEventRegistry:
 
     def trigger(self, event):
         for callback in self.events[event]:
-            callback()
+            callback(None)
 
 
 class MockIPython:


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR resolves a common complaint that the trace UI does not show up at the end of a cell as expected. To fix this, we register a post-execution hook instead of updating a display handle every time. 

I'm keeping the user-facing API as `display_traces()`, because I feel that it would be confusing to change the name to something like `update_traces_to_display()`. My main concern is that people will wonder if there's an additional `display()` function that they have to call, but actually it's handled automatically by the post-execution hook.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

I'll add some automated tests in a bit

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
