### PR TITLE
Use `getUserLocalTempDir` and `getUserNFSTempDir` to replace `getReplLocalTempDir` and `getReplNFSTempDir` in databricks runtime

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,6 +1,6 @@
 import functools
-import json
 import getpass
+import json
 import logging
 import os
 import subprocess
@@ -949,7 +949,7 @@ if is_in_databricks_runtime():
 
 def get_databricks_nfs_temp_dir():
     entry_point = _get_dbutils().entry_point
-    if getpass.getuser() == 'ROOT':
+    if getpass.getuser() == "ROOT":
         return entry_point.getReplNFSTempDir()
     else:
         try:
@@ -964,7 +964,7 @@ def get_databricks_nfs_temp_dir():
 
 def get_databricks_local_temp_dir():
     entry_point = _get_dbutils().entry_point
-    if getpass.getuser() == 'ROOT':
+    if getpass.getuser() == "ROOT":
         return entry_point.getReplLocalTempDir()
     else:
         try:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -947,14 +947,14 @@ if is_in_databricks_runtime():
         pass
 
 
-def get_databricks_nfs_tmp_dir():
+def get_databricks_nfs_temp_dir():
     entry_point = _get_dbutils().entry_point
     if getpass.getuser() == 'ROOT':
         return entry_point.getReplNFSTempDir()
     else:
         try:
-            # If it is not ROOT user, it means the code runs in Safe-spark.
-            # in this case, we should get temporary directory of current user.
+            # If it is not ROOT user, it means the code is running in Safe-spark.
+            # In this case, we should get temporary directory of current user.
             # and `getReplNFSTempDir` will be deprecated for this case.
             return entry_point.getUserNFSTempDir()
         except Exception:
@@ -962,14 +962,14 @@ def get_databricks_nfs_tmp_dir():
             return entry_point.getReplNFSTempDir()
 
 
-def get_databricks_local_tmp_dir():
+def get_databricks_local_temp_dir():
     entry_point = _get_dbutils().entry_point
     if getpass.getuser() == 'ROOT':
         return entry_point.getReplLocalTempDir()
     else:
         try:
-            # If it is not ROOT user, it means the code runs in Safe-spark.
-            # in this case, we should get temporary directory of current user.
+            # If it is not ROOT user, it means the code is running in Safe-spark.
+            # In this case, we should get temporary directory of current user.
             # and `getReplLocalTempDir` will be deprecated for this case.
             return entry_point.getUserLocalTempDir()
         except Exception:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import getpass
 import logging
 import os
 import subprocess
@@ -944,3 +945,33 @@ if is_in_databricks_runtime():
         # in this case, we don't need to initialize databricks token because
         # there is no backend mlflow service available.
         pass
+
+
+def get_databricks_nfs_tmp_dir():
+    entry_point = _get_dbutils().entry_point
+    if getpass.getuser() == 'ROOT':
+        return entry_point.getReplNFSTempDir()
+    else:
+        try:
+            # If it is not ROOT user, it means the code runs in Safe-spark.
+            # in this case, we should get temporary directory of current user.
+            # and `getReplNFSTempDir` will be deprecated for this case.
+            return entry_point.getUserNFSTempDir()
+        except Exception:
+            # fallback
+            return entry_point.getReplNFSTempDir()
+
+
+def get_databricks_local_tmp_dir():
+    entry_point = _get_dbutils().entry_point
+    if getpass.getuser() == 'ROOT':
+        return entry_point.getReplLocalTempDir()
+    else:
+        try:
+            # If it is not ROOT user, it means the code runs in Safe-spark.
+            # in this case, we should get temporary directory of current user.
+            # and `getReplLocalTempDir` will be deprecated for this case.
+            return entry_point.getUserLocalTempDir()
+        except Exception:
+            # fallback
+            return entry_point.getReplLocalTempDir()

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -50,8 +50,8 @@ from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 from mlflow.utils import download_cloud_file_chunk, merge_dicts
 from mlflow.utils.databricks_utils import (
     _get_dbutils,
-    get_databricks_local_tmp_dir,
-    get_databricks_nfs_tmp_dir,
+    get_databricks_local_temp_dir,
+    get_databricks_nfs_temp_dir,
 )
 from mlflow.utils.os import is_windows
 from mlflow.utils.process import cache_return_value_per_process
@@ -862,7 +862,7 @@ def _get_tmp_dir():
 
     if is_in_databricks_runtime():
         try:
-            return get_databricks_local_tmp_dir()
+            return get_databricks_local_temp_dir()
         except Exception:
             pass
 
@@ -894,7 +894,7 @@ def get_or_create_tmp_dir():
         # The temp directory is designed to be used by all kinds of applications,
         # so create a child directory "mlflow" for storing mlflow temp data.
         try:
-            repl_local_tmp_dir = get_databricks_local_tmp_dir()
+            repl_local_tmp_dir = get_databricks_local_temp_dir()
         except Exception:
             repl_local_tmp_dir = os.path.join("/tmp", "repl_tmp_data", get_repl_id())
 
@@ -927,7 +927,7 @@ def get_or_create_nfs_tmp_dir():
         # The temp directory is designed to be used by all kinds of applications,
         # so create a child directory "mlflow" for storing mlflow temp data.
         try:
-            repl_nfs_tmp_dir = get_databricks_nfs_tmp_dir()
+            repl_nfs_tmp_dir = get_databricks_nfs_temp_dir()
         except Exception:
             repl_nfs_tmp_dir = os.path.join(nfs_root_dir, "repl_tmp_data", get_repl_id())
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -48,7 +48,11 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MissingConfigException, MlflowException
 from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 from mlflow.utils import download_cloud_file_chunk, merge_dicts
-from mlflow.utils.databricks_utils import _get_dbutils
+from mlflow.utils.databricks_utils import (
+    _get_dbutils,
+    get_databricks_local_tmp_dir,
+    get_databricks_nfs_tmp_dir,
+)
 from mlflow.utils.os import is_windows
 from mlflow.utils.process import cache_return_value_per_process
 from mlflow.utils.request_utils import cloud_storage_http_request, download_chunk
@@ -858,7 +862,7 @@ def _get_tmp_dir():
 
     if is_in_databricks_runtime():
         try:
-            return _get_dbutils().entry_point.getReplLocalTempDir()
+            return get_databricks_local_tmp_dir()
         except Exception:
             pass
 
@@ -885,12 +889,12 @@ def get_or_create_tmp_dir():
 
     if is_in_databricks_runtime() and get_repl_id() is not None:
         # Note: For python process attached to databricks notebook, atexit does not work.
-        # The directory returned by `dbutils.entry_point.getReplLocalTempDir()`
+        # The directory returned by `get_databricks_local_tmp_dir`
         # will be removed once databricks notebook detaches.
         # The temp directory is designed to be used by all kinds of applications,
         # so create a child directory "mlflow" for storing mlflow temp data.
         try:
-            repl_local_tmp_dir = _get_dbutils().entry_point.getReplLocalTempDir()
+            repl_local_tmp_dir = get_databricks_local_tmp_dir()
         except Exception:
             repl_local_tmp_dir = os.path.join("/tmp", "repl_tmp_data", get_repl_id())
 
@@ -918,12 +922,12 @@ def get_or_create_nfs_tmp_dir():
 
     if is_in_databricks_runtime() and get_repl_id() is not None:
         # Note: In databricks, atexit hook does not work.
-        # The directory returned by `dbutils.entry_point.getReplNFSTempDir()`
+        # The directory returned by `get_databricks_nfs_tmp_dir`
         # will be removed once databricks notebook detaches.
         # The temp directory is designed to be used by all kinds of applications,
         # so create a child directory "mlflow" for storing mlflow temp data.
         try:
-            repl_nfs_tmp_dir = _get_dbutils().entry_point.getReplNFSTempDir()
+            repl_nfs_tmp_dir = get_databricks_nfs_tmp_dir()
         except Exception:
             repl_nfs_tmp_dir = os.path.join(nfs_root_dir, "repl_tmp_data", get_repl_id())
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -49,7 +49,6 @@ from mlflow.exceptions import MissingConfigException, MlflowException
 from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 from mlflow.utils import download_cloud_file_chunk, merge_dicts
 from mlflow.utils.databricks_utils import (
-    _get_dbutils,
     get_databricks_local_temp_dir,
     get_databricks_nfs_temp_dir,
 )

--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -4,9 +4,9 @@ import uuid
 
 from mlflow.utils._spark_utils import _get_active_spark_session
 from mlflow.utils.databricks_utils import (
+    get_databricks_nfs_temp_dir,
     is_in_databricks_runtime,
     is_in_databricks_serverless,
-    get_databricks_nfs_temp_dir,
 )
 
 # Set spark config "spark.mlflow.nfs.rootDir" to specify a NFS (network file system) directory

--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -4,9 +4,9 @@ import uuid
 
 from mlflow.utils._spark_utils import _get_active_spark_session
 from mlflow.utils.databricks_utils import (
-    _get_dbutils,
     is_in_databricks_runtime,
     is_in_databricks_serverless,
+    get_databricks_nfs_tmp_dir,
 )
 
 # Set spark config "spark.mlflow.nfs.rootDir" to specify a NFS (network file system) directory
@@ -35,8 +35,7 @@ def get_nfs_cache_root_dir():
             )
         if nfs_enabled:
             try:
-                # The directory `getReplNFSTempDir` returns has read/write permissions.
-                return _get_dbutils().entry_point.getReplNFSTempDir()
+                return get_databricks_nfs_tmp_dir()
             except Exception:
                 nfs_root_dir = "/local_disk0/.ephemeral_nfs"
                 # Test whether the NFS directory is writable.

--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -6,7 +6,7 @@ from mlflow.utils._spark_utils import _get_active_spark_session
 from mlflow.utils.databricks_utils import (
     is_in_databricks_runtime,
     is_in_databricks_serverless,
-    get_databricks_nfs_tmp_dir,
+    get_databricks_nfs_temp_dir,
 )
 
 # Set spark config "spark.mlflow.nfs.rootDir" to specify a NFS (network file system) directory
@@ -35,7 +35,7 @@ def get_nfs_cache_root_dir():
             )
         if nfs_enabled:
             try:
-                return get_databricks_nfs_tmp_dir()
+                return get_databricks_nfs_temp_dir()
             except Exception:
                 nfs_root_dir = "/local_disk0/.ephemeral_nfs"
                 # Test whether the NFS directory is writable.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12105?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12105/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12105
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Use `getUserLocalTempDir` and `getUserNFSTempDir` to replace `getReplLocalTempDir` and `getReplNFSTempDir` in databricks runtime

Context:

In Safe spark databricks runtime that runs DLT (delta lake table), temporary directory per REPL causes issues. One DLT pipeline might generate mulitple REPLs , but MLflow workloads might run across multiple REPLs in the same pipeline, this causes tmp directory per-REPL can't share temp files in the same pipeline.

So that in safe spark, we add temp directory per user API.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
