### PR TITLE
Patch langchain async APIs for autologging

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -958,10 +958,14 @@ def load_model(model_uri, dst_path=None):
 
 def _patch_runnable_cls(cls):
     """
-    For classes that are subclasses of Runnable, we patch the `invoke`, `batch`, and `stream`
-    methods for autologging.
+    For classes that are subclasses of Runnable, we patch the `invoke`, `batch`, `stream` and
+    `ainvoke`, `abatch`, `astream` methods for autologging.
+
+    Args:
+        cls: The class to patch.
     """
-    for func_name in ["invoke", "batch", "stream"]:
+    patch_functions = ["invoke", "batch", "stream", "ainvoke", "abatch", "astream"]
+    for func_name in patch_functions:
         if hasattr(cls, func_name):
             safe_patch(
                 FLAVOR_NAME,

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -680,6 +680,7 @@ langchain:
           "numexpr",
           "spacy",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
+          "pytest-asyncio", # for testing runnable async functions patches
         ]
     run: |
       # For MlflowCallback text analysis

--- a/mlflow/utils/openai_utils.py
+++ b/mlflow/utils/openai_utils.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from enum import Enum
 from typing import NamedTuple, Optional
 from unittest import mock
+from unittest.mock import AsyncMock
 
 import requests
 
@@ -164,6 +165,27 @@ def _mock_models_retrieve_response():
 def _mock_request(**kwargs):
     with mock.patch("requests.Session.request", **kwargs) as m:
         yield m
+
+
+@contextmanager
+def _mock_openai_arequest():
+    with mock.patch(
+        "aiohttp.ClientSession.request", side_effect=_mock_async_chat_completion_response
+    ) as mock_request:
+        yield mock_request
+
+
+async def _mock_async_chat_completion_response(content=TEST_CONTENT, **kwargs):
+    resp = AsyncMock()
+    json_data = _chat_completion_json_sample(content)
+    resp.status = 200
+    resp.content = json.dumps(json_data).encode()
+    resp.headers = {"Content-Type": "application/json"}
+    resp.text = mlflow.__version__
+    resp.json_data = json_data
+    resp.json.return_value = json_data
+    resp.read.return_value = resp.content
+    return resp
 
 
 @contextmanager

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -11,7 +11,10 @@ from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate
 from langchain.schema.runnable.config import RunnableConfig
 from langchain.text_splitter import CharacterTextSplitter
-from langchain_core.callbacks.base import BaseCallbackHandler, BaseCallbackManager
+from langchain_core.callbacks.base import (
+    BaseCallbackHandler,
+    BaseCallbackManager,
+)
 from test_langchain_model_export import FAISS, DeterministicDummyEmbeddings
 
 import mlflow
@@ -33,6 +36,7 @@ from mlflow.tracing.constant import SpanAttributeKey, TraceMetadataKey, TraceTag
 from mlflow.utils.openai_utils import (
     TEST_CONTENT,
     _mock_chat_completion_response,
+    _mock_openai_arequest,
     _mock_request,
     _MockResponse,
 )
@@ -787,6 +791,37 @@ def test_langchain_autolog_callback_injection_in_invoke(invoke_arg, generate_cal
 
 @pytest.mark.parametrize("invoke_arg", ["args", "kwargs"])
 @pytest.mark.parametrize(
+    "generate_callbacks",
+    [lambda: [CustomCallbackHandler()], lambda: BaseCallbackManager([CustomCallbackHandler()])],
+)
+@pytest.mark.asyncio
+async def test_langchain_autolog_callback_injection_in_ainvoke(invoke_arg, generate_callbacks):
+    mlflow.langchain.autolog(
+        log_models=True,
+        extra_tags={"test_tag": "test"},
+        log_inputs_outputs=True,
+    )
+    callbacks = generate_callbacks()
+
+    with mlflow.start_run() as run, _mock_openai_arequest():
+        model = create_openai_llmchain()
+        if invoke_arg == "args":
+            await model.ainvoke("MLflow", RunnableConfig(callbacks=callbacks))
+        elif invoke_arg == "kwargs":
+            await model.ainvoke("MLflow", config=RunnableConfig(callbacks=callbacks))
+        assert mlflow.active_run() is not None
+    run_data = MlflowClient().get_run(run.info.run_id).data
+    assert run_data.tags["test_tag"] == "test"
+    assert run_data.tags["mlflow.autologging"] == "langchain"
+    # original callback still works as expected
+    if isinstance(callbacks, BaseCallbackManager):
+        assert callbacks.handlers[0].logs == ["chain_start", "chain_end"]
+    else:
+        assert callbacks[0].logs == ["chain_start", "chain_end"]
+
+
+@pytest.mark.parametrize("invoke_arg", ["args", "kwargs"])
+@pytest.mark.parametrize(
     "generate_config",
     [
         lambda: RunnableConfig(callbacks=[CustomCallbackHandler()]),
@@ -835,6 +870,53 @@ def test_langchain_autolog_callback_injection_in_batch(invoke_arg, generate_conf
     [
         lambda: RunnableConfig(callbacks=[CustomCallbackHandler()]),
         lambda: RunnableConfig(callbacks=BaseCallbackManager([CustomCallbackHandler()])),
+        lambda: [
+            RunnableConfig(callbacks=[CustomCallbackHandler()]),
+            RunnableConfig(callbacks=[CustomCallbackHandler()]),
+        ],
+        lambda: [
+            RunnableConfig(callbacks=BaseCallbackManager([CustomCallbackHandler()])),
+            RunnableConfig(callbacks=BaseCallbackManager([CustomCallbackHandler()])),
+        ],
+    ],
+)
+@pytest.mark.asyncio
+async def test_langchain_autolog_callback_injection_in_abatch(invoke_arg, generate_config):
+    mlflow.langchain.autolog(
+        log_models=True,
+        extra_tags={"test_tag": "test"},
+        log_inputs_outputs=True,
+    )
+    config = generate_config()
+    with mlflow.start_run() as run, _mock_openai_arequest():
+        model = create_openai_llmchain()
+        inputs = ["MLflow"] * 2
+        if invoke_arg == "args":
+            await model.abatch(inputs, config)
+        elif invoke_arg == "kwargs":
+            await model.abatch(inputs, config=config)
+        assert mlflow.active_run() is not None
+    run_data = MlflowClient().get_run(run.info.run_id).data
+    assert run_data.tags["test_tag"] == "test"
+    assert run_data.tags["mlflow.autologging"] == "langchain"
+    if isinstance(config, list):
+        callbacks = config[0]["callbacks"]
+        expected_logs = sorted(["chain_start", "chain_end"])
+    else:
+        callbacks = config["callbacks"]
+        expected_logs = sorted(["chain_start", "chain_end"] * 2)
+    if isinstance(callbacks, BaseCallbackManager):
+        assert sorted(callbacks.handlers[0].logs) == expected_logs
+    else:
+        assert sorted(callbacks[0].logs) == expected_logs
+
+
+@pytest.mark.parametrize("invoke_arg", ["args", "kwargs"])
+@pytest.mark.parametrize(
+    "generate_config",
+    [
+        lambda: RunnableConfig(callbacks=[CustomCallbackHandler()]),
+        lambda: RunnableConfig(callbacks=BaseCallbackManager([CustomCallbackHandler()])),
     ],
 )
 def test_langchain_autolog_callback_injection_in_stream(invoke_arg, generate_config):
@@ -847,6 +929,45 @@ def test_langchain_autolog_callback_injection_in_stream(invoke_arg, generate_con
             next(model.stream("MLflow", config))
         elif invoke_arg == "kwargs":
             next(model.stream("MLflow", config=config))
+    run_data = MlflowClient().get_run(run.info.run_id).data
+    assert run_data.tags["test_tag"] == "test"
+    assert run_data.tags["mlflow.autologging"] == "langchain"
+    callbacks = config["callbacks"]
+    expected_logs = ["chain_start", "chain_end"]
+    if isinstance(callbacks, BaseCallbackManager):
+        assert callbacks.handlers[0].logs == expected_logs
+        assert (
+            sum(isinstance(handler, MlflowLangchainTracer) for handler in callbacks.handlers) == 1
+        )
+    else:
+        assert callbacks[0].logs == expected_logs
+        assert sum(isinstance(handler, MlflowLangchainTracer) for handler in callbacks) == 1
+
+
+@pytest.mark.parametrize("invoke_arg", ["args", "kwargs"])
+@pytest.mark.parametrize(
+    "generate_config",
+    [
+        lambda: RunnableConfig(callbacks=[CustomCallbackHandler()]),
+        lambda: RunnableConfig(callbacks=BaseCallbackManager([CustomCallbackHandler()])),
+    ],
+)
+@pytest.mark.asyncio
+async def test_langchain_autolog_callback_injection_in_astream(invoke_arg, generate_config):
+    mlflow.langchain.autolog(log_models=True, extra_tags={"test_tag": "test"})
+    config = generate_config()
+
+    async def _test_astream(model, invoke_arg, config):
+        if invoke_arg == "args":
+            async for result in model.astream("MLflow", config):
+                return result
+        elif invoke_arg == "kwargs":
+            async for result in model.astream("MLflow", config=config):
+                return result
+
+    with mlflow.start_run() as run, _mock_openai_arequest():
+        model = create_openai_llmchain()
+        await _test_astream(model, invoke_arg, config)
     run_data = MlflowClient().get_run(run.info.run_id).data
     assert run_data.tags["test_tag"] == "test"
     assert run_data.tags["mlflow.autologging"] == "langchain"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12114?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12114/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12114
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Patch `ainvoke, abatch, astream` methods for runnables.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Had a test on the patching:
https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/526657760899964
TLDR since autologging is not async, patching async functions will make the inference call non-async as well. For example if you have 10 inference jobs, and injecting mlflow callback takes 1 second, then total time increase would be 10 seconds instead of 1 second. 
Mlflowcallback injection won't take that long though, but logging artifacts would become a performance concern. I added a note in the docstring, so the suggestion is that if users really want to enable tracing using autologging, then they should disable logging any artifacts -- it's off by default.

**Update**: test in https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/2393426062477360/command/1344703767318006 
Conclusion is that autologging patching async methods introduces a ~0.5 second overhead on each task, but the tasks themselves are still async, so the total overhead = 0.5 * number_of_async_tasks. 
User can opt-out this behavior by setting `mlflow.langchaing.autolog(disable=True)`. 
By default mlflow langchain autologging patches all invoke methods for sync and async cases.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
