### PR TITLE
Fix some pyfunc serving problems

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -155,6 +155,7 @@ def save_model(
     persist_dir=None,
     example_no_conversion=False,
     model_config=None,
+    streamable=None,
 ):
     """
     Save a LangChain model to a path on the local file system.
@@ -339,7 +340,7 @@ def save_model(
                 mlflow_model.metadata = {}
             mlflow_model.metadata.update(schema)
 
-    streamable = isinstance(lc_model, lc_runnables_types())
+    streamable = isinstance(lc_model, lc_runnables_types()) or streamable
 
     model_data_kwargs = {}
     flavor_conf = {}
@@ -424,6 +425,7 @@ def log_model(
     example_no_conversion=False,
     run_id=None,
     model_config=None,
+    streamable=None,
 ):
     """
     Log a LangChain model as an MLflow artifact for the current run.
@@ -557,6 +559,7 @@ def log_model(
         example_no_conversion=example_no_conversion,
         run_id=run_id,
         model_config=model_config,
+        streamable=streamable,
     )
 
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -254,8 +254,8 @@ def save_model(
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
         streamable: A boolean value indicating if the model supports streaming prediction. If
-            True, the model must contain `stream` method. If None, MLflow will try to inspect
-            the model's streamability is inferred from the model type. Default to `None`.
+            True, the model must implement `stream` method. If None, the model's streamability
+            is inferred from the model type. Default to `None`.
     """
     import langchain
     from langchain.schema import BaseRetriever
@@ -538,6 +538,9 @@ def log_model(
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
+        streamable: A boolean value indicating if the model supports streaming prediction. If
+            True, the model must implement `stream` method. If None, the model's streamability
+            is inferred from the model type. Default to `None`.
 
     Returns:
         A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -343,7 +343,8 @@ def save_model(
                 mlflow_model.metadata = {}
             mlflow_model.metadata.update(schema)
 
-    streamable = streamable or isinstance(lc_model, lc_runnables_types())
+    if streamable is None:
+        streamable = isinstance(lc_model, lc_runnables_types())
 
     model_data_kwargs = {}
     flavor_conf = {}

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -155,7 +155,7 @@ def save_model(
     persist_dir=None,
     example_no_conversion=False,
     model_config=None,
-    streamable=None,
+    streamable: Optional[bool] = None,
 ):
     """
     Save a LangChain model to a path on the local file system.
@@ -253,6 +253,9 @@ def save_model(
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
+        streamable: A boolean value indicating if the model supports streaming prediction. If
+            True, the model must contain `stream` method. If None, MLflow will try to inspect
+            the model's streamability is inferred from the model type. Default to `None`.
     """
     import langchain
     from langchain.schema import BaseRetriever
@@ -340,7 +343,7 @@ def save_model(
                 mlflow_model.metadata = {}
             mlflow_model.metadata.update(schema)
 
-    streamable = isinstance(lc_model, lc_runnables_types()) or streamable
+    streamable = streamable or isinstance(lc_model, lc_runnables_types())
 
     model_data_kwargs = {}
     flavor_conf = {}

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -122,11 +122,13 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-def _infer_signature_from_input_example_for_lc_model(input_example, wrapped_model):
+def _infer_signature_from_input_example_for_lc_model(
+    input_example, wrapped_model, example_no_conversion=False
+):
     from mlflow.langchain.api_request_parallel_processor import _ChatResponse
 
     signature, prediction = _infer_signature_from_input_example(
-        input_example, wrapped_model, return_prediction=True
+        input_example, wrapped_model, return_prediction=True, no_conversion=example_no_conversion
     )
     # try assign output schema if failing to infer it from prediction
     if signature.outputs is None:
@@ -288,7 +290,7 @@ def save_model(
         if input_example is not None:
             wrapped_model = _LangChainModelWrapper(lc_model)
             signature = _infer_signature_from_input_example_for_lc_model(
-                input_example, wrapped_model
+                input_example, wrapped_model, example_no_conversion=example_no_conversion
             )
         else:
             if hasattr(lc_model, "input_keys"):

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -199,7 +199,7 @@ class APIRequest:
     convert_chat_responses: bool
     did_perform_chat_conversion: bool
     stream: bool
-    prediction_context: Optional[Context]
+    prediction_context: Optional[Context] = None
 
     def _prepare_to_serialize(self, response: dict):
         """

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -38,7 +38,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.pyfunc.context import (
     Context,
     get_prediction_context,
-    potentially_set_prediction_context,
+    maybe_set_prediction_context,
 )
 from mlflow.types.schema import Array, ColSpec, DataType, Schema
 
@@ -322,7 +322,7 @@ class APIRequest:
         _logger.debug(f"Request #{self.index} started with payload: {self.request_json}")
 
         try:
-            with potentially_set_prediction_context(self.prediction_context):
+            with maybe_set_prediction_context(self.prediction_context):
                 response = self.single_call_api(callback_handlers)
             _logger.debug(f"Request #{self.index} succeeded with response: {response}")
             self.results.append((self.index, response))
@@ -606,5 +606,5 @@ def process_stream_request(
         stream=True,
         prediction_context=get_prediction_context(),
     )
-    with potentially_set_prediction_context(api_request.prediction_context):
+    with maybe_set_prediction_context(api_request.prediction_context):
         return api_request.single_call_api(callback_handlers)

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -584,11 +584,10 @@ def process_stream_request(
     callback_handlers: Optional[List[BaseCallbackHandler]] = None,
     convert_chat_responses: bool = False,
 ):
-    from mlflow.langchain.utils import lc_runnables_types
-
-    if not isinstance(lc_model, lc_runnables_types()):
+    if not hasattr(lc_model, "stream"):
         raise MlflowException(
-            f"Model {lc_model.__class__.__name__} does not support streaming prediction output."
+            f"Model {lc_model.__class__.__name__} does not support streaming prediction output. "
+            "No `stream` method found."
         )
 
     (

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -18,7 +18,7 @@ import mlflow
 from mlflow import MlflowClient
 from mlflow.entities import LiveSpan, SpanEvent, SpanStatus, SpanStatusCode, SpanType
 from mlflow.exceptions import MlflowException
-from mlflow.pyfunc.context import Context, potentially_set_prediction_context
+from mlflow.pyfunc.context import Context, maybe_set_prediction_context
 from mlflow.utils.autologging_utils import ExceptionSafeAbstractClass
 
 _logger = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         attributes: Optional[Dict[str, Any]] = None,
     ) -> LiveSpan:
         """Start MLflow Span (or Trace if it is root component)"""
-        with potentially_set_prediction_context(self._prediction_context):
+        with maybe_set_prediction_context(self._prediction_context):
             parent = self._get_parent_span(parent_run_id)
             if parent:
                 span = self._mlflow_client.start_span(
@@ -146,7 +146,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
             # if the generator returned by stream() is not consumed completely
             return
 
-        with potentially_set_prediction_context(self._prediction_context):
+        with maybe_set_prediction_context(self._prediction_context):
             self._mlflow_client.end_span(
                 request_id=span.request_id,
                 span_id=span.span_id,

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -18,7 +18,7 @@ import mlflow
 from mlflow import MlflowClient
 from mlflow.entities import LiveSpan, SpanEvent, SpanStatus, SpanStatusCode, SpanType
 from mlflow.exceptions import MlflowException
-from mlflow.pyfunc.context import Context, set_prediction_context
+from mlflow.pyfunc.context import Context, potentially_set_prediction_context
 from mlflow.utils.autologging_utils import ExceptionSafeAbstractClass
 
 _logger = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         attributes: Optional[Dict[str, Any]] = None,
     ) -> LiveSpan:
         """Start MLflow Span (or Trace if it is root component)"""
-        with set_prediction_context(self._prediction_context):
+        with potentially_set_prediction_context(self._prediction_context):
             parent = self._get_parent_span(parent_run_id)
             if parent:
                 span = self._mlflow_client.start_span(
@@ -146,7 +146,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
             # if the generator returned by stream() is not consumed completely
             return
 
-        with set_prediction_context(self._prediction_context):
+        with potentially_set_prediction_context(self._prediction_context):
             self._mlflow_client.end_span(
                 request_id=span.request_id,
                 span_id=span.span_id,

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -351,7 +351,7 @@ def _infer_signature_from_type_hints(func, input_arg_index, input_example=None):
 
 
 def _infer_signature_from_input_example(
-    input_example: ModelInputExample, wrapped_model, return_prediction=False
+    input_example: ModelInputExample, wrapped_model, return_prediction=False, no_conversion=False
 ) -> Optional[ModelSignature]:
     """
     Infer the signature from an example input and a PyFunc wrapped model. Catches all exceptions.
@@ -370,9 +370,10 @@ def _infer_signature_from_input_example(
             input_example, params = input_example
         else:
             params = None
-        example = _Example(input_example)
-        # Copy the input example so that it is not mutated by predict()
-        input_example = deepcopy(example.inference_data)
+        if not no_conversion:
+            example = _Example(input_example)
+            # Copy the input example so that it is not mutated by predict()
+            input_example = deepcopy(example.inference_data)
         input_schema = _infer_schema(input_example)
         params_schema = _infer_param_schema(params) if params else None
         prediction = wrapped_model.predict(input_example, params=params)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2463,6 +2463,7 @@ def save_model(
                     mlflow_model.signature = _infer_signature_from_input_example(
                         input_example,
                         _PythonModelPyfuncWrapper(python_model, None, None),
+                        no_conversion=example_no_conversion,
                     )
                 except Exception as e:
                     _logger.warning(f"Failed to infer model signature from input example. {e}")

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -55,3 +55,16 @@ def get_prediction_context() -> Optional[Context]:
         The context for the current prediction request, or None if no context is set.
     """
     return _PREDICTION_REQUEST_CTX.get()
+
+
+@contextlib.contextmanager
+def potentially_set_prediction_context(context: Optional[Context]):
+    """
+    Only override the prediction context if it is provided. Otherwise, use the existing
+    prediction context or no prediction context at all.
+    """
+    if context:
+        with set_prediction_context(context):
+            yield
+    else:
+        yield

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -58,7 +58,7 @@ def get_prediction_context() -> Optional[Context]:
 
 
 @contextlib.contextmanager
-def potentially_set_prediction_context(context: Optional[Context]):
+def maybe_set_prediction_context(context: Optional[Context]):
     """
     Only override the prediction context if it is provided. Otherwise, use the existing
     prediction context or no prediction context at all.

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -60,8 +60,8 @@ def get_prediction_context() -> Optional[Context]:
 @contextlib.contextmanager
 def maybe_set_prediction_context(context: Optional[Context]):
     """
-    Only override the prediction context if it is provided. Otherwise, use the existing
-    prediction context or no prediction context at all.
+    Set the prediction context if the given context
+    is not None. Otherwise no-op.
     """
     if context:
         with set_prediction_context(context):

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -1,5 +1,4 @@
 import os
-import threading
 from operator import itemgetter
 from typing import Any, Dict, List, Optional
 from unittest import mock
@@ -52,21 +51,6 @@ from langchain_community.callbacks.mlflow_callback import (
 
 MLFLOW_CALLBACK_METRICS = mlflow_callback_metrics()
 TEXT_COMPLEXITY_METRICS = get_text_complexity_metrics()
-
-test_lock = threading.Lock()
-
-
-@pytest.fixture
-def lock_test():
-    """
-    This fixture should be applied to tests that containing
-    mlflow.pyfunc.load_model to avoid clearing dependencies schemas
-    after loading the model.
-    """
-    test_lock.acquire()
-    yield
-    # Release the lock after the test
-    test_lock.release()
 
 
 def get_mlflow_model(artifact_uri, model_subpath=MODEL_DIR):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12126?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12126/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12126
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
1. Prediction_context set on the main thread is not passed into tasks for langchain.predict because we use threadPool to run tasks in parallel. This affects saving retriever_schema on trace info tags.
2. Support logging langchain models with streamable field, and check if the model has stream method to determine if we can predict_stream on the model.
3. Support inferring signature on input_example with example_no_conversion=True. This blocks some signature inference for langchain models.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
