### PR TITLE
Add config `MLFLOW_JOHNSNOWLABS_MODEL_REUSE_SPARK_SESSION` for johnsnowlab model loading

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -604,3 +604,11 @@ _MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS = _BooleanEnvironmentVariable(
 MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS = _BooleanEnvironmentVariable(
     "MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS", False
 )
+
+
+#: Whether to reuse existing active spark session for loading johnsnowlabs model.
+#: If False, the existing spark session is killed and
+#: a new spark session is created. Default value is True.
+MLFLOW_JOHNSNOWLABS_MODEL_REUSE_SPARK_SESSION = _BooleanEnvironmentVariable(
+    "MLFLOW_JOHNSNOWLABS_MODEL_REUSE_SPARK_SESSION", True
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -608,7 +608,7 @@ MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS = _BooleanEnvironmentVariable(
 
 #: Whether to reuse existing active spark session for loading johnsnowlabs model.
 #: If False, the existing spark session is killed and
-#: a new spark session is created. Default value is True.
+#: a new spark session is created. Default value is False.
 MLFLOW_JOHNSNOWLABS_MODEL_REUSE_SPARK_SESSION = _BooleanEnvironmentVariable(
-    "MLFLOW_JOHNSNOWLABS_MODEL_REUSE_SPARK_SESSION", True
+    "MLFLOW_JOHNSNOWLABS_MODEL_REUSE_SPARK_SESSION", False
 )

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -785,6 +785,7 @@ def _get_or_create_sparksession(model_path=None):
     from johnsnowlabs import nlp
 
     from mlflow.utils._spark_utils import _get_active_spark_session
+    from mlflow.utils.databricks_utils import is_in_databricks_runtime
 
     _validate_env_vars()
 
@@ -799,6 +800,10 @@ def _get_or_create_sparksession(model_path=None):
         spark_conf["spark.python.worker.reuse"] = "true"
         os.environ["PYSPARK_PYTHON"] = sys.executable
         os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
+
+        if is_in_databricks_runtime():
+            os.environ["SPARK_DIST_CLASSPATH"] = "/databricks/jars/*"
+
         if model_path:
             jar_paths, license_path = _fetch_deps_from_path(model_path)
             # jar_paths += get_mleap_jars().split(',')  # TODO when to load MLleap Jars

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -790,8 +790,9 @@ def _get_or_create_sparksession(model_path=None):
 
     spark = _get_active_spark_session()
     if not MLFLOW_JOHNSNOWLABS_MODEL_REUSE_SPARK_SESSION.get():
-        spark.stop()
-        spark = None
+        if spark is not None:
+            spark.stop()
+            spark = None
 
     if spark is None:
         spark_conf = {}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11994?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11994/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11994
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Add environmental variable config `MLFLOW_JOHNSNOWLABS_MODEL_REUSE_SPARK_SESSION` for johnsnowlab model loading.

Motivation:

The https://github.com/mlflow/mlflow/blob/8638bcbe53ecd66a05a5141b2d2a9ffc3921a09f/mlflow/johnsnowlabs/__init__.py#L769 functionality is not fully correct.
It tries to reuse active spark session, but Johnsnow lab model requires specific `spark.jars` settings for spark session these jar settings are immutable once spark session is created, existing spark session might not satisfy the required setting.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?
Add environmental variable config `MLFLOW_JOHNSNOWLABS_MODEL_REUSE_SPARK_SESSION` for johnsnowlab model loading.

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
