### PR TITLE
Set run experiment ID in trace if it exists

### DIFF
--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -69,13 +69,12 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         span._start_time = time.time_ns()
 
     def _start_trace(self, span: OTelSpan) -> TraceInfo:
-        metadata = {}
-
         experiment_id = (
             get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID) or _get_experiment_id()
         )
 
         # If the span is started within an active MLflow run, we should record it as a trace tag
+        metadata = {}
         if run := mlflow.active_run():
             metadata[TraceMetadataKey.SOURCE_RUN] = run.info.run_id
             # if we're inside a run, the run's experiment id should

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -69,9 +69,20 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         span._start_time = time.time_ns()
 
     def _start_trace(self, span: OTelSpan) -> TraceInfo:
+        metadata = {}
+
+        # If the span is started within an active MLflow run, we should record it as a trace tag
+        run_experiment_id = None
+        if run := mlflow.active_run():
+            metadata[TraceMetadataKey.SOURCE_RUN] = run.info.run_id
+            run_experiment_id = run.info.experiment_id
+
         experiment_id = (
-            get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID) or _get_experiment_id()
+            run_experiment_id
+            or get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID)
+            or _get_experiment_id()
         )
+
         if experiment_id == DEFAULT_EXPERIMENT_ID:
             _logger.warning(
                 "Creating a trace within the default experiment with id "
@@ -82,12 +93,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                 "To avoid performance and disambiguation issues, set the experiment for "
                 "your environment using `mlflow.set_experiment()` API."
             )
-        metadata = {}
         default_tags = resolve_tags()
-
-        # If the span is started within an active MLflow run, we should record it as a trace tag
-        if run := mlflow.active_run():
-            metadata[TraceMetadataKey.SOURCE_RUN] = run.info.run_id
 
         # If the trace is created in the context of MLflow model evaluation, we extract the request
         # ID from the prediction context. Otherwise, we create a new trace info by calling the

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -151,6 +151,40 @@ def test_on_start_during_model_evaluation(clear_singleton):
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
 
 
+def test_on_start_during_run(clear_singleton, monkeypatch):
+    monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
+    monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
+
+    span = create_mock_otel_span(
+        trace_id=_TRACE_ID, span_id=1, parent_id=None, start_time=5_000_000
+    )
+
+    env_experiment_name = "env_experiment_id"
+    run_experiment_name = "run_experiment_id"
+
+    mlflow.create_experiment(env_experiment_name)
+    run_experiment_id = mlflow.create_experiment(run_experiment_name)
+
+    mlflow.set_experiment(experiment_name=env_experiment_name)
+    trace_info = create_test_trace_info(_REQUEST_ID)
+    mock_client = mock.MagicMock()
+    mock_client._start_tracked_trace.return_value = trace_info
+    processor = MlflowSpanProcessor(span_exporter=mock.MagicMock(), client=mock_client)
+
+    with mlflow.start_run(experiment_id=run_experiment_id) as run:
+        processor.on_start(span)
+        expected_run_id = run.info.run_id
+
+    mock_client._start_tracked_trace.assert_called_once_with(
+        # expect experiment id to be from the run, not from the environment
+        experiment_id=run_experiment_id,
+        timestamp_ms=5,
+        # expect run id to be set
+        request_metadata={"mlflow.sourceRun": expected_run_id},
+        tags={"mlflow.user": "bob", "mlflow.source.name": "test", "mlflow.source.type": "LOCAL"},
+    )
+
+
 def test_on_end(clear_singleton):
     trace_info = create_test_trace_info(_REQUEST_ID, 0)
     trace_manager = InMemoryTraceManager.get_instance()

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -181,7 +181,7 @@ def test_on_start_during_run(clear_singleton, monkeypatch):
         timestamp_ms=5,
         # expect run id to be set
         request_metadata={"mlflow.sourceRun": expected_run_id},
-        tags={"mlflow.user": "bob", "mlflow.source.name": "test", "mlflow.source.type": "LOCAL"},
+        tags=mock.ANY,
     )
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -362,13 +362,15 @@ def test_start_and_end_trace(clear_singleton, with_active_run):
     assert len(traces) == 1
     trace_info = traces[0].info
     assert trace_info.request_id is not None
-    assert trace_info.experiment_id == model._exp_id
     assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace_info.status == TraceStatus.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == '{"output": 25}'
     if with_active_run:
         assert trace_info.request_metadata["mlflow.sourceRun"] == run_id
+        assert trace_info.experiment_id == run.info.experiment_id
+    else:
+        assert trace_info.experiment_id == model._exp_id
 
     trace_data = traces[0].data
     assert trace_data.request == '{"x": 1, "y": 2}'


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11939?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11939/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11939
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently, we always fetch the active experiment from the environment. This causes problems in situations like:

```
import mlflow

@mlflow.trace
def foo(x, y):
  return x + y

mlflow.set_experiment(experiment_id="a")

with mlflow.start_run(experiment_id="b"):
  foo(1, 2)
```

i would expect that the trace generated by `foo()` would be logged to experiment "b", but it is actually logged to "a".

This PR fixes it by fetching the run experiment id and letting it take priority over the environment.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
