### PR TITLE
Patch all runnables for tracing

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -883,30 +883,35 @@ def load_model(model_uri, dst_path=None):
     return _load_model_from_local_fs(local_model_path)
 
 
-def _patch_runnable_cls(cls, patched_class):
-    if cls.__name__ not in patched_class:
-        for func_name in ["invoke", "batch", "stream"]:
-            if hasattr(cls, func_name):
-                safe_patch(
-                    FLAVOR_NAME,
-                    cls,
-                    func_name,
-                    functools.partial(patched_inference, func_name),
-                )
-                logger.debug(f"patched {cls.__name__}.{func_name}")
-        patched_class.add(cls.__name__)
+def _patch_runnable_cls(cls):
+    for func_name in ["invoke", "batch", "stream"]:
+        if hasattr(cls, func_name):
+            safe_patch(
+                FLAVOR_NAME,
+                cls,
+                func_name,
+                functools.partial(patched_inference, func_name),
+            )
+            logger.debug(f"patched {cls.__name__}.{func_name}")
 
 
-def _inspect_module_and_patch_cls(module, inspected_module, patched_class):
+def _should_patch_runnable_cls(cls, patched_classes):
     from langchain.schema.runnable import Runnable
 
-    if module.__name__ not in inspected_module:
-        inspected_module.add(module.__name__)
+    return (
+        inspect.isclass(cls) and issubclass(cls, Runnable) and cls.__name__ not in patched_classes
+    )
+
+
+def _inspect_module_and_patch_cls(module, inspected_modules, patched_classes):
+    if module.__name__ not in inspected_modules:
+        inspected_modules.add(module.__name__)
         for _, obj in inspect.getmembers(module):
             if inspect.ismodule(obj) and (obj.__name__.startswith("langchain")):
-                _inspect_module_and_patch_cls(obj, inspected_module, patched_class)
-            elif inspect.isclass(obj) and issubclass(obj, Runnable):
-                _patch_runnable_cls(obj, patched_class)
+                _inspect_module_and_patch_cls(obj, inspected_modules, patched_classes)
+            elif _should_patch_runnable_cls(obj, patched_classes):
+                _patch_runnable_cls(obj)
+                patched_classes.add(obj.__name__)
         logger.debug(f"Patched module {module}.\n")
 
 
@@ -982,21 +987,21 @@ def autolog(
         from langchain.agents.agent import AgentExecutor
         from langchain.chains.base import Chain
         from langchain.schema import BaseRetriever
-        from langchain.schema.runnable import Runnable
 
         # avoid duplicate patching
-        patched_class = set()
+        patched_classes = set()
         # avoid infinite recursion
-        inspected_module = set()
+        inspected_modules = set()
 
         for module in [langchain, langchain_community]:
-            _inspect_module_and_patch_cls(module, inspected_module, patched_class)
+            _inspect_module_and_patch_cls(module, inspected_modules, patched_classes)
 
         if extra_log_classes:
             unsupported_classes = []
             for cls in extra_log_classes:
-                if inspect.isclass(cls) and issubclass(cls, Runnable):
-                    _patch_runnable_cls(cls, patched_class)
+                if _should_patch_runnable_cls(cls, patched_classes):
+                    _patch_runnable_cls(cls)
+                    patched_classes.add(cls.__name__)
                 else:
                     unsupported_classes.append(cls)
             if unsupported_classes:

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -912,7 +912,7 @@ def test_langchain_tracer_injection_for_arbitrary_runnables():
     assert traces[0].data.spans[0].attributes[SpanAttributeKey.SPAN_TYPE] == "CHAIN"
 
 
-def test_langchain_autolog_extra_log_classes_no_duplicate_patching():
+def test_langchain_autolog_extra_model_classes_no_duplicate_patching():
     from langchain.schema.runnable import Runnable
 
     class CustomRunnable(Runnable):
@@ -929,7 +929,7 @@ def test_langchain_autolog_extra_log_classes_no_duplicate_patching():
         def _type(self):
             return "CHAT_MODEL"
 
-    mlflow.langchain.autolog(extra_log_classes=[CustomRunnable, AnotherRunnable])
+    mlflow.langchain.autolog(extra_model_classes=[CustomRunnable, AnotherRunnable])
     model = AnotherRunnable()
     with mock.patch("mlflow.langchain._langchain_autolog._logger.debug") as mock_debug:
         assert model.invoke("test") == "test"
@@ -937,7 +937,7 @@ def test_langchain_autolog_extra_log_classes_no_duplicate_patching():
         assert mock_debug.call_count == 1
 
 
-def test_langchain_autolog_extra_log_classes_warning():
+def test_langchain_autolog_extra_model_classes_warning():
     from langchain.schema.runnable import Runnable
 
     class NotARunnable:
@@ -945,12 +945,12 @@ def test_langchain_autolog_extra_log_classes_warning():
             self.x = x
 
     with mock.patch("mlflow.langchain.logger.warning") as mock_warning:
-        mlflow.langchain.autolog(extra_log_classes=[NotARunnable])
+        mlflow.langchain.autolog(extra_model_classes=[NotARunnable])
         mock_warning.assert_called_once_with(
-            "Unsupported classes found in extra_log_classes: ['NotARunnable']. "
+            "Unsupported classes found in extra_model_classes: ['NotARunnable']. "
             "Only subclasses of Runnable are supported."
         )
         mock_warning.reset_mock()
 
-        mlflow.langchain.autolog(extra_log_classes=[Runnable])
+        mlflow.langchain.autolog(extra_model_classes=[Runnable])
         mock_warning.assert_not_called()

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -935,3 +935,22 @@ def test_langchain_autolog_extra_log_classes_no_duplicate_patching():
         assert model.invoke("test") == "test"
         mock_debug.assert_called_once_with("Injected MLflow callbacks into the model.")
         assert mock_debug.call_count == 1
+
+
+def test_langchain_autolog_extra_log_classes_warning():
+    from langchain.schema.runnable import Runnable
+
+    class NotARunnable:
+        def __init__(self, x):
+            self.x = x
+
+    with mock.patch("mlflow.langchain.logger.warning") as mock_warning:
+        mlflow.langchain.autolog(extra_log_classes=[NotARunnable])
+        mock_warning.assert_called_once_with(
+            "Unsupported classes found in extra_log_classes: ['NotARunnable']. "
+            "Only subclasses of Runnable are supported."
+        )
+        mock_warning.reset_mock()
+
+        mlflow.langchain.autolog(extra_log_classes=[Runnable])
+        mock_warning.assert_not_called()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12022?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12022/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12022
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Patch all runnables in langchain so they can be traced.
log_models by default set to False, so it shouldn't have any impact. If user explicitly set log_models to True and the runnable is not supported for saving/loading, a clear warning will show up -- it doesn't block any code execution.

Another change: added extra_log_classes --> provide an extra option for users if they want to trace their customized model.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
Verified in /Workspace/Users/serena.ruan@databricks.com/Bugs/runnable invoke patch test

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
