### PR TITLE
Add test for pending status vs end status

### DIFF
--- a/mlflow/entities/trace_status.py
+++ b/mlflow/entities/trace_status.py
@@ -24,6 +24,16 @@ class TraceStatus(str, Enum):
     def from_otel_status(otel_status: trace_api.Status):
         return _OTEL_STATUS_CODE_TO_MLFLOW[otel_status.status_code]
 
+    @classmethod
+    def pending_statuses(cls):
+        """Traces in pending statuses can be updated to any statuses."""
+        return {cls.IN_PROGRESS}
+
+    @classmethod
+    def end_statuses(cls):
+        """Traces in end statuses cannot be updated to any statuses."""
+        return {cls.UNSPECIFIED, cls.OK, cls.ERROR}
+
 
 _OTEL_STATUS_CODE_TO_MLFLOW = {
     trace_api.StatusCode.OK: TraceStatus.OK,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -645,7 +645,7 @@ class MlflowClient:
                     f"Trace with ID {request_id} not found.",
                     error_code=RESOURCE_DOES_NOT_EXIST,
                 )
-            elif trace.info.status not in TraceStatus.pending_statuses():
+            elif trace.info.status in TraceStatus.end_statuses():
                 raise MlflowException(
                     f"Trace with ID {request_id} already finished.",
                     error_code=INVALID_PARAMETER_VALUE,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -645,7 +645,7 @@ class MlflowClient:
                     f"Trace with ID {request_id} not found.",
                     error_code=RESOURCE_DOES_NOT_EXIST,
                 )
-            elif trace.info.status == TraceStatus.OK or trace.info.status == TraceStatus.ERROR:
+            elif trace.info.status not in TraceStatus.pending_statuses():
                 raise MlflowException(
                     f"Trace with ID {request_id} already finished.",
                     error_code=INVALID_PARAMETER_VALUE,

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -658,6 +658,16 @@ def test_end_trace_raise_error_for_trace_in_end_status(clear_singleton, status):
         client.end_trace("test")
 
 
+def test_trace_status_either_pending_or_end():
+    all_statuses = {status.value for status in TraceStatus}
+    pending_or_end_statuses = TraceStatus.pending_statuses() + TraceStatus.end_statuses()
+    unclassified_statuses = all_statuses - pending_or_end_statuses
+    assert len(unclassified_statuses) == 0, (
+        f"Please add {unclassified_statuses} to "
+        "either pending_statuses or end_statuses in TraceStatus class definition"
+    )
+
+
 def test_start_span_raise_error_when_parent_id_is_not_provided():
     with pytest.raises(MlflowException, match=r"start_span\(\) must be called with"):
         mlflow.tracking.MlflowClient().start_span("span_name", request_id="test", parent_id=None)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -660,7 +660,7 @@ def test_end_trace_raise_error_for_trace_in_end_status(clear_singleton, status):
 
 def test_trace_status_either_pending_or_end():
     all_statuses = {status.value for status in TraceStatus}
-    pending_or_end_statuses = TraceStatus.pending_statuses() + TraceStatus.end_statuses()
+    pending_or_end_statuses = TraceStatus.pending_statuses() | TraceStatus.end_statuses()
     unclassified_statuses = all_statuses - pending_or_end_statuses
     assert len(unclassified_statuses) == 0, (
         f"Please add {unclassified_statuses} to "

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -632,11 +632,12 @@ def test_end_trace_raise_error_when_trace_not_exist(clear_singleton):
         client.end_trace("test")
 
 
-def test_end_trace_works_for_in_progress_trace(clear_singleton):
+@pytest.mark.parametrize("status", TraceStatus.pending_statuses())
+def test_end_trace_works_for_trace_in_pending_status(clear_singleton, status):
     client = mlflow.tracking.MlflowClient()
     mock_tracking_client = mock.MagicMock()
     mock_tracking_client.get_trace.return_value = Trace(
-        info=create_test_trace_info("test", status=TraceStatus.IN_PROGRESS), data=None
+        info=create_test_trace_info("test", status=status), data=None
     )
     client._tracking_client = mock_tracking_client
     client.end_span = lambda *args: None
@@ -644,11 +645,12 @@ def test_end_trace_works_for_in_progress_trace(clear_singleton):
     client.end_trace("test")
 
 
-def test_end_trace_raise_error_when_trace_finished_twice(clear_singleton):
+@pytest.mark.parametrize("status", TraceStatus.end_statuses())
+def test_end_trace_raise_error_for_trace_in_end_status(clear_singleton, status):
     client = mlflow.tracking.MlflowClient()
     mock_tracking_client = mock.MagicMock()
     mock_tracking_client.get_trace.return_value = Trace(
-        info=create_test_trace_info("test"), data=None
+        info=create_test_trace_info("test", status=status), data=None
     )
     client._tracking_client = mock_tracking_client
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/liangz1/mlflow/pull/12121?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12121/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12121
```

</p>
</details>

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Follow up of https://github.com/mlflow/mlflow/pull/12120

https://github.com/mlflow/mlflow/pull/12120#discussion_r1612481033

Defines pending status & end status in TraceStatus class.
Make sure end_trace can only update pending status traces, not end status traces.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
