### PR TITLE
Rename `make_custom_genai_metric` to `make_genai_metric_from_prompt`

### DIFF
--- a/mlflow/metrics/genai/__init__.py
+++ b/mlflow/metrics/genai/__init__.py
@@ -1,5 +1,5 @@
 from mlflow.metrics.genai.base import EvaluationExample
-from mlflow.metrics.genai.genai_metric import make_custom_genai_metric, make_genai_metric
+from mlflow.metrics.genai.genai_metric import make_genai_metric_from_prompt, make_genai_metric
 from mlflow.metrics.genai.metric_definitions import (
     answer_correctness,
     answer_relevance,
@@ -11,7 +11,7 @@ from mlflow.metrics.genai.metric_definitions import (
 __all__ = [
     "EvaluationExample",
     "make_genai_metric",
-    "make_custom_genai_metric",
+    "make_genai_metric_from_prompt",
     "answer_similarity",
     "answer_correctness",
     "faithfulness",

--- a/mlflow/metrics/genai/__init__.py
+++ b/mlflow/metrics/genai/__init__.py
@@ -1,5 +1,5 @@
 from mlflow.metrics.genai.base import EvaluationExample
-from mlflow.metrics.genai.genai_metric import make_genai_metric_from_prompt, make_genai_metric
+from mlflow.metrics.genai.genai_metric import make_genai_metric, make_genai_metric_from_prompt
 from mlflow.metrics.genai.metric_definitions import (
     answer_correctness,
     answer_relevance,

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -180,7 +180,7 @@ def _get_aggregate_results(scores, aggregations):
 
 
 @experimental
-def make_custom_genai_metric(
+def make_genai_metric_from_prompt(
     name: str,
     judge_prompt: Optional[str] = None,
     model: Optional[str] = _get_default_model(),
@@ -228,9 +228,9 @@ def make_custom_genai_metric(
         :test:
         :caption: Example for creating a genai metric
 
-        from mlflow.metrics.genai import make_custom_genai_metric
+        from mlflow.metrics.genai import make_genai_metric_from_prompt
 
-        metric = make_custom_genai_metric(
+        metric = make_genai_metric_from_prompt(
             name="ease_of_understanding",
             judge_prompt=(
                 "You must evaluate the output of a bot based on how easy it is to "

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -11,7 +11,7 @@ from mlflow.metrics.genai import EvaluationExample, model_utils
 from mlflow.metrics.genai.genai_metric import (
     _extract_score_and_justification,
     _format_args_string,
-    make_custom_genai_metric,
+    make_genai_metric_from_prompt,
     make_genai_metric,
 )
 from mlflow.metrics.genai.metric_definitions import (
@@ -1066,7 +1066,7 @@ def test_make_genai_metric_metric_metadata():
 def test_make_custom_judge_prompt_genai_metric():
     custom_judge_prompt = "This is a custom judge prompt that uses {input} and {output}"
 
-    custom_judge_prompt_metric = make_custom_genai_metric(
+    custom_judge_prompt_metric = make_genai_metric_from_prompt(
         name="custom",
         judge_prompt=custom_judge_prompt,
         metric_metadata={"metadata_field": "metadata_value"},
@@ -1120,7 +1120,7 @@ def test_make_custom_judge_prompt_genai_metric():
 def test_make_custom_prompt_genai_metric_validates_input_kwargs():
     custom_judge_prompt = "This is a custom judge prompt that uses {input} and {output}"
 
-    custom_judge_prompt_metric = make_custom_genai_metric(
+    custom_judge_prompt_metric = make_genai_metric_from_prompt(
         name="custom",
         judge_prompt=custom_judge_prompt,
     )

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -11,8 +11,8 @@ from mlflow.metrics.genai import EvaluationExample, model_utils
 from mlflow.metrics.genai.genai_metric import (
     _extract_score_and_justification,
     _format_args_string,
-    make_genai_metric_from_prompt,
     make_genai_metric,
+    make_genai_metric_from_prompt,
 )
 from mlflow.metrics.genai.metric_definitions import (
     answer_correctness,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/apurva-koti/mlflow/pull/11986?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11986/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11986
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Rename the method to avoid overloading the word "custom" and confusing use with the `make_genai_metric` API.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`make_custom_genai_metric` has been renamed to `make_genai_metric_from_prompt`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
