### PR TITLE
Fix end_trace to work correctly

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -38,6 +38,7 @@ from mlflow.entities import (
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
 from mlflow.entities.span import LiveSpan, NoOpSpan
+from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_LOGGING
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
@@ -638,15 +639,16 @@ class MlflowClient:
         root_span_id = trace_manager.get_root_span_id(request_id)
 
         if root_span_id is None:
-            if self.get_trace(request_id=request_id):
-                raise MlflowException(
-                    f"Trace with ID {request_id} already finished.",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
-            else:
+            trace = self.get_trace(request_id=request_id)
+            if trace is None:
                 raise MlflowException(
                     f"Trace with ID {request_id} not found.",
                     error_code=RESOURCE_DOES_NOT_EXIST,
+                )
+            elif trace.info.status == TraceStatus.OK or trace.info.status == TraceStatus.ERROR:
+                raise MlflowException(
+                    f"Trace with ID {request_id} already finished.",
+                    error_code=INVALID_PARAMETER_VALUE,
                 )
 
         self.end_span(request_id, root_span_id, outputs, attributes, status)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -632,6 +632,18 @@ def test_end_trace_raise_error_when_trace_not_exist(clear_singleton):
         client.end_trace("test")
 
 
+def test_end_trace_works_for_in_progress_trace(clear_singleton):
+    client = mlflow.tracking.MlflowClient()
+    mock_tracking_client = mock.MagicMock()
+    mock_tracking_client.get_trace.return_value = Trace(
+        info=create_test_trace_info("test", status=TraceStatus.IN_PROGRESS), data=None
+    )
+    client._tracking_client = mock_tracking_client
+    client.end_span = lambda *args: None
+
+    client.end_trace("test")
+
+
 def test_end_trace_raise_error_when_trace_finished_twice(clear_singleton):
     client = mlflow.tracking.MlflowClient()
     mock_tracking_client = mock.MagicMock()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/liangz1/mlflow/pull/12120?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12120/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12120
```

</p>
</details>


When I do
```python
import mlflow
@mlflow.trace
def f(x):
  return x

f(1)
```
The trace is still `In Pregress` after the call finished.
I tried to end it but get:
```
---------------------------------------------------------------------------
MlflowException                           Traceback (most recent call last)
File <command-1433266112202599>, line 4
      1 from mlflow import MlflowClient
      3 c = MlflowClient()
----> 4 c.end_trace(request_id='tr-a2606fe92226459c80ab5c90b0a8ee5f')

File /local_disk0/.ephemeral_nfs/envs/pythonEnv-97a19057-158d-490f-bc59-e9f108352cd3/lib/python3.11/site-packages/mlflow/tracking/client.py:639, in MlflowClient.end_trace(self, request_id, outputs, attributes, status)
    637 if root_span_id is None:
    638     if self.get_trace(request_id=request_id):
--> 639         raise MlflowException(
    640             f"Trace with ID {request_id} already finished.",
    641             error_code=INVALID_PARAMETER_VALUE,
    642         )
    643     else:
    644         raise MlflowException(
    645             f"Trace with ID {request_id} not found.",
    646             error_code=RESOURCE_DOES_NOT_EXIST,
    647         )
```
But `get_trace` shows the trace is in progress
```
trace = c.get_trace(request_id='tr-a2606fe92226459c80ab5c90b0a8ee5f')
trace.info.status
> 'IN_PROGRESS'
```
It seems that
```
    638     if self.get_trace(request_id=request_id):
```
This line should check trace status, not trace existence.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Replace the trace existence check to status check.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
<img width="1243" alt="Screenshot 2024-05-23 at 4 27 20 PM" src="https://github.com/mlflow/mlflow/assets/7851093/ed98cf96-8a31-497f-b944-ee536c18f181">


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes
NA
#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
