### PR TITLE
[MLflow] Removing langchain adding databricks_dependencies to newer models

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -36,10 +36,7 @@ from mlflow.langchain._langchain_autolog import (
     _update_langchain_model_config,
     patched_inference,
 )
-from mlflow.langchain.databricks_dependencies import (
-    _DATABRICKS_DEPENDENCY_KEY,
-    _detect_databricks_dependencies,
-)
+from mlflow.langchain.databricks_dependencies import _detect_databricks_dependencies
 from mlflow.langchain.runnables import _load_runnables, _save_runnables
 from mlflow.langchain.utils import (
     _BASE_LOAD_KEY,
@@ -376,10 +373,7 @@ def save_model(
     )
 
     if Version(langchain.__version__) >= Version("0.0.311"):
-        (databricks_dependency, databricks_resources) = _detect_databricks_dependencies(lc_model)
-        if databricks_dependency:
-            flavor_conf[_DATABRICKS_DEPENDENCY_KEY] = databricks_dependency
-        if databricks_resources:
+        if databricks_resources := _detect_databricks_dependencies(lc_model):
             serialized_databricks_resources = _ResourceBuilder.from_resources(databricks_resources)
             mlflow_model.resources = serialized_databricks_resources
 

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -1,23 +1,12 @@
 import logging
-from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List, Set
+from typing import List, Set
 
 from mlflow.models.resources import DatabricksServingEndpoint, DatabricksVectorSearchIndex, Resource
-
-_DATABRICKS_DEPENDENCY_KEY = "databricks_dependency"
-_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY = "databricks_vector_search_index_name"
-_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY = "databricks_vector_search_endpoint_name"
-_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY = "databricks_embeddings_endpoint_name"
-_DATABRICKS_LLM_ENDPOINT_NAME_KEY = "databricks_llm_endpoint_name"
-_DATABRICKS_CHAT_ENDPOINT_NAME_KEY = "databricks_chat_endpoint_name"
-
 
 _logger = logging.getLogger(__name__)
 
 
-def _extract_databricks_dependencies_from_retriever(
-    retriever, dependency_dict: DefaultDict[str, List[Any]], dependency_list: List[Resource]
-):
+def _extract_databricks_dependencies_from_retriever(retriever, dependency_list: List[Resource]):
     try:
         from langchain.embeddings import DatabricksEmbeddings as LegacyDatabricksEmbeddings
         from langchain.vectorstores import (
@@ -38,19 +27,14 @@ def _extract_databricks_dependencies_from_retriever(
     if vectorstore:
         if isinstance(vectorstore, (DatabricksVectorSearch, LegacyDatabricksVectorSearch)):
             index = vectorstore.index
-            dependency_dict[_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY].append(index.name)
-            dependency_dict[_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY].append(index.endpoint_name)
             dependency_list.append(DatabricksVectorSearchIndex(index_name=index.name))
 
         embeddings = getattr(vectorstore, "embeddings", None)
         if isinstance(embeddings, (DatabricksEmbeddings, LegacyDatabricksEmbeddings)):
-            dependency_dict[_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY].append(embeddings.endpoint)
             dependency_list.append(DatabricksServingEndpoint(endpoint_name=embeddings.endpoint))
 
 
-def _extract_databricks_dependencies_from_llm(
-    llm, dependency_dict: DefaultDict[str, List[Any]], dependency_list: List[Resource]
-):
+def _extract_databricks_dependencies_from_llm(llm, dependency_list: List[Resource]):
     try:
         from langchain.llms import Databricks as LegacyDatabricks
     except ImportError:
@@ -59,13 +43,10 @@ def _extract_databricks_dependencies_from_llm(
     from langchain_community.llms import Databricks
 
     if isinstance(llm, (LegacyDatabricks, Databricks)):
-        dependency_dict[_DATABRICKS_LLM_ENDPOINT_NAME_KEY].append(llm.endpoint_name)
         dependency_list.append(DatabricksServingEndpoint(endpoint_name=llm.endpoint_name))
 
 
-def _extract_databricks_dependencies_from_chat_model(
-    chat_model, dependency_dict: DefaultDict[str, List[Any]], dependency_list: List[Resource]
-):
+def _extract_databricks_dependencies_from_chat_model(chat_model, dependency_list: List[Resource]):
     try:
         from langchain.chat_models import ChatDatabricks as LegacyChatDatabricks
     except ImportError:
@@ -76,7 +57,6 @@ def _extract_databricks_dependencies_from_chat_model(
     from langchain_community.chat_models import ChatDatabricks
 
     if isinstance(chat_model, (LegacyChatDatabricks, ChatDatabricks)):
-        dependency_dict[_DATABRICKS_CHAT_ENDPOINT_NAME_KEY].append(chat_model.endpoint)
         dependency_list.append(DatabricksServingEndpoint(endpoint_name=chat_model.endpoint))
 
 
@@ -93,9 +73,7 @@ _LEGACY_MODEL_ATTR_SET = {
 }
 
 
-def _extract_dependency_dict_from_lc_model(
-    lc_model, dependency_dict: DefaultDict[str, List[Any]], dependency_list: List[Resource]
-):
+def _extract_dependency_list_from_lc_model(lc_model, dependency_list: List[Resource]):
     """
     This function contains the logic to examine a non-Runnable component of a langchain model.
     The logic here does not cover all legacy chains. If you need to support a custom chain,
@@ -105,26 +83,23 @@ def _extract_dependency_dict_from_lc_model(
         return
 
     # leaf node
-    _extract_databricks_dependencies_from_chat_model(lc_model, dependency_dict, dependency_list)
-    _extract_databricks_dependencies_from_retriever(lc_model, dependency_dict, dependency_list)
-    _extract_databricks_dependencies_from_llm(lc_model, dependency_dict, dependency_list)
+    _extract_databricks_dependencies_from_chat_model(lc_model, dependency_list)
+    _extract_databricks_dependencies_from_retriever(lc_model, dependency_list)
+    _extract_databricks_dependencies_from_llm(lc_model, dependency_list)
 
     # recursively inspect legacy chain
     for attr_name in _LEGACY_MODEL_ATTR_SET:
-        _extract_dependency_dict_from_lc_model(
-            getattr(lc_model, attr_name, None), dependency_dict, dependency_list
-        )
+        _extract_dependency_list_from_lc_model(getattr(lc_model, attr_name, None), dependency_list)
 
 
 def _traverse_runnable(
     lc_model,
-    dependency_dict: DefaultDict[str, List[Any]],
     dependency_list: List[Resource],
     visited: Set[str],
 ):
     """
     This function contains the logic to traverse a langchain_core.runnables.RunnableSerializable
-    object. It first inspects the current object using _extract_dependency_dict_from_lc_model
+    object. It first inspects the current object using _extract_dependency_list_from_lc_model
     and then, if the current object is a Runnable, it recursively inspects its children returned
     by lc_model.get_graph().nodes.values().
     This function supports arbitrary LCEL chain.
@@ -137,21 +112,19 @@ def _traverse_runnable(
 
     # Visit the current object
     visited.add(current_object_id)
-    _extract_dependency_dict_from_lc_model(lc_model, dependency_dict, dependency_list)
+    _extract_dependency_list_from_lc_model(lc_model, dependency_list)
 
     if isinstance(lc_model, Runnable):
         # Visit the returned graph
         for node in lc_model.get_graph().nodes.values():
-            _traverse_runnable(node.data, dependency_dict, dependency_list, visited)
+            _traverse_runnable(node.data, dependency_list, visited)
     else:
         # No-op for non-runnable, if any
         pass
     return
 
 
-def _detect_databricks_dependencies(
-    lc_model, log_errors_as_warnings=True
-) -> (Dict[str, List[Any]], List[Resource]):
+def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> List[Resource]:
     """
     Detects the databricks dependencies of a langchain model and returns a dictionary of
     detected endpoint names and index names.
@@ -162,7 +135,7 @@ def _detect_databricks_dependencies(
     support. Only RetrievalQA, StuffDocumentsChain, ReduceDocumentsChain, RefineDocumentsChain,
     MapRerankDocumentsChain, MapReduceDocumentsChain, BaseConversationalRetrievalChain are
     supported. If you need to support a custom chain, you need to monkey patch
-    the function mlflow.langchain.databricks_dependencies._extract_dependency_dict_from_lc_model().
+    the function mlflow.langchain.databricks_dependencies._extract_dependency_list_from_lc_model().
 
     For an LCEL chain, all the langchain_core.runnables.RunnableSerializable nodes will be
     traversed.
@@ -173,10 +146,9 @@ def _detect_databricks_dependencies(
     If a chat_model is found, it will be used to extract the databricks chat dependencies.
     """
     try:
-        dependency_dict = defaultdict(list)
         dependency_list = []
-        _traverse_runnable(lc_model, dependency_dict, dependency_list, set())
-        return (dict(dependency_dict), dependency_list)
+        _traverse_runnable(lc_model, dependency_list, set())
+        return dependency_list
     except Exception:
         if log_errors_as_warnings:
             _logger.warning(
@@ -184,5 +156,5 @@ def _detect_databricks_dependencies(
                 "Set logging level to DEBUG to see the full traceback."
             )
             _logger.debug("", exc_info=True)
-            return {}, []
+            return []
         raise

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -173,13 +173,6 @@ def get_model_version_dependencies(model_dir):
     Gets the specified dependencies for a particular model version and formats them
     to be passed into CreateModelVersion.
     """
-    # import here to work around circular imports
-    from mlflow.langchain.databricks_dependencies import (
-        _DATABRICKS_CHAT_ENDPOINT_NAME_KEY,
-        _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY,
-        _DATABRICKS_LLM_ENDPOINT_NAME_KEY,
-        _DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY,
-    )
     from mlflow.models.resources import ResourceType
 
     model = _load_model(model_dir)
@@ -201,8 +194,13 @@ def get_model_version_dependencies(model_dir):
         for endpoint_name in endpoint_names:
             dependencies.append({"type": "DATABRICKS_MODEL_ENDPOINT", **endpoint_name})
     else:
-        # import here to work around circular imports
-        from mlflow.langchain.databricks_dependencies import _DATABRICKS_DEPENDENCY_KEY
+        # These types of dependencies are required for old models that didn't use
+        # resources so they can be registered correctly to UC
+        _DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY = "databricks_vector_search_index_name"
+        _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY = "databricks_embeddings_endpoint_name"
+        _DATABRICKS_LLM_ENDPOINT_NAME_KEY = "databricks_llm_endpoint_name"
+        _DATABRICKS_CHAT_ENDPOINT_NAME_KEY = "databricks_chat_endpoint_name"
+        _DATABRICKS_DEPENDENCY_KEY = "databricks_dependency"
 
         databricks_dependencies = model_info.flavors.get("langchain", {}).get(
             _DATABRICKS_DEPENDENCY_KEY, {}

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -1,5 +1,4 @@
 import sys
-from collections import defaultdict
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
@@ -8,11 +7,6 @@ import pytest
 from packaging.version import Version
 
 from mlflow.langchain.databricks_dependencies import (
-    _DATABRICKS_CHAT_ENDPOINT_NAME_KEY,
-    _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY,
-    _DATABRICKS_LLM_ENDPOINT_NAME_KEY,
-    _DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY,
-    _DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY,
     _extract_databricks_dependencies_from_chat_model,
     _extract_databricks_dependencies_from_llm,
     _extract_databricks_dependencies_from_retriever,
@@ -55,10 +49,8 @@ def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch)
         llm_kwargs["allow_dangerous_deserialization"] = True
 
     llm = Databricks(**llm_kwargs)
-    d = defaultdict(list)
     resources = []
-    _extract_databricks_dependencies_from_llm(llm, d, resources)
-    assert d.get(_DATABRICKS_LLM_ENDPOINT_NAME_KEY) == ["databricks-mixtral-8x7b-instruct"]
+    _extract_databricks_dependencies_from_llm(llm, resources)
     assert resources == [
         DatabricksServingEndpoint(endpoint_name="databricks-mixtral-8x7b-instruct")
     ]
@@ -101,12 +93,8 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 
     vectorstore = DatabricksVectorSearch(vs_index, text_column="content", embedding=embedding_model)
     retriever = vectorstore.as_retriever()
-    d = defaultdict(list)
     resources = []
-    _extract_databricks_dependencies_from_retriever(retriever, d, resources)
-    assert d.get(_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY) == ["databricks-bge-large-en"]
-    assert d.get(_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY) == ["mlflow.rag.vs_index"]
-    assert d.get(_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY) == ["dbdemos_vs_endpoint"]
+    _extract_databricks_dependencies_from_retriever(retriever, resources)
     assert resources == [
         DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
         DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
@@ -134,12 +122,8 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 
     vectorstore = DatabricksVectorSearch(vs_index, text_column="content", embedding=embedding_model)
     retriever = vectorstore.as_retriever()
-    d = defaultdict(list)
     resources = []
-    _extract_databricks_dependencies_from_retriever(retriever, d, resources)
-    assert d.get(_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY) == ["databricks-bge-large-en"]
-    assert d.get(_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY) == ["mlflow.rag.vs_index"]
-    assert d.get(_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY) == ["dbdemos_vs_endpoint"]
+    _extract_databricks_dependencies_from_retriever(retriever, resources)
     assert resources == [
         DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
         DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
@@ -157,10 +141,8 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
 
     chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
-    d = defaultdict(list)
     resources = []
-    _extract_databricks_dependencies_from_chat_model(chat_model, d, resources)
-    assert d.get(_DATABRICKS_CHAT_ENDPOINT_NAME_KEY) == ["databricks-llama-2-70b-chat"]
+    _extract_databricks_dependencies_from_chat_model(chat_model, resources)
     assert resources == [DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat")]
 
 
@@ -175,10 +157,8 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
 
     chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
-    d = defaultdict(list)
     resources = []
-    _extract_databricks_dependencies_from_chat_model(chat_model, d, resources)
-    assert d.get(_DATABRICKS_CHAT_ENDPOINT_NAME_KEY) == ["databricks-llama-2-70b-chat"]
+    _extract_databricks_dependencies_from_chat_model(chat_model, resources)
     assert resources == [DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat")]
 
 
@@ -214,9 +194,8 @@ def test_parsing_dependency_correct_loads_langchain_modules():
             AttributeError, match="module 'langchain_community' has no attribute 'llms'"
         ):
             langchain_community.llms.Databricks
-        d = defaultdict(list)
         resources = []
-        _extract_databricks_dependencies_from_llm("", d, resources)
+        _extract_databricks_dependencies_from_llm("", resources)
 
         # import works as expected after _extract_databricks_dependencies_from_llm
         langchain_community.llms.Databricks
@@ -234,9 +213,8 @@ def test_parsing_dependency_correct_loads_langchain_modules():
         ):
             langchain_community.vectorstores.DatabricksVectorSearch
 
-        d = defaultdict(list)
         resources = []
-        _extract_databricks_dependencies_from_retriever("", d, resources)
+        _extract_databricks_dependencies_from_retriever("", resources)
         # import works as expected after _extract_databricks_dependencies_from_retriever
         langchain_community.vectorstores.DatabricksVectorSearch
         langchain_community.embeddings.DatabricksEmbeddings
@@ -249,9 +227,8 @@ def test_parsing_dependency_correct_loads_langchain_modules():
         ):
             langchain_community.chat_models.ChatDatabricks
 
-        d = defaultdict(list)
         resources = []
-        _extract_databricks_dependencies_from_chat_model("", d, resources)
+        _extract_databricks_dependencies_from_chat_model("", resources)
         # import works as expected after _extract_databricks_dependencies_from_chat_model
         langchain_community.chat_models.ChatDatabricks
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -5,7 +5,7 @@ import shutil
 import sqlite3
 from contextlib import contextmanager
 from operator import itemgetter
-from typing import Any, DefaultDict, Dict, Iterator, List, Mapping, Optional
+from typing import Any, Dict, Iterator, List, Mapping, Optional
 from unittest import mock
 
 import langchain
@@ -1781,11 +1781,8 @@ def test_chat_with_history(spark, fake_chat_model):
     }
 
 
-def _extract_endpoint_name_from_lc_model(
-    lc_model, dependency_dict: DefaultDict[str, List[Any]], dependency_list: List[Resource]
-):
+def _extract_endpoint_name_from_lc_model(lc_model, dependency_list: List[Resource]):
     if type(lc_model).__name__ == type(get_fake_chat_model()).__name__:
-        dependency_dict["fake_chat_model_endpoint_name"].append(lc_model.endpoint_name)
         dependency_list.append(DatabricksServingEndpoint(endpoint_name=lc_model.endpoint_name))
 
 
@@ -1793,7 +1790,7 @@ def _extract_endpoint_name_from_lc_model(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
 @mock.patch(
-    "mlflow.langchain.databricks_dependencies._extract_dependency_dict_from_lc_model",
+    "mlflow.langchain.databricks_dependencies._extract_dependency_list_from_lc_model",
     _extract_endpoint_name_from_lc_model,
 )
 def test_databricks_dependency_extraction_from_lcel_chain():
@@ -1813,16 +1810,7 @@ def test_databricks_dependency_extraction_from_lcel_chain():
 
     pyfunc_artifact_path = "basic_chain"
     with mlflow.start_run() as run:
-        model_info = mlflow.langchain.log_model(chain, pyfunc_artifact_path)
-
-    langchain_flavor = model_info.flavors["langchain"]
-    assert langchain_flavor["databricks_dependency"] == {
-        "fake_chat_model_endpoint_name": [
-            "fake-endpoint-1",
-            "fake-endpoint-2",
-            "fake-endpoint-3",
-        ]
-    }
+        mlflow.langchain.log_model(chain, pyfunc_artifact_path)
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
     pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
     reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
@@ -1835,28 +1823,21 @@ def test_databricks_dependency_extraction_from_lcel_chain():
     }
 
 
-def _extract_databricks_dependencies_from_retriever(
-    retriever, dependency_dict: DefaultDict[str, List[Any]], dependency_list: List[Resource]
-):
+def _extract_databricks_dependencies_from_retriever(retriever, dependency_list: List[Resource]):
     import langchain_community
 
     vectorstore = getattr(retriever, "vectorstore", None)
     if vectorstore:
         if isinstance(vectorstore, langchain_community.vectorstores.faiss.FAISS):
-            dependency_dict["fake_index"].append("faiss-index")
             dependency_list.append(DatabricksVectorSearchIndex(index_name="faiss-index"))
 
         embeddings = getattr(vectorstore, "embeddings", None)
         if isinstance(embeddings, FakeEmbeddings):
-            dependency_dict["fake_embeddings_size"].append(embeddings.size)
             dependency_list.append(DatabricksServingEndpoint(endpoint_name="fake-embeddings"))
 
 
-def _extract_databricks_dependencies_from_llm(
-    llm, dependency_dict: DefaultDict[str, List[Any]], dependency_list: List[Resource]
-):
+def _extract_databricks_dependencies_from_llm(llm, dependency_list: List[Resource]):
     if isinstance(llm, FakeLLM):
-        dependency_dict["fake_llm_endpoint_name"].append(llm.endpoint_name)
         dependency_list.append(DatabricksServingEndpoint(endpoint_name=llm.endpoint_name))
 
 
@@ -1893,18 +1874,12 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
 
     pyfunc_artifact_path = "retrieval_qa_chain"
     with mlflow.start_run() as run:
-        logged_model = mlflow.langchain.log_model(
+        mlflow.langchain.log_model(
             retrievalQA,
             pyfunc_artifact_path,
             loader_fn=load_retriever,
             persist_dir=persist_dir,
         )
-    langchain_flavor = logged_model.flavors["langchain"]
-    assert langchain_flavor["databricks_dependency"] == {
-        "fake_llm_endpoint_name": ["fake-llm-endpoint"],
-        "fake_index": ["faiss-index"],
-        "fake_embeddings_size": [5],
-    }
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
     pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
     reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
@@ -1931,10 +1906,7 @@ def _error_func(*args, **kwargs):
 )
 @mock.patch("mlflow.langchain.databricks_dependencies._logger.warning")
 def test_databricks_dependency_extraction_log_errors_as_warnings(mock_warning):
-    from mlflow.langchain.databricks_dependencies import (
-        _DATABRICKS_DEPENDENCY_KEY,
-        _detect_databricks_dependencies,
-    )
+    from mlflow.langchain.databricks_dependencies import _detect_databricks_dependencies
 
     model = create_openai_llmchain()
 
@@ -1949,8 +1921,7 @@ def test_databricks_dependency_extraction_log_errors_as_warnings(mock_warning):
 
     pyfunc_artifact_path = "langchain_model"
     with mlflow.start_run() as run:
-        logged_model = mlflow.langchain.log_model(model, pyfunc_artifact_path)
-    assert logged_model.flavors["langchain"].get(_DATABRICKS_DEPENDENCY_KEY) is None
+        mlflow.langchain.log_model(model, pyfunc_artifact_path)
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
     pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
     reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
@@ -2415,10 +2386,6 @@ def test_save_load_chain_as_code(chain_model_signature):
         "predictions": [APIRequest._try_transform_response_to_chat_format(answer)]
     }
 
-    langchain_flavor = model_info.flavors["langchain"]
-    assert langchain_flavor["databricks_dependency"] == {
-        "databricks_chat_endpoint_name": ["fake-endpoint"]
-    }
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{artifact_path}"
     pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
     reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
@@ -2633,10 +2600,6 @@ def test_save_load_chain_as_code_optional_code_path(chain_model_signature):
     expected_prediction["created"] = 123
     assert prediction_result == {"predictions": [expected_prediction]}
 
-    langchain_flavor = model_info.flavors["langchain"]
-    assert langchain_flavor["databricks_dependency"] == {
-        "databricks_chat_endpoint_name": ["fake-endpoint"]
-    }
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{artifact_path}"
     pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
     reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
@@ -2967,10 +2930,11 @@ def test_langchain_model_not_inject_callback_when_disabled(monkeypatch, model_pa
 def test_save_model_as_code_correct_streamable(chain_model_signature):
     input_example = {"messages": [{"role": "user", "content": "Who owns MLflow?"}]}
     answer = "Databricks"
-    with mlflow.start_run():
+    artifact_path = "model_path"
+    with mlflow.start_run() as run:
         model_info = mlflow.langchain.log_model(
             lc_model="tests/langchain/no_config/chain.py",
-            artifact_path="model_path",
+            artifact_path=artifact_path,
             signature=chain_model_signature,
             input_example=input_example,
             example_no_conversion=True,
@@ -3012,7 +2976,9 @@ def test_save_model_as_code_correct_streamable(chain_model_signature):
     expected_prediction["created"] = 123
     assert prediction_result == {"predictions": [expected_prediction]}
 
-    langchain_flavor = model_info.flavors["langchain"]
-    assert langchain_flavor["databricks_dependency"] == {
-        "databricks_chat_endpoint_name": ["fake-endpoint"]
+    pyfunc_model_uri = f"runs:/{run.info.run_id}/{artifact_path}"
+    pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
+    reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
+    assert reloaded_model.resources["databricks"] == {
+        "serving_endpoint": [{"name": "fake-endpoint"}]
     }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/11985?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11985/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11985
```

</p>
</details>

### What changes are proposed in this pull request?
[MLflow] Removing langchain adding databricks_dependencies to newer models

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
[MLflow] Removing langchain adding databricks_dependencies to newer models

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
