### PR TITLE
Store span names & types, input names & types as internal trace tag

### DIFF
--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -8,6 +8,7 @@ class TraceMetadataKey:
 class TraceTagKey:
     TRACE_NAME = "mlflow.traceName"
     EVAL_REQUEST_ID = "eval.requestId"
+    TRACE_SPANS = "mlflow.traceSpans"
 
 
 # A set of reserved attribute keys

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -72,6 +72,11 @@ class MlflowSpanExporter(SpanExporter):
             self._log_trace(trace)
 
     def _log_trace(self, trace: Trace):
+        try:
+            self._client._upload_trace_spans_as_tag(trace.info, trace.data)
+        except Exception as e:
+            _logger.debug(f"Failed to log trace spans as tag to MLflow backend: {e}", exc_info=True)
+
         # TODO: Make this async
         # The trace is already updated in processor.on_end method
         # so we just log to backend store here
@@ -80,8 +85,3 @@ class MlflowSpanExporter(SpanExporter):
             self._client._upload_ended_trace_info(trace.info)
         except Exception as e:
             _logger.debug(f"Failed to log trace to MLflow backend: {e}", exc_info=True)
-
-        try:
-            self._client._upload_trace_spans_as_tag(trace.info, trace.data)
-        except Exception as e:
-            _logger.debug(f"Failed to log trace spans as tag to MLflow backend: {e}", exc_info=True)

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -80,3 +80,8 @@ class MlflowSpanExporter(SpanExporter):
             self._client._upload_ended_trace_info(trace.info)
         except Exception as e:
             _logger.debug(f"Failed to log trace to MLflow backend: {e}", exc_info=True)
+
+        try:
+            self._client._upload_trace_spans_as_tag(trace.info, trace.data)
+        except Exception as e:
+            _logger.debug(f"Failed to log trace spans as tag to MLflow backend: {e}", exc_info=True)

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -139,6 +139,15 @@ class InMemoryTraceManager:
         """
         return self._trace_id_to_request_id.get(trace_id)
 
+    def get_mlflow_trace_from_trace(self, request_id: int) -> Optional[Trace]:
+        """
+        Get the trace data for the given trace ID and return it as a ready-to-publish Trace object.
+        """
+        with self._lock:
+            trace = self._traces.get(request_id)
+
+        return trace.to_mlflow_trace() if trace else None
+
     def pop_trace(self, trace_id: int) -> Optional[Trace]:
         """
         Pop the trace data for the given id and return it as a ready-to-publish Trace object.

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -139,7 +139,7 @@ class InMemoryTraceManager:
         """
         return self._trace_id_to_request_id.get(trace_id)
 
-    def get_mlflow_trace_from_trace(self, request_id: int) -> Optional[Trace]:
+    def get_mlflow_trace(self, request_id: int) -> Optional[Trace]:
         """
         Get the trace data for the given trace ID and return it as a ready-to-publish Trace object.
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -60,6 +60,7 @@ from mlflow.tracing.constant import (
     TRACE_SCHEMA_VERSION,
     TRACE_SCHEMA_VERSION_KEY,
     SpanAttributeKey,
+    TraceTagKey,
 )
 from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -647,6 +648,29 @@ class MlflowClient:
                 )
 
         self.end_span(request_id, root_span_id, outputs, attributes, status)
+
+    def _upload_trace_spans_as_tag(self, trace_info: TraceInfo, trace_data: TraceData):
+        # When a trace is logged, we set a mlflow.traceSpans tag via SetTraceTag API
+        # https://databricks.atlassian.net/browse/ML-40306
+        parsed_spans = []
+        for span in trace_data.spans:
+            parsed_span = {}
+
+            parsed_span["name"] = span.name
+            parsed_span["type"] = span.get_attribute(SpanAttributeKey.SPAN_TYPE)
+            span_inputs = span.get_attribute(SpanAttributeKey.INPUTS)
+            if span_inputs and isinstance(span_inputs, dict):
+                parsed_span["inputs"] = list(span_inputs.keys())
+            span_outputs = span.get_attribute(SpanAttributeKey.OUTPUTS)
+            if span_outputs and isinstance(span_outputs, dict):
+                parsed_span["outputs"] = list(span_outputs.keys())
+
+            parsed_spans.append(parsed_span)
+
+        # Directly set the tag on the trace in the backend
+        self._tracking_client.set_trace_tag(
+            trace_info.request_id, TraceTagKey.TRACE_SPANS, json.dumps(parsed_spans)
+        )
 
     @experimental
     def start_span(

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1,3 +1,4 @@
+import json
 import pickle
 import time
 from unittest import mock
@@ -540,6 +541,8 @@ def test_log_trace_with_databricks_tracking_uri(
         "mlflow.tracking._tracking_service.client.TrackingServiceClient._upload_trace_data"
     ) as mock_upload_trace_data, mock.patch(
         "mlflow.tracking._tracking_service.client.TrackingServiceClient.set_trace_tags",
+    ), mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient.set_trace_tag",
     ), mock.patch(
         "mlflow.tracking._tracking_service.client.TrackingServiceClient.get_trace_info",
     ), mock.patch(
@@ -1360,3 +1363,75 @@ def test_file_store_download_upload_trace_data(clear_singleton, tmp_path):
         trace_data = client.get_trace(span.request_id).data
         assert trace_data.request == trace.data.request
         assert trace_data.response == trace.data.response
+
+
+def test_store_trace_spans_tag():
+    client = MlflowClient()
+
+    trace_spans_tag_value = {
+        "name": "test",
+        "type": "UNKNOWN",
+        "inputs": ["test"],
+        "outputs": ["result"],
+    }
+
+    with mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient.set_trace_tag",
+    ) as mock_set_trace_tag:
+        span = client.start_trace("test", inputs={"test": 1})
+        client.end_trace(span.request_id, outputs={"result": 2})
+        mock_set_trace_tag.assert_called_once()
+        assert mock_set_trace_tag.call_args[0][0] == span.request_id
+        assert mock_set_trace_tag.call_args[0][1] == "mlflow.traceSpans"
+        result = json.loads(mock_set_trace_tag.call_args[0][2])
+        for key in trace_spans_tag_value:
+            assert result[0][key] == trace_spans_tag_value[key]
+
+
+def test_store_trace_span_tag_when_not_dict_input_outputs():
+    client = MlflowClient()
+
+    with mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient.set_trace_tag",
+    ) as mock_set_trace_tag:
+        span = client.start_trace("trace_name", inputs="test")
+        client.end_trace(span.request_id, outputs={"result": 2})
+        mock_set_trace_tag.assert_called_once()
+        assert mock_set_trace_tag.call_args[0][0] == span.request_id
+        assert mock_set_trace_tag.call_args[0][1] == "mlflow.traceSpans"
+        result = json.loads(mock_set_trace_tag.call_args[0][2])
+        assert result[0]["name"] == "trace_name"
+        assert result[0]["type"] == "UNKNOWN"
+        assert result[0]["outputs"] == ["result"]
+        assert "inputs" not in result[0]
+
+    with mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient.set_trace_tag",
+    ) as mock_set_trace_tag:
+        span = client.start_trace("trace_name", inputs="{'input': 2}")
+        client.end_trace(span.request_id, outputs="result")
+        mock_set_trace_tag.assert_called_once()
+        assert mock_set_trace_tag.call_args[0][0] == span.request_id
+        assert mock_set_trace_tag.call_args[0][1] == "mlflow.traceSpans"
+        result = json.loads(mock_set_trace_tag.call_args[0][2])
+        assert result[0]["name"] == "trace_name"
+        assert result[0]["type"] == "UNKNOWN"
+        assert "outputs" not in result[0]
+        assert "inputs" not in result[0]
+
+
+# when JSON is too large, we skip logging the tag. The trace should still be logged.
+def test_store_trace_span_tag_when_exception_raised():
+    client = MlflowClient()
+
+    with mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient._upload_trace_data"
+    ) as mock_upload_trace_data, mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient.set_trace_tag",
+        side_effect=MlflowException("Failed to log parameters"),
+    ) as mock_set_trace_tag:
+        # This should not raise an exception
+        span = client.start_trace("trace_name", inputs={"input": "a" * 1000000})
+        client.end_trace(span.request_id, outputs={"result": "b" * 1000000})
+        mock_set_trace_tag.assert_called_once()
+        mock_upload_trace_data.assert_called_once()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jessechancy/mlflow/pull/12015?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12015/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12015
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

When a trace is logged from the MLflow client to Databricks, we should set amlflow.traceSpans tag (see https://github.com/databricks/universe/pull/559943 )  via the SetTraceTag API call that includes the following information for each span:

The span name

The span type

The span input names (only if the span outputs are a dict)

The span output names (only if the span inputs are a dict)

We should store this as JSON with keys name (value is string), type (value is string), inputs (value is list of string), outputs (value is list of string). To save space, we should not pretty print the JSON - it should be as compact as possible.

If the JSON is too large, the backend will throw an INVALID_PARAMETER_EXCEPTION (see https://github.com/databricks/universe/pull/559943 ). We should try / catch the tag logging; if this exception is encountered, we should just skip logging this tag (the trace should still be logged, the user shouldn’t see any exceptions). It’s important to use SetTraceTag, not EndTrace, to set the tag because we don’t want EndTrace to fail if the tag length is too long. We should not hardcode the tag length check in the client, since the maximum tag length may differ based on the backend.

This tag will be used by the UI to populate a dropdown of span fields (inputs, outputs) that users can select, allowing them to extract the fields and view them in a table.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
