### PR TITLE
fix: cascade experiment id fk deletion in datasets table

### DIFF
--- a/mlflow/store/db_migrations/versions/949ead8d4f49_add_cascading_delete_on_experiments_fk_.py
+++ b/mlflow/store/db_migrations/versions/949ead8d4f49_add_cascading_delete_on_experiments_fk_.py
@@ -1,0 +1,64 @@
+"""add cascading delete on experiments fk in datasets table
+
+Revision ID: 949ead8d4f49
+Revises: 867495a8f9d4
+Create Date: 2024-05-09 17:43:49.128493
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "949ead8d4f49"
+down_revision = "867495a8f9d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    dialect_name = op.get_context().dialect.name
+    if dialect_name == "sqlite":
+        # Only way to drop unnamed fk constraint in sqllite
+        # See https://alembic.sqlalchemy.org/en/latest/batch.html#dropping-unnamed-or-named-foreign-key-constraints
+        with op.batch_alter_table(
+            "datasets",
+            schema=None,
+            naming_convention={
+                "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            },
+        ) as batch_op:
+            batch_op.drop_constraint("fk_datasets_experiment_id_experiments", type_="foreignkey")
+            # Need to explicitly name the fk constraint with batch alter table
+            batch_op.create_foreign_key(
+                "fk_datasets_experiment_id_experiments",
+                "experiments",
+                ["experiment_id"],
+                ["experiment_id"],
+                ondelete="CASCADE",
+            )
+    else:
+        if dialect_name == "postgresql":
+            fk_constraint_name = "datasets_experiment_id_fkey"
+        elif dialect_name == "mysql":
+            fk_constraint_name = "datasets_ibfk_1"
+        elif dialect_name == "mssql":
+            # mssql fk constraint name at 867495a8f9d4
+            fk_constraint_name = "FK__datasets__experi__6477ECF3"
+
+        # don't use batch alter table here so `create_foreign_key()` can be
+        # called with `None` as the `constraint_name` and have it set
+        # automatically based on the conventions of the sql flavor
+        op.drop_constraint(fk_constraint_name, "datasets", type_="foreignkey")
+        op.create_foreign_key(
+            None,
+            "datasets",
+            "experiments",
+            ["experiment_id"],
+            ["experiment_id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade():
+    pass

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -260,7 +260,7 @@ class SqlExperimentTag(Base):
     """
     Value associated with tag: `String` (limit 5000 characters). Could be *null*.
     """
-    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id"))
+    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id", ondelete="CASCADE"))
     """
     Experiment ID to which this tag belongs: *Foreign Key* into ``experiments`` table.
     """

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -53,7 +53,7 @@ CREATE TABLE datasets (
 	dataset_schema VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	dataset_profile VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	CONSTRAINT "FK__datasets__experi__6477ECF3" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT "FK__datasets__experi__71D1E811" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -198,7 +198,7 @@ CREATE TABLE trace_request_metadata (
 CREATE TABLE trace_tags (
 	key VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	value VARCHAR(8000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	request_id VARCHAR(50)COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	request_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT trace_tag_pk PRIMARY KEY (key, request_id),
 	CONSTRAINT fk_trace_tags_request_id FOREIGN KEY(request_id) REFERENCES trace_info (request_id)
 )

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -54,7 +54,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile MEDIUMTEXT,
 	PRIMARY KEY (experiment_id, name, digest),
-	CONSTRAINT datasets_ibfk_1 FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT datasets_ibfk_1 FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -133,7 +133,7 @@ CREATE TABLE trace_info (
 	timestamp_ms BIGINT NOT NULL,
 	execution_time_ms BIGINT,
 	status VARCHAR(50) NOT NULL,
-	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
+	PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
@@ -197,7 +197,7 @@ CREATE TABLE trace_request_metadata (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(8000),
 	request_id VARCHAR(50) NOT NULL,
-	CONSTRAINT trace_request_metadata_pk PRIMARY KEY (key, request_id),
+	PRIMARY KEY (key, request_id),
 	CONSTRAINT fk_trace_request_metadata_request_id FOREIGN KEY(request_id) REFERENCES trace_info (request_id)
 )
 
@@ -206,6 +206,6 @@ CREATE TABLE trace_tags (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(8000),
 	request_id VARCHAR(50) NOT NULL,
-	CONSTRAINT trace_tag_pk PRIMARY KEY (key, request_id),
+	PRIMARY KEY (key, request_id),
 	CONSTRAINT fk_trace_tags_request_id FOREIGN KEY(request_id) REFERENCES trace_info (request_id)
 )

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -55,7 +55,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	CONSTRAINT datasets_experiment_id_fkey FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT datasets_experiment_id_fkey FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -56,7 +56,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -56,7 +56,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/store/tracking/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/test_sqlalchemy_store_schema.py
@@ -118,7 +118,7 @@ def test_store_generated_schema_matches_base(tmp_path, db_url):
     # `diff` contains several `remove_index` operations because `Base.metadata` does not contain
     # index metadata but `mc` does. Note this doesn't mean the MLflow database is missing indexes
     # as tested in `test_create_index_on_run_uuid`.
-    # `remove_fk` index operation is from cascading deletion when an experiment is deleted as
+    # `remove_fk` operations are from cascading deletion when an experiment is deleted as
     # `experiment_id` is a foreign key in the `datasets` and `experiment_tags` tables.
     diff = [d for d in diff if (d[0] not in ["remove_index", "add_index", "add_fk", "remove_fk"])]
     assert len(diff) == 0

--- a/tests/store/tracking/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/test_sqlalchemy_store_schema.py
@@ -118,7 +118,9 @@ def test_store_generated_schema_matches_base(tmp_path, db_url):
     # `diff` contains several `remove_index` operations because `Base.metadata` does not contain
     # index metadata but `mc` does. Note this doesn't mean the MLflow database is missing indexes
     # as tested in `test_create_index_on_run_uuid`.
-    diff = [d for d in diff if (d[0] not in ["remove_index", "add_index", "add_fk"])]
+    # `remove_fk` index operation is from cascading deletion when an experiment is deleted as
+    # `experiment_id` is a foreign key in the `datasets` and `experiment_tags` tables.
+    diff = [d for d in diff if (d[0] not in ["remove_index", "add_index", "add_fk", "remove_fk"])]
     assert len(diff) == 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,9 @@ from click.testing import CliRunner
 import mlflow
 from mlflow import pyfunc
 from mlflow.cli import doctor, gc, server
+from mlflow.data import numpy_dataset
 from mlflow.entities import ViewType
+from mlflow.entities.dataset_input import DatasetInput
 from mlflow.exceptions import MlflowException
 from mlflow.server import handlers
 from mlflow.store.tracking.file_store import FileStore
@@ -379,6 +381,18 @@ def test_mlflow_gc_experiments(get_store_details, request):
             "--backend-store-uri", uri, "--experiment-ids", exp_id_5, "--older-than", "10d10h10m10s"
         )
     experiments = store.search_experiments(view_type=ViewType.ALL)
+    assert sorted([e.experiment_id for e in experiments]) == sorted(
+        [exp_id_5, store.DEFAULT_EXPERIMENT_ID]
+    )
+
+    exp_id_6 = store.create_experiment("6")
+    run_id_2 = store.create_run(exp_id_6, user_id="user", start_time=1, tags=[], run_name="2")
+    run_id_2_datasets = [
+        DatasetInput(dataset=numpy_dataset.from_numpy(np.array([1, 2, 3]))._to_mlflow_entity())
+    ]
+    store.log_inputs(run_id_2.info.run_id, datasets=run_id_2_datasets)
+    store.delete_experiment(exp_id_6)
+    invoke_gc("--backend-store-uri", uri, "--experiment-ids", exp_id_6)
     assert sorted([e.experiment_id for e in experiments]) == sorted(
         [exp_id_5, store.DEFAULT_EXPERIMENT_ID]
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chilir/mlflow/pull/11966?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11966/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11966
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #10699

### What changes are proposed in this pull request?

Apply cascading deletion to the `experiment_id` foreign key in the datasets table.
Resubmission of https://github.com/mlflow/mlflow/pull/11695

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a bug where `mlflow gc` will fail attempting to permanently delete an experiment if existing datasets are associated with the experiment.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [X] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
