### PR TITLE
[MLflow] Overriding example_no_conversion to true by default for langchain models

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -126,7 +126,7 @@ def get_default_conda_env():
 
 
 def _infer_signature_from_input_example_for_lc_model(
-    input_example, wrapped_model, example_no_conversion=False
+    input_example, wrapped_model, example_no_conversion=True
 ):
     from mlflow.langchain.api_request_parallel_processor import _ChatResponse
 
@@ -156,7 +156,7 @@ def save_model(
     metadata=None,
     loader_fn=None,
     persist_dir=None,
-    example_no_conversion=False,
+    example_no_conversion=True,
     model_config=None,
     streamable: Optional[bool] = None,
 ):
@@ -250,7 +250,10 @@ def save_model(
                     )
 
             See a complete example in examples/langchain/retrieval_qa_chain.py.
-        example_no_conversion: {{ example_no_conversion }}
+        example_no_conversion: If ``False``, the input example will be converted to a Pandas
+                DataFrame format when saving. This is useful when the model expects a DataFrame
+                input and the input example could be passed directly to the model.
+                Defaults to ``True``.
         model_config: The model configuration to apply to the model if saving model as code. This
             configuration is available during model loading.
 
@@ -429,7 +432,7 @@ def log_model(
     metadata=None,
     loader_fn=None,
     persist_dir=None,
-    example_no_conversion=False,
+    example_no_conversion=True,
     run_id=None,
     model_config=None,
     streamable=None,
@@ -532,7 +535,10 @@ def log_model(
                     )
 
             See a complete example in examples/langchain/retrieval_qa_chain.py.
-        example_no_conversion: {{ example_no_conversion }}
+        example_no_conversion: If ``False``, the input example will be converted to a Pandas
+                DataFrame format when saving. This is useful when the model expects a DataFrame
+                input and the input example could be passed directly to the model.
+                Defaults to ``True``.
         run_id: run_id to associate with this model version. If specified, we resume the
                 run and log the model to that run. Otherwise, a new run is created.
                 Default to None.

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -342,7 +342,7 @@ def test_loaded_llmchain_autolog():
             mlflow_model = get_mlflow_model(run.info.artifact_uri)
             model_path = os.path.join(run.info.artifact_uri, MODEL_DIR)
             input_example = _read_example(mlflow_model, model_path)
-            assert input_example.to_dict("records") == [question]
+            assert input_example == question
 
             pyfunc_model = mlflow.pyfunc.load_model(f"runs:/{run.info.run_id}/model")
             # _TestLangChainWrapper mocks this result
@@ -474,7 +474,7 @@ def test_loaded_agent_autolog():
             mlflow_model = get_mlflow_model(run.info.artifact_uri)
             model_path = os.path.join(run.info.artifact_uri, MODEL_DIR)
             input_example = _read_example(mlflow_model, model_path)
-            assert input_example.to_dict("records") == [input]
+            assert input_example == input
 
             pyfunc_model = mlflow.pyfunc.load_model(f"runs:/{run.info.run_id}/model")
             assert pyfunc_model.predict(input) == [TEST_CONTENT]
@@ -557,7 +557,7 @@ def test_loaded_runnable_sequence_autolog():
         mlflow_model = get_mlflow_model(run.info.artifact_uri)
         model_path = os.path.join(run.info.artifact_uri, MODEL_DIR)
         saved_example = _read_example(mlflow_model, model_path)
-        assert saved_example.to_dict("records") == [input_example]
+        assert saved_example == input_example
 
         pyfunc_model = mlflow.pyfunc.load_model(f"runs:/{run.info.run_id}/model")
         assert pyfunc_model.predict(input_example) == [TEST_CONTENT]

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1563,6 +1563,7 @@ def test_save_load_rag(tmp_path, spark, fake_chat_model):
             loader_fn=load_retriever,
             persist_dir=persist_dir,
             input_example=question,
+            example_no_conversion=False,
         )
 
     # Remove the persist_dir
@@ -3035,7 +3036,9 @@ def test_save_load_langchain_binding(fake_chat_model):
     assert model.invoke("Say something") == "Databricks"
 
     with mlflow.start_run():
-        model_info = mlflow.langchain.log_model(model, "model_path", input_example="Say something")
+        model_info = mlflow.langchain.log_model(
+            model, "model_path", input_example="Say something", example_no_conversion=False
+        )
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
     assert loaded_model.first.kwargs == {"stop": ["-"]}
     assert loaded_model.invoke("hello") == "Databricks"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/12156?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12156/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12156
```

</p>
</details>

### What changes are proposed in this pull request?
[MLflow] Overriding example_no_conversion to true by default for langchain models

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
Overriding example_no_conversion to true by default for langchain models

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
