### PR TITLE
Fix tracking URI update issue for tracing

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -68,10 +68,14 @@ def _get_tracer(module_name: str):
     return tracer_provider.get_tracer(module_name)
 
 
-def _setup_tracer_provider():
+def _setup_tracer_provider(disabled=False):
     """
     Instantiate a tracer provider and set it as the global tracer provider.
     """
+    if disabled:
+        _force_set_otel_tracer_provider(trace.NoOpTracerProvider())
+        return
+
     if is_in_databricks_model_serving_environment():
         from mlflow.tracing.export.inference_table import InferenceTableSpanExporter
         from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
@@ -87,6 +91,17 @@ def _setup_tracer_provider():
 
     tracer_provider = TracerProvider()
     tracer_provider.add_span_processor(processor)
+    _force_set_otel_tracer_provider(tracer_provider)
+
+
+def _force_set_otel_tracer_provider(tracer_provider):
+    """
+    Resetting internal flag used in OpenTelemetry. If we don't reset the flag,
+    set_tracer_provider() will be a no-op after the first call
+    in the application lifecycle.
+    """
+    with trace._TRACER_PROVIDER_SET_ONCE._lock:
+        trace._TRACER_PROVIDER_SET_ONCE._done = False
     trace.set_tracer_provider(tracer_provider)
 
 
@@ -94,27 +109,48 @@ def disable():
     """
     Disable tracing by setting the global tracer provider to NoOpTracerProvider.
     """
-    if isinstance(trace.get_tracer_provider(), trace.NoOpTracerProvider):
+    if not _is_enabled():
         _logger.info("Tracing is already disabled")
         return
-
-    with trace._TRACER_PROVIDER_SET_ONCE._lock:
-        trace._TRACER_PROVIDER_SET_ONCE._done = False
-
-    trace.set_tracer_provider(trace.NoOpTracerProvider())
+    reset_tracer_setup()  # Force re-initialization of the tracer provider
+    _TRACER_PROVIDER_INITIALIZED.do_once(lambda: _setup_tracer_provider(disabled=True))
 
 
 def enable():
     """
     Enable tracing by setting the global tracer provider to the actual tracer provider.
     """
-    from mlflow.tracing.provider import _setup_tracer_provider
-
-    if not isinstance(trace.get_tracer_provider(), trace.NoOpTracerProvider):
+    if _is_enabled():
         _logger.info("Tracing is already enabled")
         return
 
-    with trace._TRACER_PROVIDER_SET_ONCE._lock:
-        trace._TRACER_PROVIDER_SET_ONCE._done = False
-
     _setup_tracer_provider()
+
+
+def reset_tracer_setup():
+    """
+    Reset the flags that indicates whether the tracer provider has been initialized.
+    This ensures that the tracer provider is re-initialized when next tracing
+    operation is performed.
+    """
+    with _TRACER_PROVIDER_INITIALIZED._lock:
+        _TRACER_PROVIDER_INITIALIZED._done = False
+    # Set NoOp tracer provider to reset the global tracer to the initial state.
+    # Do not flip _TRACE_PROVIDER_INITIALIZED flag to True so that
+    # the next tracing operation will re-initialize the provider.
+    _setup_tracer_provider(disabled=True)
+
+
+def _is_enabled() -> bool:
+    """
+    Check if tracing is enabled based on whether the global tracer
+    is instantiated or not.
+    """
+    with _TRACER_PROVIDER_INITIALIZED._lock:
+        tracer = trace.get_tracer(__name__)
+
+        # Occasionally ProxyTracer instance wraps the actual tracer
+        if isinstance(tracer, trace.ProxyTracer):
+            tracer = tracer._tracer
+
+        return not isinstance(tracer, trace.NoOpTracer)

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -99,6 +99,7 @@ def _force_set_otel_tracer_provider(tracer_provider):
     Resetting internal flag used in OpenTelemetry. If we don't reset the flag,
     set_tracer_provider() will be a no-op after the first call
     in the application lifecycle.
+    https://github.com/open-telemetry/opentelemetry-python/blob/v1.24.0/opentelemetry-api/src/opentelemetry/trace/__init__.py#L485
     """
     with trace._TRACER_PROVIDER_SET_ONCE._lock:
         trace._TRACER_PROVIDER_SET_ONCE._done = False

--- a/mlflow/tracing/utils.py
+++ b/mlflow/tracing/utils.py
@@ -1,3 +1,4 @@
+# TODO: Split this file into multiple files and move under utils directory.
 from __future__ import annotations
 
 import inspect

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -67,12 +67,14 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
         # then .resolve() to clean the path
         uri = uri.absolute().resolve().as_uri()
     global _tracking_uri
-    _tracking_uri = uri
 
-    # Tracer provider uses tracking URI to determine where to export traces.
-    # Tracer provider stores the URI as its state so we need to reset
-    # it explicitly when the global tracking URI changes.
-    reset_tracer_setup()
+    if _tracking_uri != uri:
+        _tracking_uri = uri
+
+        # Tracer provider uses tracking URI to determine where to export traces.
+        # Tracer provider stores the URI as its state so we need to reset
+        # it explicitly when the global tracking URI changes.
+        reset_tracer_setup()
 
 
 @contextmanager
@@ -83,8 +85,7 @@ def _use_tracking_uri(uri: str) -> Generator[None, None, None]:
         uri: The tracking URI to use.
 
     """
-    global _tracking_uri
-    old_tracking_uri = _tracking_uri
+    old_tracking_uri = get_tracking_uri()
     try:
         set_tracking_uri(uri)
         yield

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -4,13 +4,14 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
-from typing import Union
+from typing import Generator, Union
 
 from mlflow.environment_variables import MLFLOW_TRACKING_URI
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.store.tracking.rest_store import RestStore
+from mlflow.tracing.provider import reset_tracer_setup
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.databricks_utils import get_databricks_host_creds
@@ -68,9 +69,14 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
     global _tracking_uri
     _tracking_uri = uri
 
+    # Tracer provider uses tracking URI to determine where to export traces.
+    # Tracer provider stores the URI as its state so we need to reset
+    # it explicitly when the global tracking URI changes.
+    reset_tracer_setup()
+
 
 @contextmanager
-def _use_tracking_uri(uri: str) -> None:
+def _use_tracking_uri(uri: str) -> Generator[None, None, None]:
     """Temporarily use the specified tracking URI.
 
     Args:
@@ -80,10 +86,10 @@ def _use_tracking_uri(uri: str) -> None:
     global _tracking_uri
     old_tracking_uri = _tracking_uri
     try:
-        _tracking_uri = uri
+        set_tracking_uri(uri)
         yield
     finally:
-        _tracking_uri = old_tracking_uri
+        set_tracking_uri(old_tracking_uri)
 
 
 def _resolve_tracking_uri(tracking_uri=None):

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -85,7 +85,8 @@ def _use_tracking_uri(uri: str) -> Generator[None, None, None]:
         uri: The tracking URI to use.
 
     """
-    old_tracking_uri = get_tracking_uri()
+    global _tracking_uri
+    old_tracking_uri = _tracking_uri
     try:
         set_tracking_uri(uri)
         yield

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -2,7 +2,6 @@ from typing import Dict
 from unittest import mock
 
 import pytest
-from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
 
 import mlflow
 from mlflow.entities import TraceInfo
@@ -27,8 +26,6 @@ def clear_singleton():
     _TRACE_BUFFER.clear()
 
     # Tracer provider also needs to be reset as it may hold reference to the singleton
-    with _TRACER_PROVIDER_SET_ONCE._lock:
-        _TRACER_PROVIDER_SET_ONCE._done = False
     with _TRACER_PROVIDER_INITIALIZED._lock:
         _TRACER_PROVIDER_INITIALIZED._done = False
 

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -5,9 +5,11 @@ from typing import List, Optional
 import opentelemetry.trace as trace_api
 from opentelemetry.sdk.trace import ReadableSpan
 
+import mlflow
 from mlflow.entities import Trace, TraceData, TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.tracing.fluent import TRACE_BUFFER
+from mlflow.tracing.processor.mlflow import MlflowSpanProcessor
 
 
 def create_mock_otel_span(
@@ -119,3 +121,17 @@ def get_traces() -> List[Trace]:
 def get_first_trace() -> Optional[Trace]:
     if traces := get_traces():
         return traces[0]
+
+
+def get_tracer_tracking_uri() -> Optional[str]:
+    """Get current tracking URI configured as the trace export destination."""
+    from opentelemetry import trace
+
+    mlflow.tracing.enable()
+    tracer = trace.get_tracer(__name__)
+    if isinstance(tracer, trace.ProxyTracer):
+        tracer = tracer._tracer
+    span_processor = tracer.span_processor._span_processors[0]
+
+    if isinstance(span_processor, MlflowSpanProcessor):
+        return span_processor._client.tracking_uri

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -375,18 +375,18 @@ def test_set_tracking_uri_with_path(tmp_path, monkeypatch, absolute):
 
 def test_set_tracking_uri_update_trace_provider():
     default_uri = mlflow.get_tracking_uri()
+    try:
+        mlflow.tracing.enable()
+        assert get_tracer_tracking_uri() != "file:///tmp"
 
-    mlflow.tracing.enable()
-    assert get_tracer_tracking_uri() != "file:///tmp"
+        set_tracking_uri("file:///tmp")
+        assert get_tracer_tracking_uri() == "file:///tmp"
 
-    set_tracking_uri("file:///tmp")
-    assert get_tracer_tracking_uri() == "file:///tmp"
-
-    set_tracking_uri("https://foo")
-    assert get_tracer_tracking_uri() == "https://foo"
-
-    # clean up
-    set_tracking_uri(default_uri)
+        set_tracking_uri("https://foo")
+        assert get_tracer_tracking_uri() == "https://foo"
+    finally:
+        # clean up
+        set_tracking_uri(default_uri)
 
 
 @pytest.mark.parametrize("store_uri", ["databricks-uc", "databricks-uc://profile"])

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -32,6 +32,8 @@ from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.os import is_windows
 
+from tests.tracing.helper import get_tracer_tracking_uri
+
 # Disable mocking tracking URI here, as we want to test setting the tracking URI via
 # environment variable. See
 # http://doc.pytest.org/en/latest/skipping.html#skip-all-test-functions-of-a-class-or-module
@@ -369,6 +371,22 @@ def test_set_tracking_uri_with_path(tmp_path, monkeypatch, absolute):
     with mock.patch("mlflow.tracking._tracking_service.utils._tracking_uri", None):
         set_tracking_uri(path)
         assert get_tracking_uri() == path.absolute().resolve().as_uri()
+
+
+def test_set_tracking_uri_update_trace_provider():
+    default_uri = mlflow.get_tracking_uri()
+
+    mlflow.tracing.enable()
+    assert get_tracer_tracking_uri() != "file:///tmp"
+
+    set_tracking_uri("file:///tmp")
+    assert get_tracer_tracking_uri() == "file:///tmp"
+
+    set_tracking_uri("https://foo")
+    assert get_tracer_tracking_uri() == "https://foo"
+
+    # clean up
+    set_tracking_uri(default_uri)
 
 
 @pytest.mark.parametrize("store_uri", ["databricks-uc", "databricks-uc://profile"])

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2045,17 +2045,8 @@ def test_start_and_end_trace(mlflow_client):
     assert trace_info == client.get_trace_info(trace_info.request_id)
 
 
-def _set_tracking_uri_and_reset_tracer(tracking_uri):
-    # NB: MLflow tracer does not handle the change of tracking URI well,
-    # so we need to reset the tracer to switch the tracking URI during testing.
-    mlflow.tracing.disable()
-    mlflow.set_tracking_uri(tracking_uri)
-    mlflow.tracing.enable()
-
-
 def test_search_traces(mlflow_client):
-    _set_tracking_uri_and_reset_tracer(mlflow_client.tracking_uri)
-
+    mlflow.set_tracking_uri(mlflow_client.tracking_uri)
     experiment_id = mlflow_client.create_experiment("search traces")
 
     # Create test traces
@@ -2099,8 +2090,7 @@ def test_search_traces(mlflow_client):
 
 
 def test_delete_traces(mlflow_client):
-    _set_tracking_uri_and_reset_tracer(mlflow_client.tracking_uri)
-
+    mlflow.set_tracking_uri(mlflow_client.tracking_uri)
     experiment_id = mlflow_client.create_experiment("delete traces")
 
     def _create_trace(name, status):
@@ -2154,6 +2144,7 @@ def test_delete_traces(mlflow_client):
 
 
 def test_set_and_delete_trace_tag(mlflow_client):
+    mlflow.set_tracking_uri(mlflow_client.tracking_uri)
     experiment_id = mlflow_client.create_experiment("set delete tag")
 
     # Create test trace
@@ -2179,7 +2170,7 @@ def test_set_and_delete_trace_tag(mlflow_client):
 
 
 def test_get_trace_artifact_handler(mlflow_client):
-    _set_tracking_uri_and_reset_tracer(mlflow_client.tracking_uri)
+    mlflow.set_tracking_uri(mlflow_client.tracking_uri)
 
     experiment_id = mlflow_client.create_experiment("get trace artifact")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12137?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12137/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12137
```

</p>
</details>

### What changes are proposed in this pull request?

Support updating tracking URI after tracer is initiated.

The global tracer stores tracking client as its instance field. Since the client is only instantiated once at the beginning, its tracking URI is not updated when calling `mlflow.set_tracking_uri()`. This PR changes `mlflow.set_tracking_uri()` function to re-instantiated the global tracing instances to reflect the change of tracking URI.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested in OSS server + notebook;
```
import mlflow

default_client = mlflow.MlflowClient()
with mlflow.start_span(name="default") as span:
    request_id_1 = span.request_id

# Change tracking URI
mlflow.set_tracking_uri("sqlite://mlruns.db")
with mlflow.start_span(name="new") as span:
    request_id_2 = span.request_id

# Pass
default_client.get_trace(request_id_1)
new_client.get_trace(request_id_2)

# Fail
default_client.get_trace(request_id_2)
new_client.get_trace(request_id_1)
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
