### PR TITLE
Provide support for hasattr references in AttrDict

### DIFF
--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -295,7 +295,7 @@ class AttrDict(dict):
         try:
             value = self[attr]
         except KeyError:
-            raise AttributeError(f"No attribute '{attr}' found in instance.")
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
         if isinstance(value, dict):
             return AttrDict(value)
         return value

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -292,7 +292,10 @@ class AttrDict(dict):
     """
 
     def __getattr__(self, attr):
-        value = self[attr]
+        try:
+            value = self[attr]
+        except KeyError:
+            raise AttributeError(f"No attribute '{attr}' found in instance.")
         if isinstance(value, dict):
             return AttrDict(value)
         return value

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from mlflow.utils import (
+    AttrDict,
     _chunk_dict,
     _get_fully_qualified_class_name,
     _truncate_dict,
@@ -140,3 +141,30 @@ def test_random_name_generation():
     names = [name_utils._generate_random_name() for i in range(1000)]
     assert all(len(name) <= 20 for name in names)
     assert all(name[-1].isnumeric() for name in names)
+
+
+def test_basic_attribute_access():
+    d = AttrDict({"a": 1, "b": 2})
+    assert d.a == 1
+    assert d.b == 2
+
+
+def test_nested_attribute_access():
+    d = AttrDict({"a": 1, "b": {"c": 3, "d": 4}})
+    assert d.b.c == 3
+    assert d.b.d == 4
+
+
+def test_non_existent_attribute():
+    d = AttrDict({"a": 1, "b": 2})
+    with pytest.raises(AttributeError, match="No attribute 'c' found in instance"):
+        _ = d.c
+
+
+def test_hasattr():
+    d = AttrDict({"a": 1, "b": {"c": 3, "d": 4}})
+    assert hasattr(d, "a")
+    assert hasattr(d, "b")
+    assert not hasattr(d, "e")
+    assert hasattr(d.b, "c")
+    assert not hasattr(d.b, "e")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -157,7 +157,7 @@ def test_nested_attribute_access():
 
 def test_non_existent_attribute():
     d = AttrDict({"a": 1, "b": 2})
-    with pytest.raises(AttributeError, match="No attribute 'c' found in instance"):
+    with pytest.raises(AttributeError, match="'AttrDict' object has no attribute 'c'"):
         _ = d.c
 
 
@@ -168,3 +168,17 @@ def test_hasattr():
     assert not hasattr(d, "e")
     assert hasattr(d.b, "c")
     assert not hasattr(d.b, "e")
+
+
+def test_subclass_hasattr():
+    class SubAttrDict(AttrDict):
+        pass
+
+    d = SubAttrDict({"a": 1, "b": {"c": 3, "d": 4}})
+    assert hasattr(d, "a")
+    assert not hasattr(d, "e")
+    assert hasattr(d.b, "c")
+    assert not hasattr(d.b, "e")
+
+    with pytest.raises(AttributeError, match="'SubAttrDict' object has no attribute 'g'"):
+        _ = d.g


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11999?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11999/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11999
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The hasattr functionality used in genai metrics for an instance of Databricks endpoints validation, when fetching values from the AttrDict implementation is incorrect and untested. This fixes that.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
