### PR TITLE
Fix `FileStore.search_traces` when traces directory doesn't exist

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1685,6 +1685,8 @@ class FileStore(AbstractStore):
     def _list_trace_infos(self, experiment_id):
         experiment_path = self._get_experiment_path(experiment_id, assert_exists=True)
         traces_path = os.path.join(experiment_path, FileStore.TRACES_FOLDER_NAME)
+        if not os.path.exists(traces_path):
+            return []
         trace_paths = list_all(traces_path, lambda x: os.path.isdir(x), full_path=True)
         trace_infos = []
         for trace_path in trace_paths:

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2909,6 +2909,11 @@ def _validate_search_traces(store, exp_ids, filter_string, expected_traces, orde
     assert traces == expected_traces
 
 
+def test_search_traces(store):
+    traces, _token = store.search_traces(["0"])
+    assert traces == []
+
+
 def test_search_traces_filter(generate_trace_infos):
     trace_infos = generate_trace_infos.trace_infos
     store = generate_trace_infos.store


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12104?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12104/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12104
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix the following error when `mlflow.search_traces` is called when `traces` directory doesn't not exist.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/tracing/fluent.py", line 316, in search_traces
    results = get_results_from_paginated_fn(
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/utils/__init__.py", line 271, in get_results_from_paginated_fn
    page_results = paginated_fn(max_results_per_page, next_page_token)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/tracing/fluent.py", line 308, in pagination_wrapper_func
    return MlflowClient().search_traces(
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/tracking/client.py", line 482, in search_traces
    traces = self._tracking_client.search_traces(
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/tracking/_tracking_service/client.py", line 337, in search_traces
    trace_infos, next_token = self._search_traces(
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/tracking/_tracking_service/client.py", line 299, in _search_traces
    return self.store.search_traces(
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/store/tracking/file_store.py", line 1678, in search_traces
    trace_infos = self._list_trace_infos(experiment_id)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/store/tracking/file_store.py", line 1688, in _list_trace_infos
    trace_paths = list_all(traces_path, lambda x: os.path.isdir(x), full_path=True)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 145, in list_all
    raise Exception(f"Invalid parent directory '{root}'")
Exception: Invalid parent directory '/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlruns/0/traces'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
