### PR TITLE
Langchain callback fix for pyfunc serving

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -652,7 +652,10 @@ class _LangChainModelWrapper:
         else:
             callbacks = None
 
-        return self._predict_with_callbacks(data, params, callback_handlers=callbacks)
+        convert_chat_responses = params.pop("convert_chat_responses", False)
+        return self._predict_with_callbacks(
+            data, params, callback_handlers=callbacks, convert_chat_responses=convert_chat_responses
+        )
 
     @experimental
     def _predict_with_callbacks(

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -641,7 +641,7 @@ class _LangChainModelWrapper:
         if is_in_databricks_model_serving_environment() and MLFLOW_ENABLE_TRACE_IN_SERVING.get():
             from mlflow.langchain.langchain_tracer import MlflowLangchainTracer
 
-            callbacks = [MlflowLangchainTracer()]
+            callbacks = [MlflowLangchainTracer(prediction_context=get_prediction_context())]
         elif (context := get_prediction_context()) and context.is_evaluate:
             # NB: We enable traces automatically for the model evaluation. Note that we have to
             #   manually pass the context instance to callback, because LangChain callback may be

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -652,7 +652,7 @@ class _LangChainModelWrapper:
         else:
             callbacks = None
 
-        convert_chat_responses = params.pop("convert_chat_responses", False)
+        convert_chat_responses = params.pop("convert_chat_responses", False) if params else False
         return self._predict_with_callbacks(
             data, params, callback_handlers=callbacks, convert_chat_responses=convert_chat_responses
         )

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -689,7 +689,7 @@ class PyFuncModel:
         if self.loader_module == "mlflow.langchain":
             convert_chat_responses = params.pop("convert_chat_responses") if params else None
         params = _validate_params(params, self.metadata)
-        if convert_chat_responses:
+        if convert_chat_responses is not None:
             params["convert_chat_responses"] = convert_chat_responses
         if HAS_PYSPARK and isinstance(data, SparkDataFrame):
             _logger.warning(
@@ -726,7 +726,7 @@ class PyFuncModel:
         Returns:
             Model predictions as one of pandas.DataFrame, pandas.Series, numpy.ndarray or list.
         """
-
+        logging.warning(f"data before schema validation:\ndata={data}\nparams={params}\n")
         data, params = self._validate_prediction_input(data, params)
         if inspect.signature(self._predict_fn).parameters.get("params"):
             return self._predict_fn(data, params=params)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -688,6 +688,8 @@ class PyFuncModel:
         # to predict method, we shouldn't validate its schema
         if self.loader_module == "mlflow.langchain":
             convert_chat_responses = params.pop("convert_chat_responses") if params else None
+        else:
+            convert_chat_responses = None
         params = _validate_params(params, self.metadata)
         if convert_chat_responses is not None:
             params["convert_chat_responses"] = convert_chat_responses

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -684,7 +684,13 @@ class PyFuncModel:
                     f"Error: {e}",
                 )
 
+        # temp workaround for rag model in model serving passing convert_chat_responses
+        # to predict method, we shouldn't validate its schema
+        if self.loader_module == "mlflow.langchain":
+            convert_chat_responses = params.pop("convert_chat_responses") if params else None
         params = _validate_params(params, self.metadata)
+        if convert_chat_responses:
+            params["convert_chat_responses"] = convert_chat_responses
         if HAS_PYSPARK and isinstance(data, SparkDataFrame):
             _logger.warning(
                 "Input data is a Spark DataFrame. Note that behaviour for "

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -687,7 +687,7 @@ class PyFuncModel:
         # temp workaround for rag model in model serving passing convert_chat_responses
         # to predict method, we shouldn't validate its schema
         if self.loader_module == "mlflow.langchain":
-            convert_chat_responses = params.pop("convert_chat_responses") if params else None
+            convert_chat_responses = params.pop("convert_chat_responses", None) if params else None
         else:
             convert_chat_responses = None
         params = _validate_params(params, self.metadata)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -726,7 +726,6 @@ class PyFuncModel:
         Returns:
             Model predictions as one of pandas.DataFrame, pandas.Series, numpy.ndarray or list.
         """
-        logging.warning(f"data before schema validation:\ndata={data}\nparams={params}\n")
         data, params = self._validate_prediction_input(data, params)
         if inspect.signature(self._predict_fn).parameters.get("params"):
             return self._predict_fn(data, params=params)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12023?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12023/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12023
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix langchain tracer to use prediction_context, and support passing convert_chat_responses as params.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
