### PR TITLE
Improve `test_build_image_and_serve`

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -72,4 +72,4 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest 'tests/pyfunc/docker
+          pytest tests/pyfunc/docker

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -72,4 +72,4 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest tests/pyfunc/docker
+          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} tests/pyfunc/docker

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -6,7 +6,7 @@ on:
     paths:
       # Run this workflow in PR when relevant files change
       - ".github/workflows/slow-tests.yml"
-      - "tests/pyfunc/docker/test_docker.py"
+      - "tests/pyfunc/docker/**"
   workflow_dispatch:
     inputs:
       repository:
@@ -72,4 +72,4 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} tests/pyfunc/docker
+          pytest 'tests/pyfunc/docker

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -1,12 +1,11 @@
 import os
-from subprocess import PIPE, STDOUT, Popen
+from subprocess import Popen
 from typing import Optional, Union
 from urllib.parse import urlparse
 
 from mlflow.environment_variables import MLFLOW_DOCKER_OPENJDK_VERSION
 from mlflow.utils import env_manager as em
 from mlflow.utils.file_utils import _copy_project
-from mlflow.utils.logging_utils import eprint
 from mlflow.version import VERSION
 
 UBUNTU_BASE_IMAGE = "ubuntu:20.04"
@@ -227,9 +226,6 @@ def build_image_from_context(context_dir: str, image_name: str):
         *platform_option,
         ".",
     ]
-    proc = Popen(commands, cwd=context_dir, stdout=PIPE, stderr=STDOUT, text=True, encoding="utf-8")
-    for x in iter(proc.stdout.readline, ""):
-        eprint(x, end="")
-
+    proc = Popen(commands, cwd=context_dir)
     if proc.wait():
         raise RuntimeError("Docker build failed.")

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -88,8 +88,6 @@ def start_container(port: int):
         image=TEST_IMAGE_NAME,
         ports={8080: port},
         detach=True,
-        stdout=True,
-        stderr=True,
     )
 
     try:

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -112,7 +112,7 @@ def start_container(port: int):
                 time.sleep(5)
 
             container.reload()
-            if container.status != "exited":
+            if container.status == "exited":
                 raise Exception("Container exited unexpectedly.")
 
             sys.stdout.write(f"Container status: {container.status}\n")

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -104,6 +104,7 @@ def start_container(port: int):
     try:
         # Wait for the server to start
         for _ in range(30):
+            sys.stdout.write(f"Container status: {container.status}\n")
             try:
                 response = requests.get(url=f"http://localhost:{port}/ping")
                 if response.ok:
@@ -111,8 +112,6 @@ def start_container(port: int):
             except requests.exceptions.ConnectionError:
                 time.sleep(5)
 
-            if container.status != "running":
-                raise Exception("Container stopped unexpectedly")
         else:
             raise TimeoutError("Failed to start server.")
 

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -104,13 +104,15 @@ def start_container(port: int):
     try:
         # Wait for the server to start
         for _ in range(30):
-            sys.stdout.write(f"Container status: {container.status}\n")
             try:
                 response = requests.get(url=f"http://localhost:{port}/ping")
                 if response.ok:
                     break
             except requests.exceptions.ConnectionError:
                 time.sleep(5)
+
+            container.reload()
+            sys.stdout.write(f"Container status: {container.status}\n")
 
         else:
             raise TimeoutError("Failed to start server.")

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -110,6 +110,9 @@ def start_container(port: int):
                     break
             except requests.exceptions.ConnectionError:
                 time.sleep(5)
+
+            if container.status != "running":
+                raise Exception("Container stopped unexpectedly")
         else:
             raise TimeoutError("Failed to start server.")
 

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -109,7 +109,7 @@ def start_container(port: int):
             except requests.exceptions.ConnectionError:
                 time.sleep(5)
 
-            container.reload()
+            container.reload()  # update container status
             if container.status == "exited":
                 raise Exception("Container exited unexpectedly.")
 

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -8,10 +8,11 @@ To run this test, run the following command manually
     $ pytest tests/pyfunc/test_docker_flavors.py
 
 """
-
+import contextlib
 import json
 import os
 import shutil
+import sys
 import time
 from operator import itemgetter
 
@@ -81,6 +82,35 @@ def model_path(tmp_path):
         shutil.rmtree(model_path, ignore_errors=True)
 
 
+@contextlib.contextmanager
+def start_container(port: int):
+    container = docker_client.containers.run(
+        image=TEST_IMAGE_NAME,
+        ports={8080: port},
+        detach=True,
+        stdout=True,
+        stderr=True,
+    )
+
+    try:
+        # Wait for the server to start
+        for _ in range(30):
+            sys.stdout.write(container.logs().decode("utf-8"))
+            try:
+                response = requests.get(url=f"http://localhost:{port}/ping")
+                if response.ok:
+                    break
+            except requests.exceptions.ConnectionError:
+                time.sleep(5)
+        else:
+            raise TimeoutError("Failed to start server.")
+
+        yield container
+    finally:
+        container.stop()
+        container.remove()
+
+
 @pytest.mark.parametrize(
     ("flavor"),
     [
@@ -123,40 +153,23 @@ def test_build_image_and_serve(flavor, request):
 
     # Run a container
     port = get_safe_port()
-    docker_client.containers.run(
-        image=TEST_IMAGE_NAME,
-        ports={8080: port},
-        detach=True,
-    )
+    with start_container(port):
+        # Make a scoring request with a saved input example
+        with open(os.path.join(model_path, "input_example.json")) as f:
+            input_example = json.load(f)
 
-    # Wait for the container to start
-    iteration_limit = 60 if flavor in ["h2o", "spark"] else 30
-    for _ in range(iteration_limit):
-        try:
-            response = requests.get(url=f"http://localhost:{port}/ping")
-            if response.ok:
-                break
-        except requests.exceptions.ConnectionError:
-            time.sleep(5)
-    else:
-        raise TimeoutError("Failed to start server.")
+        # Wrap Pandas dataframe in a proper payload format
+        if "columns" in input_example or "data" in input_example:
+            input_example = {"dataframe_split": input_example}
 
-    # Make a scoring request with a saved input example
-    with open(os.path.join(model_path, "input_example.json")) as f:
-        input_example = json.load(f)
+        response = requests.post(
+            url=f"http://localhost:{port}/invocations",
+            data=json.dumps(input_example),
+            headers={"Content-Type": "application/json"},
+        )
 
-    # Wrap Pandas dataframe in a proper payload format
-    if "columns" in input_example or "data" in input_example:
-        input_example = {"dataframe_split": input_example}
-
-    response = requests.post(
-        url=f"http://localhost:{port}/invocations",
-        data=json.dumps(input_example),
-        headers={"Content-Type": "application/json"},
-    )
-
-    assert response.status_code == 200, f"Response: {response.text}"
-    assert "predictions" in response.json(), f"Response: {response.text}"
+        assert response.status_code == 200, f"Response: {response.text}"
+        assert "predictions" in response.json(), f"Response: {response.text}"
 
 
 @pytest.fixture

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -98,7 +98,7 @@ def start_container(port: int):
             sys.stdout.write(line.decode("utf-8"))
 
     # Start a thread to stream logs from the container
-    thread = threading.Thread(target=log_stream)
+    thread = threading.Thread(target=log_stream, daemon=True)
     thread.start()
 
     try:

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -91,15 +91,13 @@ def start_container(port: int):
         detach=True,
     )
 
-    stream = container.logs(stream=True)
-
-    def log_stream():
-        for line in stream:
+    def stream_logs():
+        for line in container.logs(stream=True):
             sys.stdout.write(line.decode("utf-8"))
 
     # Start a thread to stream logs from the container
-    thread = threading.Thread(target=log_stream, daemon=True)
-    thread.start()
+    t = threading.Thread(target=stream_logs, daemon=True)
+    t.start()
 
     try:
         # Wait for the server to start
@@ -124,7 +122,7 @@ def start_container(port: int):
     finally:
         container.stop()
         container.remove()
-        thread.join(timeout=5)
+        t.join(timeout=5)
 
 
 @pytest.mark.parametrize(

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -112,6 +112,9 @@ def start_container(port: int):
                 time.sleep(5)
 
             container.reload()
+            if container.status != "exited":
+                raise Exception("Container exited unexpectedly.")
+
             sys.stdout.write(f"Container status: {container.status}\n")
 
         else:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12020?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12020/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12020
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

To investigate the recent test failure for h2o and spark in the slow-tests, update `test_build_image_and_serve` to stream logs in the container:

https://github.com/mlflow-automation/mlflow/actions/runs/9112968815/job/25053353778

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
