### PR TITLE
Catch JSON parse errors when deserializing log-model tags

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.test.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.test.tsx
@@ -705,6 +705,43 @@ test('getLoggedModelsFromTags should not crash on invalid JSON', () => {
   expect(models.length).toEqual(0);
 });
 
+test('mergeLoggedAndRegisteredModels should merge logged and registered model', () => {
+  const tags = {
+    'mlflow.log-model.history': (RunTag as any).fromJs({
+      key: 'mlflow.log-model.history',
+      value: JSON.stringify([
+        {
+          run_id: 'run-uuid',
+          artifact_path: 'somePath',
+          utc_time_created: '2020-10-31',
+          flavors: { keras: {}, python_function: {} },
+        },
+      ]),
+    }),
+  };
+  const modelVersions = [
+    {
+      name: 'someModel',
+      version: '3',
+      source: 'nananaBatman/artifacts/somePath',
+      creation_timestamp: 123456,
+      run_id: 'run-uuid',
+    },
+  ];
+  const loggedModels = Utils.getLoggedModelsFromTags(tags);
+  const models = Utils.mergeLoggedAndRegisteredModels(loggedModels, modelVersions);
+  expect(models).toEqual([
+    {
+      artifactPath: 'somePath',
+      flavors: ['keras'],
+      utcTimeCreated: 1604102400,
+      registeredModelName: 'someModel',
+      registeredModelVersion: '3',
+      registeredModelCreationTimestamp: 123456,
+    },
+  ]);
+})
+
 test('mergeLoggedAndRegisteredModels should output 2 logged and 1 registered model', () => {
   const tags = {
     'mlflow.log-model.history': (RunTag as any).fromJs({

--- a/mlflow/server/js/src/common/utils/Utils.test.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.test.tsx
@@ -740,7 +740,7 @@ test('mergeLoggedAndRegisteredModels should merge logged and registered model', 
       registeredModelCreationTimestamp: 123456,
     },
   ]);
-})
+});
 
 test('mergeLoggedAndRegisteredModels should output 2 logged and 1 registered model', () => {
   const tags = {

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -889,7 +889,16 @@ class Utils {
   }[] {
     const modelsTag = tags[Utils.loggedModelsTag];
     if (modelsTag) {
-      const models = JSON.parse(modelsTag.value);
+      let models = null;
+      try {
+        models = JSON.parse(modelsTag.value);
+      } catch (e) {
+        // TODO: for now, we ignore parsing errors to prevent
+        // crashing the page. However, we should come up with
+        // a better solution (e.g. keep only the last X entries
+        // to prevent exceeding tag value limits).
+        // See https://github.com/mlflow/mlflow/issues/12032
+      }
       if (models) {
         // extract artifact path, flavors and creation time from tag.
         // 'python_function' should be interpreted as pyfunc flavor


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/12075?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12075/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12075
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #12032

### What changes are proposed in this pull request?

Quick fix to resolve the problem described in #12032

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
$ yarn test src/common/utils/Utils.test.tsx
 PASS  src/common/utils/Utils.test.tsx
  ✓ formatMetric (3 ms)
  ✓ formatDuration (1 ms)
  ✓ getDuration (1 ms)
  ✓ baseName
  ✓ renderNotebookSource (3 ms)
  ✓ renderJobSource (1 ms)
  ✓ formatSource & renderSource (1 ms)
  ✓ setQueryParams (1 ms)
  ✓ ensureUrlScheme
  ✓ addQueryParams (2 ms)
  ✓ getDefaultJobRunName
  ✓ getDefaultNotebookRevisionName (1 ms)
  ✓ dropExtension
  ✓ getGitHubRegex
  ✓ getGitLabRegex (1 ms)
  ✓ getRegex
  ✓ getMetricPlotStateFromUrl (1 ms)
  ✓ getSearchParamsFromUrl (4 ms)
  ✓ getSearchUrlFromState (1 ms)
  ✓ compareExperiments (6 ms)
  ✓ normalize (1 ms)
  ✓ getLoggedModelsFromTags correctly parses run tag for logged models (1 ms)
  ✓ getLoggedModelsFromTags should correctly dedup and sort logged models
  ✓ getLoggedModelsFromTags should not crash on invalid JSON
  ✓ mergeLoggedAndRegisteredModels should merge logged and registered model (1 ms)
  ✓ mergeLoggedAndRegisteredModels should output 2 logged and 1 registered model
  ✓ mergeLoggedAndRegisteredModels should output registered models in order (2 ms)
  ✓ concatAndGroupArraysById
  ✓ isValidHttpUrl (1 ms)
```

| Before | After |
|--------|------|
| <img width="1714" alt="Screenshot 2024-05-21 at 8 30 53 AM" src="https://github.com/mlflow/mlflow/assets/148037680/001c14be-a4b7-4ca2-ae72-4e9200509290"> | <img width="1713" alt="Screenshot 2024-05-21 at 8 31 09 AM" src="https://github.com/mlflow/mlflow/assets/148037680/a21e9e33-8d1b-426f-8378-4426d0796117"> |

Added a console.error to the `catch` for testing, but left it empty for the final PR 

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
