### PR TITLE
[WIP] Support exporting multiple trace per request for inference table

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -568,16 +568,16 @@ _MLFLOW_RUN_SLOW_TESTS = _BooleanEnvironmentVariable("MLFLOW_RUN_SLOW_TESTS", Fa
 #: (default: ``11``)
 MLFLOW_DOCKER_OPENJDK_VERSION = _EnvironmentVariable("MLFLOW_DOCKER_OPENJDK_VERSION", str, "11")
 
-# How many traces to be buffered at the Trace Client.
-MLFLOW_TRACING_CLIENT_BUFFER_SIZE = _EnvironmentVariable(
-    "MLFLOW_TRACING_CLIENT_BUFFER_SIZE", int, 1000
-)
+# How long a trace can be buffered at the in-memory trace buffer before being abandoned.
+MLFLOW_TRACE_BUFFER_TTL_SECONDS = _EnvironmentVariable(
+    "MLFLOW_TRACE_BUFFER_TTL_SECONDS", int, 3600
+)  # 1 hour
 
-# How long a trace can be buffered at the in-memory trace client before being abandoned.
-MLFLOW_TRACE_BUFFER_TTL_SECONDS = _EnvironmentVariable("MLFLOW_TRACE_BUFFER_TTL_SECONDS", int, 3600)
-
-# How many traces to be buffered at the in-memory trace client.
-MLFLOW_TRACE_BUFFER_MAX_SIZE = _EnvironmentVariable("MLFLOW_TRACE_BUFFER_MAX_SIZE", int, 1000)
+# The maximum size of the trace buffer in bytes. If the buffer exceeds this size, the oldest
+# traces will be dropped.
+MLFLOW_TRACE_BUFFER_MAX_SIZE_BYTES = _EnvironmentVariable(
+    "MLFLOW_TRACE_BUFFER_MAX_SIZE_BYTES", int, 100_000_000
+)  # 100 MB
 
 #: Whether or not to enable trace logging in model serving.
 #: The default value is set to False to ensure that this flag is only enabled

--- a/mlflow/tracing/cache.py
+++ b/mlflow/tracing/cache.py
@@ -1,0 +1,65 @@
+import logging
+from typing import Any, Callable
+
+from cachetools import TTLCache
+
+from mlflow.tracing.utils import size
+
+_logger = logging.getLogger(__name__)
+
+
+class SizedTTLCache(TTLCache):
+    """
+    Extended TTL Cache that keeps track of the size (byte) of the cache records and evicts the
+    oldest records when the cache size exceeds the specified maximum size.
+
+    In order to calculate the size of the entry, we need to serialize Based on the implementation
+    of TTLCache, the size calculation is only done once when the entry is added to the cache,
+    so the serialization cost is not a big concern for typical trace size (~MB).
+    https://github.com/tkem/cachetools/blob/d8b5c608273051f2ebddaec8a4d033c66369dd7d/src/cachetools/__init__.py#L74
+
+    Args:
+        maxsize_bytes: The maximum size of the cache in bytes.
+        ttl: The time-to-live value (sec) for the cache entries.
+        serializer: The serializer function to calculate the size of the cache entries.
+    """
+
+    def __init__(self, maxsize_bytes: int, ttl: int, serializer: Callable[[Any], str]):
+        super().__init__(maxsize=maxsize_bytes, ttl=ttl)
+        self._serializer = serializer
+
+    def getsizeof(self, value):
+        # NB: For list, the size must be calculated for individual elements and summed up,
+        # as sys.getsizeofdoes not handle the size of container well. This is not an accurate
+        # size calculation because the list may contain reference to the same object, but it
+        # should be good enough for our purpose.
+        if isinstance(value, (list, tuple)):
+            return sum(size(value, serializer=self._serializer) for value in value)
+        return size(value, serializer=self._serializer)
+
+    def __setitem__(self, key, value):
+        try:
+            super().__setitem__(key, value)
+        except ValueError as e:
+            # TTLCache by default raises ValueError when the size of the value exceeds the maxsize.
+            # We catch the exception and discard the trace instead of blocking the application.
+            if "value too large" in str(e):
+                _logger.warning(
+                    "The size of the trace exceeds the maximum size of the buffer. "
+                    "The trace will be dropped. Please consider increasing the buffer "
+                    "size by setting the environment variable MLFLOW_TRACE_BUFFER_MAX_SIZE_BYTES."
+                )
+
+    def update_size(self, key: str, delta: int):
+        """
+        Update the size of the cache by the given delta value.
+
+        Args:
+            key: The key of the cache entry.
+            delta: The size change in bytes of the cache entry.
+        """
+        # Accessing private attributes is not ideal, but this is the only way to update size
+        self._Cache__size[key] += delta
+        self._Cache__currsize += delta
+        while self.currsize > self.maxsize:
+            self.popitem()

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -19,15 +19,34 @@ def pop_trace(request_id: str) -> Optional[List[Dict[str, Any]]]:
     """
     Pop the completed trace data from the buffer. This method is used in
     the Databricks model serving so please be careful when modifying it.
+
+    Args:
+        request_id: The request ID of the trace.
+
+    Returns:
+        The list of trace dictionaries if the trace is found, otherwise None.
+        It can contain multiple traces if the model generated multiple traces
+        for a single prediction call.
     """
     return _TRACE_BUFFER.pop(request_id, None)
 
 
-# For Inference Table, we use special TTLCache to store the finished traces
-# so that they can be retrieved by Databricks model serving. The values
-# in the buffer are not Trace dataclass, but rather a dictionary with the schema
-# that is used within Databricks model serving.
 def _initialize_trace_buffer():  # Define as a function for testing purposes
+    """
+    Create trace buffer that stores the mapping request_id (str) -> List[Dict[str, Any]]
+
+    For Inference Table, we use special TTLCache to store the finished traces
+    so that they can be retrieved by Databricks model serving. The values
+    in the buffer are not Trace dataclass, but rather list of a dictionary with
+    the schema that is used within Databricks model serving.
+
+    TODO: In model serving, the request_id of trace will be Flask request ID for the
+      prediction request. However, the model may generated multiple traces for a single
+      prediction call depending on how it is instrumented. In such case, the request ID
+      is no longer unique for a trace. In the interest of time, we don't handle this and
+      simply store *list of traces* for each request ID. This should be revisited in the
+      future to ensure the uniqueness of the request ID.
+    """
     return SizedTTLCache(
         maxsize_bytes=MLFLOW_TRACE_BUFFER_MAX_SIZE_BYTES.get(),
         ttl=MLFLOW_TRACE_BUFFER_TTL_SECONDS.get(),
@@ -70,4 +89,8 @@ class InferenceTableSpanExporter(SpanExporter):
                 continue
 
             # Add the trace to the in-memory buffer so it can be retrieved by upstream
-            _TRACE_BUFFER[trace.info.request_id] = trace.to_dict()
+            trace_dict = trace.to_dict()
+            if trace.info.request_id not in _TRACE_BUFFER:
+                _TRACE_BUFFER[trace.info.request_id] = [trace_dict]
+            else:
+                _TRACE_BUFFER[trace.info.request_id].append(trace_dict)

--- a/mlflow/tracing/utils.py
+++ b/mlflow/tracing/utils.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import sys
 import uuid
 from collections import Counter, defaultdict
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, NamedTuple, Optional, Union
 
 from opentelemetry import trace as trace_api
 from packaging.version import Version
@@ -383,3 +384,17 @@ def exclude_immutable_tags(tags: Dict[str, str]) -> Dict[str, str]:
 
 def generate_request_id() -> str:
     return uuid.uuid4().hex
+
+
+def size(x: Any, serializer: Callable[[Any], str] = lambda x: json.dumps(x, default=str)) -> int:
+    """
+    Get the size of any object in bytes.
+
+    Args:
+        x: The object to get the size of.
+        serializer: A function that serializes the object to a string. Default is json.dumps.
+
+    Returns:
+        The size of the object in bytes.
+    """
+    return sys.getsizeof(serializer(x))

--- a/tests/tracing/export/test_inference_table_exporter.py
+++ b/tests/tracing/export/test_inference_table_exporter.py
@@ -50,12 +50,13 @@ def test_export():
 
     # Trace should be added to the in-memory buffer and can be extracted
     assert len(_TRACE_BUFFER) == 1
-    trace_dict = pop_trace(_REQUEST_ID)
-    trace_info = trace_dict["info"]
+    trace_dicts = pop_trace(_REQUEST_ID)
+    assert len(trace_dicts) == 1
+    trace_info = trace_dicts[0]["info"]
     assert trace_info["timestamp_ms"] == 0
     assert trace_info["execution_time_ms"] == 1
 
-    spans = trace_dict["data"]["spans"]
+    spans = trace_dicts[0]["data"]["spans"]
     assert len(spans) == 2
     assert spans[0]["name"] == "root"
     assert spans[0]["context"] == {
@@ -63,6 +64,38 @@ def test_export():
         "span_id": encode_span_id(1),
     }
     assert isinstance(spans[0]["attributes"], dict)
+
+
+def test_export_multiple_traces_per_request_id():
+    exporter = InferenceTableSpanExporter()
+
+    trace_id_1 = 12345
+    otel_span_1 = create_mock_otel_span(trace_id=trace_id_1, span_id=1)
+    span1 = LiveSpan(otel_span_1, request_id=_REQUEST_ID)
+    _register_span_and_trace(span1)
+
+    exporter.export([otel_span_1])
+
+    trace_id_2 = 23456
+    otel_span_2 = create_mock_otel_span(trace_id=trace_id_2, span_id=1)
+    span2 = LiveSpan(otel_span_2, request_id=_REQUEST_ID)
+    _register_span_and_trace(span2)
+
+    exporter.export([otel_span_2])
+
+    # Spans should be cleared from the trace manager
+    assert len(exporter._trace_manager._traces) == 0
+
+    # Trace should be added to the in-memory buffer and can be extracted
+    assert len(_TRACE_BUFFER) == 1
+    trace_dicts = pop_trace(_REQUEST_ID)
+    assert len(trace_dicts) == 2
+
+    trace_info = trace_dicts[0]["info"]
+    assert trace_info["request_id"] == _REQUEST_ID
+
+    trace_info = trace_dicts[1]["info"]
+    assert trace_info["request_id"] == _REQUEST_ID
 
 
 def test_export_warn_invalid_attributes():
@@ -77,8 +110,9 @@ def test_export_warn_invalid_attributes():
     exporter = InferenceTableSpanExporter()
     exporter.export([otel_span])
 
-    trace_dict = pop_trace(_REQUEST_ID)
-    trace = Trace.from_dict(trace_dict)
+    trace_dicts = pop_trace(_REQUEST_ID)
+    assert len(trace_dicts) == 1
+    trace = Trace.from_dict(trace_dicts[0])
     stored_span = trace.data.spans[0]
     assert stored_span.attributes == {
         "mlflow.traceRequestId": _REQUEST_ID,

--- a/tests/tracing/test_cache.py
+++ b/tests/tracing/test_cache.py
@@ -1,0 +1,67 @@
+import time
+
+from mlflow.tracing.cache import SizedTTLCache
+
+
+def test_sized_ttl_cache_limit_size():
+    cache = SizedTTLCache(maxsize_bytes=150, ttl=60, serializer=lambda x: x)
+
+    assert cache.getsizeof("a") == 50
+    assert cache.getsizeof(["a", "b", "c"]) == 150
+
+    cache["key1"] = "ab"  # This is 51 bytes in Python3
+    cache["key2"] = "c"  # This is 50 bytes
+    assert len(cache) == 2
+
+    cache["key3"] = "c"  # Breach the limit and push out the oldest key
+    assert len(cache) == 2
+    assert "key1" not in cache
+
+    cache["key4"] = "d"  # Just fit
+    assert len(cache) == 3
+    assert "key2" in cache
+    assert "key3" in cache
+    assert "key4" in cache
+
+    cache["key5"] = ["e", "f"]  # Breach the limit again (100 bytes) and push out two keys
+    assert len(cache) == 2
+    assert "key2" not in cache
+    assert "key3" not in cache
+    assert "key4" in cache
+    assert "key5" in cache
+
+
+def test_sized_ttl_cache_drop_too_large_value():
+    cache = SizedTTLCache(maxsize_bytes=100, ttl=60, serializer=str)
+    cache["key1"] = "a" * 500
+    assert len(cache) == 0  # Just drop with warning
+
+
+def test_sized_ttl_cache_handle_value_update():
+    cache = SizedTTLCache(maxsize_bytes=200, ttl=60, serializer=str)
+    value1 = ["a", "b"]
+    cache["key1"] = value1
+    value2 = ["c", "d"]
+    cache["key2"] = value2
+    assert len(cache) == 2
+
+    # Update the value container in-place
+    value2.append("e")
+    cache.update_size("key2", 50)
+    assert len(cache) == 1
+    assert "key2" in cache
+
+    # If the container size exceeds max size, it should push out itself
+    value2.extend(["f", "g"])
+    cache.update_size("key2", 100)
+    assert len(cache) == 0
+
+
+def test_sized_ttl_cache_expore_after_ttl():
+    cache = SizedTTLCache(maxsize_bytes=100, ttl=1, serializer=str)
+    cache["key1"] = "a"
+    cache["key2"] = "b"
+    assert len(cache) == 2
+
+    time.sleep(1.1)
+    assert len(cache) == 0


### PR DESCRIPTION
### Related Issues/PRs

This is required for allowing serving endpoint to return list of traces instead of single trace, for models that emits multiple traces per single request. 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
