### PR TITLE
Ensure RegisteredModel, RegisteredModelSearch and ModelVersion, ModelVersionSearch equality

### DIFF
--- a/mlflow/entities/model_registry/model_version_search.py
+++ b/mlflow/entities/model_registry/model_version_search.py
@@ -3,6 +3,8 @@ from mlflow.entities.model_registry import ModelVersion
 
 class ModelVersionSearch(ModelVersion):
     def __init__(self, *args, **kwargs):
+        kwargs["tags"] = []
+        kwargs["aliases"] = []
         super().__init__(*args, **kwargs)
 
     def tags(self):
@@ -16,3 +18,8 @@ class ModelVersionSearch(ModelVersion):
             "UC Model Versions gathered through search_model_versions do not have aliases. "
             "Please use get_model_version to obtain an individual version's aliases."
         )
+
+    def __eq__(self, other):
+        if type(other) in {type(self), ModelVersion}:
+            return self.__dict__ == other.__dict__
+        return False

--- a/mlflow/entities/model_registry/registered_model_search.py
+++ b/mlflow/entities/model_registry/registered_model_search.py
@@ -3,6 +3,8 @@ from mlflow.entities.model_registry import RegisteredModel
 
 class RegisteredModelSearch(RegisteredModel):
     def __init__(self, *args, **kwargs):
+        kwargs["tags"] = []
+        kwargs["aliases"] = []
         super().__init__(*args, **kwargs)
 
     def tags(self):
@@ -16,3 +18,8 @@ class RegisteredModelSearch(RegisteredModel):
             "UC Registered Models gathered through search_registered_models do not have aliases. "
             "Please use get_registered_model to obtain an individual model's aliases."
         )
+
+    def __eq__(self, other):
+        if type(other) in {type(self), RegisteredModel}:
+            return self.__dict__ == other.__dict__
+        return False

--- a/tests/utils/test_unity_catalog_utils.py
+++ b/tests/utils/test_unity_catalog_utils.py
@@ -216,3 +216,32 @@ def test_registered_model_search_from_uc_proto():
 
     with pytest.raises(Exception):  # noqa: PT011
         actual_registered_model.aliases()
+
+
+def test_registered_model_and_registered_model_search_equality():
+    kwargs = {
+        "name": "name",
+        "creation_timestamp": 1,
+        "last_updated_timestamp": 2,
+        "description": "description",
+        "aliases": [
+            RegisteredModelAlias(alias="alias1", version="1"),
+            RegisteredModelAlias(alias="alias2", version="2"),
+        ],
+        "tags": [
+            RegisteredModelTag(key="key1", value="value"),
+            RegisteredModelTag(key="key2", value=""),
+        ],
+    }
+    registered_model = RegisteredModel(**kwargs)
+    registered_model_search = RegisteredModelSearch(**kwargs)
+
+    assert registered_model != registered_model_search
+
+    kwargs["tags"] = []
+    kwargs["aliases"] = []
+
+    registered_model_2 = RegisteredModel(**kwargs)
+    registered_model_search_2 = RegisteredModelSearch(**kwargs)
+
+    assert registered_model_2 == registered_model_search_2

--- a/tests/utils/test_unity_catalog_utils.py
+++ b/tests/utils/test_unity_catalog_utils.py
@@ -120,6 +120,38 @@ def test_model_version_search_from_uc_proto():
         actual_model_version.aliases()
 
 
+def test_model_version_and_model_version_search_equality():
+    kwargs = {
+        "name": "name",
+        "version": "1",
+        "creation_timestamp": 1,
+        "last_updated_timestamp": 2,
+        "description": "description",
+        "user_id": "user_id",
+        "source": "source",
+        "run_id": "run_id",
+        "status": "READY",
+        "status_message": "status_message",
+        "aliases": ["alias1", "alias2"],
+        "tags": [
+            ModelVersionTag(key="key1", value="value"),
+            ModelVersionTag(key="key2", value=""),
+        ],
+    }
+    model_version = ModelVersion(**kwargs)
+    model_version_search = ModelVersionSearch(**kwargs)
+
+    assert model_version != model_version_search
+
+    kwargs["tags"] = []
+    kwargs["aliases"] = []
+
+    model_version_2 = ModelVersion(**kwargs)
+    model_version_search_2 = ModelVersionSearch(**kwargs)
+
+    assert model_version_2 == model_version_search_2
+
+
 def test_registered_model_from_uc_proto():
     expected_registered_model = RegisteredModel(
         name="name",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/12013?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12013/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12013
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Title.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manual testing included getting model versions from Unity Catalog using `get_model_version` and `search_model_versions` and asserting equality.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
