### PR TITLE
Fix proxy artifact URI handling for fetching trace data

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -21,6 +21,7 @@ from google.protobuf.json_format import ParseError
 from mlflow.entities import DatasetInput, ExperimentTag, FileInfo, Metric, Param, RunTag, ViewType
 from mlflow.entities.model_registry import ModelVersionTag, RegisteredModelTag
 from mlflow.entities.multipart_upload import MultipartUploadPart
+from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_DEPLOYMENTS_TARGET
 from mlflow.exceptions import MlflowException, _UnsupportedMultipartUploadException
@@ -185,6 +186,38 @@ def _get_artifact_repo_mlflow_artifacts():
     if _artifact_repo is None:
         _artifact_repo = get_artifact_repository(os.environ[ARTIFACTS_DESTINATION_ENV_VAR])
     return _artifact_repo
+
+
+def _get_trace_artifact_repo(trace_info: TraceInfo):
+    """
+    Resolve the artifact repository for fetching data for the given trace.
+
+    Args:
+        trace_info: The trace info object containing metadata about the trace.
+    """
+    artifact_uri = get_artifact_uri_for_trace(trace_info)
+
+    if _is_servable_proxied_run_artifact_root(artifact_uri):
+        # If the artifact location is a proxied run artifact root (e.g. mlflow-artifacts://...),
+        # we need to resolve it to the actual artifact location.
+        from mlflow.server import ARTIFACTS_DESTINATION_ENV_VAR
+
+        if not (path := _get_proxied_run_artifact_destination_path(artifact_uri)):
+            raise MlflowException(
+                f"Failed to resolve the proxied run artifact URI: {artifact_uri}.",
+                "Trace artifact URI must contain subpath to the trace data directory.",
+                error_code=BAD_REQUEST,
+            )
+        root = os.environ[ARTIFACTS_DESTINATION_ENV_VAR]
+        artifact_uri = posixpath.join(root, path)
+
+        # We don't set it to global var unlike run artifact, because the artifact repo has
+        # to be created with full trace artifact URI including request_id.
+        # e.g. s3://<experiment_id>/traces/<request_id>
+        artifact_repo = get_artifact_repository(artifact_uri)
+    else:
+        artifact_repo = get_artifact_repository(artifact_uri)
+    return artifact_repo
 
 
 def _is_serving_proxied_artifacts():
@@ -2455,15 +2488,10 @@ def get_trace_artifact_handler():
         )
 
     trace_info = _get_tracking_store().get_trace_info(request_id)
-    artifact_uri = get_artifact_uri_for_trace(trace_info)
+    trace_data = _get_trace_artifact_repo(trace_info).download_trace_data()
 
-    if _is_servable_proxied_run_artifact_root(artifact_uri):
-        artifact_repo = _get_artifact_repo_mlflow_artifacts()
-    else:
-        artifact_repo = get_artifact_repository(artifact_uri)
-
+    # Write data to a BytesIO buffer instead of needing to save a temp file
     buf = io.BytesIO()
-    trace_data = artifact_repo.download_trace_data()
     buf.write(json.dumps(trace_data).encode())
     buf.seek(0)
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -202,9 +202,10 @@ def _get_trace_artifact_repo(trace_info: TraceInfo):
         # we need to resolve it to the actual artifact location.
         from mlflow.server import ARTIFACTS_DESTINATION_ENV_VAR
 
-        if not (path := _get_proxied_run_artifact_destination_path(artifact_uri)):
+        path = _get_proxied_run_artifact_destination_path(artifact_uri)
+        if not path:
             raise MlflowException(
-                f"Failed to resolve the proxied run artifact URI: {artifact_uri}.",
+                f"Failed to resolve the proxied run artifact URI: {artifact_uri}. ",
                 "Trace artifact URI must contain subpath to the trace data directory.",
                 error_code=BAD_REQUEST,
             )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12147?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12147/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12147
```

</p>
</details>

### What changes are proposed in this pull request?

Fix a bug in `/get-trace-artifact` API of tracking server. 

The `/get-trace-artifact` API is used to fetch trace data artifact for the given request ID. It was validated to work with local/remote artifact store with direct access, but did not work correctly if the artifact storage is behind a proxy of tracking server.

```
import mlflow
import requests

mlflow.set_tracking_uri("http://127.0.0.1:5000)
mlflow.set_experiment("traces")

@mlflow.trace
def foo(a, b):
    return a + b

with mlflow.start_run():
  foo(1, 2)

data = requests.get(
  "http://localhost:5000/ajax-api/2.0/mlflow/get-trace-artifact",
  params={"request_id": "ff4f9017c4524bf2bb29dc0bf2d693d5"}
)
print(data)

## <Response [404]>
```

This was because the handler uses root artifact URI in the tracking server ([code](https://github.com/mlflow/mlflow/blob/358886800f91607c0e4847b33f07b4ab67fab3e2/mlflow/server/handlers.py#L2461)), not including subpath `traces/{request_id}`, when proxy artifact URI is specified.  This PR updates the URI handling to fix the issue.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1169" alt="Screenshot 2024-05-28 at 13 17 28" src="https://github.com/mlflow/mlflow/assets/31463517/264fe176-f177-4bf6-954f-34182dfcd76c">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
