### PR TITLE
Adding `name` as a parameter for retriever schemas

### DIFF
--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -6,10 +6,11 @@ from typing import Dict, List, Optional
 
 from mlflow.utils.annotations import experimental
 
-DATABRICKS_RETRIEVER_PRIMARY_KEY = "__databricks_retriever_primary_key__"
-DATABRICKS_RETRIEVER_TEXT_COLUMN = "__databricks_retriever_text_column__"
-DATABRICKS_RETRIEVER_DOC_URI = "__databricks_retriever_doc_uri__"
-DATABRICKS_RETRIEVER_OTHER_COLUMNS = "__databricks_retriever_other_columns__"
+_RETRIEVER_PRIMARY_KEY = "__retriever_primary_key__"
+_RETRIEVER_TEXT_COLUMN = "__retriever_text_column__"
+_RETRIEVER_DOC_URI = "__retriever_doc_uri__"
+_RETRIEVER_OTHER_COLUMNS = "__retriever_other_columns__"
+_RETRIEVER_NAME = "__retriever_name__"
 
 
 class DependenciesSchemasType(Enum):
@@ -22,10 +23,12 @@ class DependenciesSchemasType(Enum):
 
 @experimental
 def set_retriever_schema(
+    *,
     primary_key: str,
     text_column: str,
     doc_uri: Optional[str] = None,
     other_columns: Optional[List[str]] = None,
+    name: Optional[str] = "retriever",
 ):
     """
     After defining your vector store in a Python file or notebook, call
@@ -34,12 +37,12 @@ def set_retriever_schema(
     determine which fields correspond to the document text, document URI, etc.
 
     Args:
-        primary_key: The primary key of the vector index.
+        primary_key: The primary key of the retriever or vector index.
         text_column: The name of the text column to use for the embeddings.
         doc_uri: The name of the column that contains the document URI.
         other_columns: A list of other columns that are part of the vector index
                           that need to be retrieved during trace logging.
-        Note: Make sure the text column specified is in the index.
+        name: The name of the retriever or vector store.
 
     .. code-block:: Python
             :caption: Example
@@ -53,10 +56,11 @@ def set_retriever_schema(
                 other_columns=["title"],
             )
     """
-    globals()[DATABRICKS_RETRIEVER_PRIMARY_KEY] = primary_key
-    globals()[DATABRICKS_RETRIEVER_TEXT_COLUMN] = text_column
-    globals()[DATABRICKS_RETRIEVER_DOC_URI] = doc_uri
-    globals()[DATABRICKS_RETRIEVER_OTHER_COLUMNS] = other_columns or []
+    globals()[_RETRIEVER_PRIMARY_KEY] = primary_key
+    globals()[_RETRIEVER_TEXT_COLUMN] = text_column
+    globals()[_RETRIEVER_DOC_URI] = doc_uri
+    globals()[_RETRIEVER_OTHER_COLUMNS] = other_columns or []
+    globals()[_RETRIEVER_NAME] = name
 
 
 def _get_retriever_schema():
@@ -66,18 +70,18 @@ def _get_retriever_schema():
     Returns:
         VectorSearchIndex: The vector search index schema.
     """
-    if not globals().get(DATABRICKS_RETRIEVER_PRIMARY_KEY, None) or not globals().get(
-        DATABRICKS_RETRIEVER_TEXT_COLUMN, None
+    if not globals().get(_RETRIEVER_PRIMARY_KEY, None) or not globals().get(
+        _RETRIEVER_TEXT_COLUMN, None
     ):
         return []
 
     return [
         RetrieverSchema(
-            name="retriever",
-            primary_key=globals().get(DATABRICKS_RETRIEVER_PRIMARY_KEY, None),
-            text_column=globals().get(DATABRICKS_RETRIEVER_TEXT_COLUMN, None),
-            doc_uri=globals().get(DATABRICKS_RETRIEVER_DOC_URI, None),
-            other_columns=globals().get(DATABRICKS_RETRIEVER_OTHER_COLUMNS, None),
+            name=globals().get(_RETRIEVER_NAME, None),
+            primary_key=globals().get(_RETRIEVER_PRIMARY_KEY, None),
+            text_column=globals().get(_RETRIEVER_TEXT_COLUMN, None),
+            doc_uri=globals().get(_RETRIEVER_DOC_URI, None),
+            other_columns=globals().get(_RETRIEVER_OTHER_COLUMNS, None),
         )
     ]
 
@@ -86,10 +90,11 @@ def _clear_retriever_schema():
     """
     Clear the vector search schema defined by the user.
     """
-    globals().pop(DATABRICKS_RETRIEVER_PRIMARY_KEY, None)
-    globals().pop(DATABRICKS_RETRIEVER_TEXT_COLUMN, None)
-    globals().pop(DATABRICKS_RETRIEVER_DOC_URI, None)
-    globals().pop(DATABRICKS_RETRIEVER_OTHER_COLUMNS, None)
+    globals().pop(_RETRIEVER_PRIMARY_KEY, None)
+    globals().pop(_RETRIEVER_TEXT_COLUMN, None)
+    globals().pop(_RETRIEVER_DOC_URI, None)
+    globals().pop(_RETRIEVER_OTHER_COLUMNS, None)
+    globals().pop(_RETRIEVER_NAME, None)
 
 
 def _clear_dependencies_schemas():

--- a/tests/models/test_dependencies_schema.py
+++ b/tests/models/test_dependencies_schema.py
@@ -106,6 +106,34 @@ def test_set_retriever_schema_creation():
             ]
         }
 
+    # Schema is automatically reset
+    with _get_dependencies_schemas() as schema:
+        assert schema.to_dict() is None
+    assert _get_retriever_schema() == []
+
+
+def test_set_retriever_schema_creation_with_name():
+    set_retriever_schema(
+        name="my_ret_2",
+        primary_key="primary-key",
+        text_column="text-column",
+        doc_uri="doc-uri",
+        other_columns=["column1", "column2"],
+    )
+    with _get_dependencies_schemas() as schema:
+        assert schema.retriever_schemas[0].to_dict() == {
+            DependenciesSchemasType.RETRIEVERS.value: [
+                {
+                    "doc_uri": "doc-uri",
+                    "name": "my_ret_2",
+                    "other_columns": ["column1", "column2"],
+                    "primary_key": "primary-key",
+                    "text_column": "text-column",
+                }
+            ]
+        }
+
+    # Schema is automatically reset
     with _get_dependencies_schemas() as schema:
         assert schema.to_dict() is None
     assert _get_retriever_schema() == []


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mparkhe/mlflow/pull/12098?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12098/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12098
```

</p>
</details>

### What changes are proposed in this pull request?
Adding `name` as a parameter for retriever schemas and making all arguments as named arguments.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
