### PR TITLE
Fix Johnsnowlab model loading in Databricks serving container

### DIFF
--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -77,8 +77,8 @@ from mlflow.tracking.artifact_utils import (
 from mlflow.utils import databricks_utils
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
-    is_in_databricks_runtime,
     is_in_databricks_model_serving_environment,
+    is_in_databricks_runtime,
 )
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -768,12 +768,14 @@ def _load_pyfunc(path, spark=None):
         if not is_in_databricks_runtime() or is_in_databricks_model_serving_environment():
             # Johnsnowlab code uses incorrect logic to check if it is in Databricks Runtime
             # if there is any environmental variable key contains 'DATABRICKS', it is regarded
-            # as the databricks runtime.
-            # to fix this, we popped these environmental variables temporarily as the patch.
+            # as the databricks runtime, see
+            # https://github.com/JohnSnowLabs/nlu/blob/909a4cc6d873e25233503ad2aa4592160d5b8c7e/nlu/__init__.py#L328
+            # and
+            # https://github.com/JohnSnowLabs/johnsnowlabs/blob/705f2772b8e60e40317931e63c86031bddd5c8cd/johnsnowlabs/utils/env_utils.py#L106
+            # to fix this, we popped these environmental variables temporarily.
             for k in os.environ:
                 if 'DATABRICKS' in k:
-                    v = os.environ.pop(k)
-                    popped_envs[k] = v
+                    popped_envs[k] = os.environ.pop(k)
         return _PyFuncModelWrapper(
             _load_model(model_uri=path),
             spark or _get_or_create_sparksession(path),

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -76,7 +76,10 @@ from mlflow.tracking.artifact_utils import (
 )
 from mlflow.utils import databricks_utils
 from mlflow.utils.annotations import experimental
-from mlflow.utils.databricks_utils import is_in_databricks_runtime
+from mlflow.utils.databricks_utils import (
+    is_in_databricks_runtime,
+    is_in_databricks_model_serving_environment,
+)
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -759,11 +762,10 @@ def _load_pyfunc(path, spark=None):
 
     Returns:
         None.
-
     """
-    if not is_in_databricks_runtime():
+    try:
         popped_envs = {}
-        try:
+        if not is_in_databricks_runtime() or is_in_databricks_model_serving_environment():
             # Johnsnowlab code uses incorrect logic to check if it is in Databricks Runtime
             # if there is any environmental variable key contains 'DATABRICKS', it is regarded
             # as the databricks runtime.
@@ -772,16 +774,12 @@ def _load_pyfunc(path, spark=None):
                 if 'DATABRICKS' in k:
                     v = os.environ.pop(k)
                     popped_envs[k] = v
-            spark = spark or _get_or_create_sparksession(path)
-        finally:
-            os.environ.update(popped_envs)
-    else:
-        spark = spark or _get_or_create_sparksession(path)
-
-    return _PyFuncModelWrapper(
-        _load_model(model_uri=path),
-        spark,
-    )
+        return _PyFuncModelWrapper(
+            _load_model(model_uri=path),
+            spark or _get_or_create_sparksession(path),
+        )
+    finally:
+        os.environ.update(popped_envs)
 
 
 def _get_or_create_sparksession(model_path=None):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12059?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12059/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12059
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix Johnsnowlab model loading in Databricks serving container

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
