### PR TITLE
Fix vector search dependencies to check for embedding endpoint

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -8,16 +8,13 @@ _logger = logging.getLogger(__name__)
 
 def _get_embedding_model_endpoint_names(index):
     embedding_model_endpoint_names = []
-    try:
-        desc = index.describe()
-        delta_sync_index_spec = desc.get('delta_sync_index_spec', {})
-        embedding_source_columns = delta_sync_index_spec.get('embedding_source_columns', [])
-        for column in embedding_source_columns:
-            embedding_model_endpoint_name = column.get('embedding_model_endpoint_name')
-            if embedding_model_endpoint_name:
-                embedding_model_endpoint_names.append(embedding_model_endpoint_name)
-    except:
-        _logger.warning("Failed to get embedding model endpoint names from index")
+    desc = index.describe()
+    delta_sync_index_spec = desc.get("delta_sync_index_spec", {})
+    embedding_source_columns = delta_sync_index_spec.get("embedding_source_columns", [])
+    for column in embedding_source_columns:
+        embedding_model_endpoint_name = column.get("embedding_model_endpoint_name", None)
+        if embedding_model_endpoint_name:
+            embedding_model_endpoint_names.append(embedding_model_endpoint_name)
     return embedding_model_endpoint_names
 
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -57,19 +57,64 @@ def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch)
 
 
 class MockVectorSearchIndex:
-    def __init__(self, endpoint_name, index_name) -> None:
+    def __init__(self, endpoint_name, index_name, has_embedding_endpoint) -> None:
         self.endpoint_name = endpoint_name
         self.name = index_name
+        self.has_embedding_endpoint = has_embedding_endpoint
 
     def describe(self):
-        return {
-            "primary_key": "id",
-        }
+        if self.has_embedding_endpoint:
+            return {
+                "name": self.name,
+                "endpoint_name": self.endpoint_name,
+                "primary_key": "id",
+                "index_type": "DELTA_SYNC",
+                "delta_sync_index_spec": {
+                    "source_table": "ml.schema.databricks_documentation",
+                    "embedding_source_columns": [
+                        {"name": "content", "embedding_model_endpoint_name": "embedding-model"}
+                    ],
+                    "pipeline_type": "TRIGGERED",
+                    "pipeline_id": "79a76fcc-67ad-4ac6-8d8e-20f7d485ffa6",
+                },
+                "status": {
+                    "detailed_state": "OFFLINE_FAILED",
+                    "message": "Index creation failed.",
+                    "indexed_row_count": 0,
+                    "failed_status": {"error_message": ""},
+                    "ready": False,
+                    "index_url": "e2-dogfood.staging.cloud.databricks.com/rest_of_url",
+                },
+                "creator": "first.last@databricks.com",
+            }
+        else:
+            return {
+                "name": self.name,
+                "endpoint_name": self.endpoint_name,
+                "primary_key": "chunk_id",
+                "index_type": "DELTA_SYNC",
+                "delta_sync_index_spec": {
+                    "source_table": "ml.schema.databricks_documentation",
+                    "embedding_vector_columns": [
+                        {"name": "chunk_embedding", "embedding_dimension": 1024}
+                    ],
+                    "pipeline_type": "TRIGGERED",
+                    "pipeline_id": "fbbd5bf1-2b9b-4a7e-8c8d-c0f6cc1030de",
+                },
+                "status": {
+                    "detailed_state": "ONLINE",
+                    "message": "Index is currently online",
+                    "indexed_row_count": 17183,
+                    "ready": True,
+                    "index_url": "e2-dogfood.staging.cloud.databricks.com/rest_of_url",
+                },
+                "creator": "first.last@databricks.com",
+            }
 
 
 class MockVectorSearchClient:
-    def get_index(self, endpoint_name, index_name):
-        return MockVectorSearchIndex(endpoint_name, index_name)
+    def get_index(self, endpoint_name, index_name, has_embedding_endpoint=False):
+        return MockVectorSearchIndex(endpoint_name, index_name, has_embedding_endpoint)
 
 
 @pytest.mark.skipif(
@@ -104,12 +149,18 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.MonkeyPatch):
+def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+):
     from langchain_community.embeddings import DatabricksEmbeddings
     from langchain_community.vectorstores import DatabricksVectorSearch
 
     vsc = MockVectorSearchClient()
-    vs_index = vsc.get_index(endpoint_name="dbdemos_vs_endpoint", index_name="mlflow.rag.vs_index")
+    vs_index = vsc.get_index(
+        endpoint_name="dbdemos_vs_endpoint",
+        index_name="mlflow.rag.vs_index",
+        has_embedding_endpoint=True,
+    )
     mock_get_deploy_client = MagicMock()
 
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
@@ -126,6 +177,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     _extract_databricks_dependencies_from_retriever(retriever, resources)
     assert resources == [
         DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
+        DatabricksServingEndpoint(endpoint_name="embedding-model"),
         DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
     ]
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/12132?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12132/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12132
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Fix vector search dependencies logic to check for embedding endpoint
- Add embedding endpoint to list of serving endpoints in dependency_list

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
  - Tested e2e in databricks. MLmodel file is written correctly and credentials are passed correctly.
  - https://e2-dogfood.staging.cloud.databricks.com/ml/experiments/1666223674545324/runs/94ee7c567b63483ba18a2b90b79d8ec4/artifacts?o=6051921418418893

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
