### PR TITLE
Revert "Obfuscate tracing pydoc entries"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -398,28 +398,6 @@ nitpick_ignore = [
     ("py:class", "pytorch_lightning.core.module.LightningModule"),
     ("py:class", "pytorch_lightning.core.LightningModule"),
     ("py:class", "torch.dtype"),
-    # Temporarily ignore trace references - remove prior to launch
-    ("py:func", "trace"),
-    ("py:func", "mlflow.start_span"),
-    ("py:class", "mlflow.entities.SpanType"),
-    ("py:func", "mlflow.client.MlflowClient.start_trace"),
-    ("py:func", "mlflow.client.MlflowClient.start_trace"),
-    ("py:class", "mlflow.entities.Span"),
-    ("py:class", "mlflow.entities.Trace"),
-    ("py:func", "mlflow.trace"),
-    ("py:func", "start_span"),
-    ("py:class", "mlflow.entities.SpanStatus"),
-    ("py:class", "mlflow.entities.SpanStatusCode"),
-    ("py:func", "mlflow.start_span"),
-    ("py:func", "start_trace"),
-    ("py:func", "end_span"),
-    ("py:class", "mlflow.entities.SpanType"),
-    ("py:func", "mlflow.client.MlflowClient.start_trace"),
-    ("py:func", "mlflow.client.MlflowClient.end_trace"),
-    ("py:func", "mlflow.client.MlflowClient.start_span"),
-    ("py:func", "mlflow.client.MlflowClient.start_span"),
-    ("py:func", "mlflow.client.MlflowClient.end_span"),
-    ("py:func", "mlflow.client.MlflowClient.end_trace"),
 ]
 
 

--- a/docs/source/python_api/mlflow.tracing.rst
+++ b/docs/source/python_api/mlflow.tracing.rst
@@ -1,0 +1,59 @@
+mlflow.tracing
+==============
+
+.. attention::
+
+    This is a tentative documentation for the development period. The main objective is to serve as an up-to-date internal reference for API specifications and notable implementation details. The documentation must be updated and polished before the official release.
+
+MLflow Tracing Python APIs instrument machine learning application, so that developers can easily debug and monitor their systems.
+
+.. contents:: Table of Contents
+  :local:
+  :depth: 2
+
+
+.. _tracing-automatic-instrumentation:
+
+Automatic instrumentation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*This will cover LangChain/OpenAI/etc auto-instrumentation once implemented.*
+
+
+.. _tracing-fluent-apis:
+
+Fluent APIs
+~~~~~~~~~~~
+
+Fluent APIs are high-level APIs that allow developers to instrument their code with minimal changes. The APIs are designed to be easy to use that manages the spans parent-child relationships and set some fields of the span automatically. When instrumenting Python code, it is generally recommended to use Fluent APIs over MLflow Client APIs as they are more user-friendly and less error-prone.
+
+
+.. autofunction:: mlflow.trace
+    :noindex:
+
+
+.. autofunction:: mlflow.start_span
+    :noindex:
+
+
+.. autofunction:: mlflow.get_trace
+    :noindex:
+
+.. _tracing-client-apis:
+
+MLflow Client APIs
+~~~~~~~~~~~~~~~~~~
+
+:py:class:`MlflowClient <mlflow.client.MlflowClient>` exposes APIs to start and end traces, spans, and set fields of the spans, with more flexibility and control to the trace lifecycle and structure. They are useful when the Fluent APIs are not sufficient for the use case, such as multi-threaded applications, callbacks, etc.
+
+.. autofunction:: mlflow.client.MlflowClient.start_trace
+    :noindex:
+
+.. autofunction:: mlflow.client.MlflowClient.end_trace
+    :noindex:
+
+.. autofunction:: mlflow.client.MlflowClient.start_span
+    :noindex:
+
+.. autofunction:: mlflow.client.MlflowClient.end_span
+    :noindex:

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -28,8 +28,6 @@ _logger = logging.getLogger(__name__)
 class SpanType:
     """
     Predefined set of span types.
-
-    :meta private:
     """
 
     LLM = "LLM"
@@ -52,8 +50,6 @@ class Span:
     This Span class represents immutable span data that is already finished and persisted.
     The "live" span that is being created and updated during the application runtime is
     represented by the :py:class:`LiveSpan <mlflow.entities.LiveSpan>` subclass.
-
-    :meta private:
     """
 
     def __init__(self, otel_span: OTelReadableSpan):
@@ -238,8 +234,6 @@ class LiveSpan(Span):
     The live spans are those being created and updated during the application runtime.
     When users start a new span using the tracing APIs within their code, this live span
     object is returned to get and set the span attributes, status, events, and etc.
-
-    :meta private:
     """
 
     def __init__(
@@ -369,7 +363,6 @@ class NoOpSpan(Span):
             span.set_inputs({"x": 1})
             # Do something
 
-    :meta private:
     """
 
     def __init__(self, *args, **kwargs):
@@ -438,8 +431,6 @@ class _SpanAttributesRegistry:
     Therefore, we serialize all values into JSON string before storing them in the span.
     This class provides simple getter and setter methods to interact with the span attributes
     without worrying about the serde process.
-
-    :meta private:
     """
 
     def __init__(self, otel_span: OTelSpan):

--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -25,8 +25,6 @@ class SpanEvent(_MlflowObject):
             attributes of the event, such as the exception stack trace.
             Attributes value must be one of ``[str, int, float, bool, bytes]``
             or a sequence of these types.
-
-    :meta private:
     """
 
     name: str

--- a/mlflow/entities/span_status.py
+++ b/mlflow/entities/span_status.py
@@ -10,10 +10,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
 
 class SpanStatusCode(str, Enum):
-    """Enum for status code of a span
-
-    :meta private:
-    """
+    """Enum for status code of a span"""
 
     # Uses the same set of status codes as OpenTelemetry
     UNSET = "UNSET"
@@ -32,8 +29,6 @@ class SpanStatus:
             representation of it like "OK", "ERROR".
         description: Description of the status. This should be only set when the status
             is ERROR, otherwise it will be ignored.
-
-    :meta private:
     """
 
     status_code: SpanStatusCode

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -18,8 +18,6 @@ class Trace(_MlflowObject):
     Args:
         info: A lightweight object that contains the metadata of a trace.
         data: A container object that holds the spans data of a trace.
-
-    :meta private:
     """
 
     info: TraceInfo

--- a/mlflow/entities/trace_data.py
+++ b/mlflow/entities/trace_data.py
@@ -14,8 +14,6 @@ class TraceData:
             but added for ease of access. Stored as a JSON string.
         response: Output data for the entire trace. Equivalent to the output of the root span.
             Stored as a JSON string.
-
-    :meta private:
     """
 
     spans: List[Span] = field(default_factory=list)

--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -20,8 +20,6 @@ class TraceInfo(_MlflowObject):
         status: status of the trace.
         request_metadata: request metadata associated with the trace.
         tags: tags associated with the trace.
-
-    :meta private:
     """
 
     request_id: str

--- a/mlflow/entities/trace_status.py
+++ b/mlflow/entities/trace_status.py
@@ -6,10 +6,7 @@ from mlflow.protos.service_pb2 import TraceStatus as ProtoTraceStatus
 
 
 class TraceStatus(str, Enum):
-    """Enum for status of an :py:class:`mlflow.entities.TraceInfo`.
-
-    :meta private:
-    """
+    """Enum for status of an :py:class:`mlflow.entities.TraceInfo`."""
 
     UNSPECIFIED = "TRACE_STATUS_UNSPECIFIED"
     OK = "OK"

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -171,10 +171,7 @@ class _UnsupportedMultipartUploadException(MlflowException):
 
 
 class MlflowTraceDataException(MlflowException):
-    """Exception thrown for trace data related error
-
-    :meta private:
-    """
+    """Exception thrown for trace data related error"""
 
     def __init__(
         self, error_code: str, request_id: Optional[str] = None, artifact_path: Optional[str] = None
@@ -191,20 +188,14 @@ class MlflowTraceDataException(MlflowException):
 
 
 class MlflowTraceDataNotFound(MlflowTraceDataException):
-    """Exception thrown when trace data is not found
-
-    :meta private:
-    """
+    """Exception thrown when trace data is not found"""
 
     def __init__(self, request_id: Optional[str] = None, artifact_path: Optional[str] = None):
         super().__init__(NOT_FOUND, request_id, artifact_path)
 
 
 class MlflowTraceDataCorrupted(MlflowTraceDataException):
-    """Exception thrown when trace data is corrupted
-
-    :meta private:
-    """
+    """Exception thrown when trace data is corrupted"""
 
     def __init__(self, request_id: Optional[str] = None, artifact_path: Optional[str] = None):
         super().__init__(INVALID_STATE, request_id, artifact_path)

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -650,15 +650,19 @@ langchain:
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
         ]
     run: |
+      LANGCHAIN_NEW=$(python -c "from packaging.version import Version;import langchain;print(Version(langchain.__version__) >= Version('0.0.267'))")
       pytest tests/langchain/test_langchain_model_export.py
       pytest tests/langchain/test_langchain_databricks_dependency_extraction.py
+      if [[ $LANGCHAIN_NEW = "True" ]]; then
+        pytest tests/langchain/test_langchain_tracer.py
+      fi
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
-      LANGCHAIN_NEW=$(python -c "from packaging.version import Version;import langchain;print(Version(langchain.__version__) >= Version('0.0.267'))")
       if [[ $PYDANTIC_VERSION == 1.* && $LANGCHAIN_NEW = "True" ]]; then
         pip install 'pydantic>2'
         echo "Testing langchain model export with pydantic v2"
         pytest tests/langchain/test_langchain_model_export.py
+        pytest tests/langchain/test_langchain_tracer.py
         pytest tests/langchain/test_langchain_databricks_dependency_extraction.py
       fi
   autologging:

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -18,8 +18,6 @@ def pop_trace(request_id: str) -> Optional[Dict[str, Any]]:
     """
     Pop the completed trace data from the buffer. This method is used in
     the Databricks model serving so please be careful when modifying it.
-
-    :meta private:
     """
     return _TRACE_BUFFER.pop(request_id, None)
 
@@ -46,8 +44,6 @@ class InferenceTableSpanExporter(SpanExporter):
     but rather actively fetches the trace during the prediction process. In the
     future, we may consider using collector-based approach and this exporter should
     send the traces instead of storing them in the buffer.
-
-    :meta private:
     """
 
     def __init__(self):

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -110,8 +110,6 @@ def trace(
         span_type: The type of the span. Can be either a string or a
             :py:class:`SpanType <mlflow.entities.SpanType>` enum value.
         attributes: A dictionary of attributes to set on the span.
-
-    :meta private:
     """
 
     def decorator(fn):
@@ -194,8 +192,6 @@ def start_span(
 
     Returns:
         Yields an :py:class:`mlflow.entities.Span` that represents the created span.
-
-    :meta private:
     """
     try:
         otel_span = provider.start_span_in_context(name)
@@ -228,8 +224,6 @@ def get_trace(request_id: str) -> Trace:
 
     Returns:
         A :py:class:`mlflow.entities.Trace` objects with the given request ID.
-
-    :meta private:
     """
     return TRACE_BUFFER.get(request_id, None)
 
@@ -291,8 +285,6 @@ def search_traces(
         mlflow.search_traces(
             extract_fields=["non_dict_span.inputs", "non_dict_span.outputs"],
         )
-
-    :meta private:
     """
     # Check if pandas is installed early to avoid unnecessary computation
     if importlib.util.find_spec("pandas") is None:
@@ -353,8 +345,6 @@ def get_current_active_span():
 
     Returns:
         The current active span if exists, otherwise None.
-
-    :meta private:
     """
     otel_span = trace_api.get_current_span()
     # NonRecordingSpan is returned if a tracer is not instantiated.

--- a/mlflow/tracing/processor/inference_table.py
+++ b/mlflow/tracing/processor/inference_table.py
@@ -36,8 +36,6 @@ class InferenceTableSpanProcessor(SimpleSpanProcessor):
     Defines custom hooks to be executed when a span is started or ended (before exporting).
 
     This processor is used when the tracing destination is Databricks Inference Table.
-
-    :meta private:
     """
 
     def __init__(self, span_exporter: SpanExporter):

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -40,8 +40,6 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
     Defines custom hooks to be executed when a span is started or ended (before exporting).
 
     This processor is used when the tracing destination is MLflow Tracking Server.
-
-    :meta private:
     """
 
     def __init__(self, span_exporter: SpanExporter, client: Optional[MlflowClient] = None):

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -28,8 +28,6 @@ def start_span_in_context(name: str) -> trace.Span:
 
     Returns:
         The newly created OpenTelemetry span.
-
-    :meta private:
     """
     return _get_tracer(__name__).start_span(name)
 
@@ -48,8 +46,6 @@ def start_detached_span(
 
     Returns:
         The newly created OpenTelemetry span.
-
-    :meta private:
     """
     tracer = _get_tracer(__name__)
     context = trace.set_span_in_context(parent) if parent else None
@@ -95,8 +91,6 @@ def _setup_tracer_provider():
 def disable():
     """
     Disable tracing by setting the global tracer provider to NoOpTracerProvider.
-
-    :meta private:
     """
     if isinstance(trace.get_tracer_provider(), trace.NoOpTracerProvider):
         _logger.info("Tracing is already disabled")
@@ -111,8 +105,6 @@ def disable():
 def enable():
     """
     Enable tracing by setting the global tracer provider to the actual tracer provider.
-
-    :meta private:
     """
     from mlflow.tracing.provider import _setup_tracer_provider
 

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -37,8 +37,6 @@ class _Trace:
 class InMemoryTraceManager:
     """
     Manage spans and traces created by the tracing system in memory.
-
-    :meta private:
     """
 
     _instance_lock = threading.Lock()

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -419,8 +419,6 @@ class MlflowClient:
 
         Returns:
             The number of traces deleted.
-
-        :meta private:
         """
         return self._tracking_client.delete_traces(
             experiment_id=experiment_id,
@@ -448,8 +446,6 @@ class MlflowClient:
             client = MlflowClient()
             request_id = "12345678"
             trace = client.get_trace(request_id)
-
-        :meta private:
         """
         trace = self._tracking_client.get_trace(request_id)
         get_display_handler().display_traces([trace])
@@ -482,8 +478,6 @@ class MlflowClient:
             next page may be obtained via the ``token`` attribute of the returned object; however,
             some store implementations may not support pagination and thus the returned token would
             not be meaningful in such cases.
-
-        :meta private:
         """
         traces = self._tracking_client.search_traces(
             experiment_ids=experiment_ids,
@@ -555,8 +549,6 @@ class MlflowClient:
                 client.end_span(request_id=request_id, span_id=child_span.span_id)
 
                 client.end_trace(request_id)
-
-        :meta private:
         """
         # Validate no active trace is set in the global context. If there is an active trace,
         # the span created by this method will be a child span under the active trace rather than
@@ -641,8 +633,6 @@ class MlflowClient:
                 representing the status code defined in
                 :py:class:`SpanStatusCode <mlflow.entities.SpanStatusCode>`
                 e.g. ``"OK"``, ``"ERROR"``. The default status is OK.
-
-        :meta private:
         """
         trace_manager = InMemoryTraceManager.get_instance()
         root_span_id = trace_manager.get_root_span_id(request_id)
@@ -767,7 +757,7 @@ class MlflowClient:
             attributes: A dictionary of attributes to set on the span.
 
         Returns:
-            A :py:class:`mlflow.entities.Span` object representing the span.
+            An :py:class:`mlflow.entities.Span` object representing the span.
 
         Example:
 
@@ -799,8 +789,6 @@ class MlflowClient:
                 )
 
                 client.end_trace(request_id)
-
-        :meta private:
         """
         if not parent_id:
             raise MlflowException(
@@ -864,8 +852,6 @@ class MlflowClient:
                 representing the status code defined in
                 :py:class:`SpanStatusCode <mlflow.entities.SpanStatusCode>`
                 e.g. ``"OK"``, ``"ERROR"``. The default status is OK.
-
-        :meta private:
         """
         trace_manager = InMemoryTraceManager.get_instance()
         span = trace_manager.get_span_from_id(request_id, span_id)
@@ -957,8 +943,6 @@ class MlflowClient:
                 it will be truncated when stored.
             value: The string value of the tag. Must be at most 250 characters long, otherwise
                 it will be truncated when stored.
-
-        :meta private:
         """
         if key.startswith("mlflow."):
             raise MlflowException(
@@ -999,8 +983,6 @@ class MlflowClient:
             request_id: The ID of the trace to delete the tag from.
             key: The string key of the tag. Must be at most 250 characters long, otherwise
                 it will be truncated when stored.
-
-        :meta private:
         """
         # Trying to delete the tag on the active trace first
         with InMemoryTraceManager.get_instance().get_trace(request_id) as trace:

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2416,11 +2416,11 @@ def test_save_load_chain_as_code(chain_model_signature):
     )
     assert response["choices"][0]["message"]["content"] == "Databricks"
     trace = mlflow.get_trace(tracer._request_id)
-    assert trace.info.tags["vector_search_index"] == json.dumps(
+    assert trace.info.tags[DependenciesSchemasType.RETRIEVERS.value] == json.dumps(
         [
             {
                 "doc_uri": "doc-uri",
-                "name": "vector_search_index",
+                "name": "retriever",
                 "other_columns": ["column1", "column2"],
                 "primary_key": "primary-key",
                 "text_column": "text-column",


### PR DESCRIPTION
branch-2.13 has been cut. Reverts mlflow/mlflow#12025


<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mparkhe/mlflow/pull/12055?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12055/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12055
```

</p>
</details>

### What changes are proposed in this pull request?

Adding dependencies to PyFunc models

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
