### PR TITLE
Support `protobuf >= 5`

### DIFF
--- a/dev/generate-protos.sh
+++ b/dev/generate-protos.sh
@@ -70,5 +70,5 @@ rm "$PROTOS/databricks_managed_catalog_service_pb2.py.old"
 rm "$TEST_PROTOS/test_message_pb2.py.old"
 rm "$PROTOS/databricks_filesystem_service_pb2.py.old"
 
-python ./dev/proto_to_graphql/protobuf_v26_workaround.py
+python ./dev/protobuf_v26_workaround.py
 python ./dev/proto_to_graphql/code_generator.py

--- a/dev/generate-protos.sh
+++ b/dev/generate-protos.sh
@@ -70,4 +70,5 @@ rm "$PROTOS/databricks_managed_catalog_service_pb2.py.old"
 rm "$TEST_PROTOS/test_message_pb2.py.old"
 rm "$PROTOS/databricks_filesystem_service_pb2.py.old"
 
+python ./dev/proto_to_graphql/protobuf_v26_workaround.py
 python ./dev/proto_to_graphql/code_generator.py

--- a/dev/protobuf_v26_workaround.py
+++ b/dev/protobuf_v26_workaround.py
@@ -1,0 +1,48 @@
+import textwrap
+
+
+def main():
+    scalapb_pb2_code = """\
+  google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(options)
+  google_dot_protobuf_dot_descriptor__pb2.MessageOptions.RegisterExtension(message)
+  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(field)"""
+
+    databricks_pb2_code = """\
+  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(visibility)
+  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(validate_required)
+  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(json_inline)
+  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(json_map)
+  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(field_doc)
+  google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(rpc)
+  google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(method_doc)
+  google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(graphql)
+  google_dot_protobuf_dot_descriptor__pb2.MessageOptions.RegisterExtension(message_doc)
+  google_dot_protobuf_dot_descriptor__pb2.ServiceOptions.RegisterExtension(service_doc)
+  google_dot_protobuf_dot_descriptor__pb2.EnumOptions.RegisterExtension(enum_doc)
+  google_dot_protobuf_dot_descriptor__pb2.EnumValueOptions.RegisterExtension(enum_value_visibility)
+  google_dot_protobuf_dot_descriptor__pb2.EnumValueOptions.RegisterExtension(enum_value_doc)"""
+
+    for code, path in [
+        (scalapb_pb2_code, "mlflow/protos/scalapb/scalapb_pb2.py"),
+        (databricks_pb2_code, "mlflow/protos/databricks_pb2.py"),
+    ]:
+        new_code = f"""\
+  # `RegisterExtension` was removed in v26: https://github.com/protocolbuffers/protobuf/pull/15270
+  # The following code is a workaround for this breaking change.
+  import google.protobuf.__version__ as protobuf_version
+  if int(protobuf_version.split(".", 1)[0]) >= 5:
+{textwrap.indent(code, " " * 2)}"""
+
+        with open(path) as f:
+            original = f.read()
+            if new_code in original:
+                continue
+
+            assert code in original
+
+        with open(path, "w") as f:
+            f.write(original.replace(code, new_code))
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/protobuf_v26_workaround.py
+++ b/dev/protobuf_v26_workaround.py
@@ -30,7 +30,7 @@ def main():
   # `RegisterExtension` was removed in v26: https://github.com/protocolbuffers/protobuf/pull/15270
   # The following code is a workaround for this breaking change.
   import google.protobuf
-  if int(google.protobuf.__version__.split(".", 1)[0]) >= 5:
+  if int(google.protobuf.__version__.split(".", 1)[0]) < 5:
 {textwrap.indent(original_code, " " * 2)}"""
 
         with open(path) as f:

--- a/dev/protobuf_v26_workaround.py
+++ b/dev/protobuf_v26_workaround.py
@@ -22,7 +22,7 @@ def main():
   google_dot_protobuf_dot_descriptor__pb2.EnumValueOptions.RegisterExtension(enum_value_visibility)
   google_dot_protobuf_dot_descriptor__pb2.EnumValueOptions.RegisterExtension(enum_value_doc)"""
 
-    for code, path in [
+    for original_code, path in [
         (scalapb_pb2_code, "mlflow/protos/scalapb/scalapb_pb2.py"),
         (databricks_pb2_code, "mlflow/protos/databricks_pb2.py"),
     ]:
@@ -31,17 +31,17 @@ def main():
   # The following code is a workaround for this breaking change.
   import google.protobuf.__version__ as protobuf_version
   if int(protobuf_version.split(".", 1)[0]) >= 5:
-{textwrap.indent(code, " " * 2)}"""
+{textwrap.indent(original_code, " " * 2)}"""
 
         with open(path) as f:
-            original = f.read()
-            if new_code in original:
+            content = f.read()
+            if new_code in content:
                 continue
 
-            assert code in original
+            assert original_code in content
 
         with open(path, "w") as f:
-            f.write(original.replace(code, new_code))
+            f.write(content.replace(original_code, new_code))
 
 
 if __name__ == "__main__":

--- a/dev/protobuf_v26_workaround.py
+++ b/dev/protobuf_v26_workaround.py
@@ -29,8 +29,8 @@ def main():
         new_code = f"""\
   # `RegisterExtension` was removed in v26: https://github.com/protocolbuffers/protobuf/pull/15270
   # The following code is a workaround for this breaking change.
-  import google.protobuf.__version__ as protobuf_version
-  if int(protobuf_version.split(".", 1)[0]) >= 5:
+  import google.protobuf
+  if int(google.protobuf.__version__.split(".", 1)[0]) >= 5:
 {textwrap.indent(original_code, " " * 2)}"""
 
         with open(path) as f:

--- a/mlflow/protos/databricks_pb2.py
+++ b/mlflow/protos/databricks_pb2.py
@@ -184,8 +184,8 @@ _sym_db.RegisterMessage(DocumentationMetadata)
 if _descriptor._USE_C_DESCRIPTORS == False:
   # `RegisterExtension` was removed in v26: https://github.com/protocolbuffers/protobuf/pull/15270
   # The following code is a workaround for this breaking change.
-  import google.protobuf.__version__ as protobuf_version
-  if int(protobuf_version.split(".", 1)[0]) >= 5:
+  import google.protobuf
+  if int(google.protobuf.__version__.split(".", 1)[0]) >= 5:
     google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(visibility)
     google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(validate_required)
     google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(json_inline)

--- a/mlflow/protos/databricks_pb2.py
+++ b/mlflow/protos/databricks_pb2.py
@@ -182,19 +182,23 @@ DocumentationMetadata = _reflection.GeneratedProtocolMessageType('DocumentationM
 _sym_db.RegisterMessage(DocumentationMetadata)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
-  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(visibility)
-  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(validate_required)
-  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(json_inline)
-  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(json_map)
-  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(field_doc)
-  google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(rpc)
-  google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(method_doc)
-  google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(graphql)
-  google_dot_protobuf_dot_descriptor__pb2.MessageOptions.RegisterExtension(message_doc)
-  google_dot_protobuf_dot_descriptor__pb2.ServiceOptions.RegisterExtension(service_doc)
-  google_dot_protobuf_dot_descriptor__pb2.EnumOptions.RegisterExtension(enum_doc)
-  google_dot_protobuf_dot_descriptor__pb2.EnumValueOptions.RegisterExtension(enum_value_visibility)
-  google_dot_protobuf_dot_descriptor__pb2.EnumValueOptions.RegisterExtension(enum_value_doc)
+  # `RegisterExtension` was removed in v26: https://github.com/protocolbuffers/protobuf/pull/15270
+  # The following code is a workaround for this breaking change.
+  import google.protobuf.__version__ as protobuf_version
+  if int(protobuf_version.split(".", 1)[0]) >= 5:
+    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(visibility)
+    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(validate_required)
+    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(json_inline)
+    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(json_map)
+    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(field_doc)
+    google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(rpc)
+    google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(method_doc)
+    google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(graphql)
+    google_dot_protobuf_dot_descriptor__pb2.MessageOptions.RegisterExtension(message_doc)
+    google_dot_protobuf_dot_descriptor__pb2.ServiceOptions.RegisterExtension(service_doc)
+    google_dot_protobuf_dot_descriptor__pb2.EnumOptions.RegisterExtension(enum_doc)
+    google_dot_protobuf_dot_descriptor__pb2.EnumValueOptions.RegisterExtension(enum_value_visibility)
+    google_dot_protobuf_dot_descriptor__pb2.EnumValueOptions.RegisterExtension(enum_value_doc)
 
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\n#com.databricks.api.proto.databricks\342?\002\020\001'

--- a/mlflow/protos/databricks_pb2.py
+++ b/mlflow/protos/databricks_pb2.py
@@ -185,7 +185,7 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   # `RegisterExtension` was removed in v26: https://github.com/protocolbuffers/protobuf/pull/15270
   # The following code is a workaround for this breaking change.
   import google.protobuf
-  if int(google.protobuf.__version__.split(".", 1)[0]) >= 5:
+  if int(google.protobuf.__version__.split(".", 1)[0]) < 5:
     google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(visibility)
     google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(validate_required)
     google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(json_inline)

--- a/mlflow/protos/scalapb/scalapb_pb2.py
+++ b/mlflow/protos/scalapb/scalapb_pb2.py
@@ -52,8 +52,8 @@ _sym_db.RegisterMessage(FieldOptions)
 if _descriptor._USE_C_DESCRIPTORS == False:
   # `RegisterExtension` was removed in v26: https://github.com/protocolbuffers/protobuf/pull/15270
   # The following code is a workaround for this breaking change.
-  import google.protobuf.__version__ as protobuf_version
-  if int(protobuf_version.split(".", 1)[0]) >= 5:
+  import google.protobuf
+  if int(google.protobuf.__version__.split(".", 1)[0]) >= 5:
     google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(options)
     google_dot_protobuf_dot_descriptor__pb2.MessageOptions.RegisterExtension(message)
     google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(field)

--- a/mlflow/protos/scalapb/scalapb_pb2.py
+++ b/mlflow/protos/scalapb/scalapb_pb2.py
@@ -53,7 +53,7 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   # `RegisterExtension` was removed in v26: https://github.com/protocolbuffers/protobuf/pull/15270
   # The following code is a workaround for this breaking change.
   import google.protobuf
-  if int(google.protobuf.__version__.split(".", 1)[0]) >= 5:
+  if int(google.protobuf.__version__.split(".", 1)[0]) < 5:
     google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(options)
     google_dot_protobuf_dot_descriptor__pb2.MessageOptions.RegisterExtension(message)
     google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(field)

--- a/mlflow/protos/scalapb/scalapb_pb2.py
+++ b/mlflow/protos/scalapb/scalapb_pb2.py
@@ -50,9 +50,13 @@ FieldOptions = _reflection.GeneratedProtocolMessageType('FieldOptions', (_messag
 _sym_db.RegisterMessage(FieldOptions)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
-  google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(options)
-  google_dot_protobuf_dot_descriptor__pb2.MessageOptions.RegisterExtension(message)
-  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(field)
+  # `RegisterExtension` was removed in v26: https://github.com/protocolbuffers/protobuf/pull/15270
+  # The following code is a workaround for this breaking change.
+  import google.protobuf.__version__ as protobuf_version
+  if int(protobuf_version.split(".", 1)[0]) >= 5:
+    google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(options)
+    google_dot_protobuf_dot_descriptor__pb2.MessageOptions.RegisterExtension(message)
+    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(field)
 
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\n\034org.mlflow.scalapb_interface'

--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-api<3,>=1.0.0",
   "opentelemetry-sdk<3,>=1.0.0",
   "packaging<25",
-  "protobuf<5,>=3.12.0",
+  "protobuf<6,>=3.12.0",
   "pytz<2025",
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "opentelemetry-sdk<3,>=1.0.0",
   "packaging<25",
   "pandas<3",
-  "protobuf<5,>=3.12.0",
+  "protobuf<6,>=3.12.0",
   "pyarrow<16,>=4.0.0",
   "pytz<2025",
   "pyyaml<7,>=5.1",

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -7,7 +7,7 @@ cloudpickle<4
 entrypoints<1
 gitpython<4,>=3.1.9
 pyyaml<7,>=5.1
-protobuf<5,>=3.12.0
+protobuf<6,>=3.12.0
 pytz<2025
 requests<3,>=2.17.3
 packaging<25

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -30,7 +30,7 @@ pyyaml:
 protobuf:
   pip_release: protobuf
   minimum: "3.12.0"
-  max_major_version: 4
+  max_major_version: 5
 
 pytz:
   pip_release: pytz


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12048?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12048/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12048
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #11811

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

As a short term solution for #11811, avoid touching `RegisterExtension` if `google.protobuf.__version__` >= 5.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
