### PR TITLE
Convert spans to non-live once completed

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -345,6 +345,15 @@ class LiveSpan(Span):
     def from_dict(cls, data: Dict[str, Any]) -> "Span":
         raise NotImplementedError("The `from_dict` method is not supported for the LiveSpan class.")
 
+    def to_completed_span(self) -> "Span":
+        """
+        Downcast the live span object to the immutable span.
+
+        :meta private:
+        """
+        # All state of the live span is already persisted in the OpenTelemetry span object.
+        return Span(self._span)
+
 
 class NoOpSpan(Span):
     """

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -345,7 +345,7 @@ class LiveSpan(Span):
     def from_dict(cls, data: Dict[str, Any]) -> "Span":
         raise NotImplementedError("The `from_dict` method is not supported for the LiveSpan class.")
 
-    def to_completed_span(self) -> "Span":
+    def to_immutable_span(self) -> "Span":
         """
         Downcast the live span object to the immutable span.
 

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -26,7 +26,7 @@ class _Trace:
     def to_mlflow_trace(self) -> Trace:
         trace_data = TraceData()
         for span in self.span_dict.values():
-            trace_data.spans.append(span)
+            trace_data.spans.append(span.to_completed_span())
             if span.parent_id is None:
                 # Accessing the OTel span directly get serialized value directly.
                 trace_data.request = span._span.attributes.get(SpanAttributeKey.INPUTS)

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -26,7 +26,8 @@ class _Trace:
     def to_mlflow_trace(self) -> Trace:
         trace_data = TraceData()
         for span in self.span_dict.values():
-            trace_data.spans.append(span.to_completed_span())
+            # Convert LiveSpan, mutable objects, into immutable Span objects before persisting.
+            trace_data.spans.append(span.to_immutable_span())
             if span.parent_id is None:
                 # Accessing the OTel span directly get serialized value directly.
                 trace_data.request = span._span.attributes.get(SpanAttributeKey.INPUTS)

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -154,6 +154,38 @@ def test_dict_conversion(clear_singleton):
         recovered_span.set_status("OK")
 
 
+def test_completed_span(clear_singleton):
+    request_id = "tr-12345"
+
+    tracer = _get_tracer("test")
+    with tracer.start_as_current_span("parent") as parent_span:
+        live_span = LiveSpan(parent_span, request_id=request_id, span_type=SpanType.LLM)
+        live_span.set_inputs({"input": 1})
+        live_span.set_outputs(2)
+        live_span.set_attribute("key", 3)
+        live_span.set_status("OK")
+        live_span.add_event(SpanEvent("test_event", timestamp=0, attributes={"foo": "bar"}))
+
+    span = live_span.to_completed_span()
+
+    assert isinstance(span, Span)
+    assert span.request_id == request_id
+    assert span._trace_id == encode_trace_id(parent_span.context.trace_id)
+    assert span.span_id == encode_span_id(parent_span.context.span_id)
+    assert span.name == "parent"
+    assert span.start_time_ns == parent_span.start_time
+    assert span.end_time_ns is not None
+    assert span.parent_id is None
+    assert span.inputs == {"input": 1}
+    assert span.outputs == 2
+    assert span.get_attribute("key") == 3
+    assert span.status == SpanStatus(SpanStatusCode.OK, description="")
+    assert span.events == [SpanEvent("test_event", timestamp=0, attributes={"foo": "bar"})]
+
+    with pytest.raises(AttributeError, match="set_attribute"):
+        span.set_attribute("OK")
+
+
 def test_from_dict_raises_when_request_id_is_empty():
     with pytest.raises(MlflowException, match=r"Failed to create a Span object from "):
         Span.from_dict(

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -154,7 +154,7 @@ def test_dict_conversion(clear_singleton):
         recovered_span.set_status("OK")
 
 
-def test_completed_span(clear_singleton):
+def test_to_immutable_span(clear_singleton):
     request_id = "tr-12345"
 
     tracer = _get_tracer("test")
@@ -166,7 +166,7 @@ def test_completed_span(clear_singleton):
         live_span.set_status("OK")
         live_span.add_event(SpanEvent("test_event", timestamp=0, attributes={"foo": "bar"}))
 
-    span = live_span.to_completed_span()
+    span = live_span.to_immutable_span()
 
     assert isinstance(span, Span)
     assert span.request_id == request_id

--- a/tests/tracing/test_trace_manager.py
+++ b/tests/tracing/test_trace_manager.py
@@ -2,7 +2,7 @@ import time
 from threading import Thread
 from typing import Optional
 
-from mlflow.entities import LiveSpan, Trace
+from mlflow.entities import LiveSpan, Span, Trace
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 
 from tests.tracing.helper import create_mock_otel_span, create_test_trace_info
@@ -56,6 +56,10 @@ def test_add_spans():
     assert trace.info.request_id == request_id_1
     assert len(trace.data.spans) == 3
     assert request_id_1 not in trace_manager._traces
+
+    # The popped trace should only contain non-live (immutable) spans
+    assert isinstance(trace.data.spans[0], Span)
+    assert not isinstance(trace.data.spans[0], LiveSpan)
 
     trace = trace_manager.pop_trace(trace_id_2)
     assert isinstance(trace, Trace)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12078?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12078/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12078
```

</p>
</details>

### What changes are proposed in this pull request?

We have two type of spans - LiveSpan (mutable) and non-live Span (immutable). The LiveSpan is only present until the span is finished. However, currently we don't convert it to non-live Span so users can still access LiveSpan after its completion. As shown in the example below, the trace extracted from the in-memory trace buffer contains LiveSpan. This PR fixes the bug to avoid confusion and unexpected mutation.

```
with mlflow.start_span(...) as span: # <- This gives LiveSpan (ok)
    span.set_attribute("key", "value)

# Fetching span from in-memory buffer
trace = mlflow.get_trace(request_id="foo_id")
span = trace.data.spans[0] # <- This currently gives LiveSpan, but should be non-live Span

# Fetching span from backend
trace = MlflowClient().get_trace(request_id="foo_id")
span = trace.data.spans[0] # <- This gives non-live Span (ok)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Verified in staging notebook.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
