### PR TITLE
Fix file store list run_infos

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -157,13 +157,17 @@ class FileStore(AbstractStore):
     EXPERIMENT_TAGS_FOLDER_NAME = "tags"
     DATASETS_FOLDER_NAME = "datasets"
     INPUTS_FOLDER_NAME = "inputs"
-    RESERVED_EXPERIMENT_FOLDERS = [EXPERIMENT_TAGS_FOLDER_NAME, DATASETS_FOLDER_NAME]
     META_DATA_FILE_NAME = "meta.yaml"
     DEFAULT_EXPERIMENT_ID = "0"
     TRACE_INFO_FILE_NAME = "trace_info.yaml"
     TRACES_FOLDER_NAME = "traces"
     TRACE_TAGS_FOLDER_NAME = "tags"
     TRACE_REQUEST_METADATA_FOLDER_NAME = "request_metadata"
+    RESERVED_EXPERIMENT_FOLDERS = [
+        EXPERIMENT_TAGS_FOLDER_NAME,
+        DATASETS_FOLDER_NAME,
+        TRACES_FOLDER_NAME,
+    ]
 
     def __init__(self, root_directory=None, artifact_root_uri=None):
         """
@@ -908,12 +912,8 @@ class FileStore(AbstractStore):
                     continue
                 if LifecycleStage.matches_view_type(view_type, run_info.lifecycle_stage):
                     run_infos.append(run_info)
-            except MissingConfigException as rnfe:
-                # trap malformed run exception and log warning
-                r_id = os.path.basename(r_dir)
-                logging.warning(
-                    "Malformed run '%s'. Detailed error %s", r_id, str(rnfe), exc_info=True
-                )
+            except MissingConfigException:
+                pass
         return run_infos
 
     def _search_runs(

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -917,7 +917,7 @@ class FileStore(AbstractStore):
                 # this is at debug level because if the same store is used for
                 # artifact storage, it's common the folder is not a run folder
                 r_id = os.path.basename(r_dir)
-                logging.warning(
+                logging.debug(
                     "Malformed run '%s'. Detailed error %s", r_id, str(rnfe), exc_info=True
                 )
         return run_infos

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -912,8 +912,14 @@ class FileStore(AbstractStore):
                     continue
                 if LifecycleStage.matches_view_type(view_type, run_info.lifecycle_stage):
                     run_infos.append(run_info)
-            except MissingConfigException:
-                pass
+            except MissingConfigException as rnfe:
+                # trap malformed run exception and log
+                # this is at debug level because if the same store is used for
+                # artifact storage, it's common the folder is not a run folder
+                r_id = os.path.basename(r_dir)
+                logging.warning(
+                    "Malformed run '%s'. Detailed error %s", r_id, str(rnfe), exc_info=True
+                )
         return run_infos
 
     def _search_runs(

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -3109,8 +3109,8 @@ def test_search_traces_pagination(generate_trace_infos):
     assert token is None
 
 
-@pytest.mark.notrackingurimock
-def test_traces_not_listed_as_runs():
+def test_traces_not_listed_as_runs(tmp_path):
+    mlflow.set_tracking_uri(tmp_path.joinpath("mlruns").as_uri())
     client = mlflow.MlflowClient()
     with mlflow.start_run() as run:
         client.start_trace("test")

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -3116,20 +3116,7 @@ def test_traces_not_listed_as_runs(clear_singleton, tmp_path):
         client = mlflow.MlflowClient()
         with mlflow.start_run() as run:
             client.start_trace("test")
-            table_dict = {
-                "inputs": ["What is MLflow?", "What is Databricks?"],
-                "outputs": ["MLflow is ...", "Databricks is ..."],
-                "toxicity": [0.0, 0.0],
-            }
-
-            mlflow.log_table(
-                data=table_dict, artifact_file="qabot_eval_results.json", run_id=run.info.run_id
-            )
 
         with mock.patch("mlflow.store.tracking.file_store.logging.debug") as mock_debug:
-            mlflow.load_table(
-                "qabot_eval_results.json",
-                run_ids=[run.info.run_id],
-                extra_columns=["run_id"],
-            )
+            client.search_runs([run.info.experiment_id], "", ViewType.ALL, max_results=1)
             mock_debug.assert_not_called()

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -39,7 +39,7 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking._model_registry.utils import (
     _get_store_registry as _get_model_registry_store_registry,
 )
-from mlflow.tracking._tracking_service.utils import _register
+from mlflow.tracking._tracking_service.utils import _register, _use_tracking_uri
 from mlflow.utils.databricks_utils import _construct_databricks_run_url
 from mlflow.utils.mlflow_tags import (
     MLFLOW_GIT_COMMIT,
@@ -1352,11 +1352,35 @@ def test_enable_async_logging(mock_store, setup_async_logging):
 
 
 def test_file_store_download_upload_trace_data(clear_singleton, tmp_path):
-    mlflow.set_tracking_uri(tmp_path.joinpath("mlruns").as_uri())
-    client = MlflowClient()
-    span = client.start_trace("test", inputs={"test": 1})
-    client.end_trace(span.request_id, outputs={"result": 2})
-    trace = mlflow.get_trace(span.request_id)
-    trace_data = client.get_trace(span.request_id).data
-    assert trace_data.request == trace.data.request
-    assert trace_data.response == trace.data.response
+    with _use_tracking_uri(tmp_path.joinpath("mlruns").as_uri()):
+        client = MlflowClient()
+        span = client.start_trace("test", inputs={"test": 1})
+        client.end_trace(span.request_id, outputs={"result": 2})
+        trace = mlflow.get_trace(span.request_id)
+        trace_data = client.get_trace(span.request_id).data
+        assert trace_data.request == trace.data.request
+        assert trace_data.response == trace.data.response
+
+
+def test_traces_not_listed_as_runs(clear_singleton, tmp_path):
+    with _use_tracking_uri(tmp_path.joinpath("mlruns").as_uri()):
+        client = MlflowClient()
+        with mlflow.start_run() as run:
+            client.start_trace("test")
+            table_dict = {
+                "inputs": ["What is MLflow?", "What is Databricks?"],
+                "outputs": ["MLflow is ...", "Databricks is ..."],
+                "toxicity": [0.0, 0.0],
+            }
+
+            mlflow.log_table(
+                data=table_dict, artifact_file="qabot_eval_results.json", run_id=run.info.run_id
+            )
+
+        with mock.patch("mlflow.store.tracking.file_store.logging.debug") as mock_debug:
+            mlflow.load_table(
+                "qabot_eval_results.json",
+                run_ids=[run.info.run_id],
+                extra_columns=["run_id"],
+            )
+            mock_debug.assert_not_called()

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1360,27 +1360,3 @@ def test_file_store_download_upload_trace_data(clear_singleton, tmp_path):
         trace_data = client.get_trace(span.request_id).data
         assert trace_data.request == trace.data.request
         assert trace_data.response == trace.data.response
-
-
-def test_traces_not_listed_as_runs(clear_singleton, tmp_path):
-    with _use_tracking_uri(tmp_path.joinpath("mlruns").as_uri()):
-        client = MlflowClient()
-        with mlflow.start_run() as run:
-            client.start_trace("test")
-            table_dict = {
-                "inputs": ["What is MLflow?", "What is Databricks?"],
-                "outputs": ["MLflow is ...", "Databricks is ..."],
-                "toxicity": [0.0, 0.0],
-            }
-
-            mlflow.log_table(
-                data=table_dict, artifact_file="qabot_eval_results.json", run_id=run.info.run_id
-            )
-
-        with mock.patch("mlflow.store.tracking.file_store.logging.debug") as mock_debug:
-            mlflow.load_table(
-                "qabot_eval_results.json",
-                run_ids=[run.info.run_id],
-                extra_columns=["run_id"],
-            )
-            mock_debug.assert_not_called()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12004?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12004/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12004
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Remove warnings for list_run_infos for file store. It's common that the same file store is used as artifacts storage, and in such cases we shouldn't warn because it's not a run folder. We're now skipping the warning for all non-run folders.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
