### PR TITLE
Raise exception when accessing tags and aliases from search rpcs

### DIFF
--- a/mlflow/entities/model_registry/model_version_search.py
+++ b/mlflow/entities/model_registry/model_version_search.py
@@ -13,6 +13,6 @@ class ModelVersionSearch(ModelVersion):
 
     def aliases(self):
         raise Exception(
-            "UC Model Versions gathered through search_registered_models do not have aliases. "
+            "UC Model Versions gathered through search_model_versions do not have aliases. "
             "Please use get_model_version to obtain an individual version's aliases."
         )

--- a/mlflow/entities/model_registry/model_version_search.py
+++ b/mlflow/entities/model_registry/model_version_search.py
@@ -1,0 +1,18 @@
+from mlflow.entities.model_registry import ModelVersion
+
+
+class ModelVersionSearch(ModelVersion):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def tags(self):
+        raise Exception(
+            "UC Model Versions gathered through search_model_versions do not have tags. "
+            "Please use get_model_version to obtain an individual version's tags."
+        )
+
+    def aliases(self):
+        raise Exception(
+            "UC Model Versions gathered through search_registered_models do not have aliases. "
+            "Please use get_model_version to obtain an individual version's aliases."
+        )

--- a/mlflow/entities/model_registry/registered_model_search.py
+++ b/mlflow/entities/model_registry/registered_model_search.py
@@ -1,0 +1,18 @@
+from mlflow.entities.model_registry import RegisteredModel
+
+
+class RegisteredModelSearch(RegisteredModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def tags(self):
+        raise Exception(
+            "UC Registered Models gathered through search_registered_models do not have tags. "
+            "Please use get_registered_model to obtain an individual model's tags."
+        )
+
+    def aliases(self):
+        raise Exception(
+            "UC Registered Models gathered through search_registered_models do not have aliases. "
+            "Please use get_registered_model to obtain an individual model's aliases."
+        )

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -75,7 +75,9 @@ from mlflow.utils._unity_catalog_utils import (
     get_artifact_repo_from_storage_info,
     get_full_name_from_sc,
     model_version_from_uc_proto,
+    model_version_search_from_uc_proto,
     registered_model_from_uc_proto,
+    registered_model_search_from_uc_proto,
     uc_model_version_tag_from_mlflow_tags,
     uc_registered_model_tag_from_mlflow_tags,
 )
@@ -391,7 +393,7 @@ class UcModelRegistryStore(BaseRestStore):
         )
         response_proto = self._call_endpoint(SearchRegisteredModelsRequest, req_body)
         registered_models = [
-            registered_model_from_uc_proto(registered_model)
+            registered_model_search_from_uc_proto(registered_model)
             for registered_model in response_proto.registered_models
         ]
         return PagedList(registered_models, response_proto.next_page_token)
@@ -903,7 +905,9 @@ class UcModelRegistryStore(BaseRestStore):
             )
         )
         response_proto = self._call_endpoint(SearchModelVersionsRequest, req_body)
-        model_versions = [model_version_from_uc_proto(mvd) for mvd in response_proto.model_versions]
+        model_versions = [
+            model_version_search_from_uc_proto(mvd) for mvd in response_proto.model_versions
+        ]
         return PagedList(model_versions, response_proto.next_page_token)
 
     def set_model_version_tag(self, name, version, tag):

--- a/mlflow/utils/_unity_catalog_utils.py
+++ b/mlflow/utils/_unity_catalog_utils.py
@@ -7,6 +7,8 @@ from mlflow.entities.model_registry import (
     RegisteredModelAlias,
     RegisteredModelTag,
 )
+from mlflow.entities.model_registry.model_version_search import ModelVersionSearch
+from mlflow.entities.model_registry.registered_model_search import RegisteredModelSearch
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_uc_registry_messages_pb2 import ModelVersion as ProtoModelVersion
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
@@ -51,6 +53,23 @@ def model_version_from_uc_proto(uc_proto: ProtoModelVersion) -> ModelVersion:
     )
 
 
+def model_version_search_from_uc_proto(uc_proto: ProtoModelVersion) -> ModelVersionSearch:
+    return ModelVersionSearch(
+        name=uc_proto.name,
+        version=uc_proto.version,
+        creation_timestamp=uc_proto.creation_timestamp,
+        last_updated_timestamp=uc_proto.last_updated_timestamp,
+        description=uc_proto.description,
+        user_id=uc_proto.user_id,
+        source=uc_proto.source,
+        run_id=uc_proto.run_id,
+        status=uc_model_version_status_to_string(uc_proto.status),
+        status_message=uc_proto.status_message,
+        aliases=[],
+        tags=[],
+    )
+
+
 def registered_model_from_uc_proto(uc_proto: ProtoRegisteredModel) -> RegisteredModel:
     return RegisteredModel(
         name=uc_proto.name,
@@ -62,6 +81,17 @@ def registered_model_from_uc_proto(uc_proto: ProtoRegisteredModel) -> Registered
             for alias in (uc_proto.aliases or [])
         ],
         tags=[RegisteredModelTag(key=tag.key, value=tag.value) for tag in (uc_proto.tags or [])],
+    )
+
+
+def registered_model_search_from_uc_proto(uc_proto: ProtoRegisteredModel) -> RegisteredModelSearch:
+    return RegisteredModelSearch(
+        name=uc_proto.name,
+        creation_timestamp=uc_proto.creation_timestamp,
+        last_updated_timestamp=uc_proto.last_updated_timestamp,
+        description=uc_proto.description,
+        aliases=[],
+        tags=[],
     )
 
 

--- a/tests/utils/test_unity_catalog_utils.py
+++ b/tests/utils/test_unity_catalog_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mlflow.entities.model_registry import (
     ModelVersion,
     ModelVersionTag,
@@ -5,6 +7,8 @@ from mlflow.entities.model_registry import (
     RegisteredModelAlias,
     RegisteredModelTag,
 )
+from mlflow.entities.model_registry.model_version_search import ModelVersionSearch
+from mlflow.entities.model_registry.registered_model_search import RegisteredModelSearch
 from mlflow.protos.databricks_uc_registry_messages_pb2 import ModelVersion as ProtoModelVersion
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     ModelVersionStatus as ProtoModelVersionStatus,
@@ -23,7 +27,9 @@ from mlflow.protos.databricks_uc_registry_messages_pb2 import (
 )
 from mlflow.utils._unity_catalog_utils import (
     model_version_from_uc_proto,
+    model_version_search_from_uc_proto,
     registered_model_from_uc_proto,
+    registered_model_search_from_uc_proto,
 )
 
 
@@ -69,6 +75,51 @@ def test_model_version_from_uc_proto():
     assert actual_model_version == expected_model_version
 
 
+def test_model_version_search_from_uc_proto():
+    expected_model_version = ModelVersionSearch(
+        name="name",
+        version="1",
+        creation_timestamp=1,
+        last_updated_timestamp=2,
+        description="description",
+        user_id="user_id",
+        source="source",
+        run_id="run_id",
+        status="READY",
+        status_message="status_message",
+        aliases=[],
+        tags=[],
+    )
+    uc_proto = ProtoModelVersion(
+        name="name",
+        version="1",
+        creation_timestamp=1,
+        last_updated_timestamp=2,
+        description="description",
+        user_id="user_id",
+        source="source",
+        run_id="run_id",
+        status=ProtoModelVersionStatus.Value("READY"),
+        status_message="status_message",
+        aliases=[
+            ProtoRegisteredModelAlias(alias="alias1", version="1"),
+            ProtoRegisteredModelAlias(alias="alias2", version="2"),
+        ],
+        tags=[
+            ProtoModelVersionTag(key="key1", value="value"),
+            ProtoModelVersionTag(key="key2", value=""),
+        ],
+    )
+    actual_model_version = model_version_search_from_uc_proto(uc_proto)
+    assert actual_model_version == expected_model_version
+
+    with pytest.raises(Exception):
+        actual_model_version.tags()
+
+    with pytest.raises(Exception):
+        actual_model_version.aliases()
+
+
 def test_registered_model_from_uc_proto():
     expected_registered_model = RegisteredModel(
         name="name",
@@ -100,3 +151,36 @@ def test_registered_model_from_uc_proto():
     )
     actual_registered_model = registered_model_from_uc_proto(uc_proto)
     assert actual_registered_model == expected_registered_model
+
+
+def test_registered_model_search_from_uc_proto():
+    expected_registered_model = RegisteredModelSearch(
+        name="name",
+        creation_timestamp=1,
+        last_updated_timestamp=2,
+        description="description",
+        aliases=[],
+        tags=[],
+    )
+    uc_proto = ProtoRegisteredModel(
+        name="name",
+        creation_timestamp=1,
+        last_updated_timestamp=2,
+        description="description",
+        aliases=[
+            ProtoRegisteredModelAlias(alias="alias1", version="1"),
+            ProtoRegisteredModelAlias(alias="alias2", version="2"),
+        ],
+        tags=[
+            ProtoRegisteredModelTag(key="key1", value="value"),
+            ProtoRegisteredModelTag(key="key2", value=""),
+        ],
+    )
+    actual_registered_model = registered_model_search_from_uc_proto(uc_proto)
+    assert actual_registered_model == expected_registered_model
+
+    with pytest.raises(Exception):
+        actual_registered_model.tags()
+
+    with pytest.raises(Exception):
+        actual_registered_model.aliases()

--- a/tests/utils/test_unity_catalog_utils.py
+++ b/tests/utils/test_unity_catalog_utils.py
@@ -113,10 +113,10 @@ def test_model_version_search_from_uc_proto():
     actual_model_version = model_version_search_from_uc_proto(uc_proto)
     assert actual_model_version == expected_model_version
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: PT011
         actual_model_version.tags()
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: PT011
         actual_model_version.aliases()
 
 
@@ -179,8 +179,8 @@ def test_registered_model_search_from_uc_proto():
     actual_registered_model = registered_model_search_from_uc_proto(uc_proto)
     assert actual_registered_model == expected_registered_model
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: PT011
         actual_registered_model.tags()
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: PT011
         actual_registered_model.aliases()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/11961?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11961/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11961
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?
Object returned through `Search` RPCs (registered models and models versions) do not contain tags or aliases for performance reasons. However, these aliases and tags may well exist. This PR introduces a new type that raises an error when the tags or the aliases are returned from a `Search` RPC to inform the user to use the `Get` RPC to obtain that information. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="956" alt="image" src="https://github.com/mlflow/mlflow/assets/145406764/bfba3e0d-c92b-4a5d-b25d-fde634b39d41">
<img width="962" alt="image" src="https://github.com/mlflow/mlflow/assets/145406764/6da936b0-24aa-47f0-b98f-32ec5b4bd557">


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Raises an error when accessing tags / aliases of registered models or model versions when those have been acquired through `Search` RPCs.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
