### PR TITLE
Auto set prediction_context for offline prediction

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -726,8 +726,7 @@ class PyFuncModel:
         # set context for prediction if it's not set
         # NB: in model serving the prediction context must be set
         # with a request_id
-        if (context := _try_get_prediction_context()) is None:
-            context = Context()
+        context = _try_get_prediction_context() or Context()
         with set_prediction_context(context):
             yield context
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -380,7 +380,6 @@ In summary, use the function-based Model when you have a simple function to seri
 If you need more power, use  the class-based model.
 
 """
-
 import collections
 import functools
 import importlib
@@ -394,6 +393,7 @@ import sys
 import tempfile
 import threading
 import warnings
+from contextlib import contextmanager
 from copy import deepcopy
 from functools import lru_cache
 from pathlib import Path
@@ -452,7 +452,7 @@ from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     LineageHeaderInfo,
     Notebook,
 )
-from mlflow.pyfunc.context import get_prediction_context
+from mlflow.pyfunc.context import Context, set_prediction_context
 from mlflow.pyfunc.model import (
     ChatModel,
     PythonModel,
@@ -462,6 +462,7 @@ from mlflow.pyfunc.model import (
     get_default_conda_env,  # noqa: F401
     get_default_pip_requirements,
 )
+from mlflow.tracing.utils import _try_get_prediction_context
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.llm import (
@@ -710,8 +711,8 @@ class PyFuncModel:
             )
         return data, params
 
-    def _update_dependencies_schemas_in_prediction_context(self):
-        if self._model_meta and self._model_meta.metadata and (context := get_prediction_context()):
+    def _update_dependencies_schemas_in_prediction_context(self, context: Context):
+        if self._model_meta and self._model_meta.metadata:
             dependencies_schemas = self._model_meta.metadata.get("dependencies_schemas", {})
             context.update(
                 dependencies_schemas={
@@ -720,7 +721,22 @@ class PyFuncModel:
                 }
             )
 
+    @contextmanager
+    def _try_get_or_generate_prediction_context(self):
+        # set context for prediction if it's not set
+        # NB: in model serving the prediction context must be set
+        # with a request_id
+        if (context := _try_get_prediction_context()) is None:
+            context = Context()
+        with set_prediction_context(context):
+            yield context
+
     def predict(self, data: PyFuncInput, params: Optional[Dict[str, Any]] = None) -> PyFuncOutput:
+        with self._try_get_or_generate_prediction_context() as context:
+            self._update_dependencies_schemas_in_prediction_context(context)
+            return self._predict(data, params)
+
+    def _predict(self, data: PyFuncInput, params: Optional[Dict[str, Any]] = None) -> PyFuncOutput:
         """
         Generates model predictions.
 
@@ -748,7 +764,6 @@ class PyFuncModel:
         Returns:
             Model predictions as one of pandas.DataFrame, pandas.Series, numpy.ndarray or list.
         """
-        self._update_dependencies_schemas_in_prediction_context()
         data, params = self._validate_prediction_input(data, params)
         if inspect.signature(self._predict_fn).parameters.get("params"):
             return self._predict_fn(data, params=params)
@@ -757,6 +772,13 @@ class PyFuncModel:
         return self._predict_fn(data)
 
     def predict_stream(
+        self, data: PyFuncLLMSingleInput, params: Optional[Dict[str, Any]] = None
+    ) -> Iterator[PyFuncLLMOutputChunk]:
+        with self._try_get_or_generate_prediction_context() as context:
+            self._update_dependencies_schemas_in_prediction_context(context)
+            return self._predict_stream(data, params)
+
+    def _predict_stream(
         self, data: PyFuncLLMSingleInput, params: Optional[Dict[str, Any]] = None
     ) -> Iterator[PyFuncLLMOutputChunk]:
         """
@@ -779,7 +801,6 @@ class PyFuncModel:
         if self._predict_stream_fn is None:
             raise MlflowException("This model does not support predict_stream method.")
 
-        self._update_dependencies_schemas_in_prediction_context()
         data, params = self._validate_prediction_input(data, params)
         data = _convert_llm_input_data(data)
         if isinstance(data, list):

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -13,7 +13,7 @@ _PREDICTION_REQUEST_CTX = ContextVar("mlflow_prediction_request_context", defaul
 @dataclass
 class Context:
     # A unique identifier for the current prediction request.
-    request_id: str
+    request_id: Optional[str] = None
     # Whether the current prediction request is as a part of MLflow model evaluation.
     is_evaluate: bool = False
     # The schema of the dependencies to be added into the tag of trace info.

--- a/mlflow/tracing/utils.py
+++ b/mlflow/tracing/utils.py
@@ -178,9 +178,10 @@ def maybe_get_request_id(is_evaluate=False) -> Optional[str]:
     if not context or (is_evaluate and not context.is_evaluate):
         return None
 
-    if not context.request_id:
+    if not context.request_id and is_evaluate:
         raise MlflowException(
-            f"Missing request_id for context {context}.",
+            f"Missing request_id for context {context}. "
+            "request_id can't be None when is_evaluate=True.",
             error_code=BAD_REQUEST,
         )
 

--- a/tests/pyfunc/sample_code/code_with_dependencies.py
+++ b/tests/pyfunc/sample_code/code_with_dependencies.py
@@ -4,7 +4,7 @@ import mlflow
 from mlflow.models import set_model, set_retriever_schema
 from mlflow.pyfunc import PythonModel
 
-test_trace = os.environ.get("TEST_TRACE", "false").lower() == "true"
+test_trace = os.environ.get("TEST_TRACE", "true").lower() == "true"
 
 
 class MyModel(PythonModel):

--- a/tests/pyfunc/sample_code/code_with_dependencies.py
+++ b/tests/pyfunc/sample_code/code_with_dependencies.py
@@ -1,9 +1,24 @@
+import os
+
 import mlflow
 from mlflow.models import set_model, set_retriever_schema
 from mlflow.pyfunc import PythonModel
 
+test_trace = os.environ.get("TEST_TRACE", "false").lower() == "true"
+
 
 class MyModel(PythonModel):
+    def _call_retriver(self, id):
+        return f"Retriever called with ID: {id}. Output: 42."
+
+    def predict(self, context, model_input):
+        return f"Input: {model_input}. {self._call_retriver(model_input)}"
+
+    def predict_stream(self, context, model_input, params=None):
+        yield f"Input: {model_input}. {self._call_retriver(model_input)}"
+
+
+class MyModelWithTrace(PythonModel):
     def _call_retriver(self, id):
         return f"Retriever called with ID: {id}. Output: 42."
 
@@ -16,7 +31,8 @@ class MyModel(PythonModel):
         yield f"Input: {model_input}. {self._call_retriver(model_input)}"
 
 
-set_model(MyModel())
+model = MyModelWithTrace() if test_trace else MyModel()
+set_model(model)
 set_retriever_schema(
     primary_key="primary-key",
     text_column="text-column",

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1833,8 +1833,9 @@ def test_pyfunc_as_code_with_dependencies():
 
 
 @pytest.mark.parametrize("is_in_db_model_serving", ["true", "false"])
+@pytest.mark.parametrize("stream", [True, False])
 def test_pyfunc_as_code_with_dependencies_store_dependencies_schemas_in_trace(
-    clear_singleton, monkeypatch, is_in_db_model_serving
+    clear_singleton, monkeypatch, is_in_db_model_serving, stream
 ):
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", is_in_db_model_serving)
     is_in_db_model_serving = is_in_db_model_serving == "true"
@@ -1848,9 +1849,61 @@ def test_pyfunc_as_code_with_dependencies_store_dependencies_schemas_in_trace(
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     model_input = "user_123"
     expected_output = f"Input: {model_input}. Retriever called with ID: {model_input}. Output: 42."
+    func = loaded_model.predict_stream if stream else loaded_model.predict
+
+    def _get_result(output):
+        return next(output) if stream else output
+
     if is_in_db_model_serving:
         with set_prediction_context(Context(request_id="1234")):
-            assert loaded_model.predict(model_input) == expected_output
+            assert _get_result(func(model_input)) == expected_output
+    else:
+        assert _get_result(func(model_input)) == expected_output
+
+    pyfunc_model_path = _download_artifact_from_uri(model_info.model_uri)
+    reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
+    expected_dependencies_schemas = {
+        DependenciesSchemasType.RETRIEVERS.value: [
+            {
+                "doc_uri": "doc-uri",
+                "name": "retriever",
+                "other_columns": ["column1", "column2"],
+                "primary_key": "primary-key",
+                "text_column": "text-column",
+            }
+        ]
+    }
+    assert reloaded_model.metadata["dependencies_schemas"] == expected_dependencies_schemas
+
+    if is_in_db_model_serving:
+        trace_dict = pop_trace("1234")
+        trace = Trace.from_dict(trace_dict)
+        assert trace.info.request_id == "1234"
+    else:
+        trace = get_traces()[0]
+    assert trace.info.tags[DependenciesSchemasType.RETRIEVERS.value] == json.dumps(
+        expected_dependencies_schemas[DependenciesSchemasType.RETRIEVERS.value]
+    )
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_no_traces_collected_for_pyfunc_as_code_with_dependencies_if_no_tracing_enabled(
+    clear_singleton, monkeypatch, stream
+):
+    # This sets model without trace inside code_with_dependencies.py file
+    monkeypatch.setenv("TEST_TRACE", "false")
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model="tests/pyfunc/sample_code/code_with_dependencies.py",
+            artifact_path="model",
+            pip_requirements=["pandas"],
+        )
+
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    model_input = "user_123"
+    expected_output = f"Input: {model_input}. Retriever called with ID: {model_input}. Output: 42."
+    if stream:
+        assert next(loaded_model.predict_stream(model_input)) == expected_output
     else:
         assert loaded_model.predict(model_input) == expected_output
 
@@ -1869,63 +1922,9 @@ def test_pyfunc_as_code_with_dependencies_store_dependencies_schemas_in_trace(
     }
     assert reloaded_model.metadata["dependencies_schemas"] == expected_dependencies_schemas
 
-    if is_in_db_model_serving:
-        trace_dict = pop_trace("1234")
-        trace = Trace.from_dict(trace_dict)
-        assert trace.info.request_id == "1234"
-    else:
-        trace = get_traces()[0]
-    assert trace.info.tags[DependenciesSchemasType.RETRIEVERS.value] == json.dumps(
-        expected_dependencies_schemas[DependenciesSchemasType.RETRIEVERS.value]
-    )
-
-
-@pytest.mark.parametrize("is_in_db_model_serving", ["true", "false"])
-def test_pyfunc_as_code_with_dependencies_store_dependencies_schemas_in_trace_stream(
-    clear_singleton, monkeypatch, is_in_db_model_serving
-):
-    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", is_in_db_model_serving)
-    is_in_db_model_serving = is_in_db_model_serving == "true"
-    with mlflow.start_run():
-        model_info = mlflow.pyfunc.log_model(
-            python_model="tests/pyfunc/sample_code/code_with_dependencies.py",
-            artifact_path="model",
-            pip_requirements=["pandas"],
-        )
-
-    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    model_input = "user_123"
-    expected_output = f"Input: {model_input}. Retriever called with ID: {model_input}. Output: 42."
-    if is_in_db_model_serving:
-        with set_prediction_context(Context(request_id="1234")):
-            assert next(loaded_model.predict_stream(model_input)) == expected_output
-    else:
-        assert next(loaded_model.predict_stream(model_input)) == expected_output
-
-    pyfunc_model_path = _download_artifact_from_uri(model_info.model_uri)
-    reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
-    expected_dependencies_schemas = {
-        DependenciesSchemasType.RETRIEVERS.value: [
-            {
-                "doc_uri": "doc-uri",
-                "name": "retriever",
-                "other_columns": ["column1", "column2"],
-                "primary_key": "primary-key",
-                "text_column": "text-column",
-            }
-        ]
-    }
-    assert reloaded_model.metadata["dependencies_schemas"] == expected_dependencies_schemas
-
-    if is_in_db_model_serving:
-        trace_dict = pop_trace("1234")
-        trace = Trace.from_dict(trace_dict)
-        assert trace.info.request_id == "1234"
-    else:
-        trace = get_traces()[0]
-    assert trace.info.tags[DependenciesSchemasType.RETRIEVERS.value] == json.dumps(
-        expected_dependencies_schemas[DependenciesSchemasType.RETRIEVERS.value]
-    )
+    # no traces will be logged at all
+    traces = get_traces()
+    assert len(traces) == 0
 
 
 def test_pyfunc_as_code_log_and_load_wrong_path():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12084?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12084/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12084
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We want to align online predict and offline predict UJ.
To make sure the same dependencies_schemas can propagate in both cases, we should auto-detect prediction_context in pyfunc predict/predict_stream. If there's no context then we create an empty context without request_id, and potentially store dependencies_schemas within the context.
NB: we don't pass request_id in context for offline predict because the request_id should always be generated by backend store.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
