### PR TITLE
Raise `MlflowTraceDataNotFound` if trace data download fails

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -319,6 +319,9 @@ class ArtifactRepository:
             - `MlflowTraceDataNotFound`: The trace data is not found.
             - `MlflowTraceDataCorrupted`: The trace data is corrupted.
         """
+        if not any(a.path == TRACE_DATA_FILE_NAME for a in self.list_artifacts()):
+            raise MlflowTraceDataNotFound(artifact_path=TRACE_DATA_FILE_NAME)
+
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_file = Path(temp_dir, TRACE_DATA_FILE_NAME)
             self._download_file(TRACE_DATA_FILE_NAME, temp_file)

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -324,7 +324,7 @@ class ArtifactRepository:
             try:
                 self._download_file(TRACE_DATA_FILE_NAME, temp_file)
             except Exception as e:
-                # `TrackingServiceClient.MlflowTraceDataNotFound` is caught in `search_traces` and
+                # `MlflowTraceDataNotFound` is caught in `TrackingServiceClient.search_traces` and
                 # is used to filter out traces with failed trace data download.
                 raise MlflowTraceDataNotFound(artifact_path=TRACE_DATA_FILE_NAME) from e
             return try_read_trace_data(temp_file)

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -322,9 +322,10 @@ class TrackingServiceClient:
                 trace_data = self._download_trace_data(trace_info)
             except MlflowTraceDataException as e:
                 _logger.warning(
-                    f"Failed to download trace data for trace with {e.ctx}. "
-                    "For full traceback, set logging level to DEBUG.",
-                    trace_info.request_id,
+                    (
+                        f"Failed to download trace data for trace {trace_info.request_id!r} "
+                        f"with {e.ctx}. For full traceback, set logging level to DEBUG."
+                    ),
                     exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
                 return None

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -321,10 +321,11 @@ class TrackingServiceClient:
             try:
                 trace_data = self._download_trace_data(trace_info)
             except MlflowTraceDataException as e:
-                _logger.debug(
-                    f"Failed to download trace data for trace with {e.ctx}",
+                _logger.warning(
+                    f"Failed to download trace data for trace with {e.ctx}. "
+                    "For full traceback, set logging level to DEBUG.",
                     trace_info.request_id,
-                    exc_info=True,
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
                 return None
             else:

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -429,7 +429,7 @@ def test_abort_multipart_upload(s3_artifact_root):
 def test_trace_data(s3_artifact_root):
     repo = get_artifact_repository(s3_artifact_root)
     # s3 download_file raises exception directly if the file doesn't exist
-    with pytest.raises(Exception, match=r"Not Found"):
+    with pytest.raises(Exception, match=r"Trace data not found"):
         repo.download_trace_data()
     repo.upload_trace_data("invalid data")
     with pytest.raises(MlflowTraceDataCorrupted, match=r"Trace data is corrupted for path="):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -313,7 +313,7 @@ def test_client_search_traces_trace_data_download_error(mock_store):
                 timestamp_ms=123,
                 execution_time_ms=456,
                 status=TraceStatus.OK,
-                tags={"mlflow.artifactLocation": "dbfs:/path/to/artifacts/1"},
+                tags={"mlflow.artifactLocation": "test"},
             ),
         ]
         mock_store.search_traces.return_value = (mock_traces, None)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -30,6 +30,7 @@ from mlflow.entities.param import Param
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
 from mlflow.exceptions import MlflowException, MlflowTraceDataCorrupted, MlflowTraceDataNotFound
+from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.model_registry.sqlalchemy_store import (
     SqlAlchemyStore as SqlAlchemyModelRegistryStore,
 )
@@ -285,6 +286,39 @@ def test_client_search_traces(mock_store, mock_artifact_repo):
     # The TraceInfo is already fetched prior to the upload_trace_data call,
     # so we should not call _get_trace_info again
     mock_store.get_trace_info.assert_not_called()
+
+
+def test_client_search_traces_trace_data_download_error(mock_store):
+    class CustomArtifactRepository(ArtifactRepository):
+        def log_artifact(self, local_file, artifact_path=None):
+            raise NotImplementedError("Should not be called")
+
+        def log_artifacts(self, local_dir, artifact_path=None):
+            raise NotImplementedError("Should not be called")
+
+        def list_artifacts(self, path):
+            raise NotImplementedError("Should not be called")
+
+        def _download_file(self, *args, **kwargs):
+            raise Exception("Failed to download trace data")
+
+    with mock.patch(
+        "mlflow.tracking._tracking_service.client.get_artifact_repository",
+        return_value=CustomArtifactRepository("test"),
+    ) as mock_get_artifact_repository:
+        mock_traces = [
+            TraceInfo(
+                request_id="1234567",
+                experiment_id="1",
+                timestamp_ms=123,
+                execution_time_ms=456,
+                status=TraceStatus.OK,
+                tags={"mlflow.artifactLocation": "dbfs:/path/to/artifacts/1"},
+            ),
+        ]
+        mock_store.search_traces.return_value = (mock_traces, None)
+        assert MlflowClient().search_traces(experiment_ids=["1"]) == []
+        mock_get_artifact_repository.assert_called()
 
 
 def test_client_delete_traces(mock_store):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12146?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12146/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12146
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Throw `MlflowTraceDataNotFound ` if trace data download fails so `search_traces` can filter out traces with failed trace data download.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
