### PR TITLE
Rename `IS_IN_DATABRICKS_MODEL_SERVING_ENV` to `IS_IN_DB_MODEL_SERVING`

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -175,13 +175,15 @@ def is_in_databricks_model_serving_environment():
     Check if the code is running in Databricks Model Serving environment.
     The environment variable set by Databricks when starting the serving container.
     """
-    return (
-        os.environ.get("IS_IN_DB_MODEL_SERVING_ENV", "false").lower() == "true"
+    val = (
+        os.environ.get("IS_IN_DB_MODEL_SERVING_ENV")
         # Checking the old env var name for backward compatibility. The env var was renamed once
         # to fix a model loading issue, but we still need to support it for a while.
         # TODO: Remove this once the new env var is fully rolled out.
-        or os.environ.get("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "false").lower() == "true"
+        or os.environ.get("IS_IN_DATABRICKS_MODEL_SERVING_ENV")
+        or "false"
     )
+    return val.lower() == "true"
 
 
 # this should only be the case when we are in model serving environment

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -171,7 +171,17 @@ def is_in_databricks_job():
 
 
 def is_in_databricks_model_serving_environment():
-    return "IS_IN_DATABRICKS_MODEL_SERVING_ENV" in os.environ
+    """
+    Check if the code is running in Databricks Model Serving environment.
+    The environment variable set by Databricks when starting the serving container.
+    """
+    return (
+        os.environ.get("IS_IN_DB_MODEL_SERVING_ENV", "false").lower() == "true"
+        # Checking the old env var name for backward compatibility. The env var was renamed once
+        # to fix a model loading issue, but we still need to support it for a while.
+        # TODO: Remove this once the new env var is fully rolled out.
+        or os.environ.get("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "false").lower() == "true"
+    )
 
 
 # this should only be the case when we are in model serving environment

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2921,7 +2921,7 @@ def test_langchain_model_inject_callback_in_model_serving(
     clear_trace_singleton, monkeypatch, model_path
 ):
     # Emulate the model serving environment
-    monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
 
     model = create_openai_llmchain()
     mlflow.langchain.save_model(model, model_path)
@@ -2945,7 +2945,7 @@ def test_langchain_model_not_inject_callback_when_disabled(
     clear_trace_singleton, monkeypatch, model_path
 ):
     # Emulate the model serving environment
-    monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
 
     # Disable tracing
     monkeypatch.setenv("MLFLOW_ENABLE_TRACE_IN_SERVING", "false")

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -365,7 +365,7 @@ def _predict_with_callbacks(lc_model, request_id, data):
 
 
 def test_e2e_rag_model_tracing_in_serving(clear_singleton, monkeypatch):
-    monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
 
     llm_chain = create_openai_llmchain()
 
@@ -406,7 +406,7 @@ def test_e2e_rag_model_tracing_in_serving(clear_singleton, monkeypatch):
 
 
 def test_agent_success(clear_singleton, monkeypatch):
-    monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
 
     agent = create_openai_llmagent()
     langchain_input = {"input": "What is 123 raised to the .023 power?"}
@@ -457,7 +457,7 @@ def test_agent_success(clear_singleton, monkeypatch):
 
 
 def test_tool_success(clear_singleton, monkeypatch):
-    monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
     prompt = SystemMessagePromptTemplate.from_template("You are a nice assistant.") + "{question}"
     llm = OpenAI(temperature=0.9)
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -165,7 +165,7 @@ def test_trace_with_databricks_tracking_uri(
 
 
 def test_trace_in_databricks_model_serving(clear_singleton, monkeypatch):
-    monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
 
     # Dummy flask app for prediction
     import flask

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -32,7 +32,7 @@ def test_span_processor_and_exporter_default():
 
 
 def test_span_processor_and_exporter_model_serving(monkeypatch):
-    monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "True")
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "True")
 
     _TRACER_PROVIDER_INITIALIZED._done = False
     tracer = _get_tracer("test")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12064?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12064/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12064
```

</p>
</details>

### What changes are proposed in this pull request?

The env var `IS_IN_DATABRICKS_MODEL_SERVING_ENV` caused issue in JSL model loading (ES-1080421) due to the incorrect check using env var name (https://github.com/JohnSnowLabs/johnsnowlabs/pull/1222. We've filed a patch for new MLflow version and JSL, but we also need to rename the env var to address the issue for existing models.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
