### PR TITLE
Skip hashing of unsupported types in mlflow.evaluate

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -492,13 +492,15 @@ def _hash_ndarray_as_bytes(nd_array):
 
 
 def _hash_data_as_bytes(data):
-    if isinstance(data, (list, np.ndarray)):
-        return _hash_ndarray_as_bytes(data)
-    if isinstance(data, dict):
-        return _hash_dict_as_bytes(data)
-    if np.isscalar(data):
-        return _hash_uint64_ndarray_as_bytes(pd.util.hash_array(np.array([data])))
-    raise MlflowException(f"Unsupported data type for hashing: `{type(data)}`")
+    try:
+        if isinstance(data, (list, np.ndarray)):
+            return _hash_ndarray_as_bytes(data)
+        if isinstance(data, dict):
+            return _hash_dict_as_bytes(data)
+        if np.isscalar(data):
+            return _hash_uint64_ndarray_as_bytes(pd.util.hash_array(np.array([data])))
+    finally:
+        return b""  # Skip unsupported types by returning an empty byte string
 
 
 def _hash_dict_as_bytes(data_dict):
@@ -531,7 +533,12 @@ def _hash_array_like_obj_as_bytes(data):
                     return _hash_ndarray_as_bytes(v.toArray())
             if isinstance(v, (dict, list, np.ndarray)):
                 return _hash_data_as_bytes(v)
-            return v
+            try:
+                # Attempt to hash the value, if it fails, return an empty byte string
+                pd.util.hash_pandas_object(data)
+                return v
+            except TypeError:
+                return b""  # Skip unhashable types by returning an empty byte string
 
         if Version(pd.__version__) >= Version("2.1.0"):
             data = data.map(_hash_array_like_element_as_bytes)

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -533,9 +533,10 @@ def _hash_array_like_obj_as_bytes(data):
                     return _hash_ndarray_as_bytes(v.toArray())
             if isinstance(v, (dict, list, np.ndarray)):
                 return _hash_data_as_bytes(v)
+
             try:
                 # Attempt to hash the value, if it fails, return an empty byte string
-                pd.util.hash_pandas_object(data)
+                pd.util.hash_array(np.array([v]))
                 return v
             except TypeError:
                 return b""  # Skip unhashable types by returning an empty byte string

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -32,6 +32,7 @@ from sklearn.metrics import (
 import mlflow
 from mlflow import MlflowClient
 from mlflow.data.pandas_dataset import from_pandas
+from mlflow.entities import Trace, TraceData
 from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation import (
     EvaluationArtifact,
@@ -59,6 +60,7 @@ from mlflow.tracking.artifact_utils import get_artifact_uri
 from mlflow.utils import insecure_hash
 from mlflow.utils.file_utils import TempDir
 
+from tests.tracing.helper import create_test_trace_info
 from tests.utils.test_file_utils import spark_session  # noqa: F401
 
 
@@ -697,6 +699,15 @@ def test_dataset_hash(
     assert iris_pandas_df_dataset.hash == "799d4f50e2e353127f94a0e5300add06"
     assert iris_pandas_df_num_cols_dataset.hash == "3c5fc56830a0646001253e25e17bdce4"
     assert diabetes_spark_dataset.hash == "ebfb050519e7e5b463bd38b0c8d04243"
+
+
+def test_trace_dataset_hash():
+    # Validates that a dataset containing Traces can be hashed.
+    df = pd.DataFrame(
+        {"trace": [Trace(info=create_test_trace_info("tr"), data=TraceData([], "", ""))]}
+    )
+    dataset = EvaluationDataset(data=df)
+    assert dataset.hash == "0f29dc5255bd62a2b1d26832bc08dfd4"
 
 
 def test_dataset_with_pandas_dataframe():

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -704,10 +704,22 @@ def test_dataset_hash(
 def test_trace_dataset_hash():
     # Validates that a dataset containing Traces can be hashed.
     df = pd.DataFrame(
-        {"trace": [Trace(info=create_test_trace_info("tr"), data=TraceData([], "", ""))]}
+        {
+            "request": ["Hello"],
+            "trace": [Trace(info=create_test_trace_info("tr"), data=TraceData([], "", ""))],
+        }
     )
     dataset = EvaluationDataset(data=df)
-    assert dataset.hash == "0f29dc5255bd62a2b1d26832bc08dfd4"
+    assert dataset.hash == "757c14bf38aa42d36b93ccd70b1ea719"
+    # Hash of a dataset with a different column should be different
+    df2 = pd.DataFrame(
+        {
+            "request": ["Hi"],
+            "trace": [Trace(info=create_test_trace_info("tr"), data=TraceData([], "", ""))],
+        }
+    )
+    dataset2 = EvaluationDataset(data=df2)
+    assert dataset2.hash != dataset.hash
 
 
 def test_dataset_with_pandas_dataframe():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AveshCSingh/mlflow/pull/12012?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12012/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12012
```

</p>
</details>

### What changes are proposed in this pull request?

`mlflow.evaluate` hashes several rows of the provided DataFrame to generate an id. This logic causes `mlflow.evaluate` to fail when unhashable types like `Trace` are included in the provided DataFrame. This PR updates the logic to skip hashing of unhashable types.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
