### PR TITLE
Add documentation for the expanded code path inference feature

### DIFF
--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -278,7 +278,7 @@ the ``__main__`` module.
 
 
 Saving Extra Code with an MLflow Model - Manual Declaration
-------------------------------------------------------------------
+-----------------------------------------------------------
 MLflow also supports saving your custom Python code as dependencies to the model. This is particularly useful
 when you want to deploy your custom modules that are required for prediction with the model.
 To do so, specify **code_paths** when logging the model. For example, if you have the following file structure in your project:

--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -277,7 +277,7 @@ the ``__main__`` module.
     - If you must define functions and classes in the ``__main__`` module, use ``cloudpickle`` to serialize your model to ensure that all dependencies are correctly handled.
 
 
-Saving Extra Code with an MLflow Model - Legacy Manual Declaration
+Saving Extra Code with an MLflow Model - Manual Declaration
 ------------------------------------------------------------------
 MLflow also supports saving your custom Python code as dependencies to the model. This is particularly useful
 when you want to deploy your custom modules that are required for prediction with the model.

--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -177,8 +177,87 @@ The manually defined dependencies will override the default ones MLflow detects 
     test your model in a virtual environment. Please refer to :ref:`Validating Environment for Prediction <validating-environment-for-prediction>` for more details.
 
 
-Saving Extra Code with an MLflow Model
---------------------------------------
+Saving Extra Code dependencies with an MLflow Model - Automatic inference
+-------------------------------------------------------------------------
+
+.. note::
+    Automatic code dependency inference is a feature that was introduced in MLflow 2.13.0 and is marked as Experimental. The base implementation may be 
+    modified, improved, and adjusted with no prior notice in order to address potential issues and edge cases. 
+
+.. note::
+    Automatic code dependency inference is currently supported for Python Function Models only. Support for additional named model flavors will be coming in 
+    future releases of MLflow.
+
+.. warning::
+    Before using dependency inference, ensure that your dependent code modules do not have sensitive data hard-coded within the modules (e.g., passwords, 
+    access tokens, or secrets). Code inference does not obfuscate sensitive information and will capture and log (save) the module, regardless of what it contains. 
+
+In the MLflow 2.13.0 release, a new method of including custom dependent code was introduced that expands on the existing feature of declaring ``code_paths`` when 
+saving or logging a model. This new feature utilizes import dependency analysis to automatically infer the code dependencies required by the model by checking which 
+modules are imported within the references of a Python Model's definition. 
+
+In order to use this new feature, you can simply set the argument ``infer_code_paths`` (Default ``False``) to ``True`` when logging. You do not have to define 
+file locations explicitly via declaring ``code_paths`` directory locations when utilizing this method of dependency inference, as you would have had to 
+prior to MLflow 2.13.0. 
+
+An example of using this feature is shown below, where we are logging a model that contains an external dependency. 
+In the first section, we are defining an external module named ``custom_code`` that exists in a different than our model definition. 
+
+.. code-block:: python
+    :caption: custom_code.py
+
+    from typing import List
+
+    iris_types = ["setosa", "versicolor", "viginica"]
+
+
+    def map_iris_types(predictions: int) -> List[str]:
+        return [iris_types[pred] for pred in predictions]
+
+With this ``custom_code.py`` module defined, it is ready for use in our Python Model:
+
+.. code-block:: python
+    :caption: model.py
+
+    from typing import Any, Dict, List, Optional
+
+    from custom_code import map_iris_types  # import the external reference
+
+    import mlflow
+
+
+    class FlowerMapping(mlflow.pyfunc.PythonModel):
+        """Custom model with an external dependency"""
+
+        def predict(
+            self, context, model_input, params: Optional[Dict[str, Any]] = None
+        ) -> List[str]:
+            predictions = [pred % 3 for pred in model_input]
+
+            # Call the external function
+            return map_iris_types(predictions)
+
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            artifact_path="flowers",
+            python_model=FlowerMapping(),
+            infer_code_paths=True,  # Enabling automatic code dependency inference
+        )
+
+With ``infer_code_paths`` set to ``True``, the dependency of ``map_iris_types`` will be analyzed, its source declaration detected as originating in 
+the ``custom_code.py`` module, and the code reference within ``custom_code.py`` will be stored along with the model artifact. Note that defining the 
+external code dependency by using the ``code_paths`` argument (discussed in the next section) is not needed.
+
+.. warning::
+    Only modules that are within the current working directory as accessible. Dependency inference will not work across module boundaries or if your 
+    custom code is defined in an entirely different library. If your code base is structured in such a way that common modules are entirely external to 
+    the path that your model logging code is executing in, the original ``code_paths`` option is required in order to capture these dependencies, as 
+    dependency inference will not capture those requirements. 
+
+
+Saving Extra Code with an MLflow Model - Legacy Manual Declaration
+------------------------------------------------------------------
 MLflow also supports saving your custom Python code as dependencies to the model. This is particularly useful
 when you want to deploy your custom modules that are required for prediction with the model.
 To do so, specify **code_paths** when logging the model. For example, if you have the following file structure in your project:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11997?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11997/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11997
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds documentation regarding the expanded code paths dependency inference feature

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
