### PR TITLE
Populate columns of dataframe returned by `mlflow.search_traces`

### DIFF
--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -85,3 +85,18 @@ class Trace(_MlflowObject):
             "spans": [span.to_dict() for span in self.data.spans],
             "tags": self.info.tags,
         }
+
+    @staticmethod
+    def pandas_dataframe_columns():
+        return [
+            "request_id",
+            "trace",
+            "timestamp_ms",
+            "status",
+            "execution_time_ms",
+            "request",
+            "response",
+            "request_metadata",
+            "spans",
+            "tags",
+        ]

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.trace_data import TraceData
@@ -87,7 +87,7 @@ class Trace(_MlflowObject):
         }
 
     @staticmethod
-    def pandas_dataframe_columns():
+    def pandas_dataframe_columns() -> List[str]:
         return [
             "request_id",
             "trace",

--- a/mlflow/tracing/utils.py
+++ b/mlflow/tracing/utils.py
@@ -201,8 +201,10 @@ def traces_to_df(traces: List[Trace]) -> "pandas.DataFrame":
     """
     import pandas as pd
 
+    from mlflow.entities.trace import Trace  # import here to avoid circular import
+
     rows = [trace.to_pandas_dataframe_row() for trace in traces]
-    return pd.DataFrame.from_records(rows)
+    return pd.DataFrame.from_records(data=rows, columns=Trace.pandas_dataframe_columns())
 
 
 def extract_span_inputs_outputs(

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -7,14 +7,14 @@ from packaging.version import Version
 
 import mlflow
 import mlflow.tracking.context.default_context
-from mlflow.entities import SpanType, Trace
+from mlflow.entities import SpanType, Trace, TraceData
 from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
 from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_KEY
 from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.utils.mlflow_tags import MLFLOW_ARTIFACT_LOCATION
 
 from tests.tracing.conftest import clear_singleton  # noqa: F401
-from tests.tracing.helper import get_first_trace
+from tests.tracing.helper import create_test_trace_info, get_first_trace
 
 
 def _test_model(datetime=datetime.now()):
@@ -222,3 +222,11 @@ def test_trace_to_from_dict_and_json(clear_singleton):
                 assert getattr(trace.data.spans[i], attr) == getattr(
                     loaded_trace.data.spans[i], attr
                 )
+
+
+def test_trace_pandas_dataframe_columns():
+    t = Trace(
+        info=create_test_trace_info("a"),
+        data=TraceData(),
+    )
+    assert Trace.pandas_dataframe_columns() == list(t.to_pandas_dataframe_row())

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -553,6 +553,8 @@ def test_test_search_traces_empty(mock_client):
     traces = mlflow.search_traces(extract_fields=["foo.inputs.bar"])
     assert traces.columns.tolist() == [*default_columns, "foo.inputs.bar"]
 
+    mock_client.search_traces.assert_called()
+
 
 def test_search_traces(mock_client):
     mock_client.search_traces.return_value = PagedList(

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -541,6 +541,19 @@ def test_start_span_context_manager_with_imperative_apis(clear_singleton):
     }
 
 
+def test_test_search_traces_empty(mock_client):
+    mock_client.search_traces.return_value = PagedList([], token=None)
+
+    traces = mlflow.search_traces()
+    assert traces.empty
+
+    default_columns = Trace.pandas_dataframe_columns()
+    assert traces.columns.tolist() == default_columns
+
+    traces = mlflow.search_traces(extract_fields=["foo.inputs.bar"])
+    assert traces.columns.tolist() == [*default_columns, "foo.inputs.bar"]
+
+
 def test_search_traces(mock_client):
     mock_client.search_traces.return_value = PagedList(
         [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12159?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12159/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12159
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix the following bug:

```
import mlflow

mlflow.search_traces(extract_fields=["span.inputs"])
```

```
Traceback (most recent call last):
  File "a.py", line 8, in <module>
    mlflow.search_traces(
  File "/Users/foo.bar/Desktop/repositories/mlflow/mlflow/tracing/fluent.py", line 364, in search_traces
    traces_df = extract_span_inputs_outputs(
  File "/Users/foo.bar/Desktop/repositories/mlflow/mlflow/tracing/utils.py", line 247, in extract_span_inputs_outputs
    return _extract_from_traces_pandas_df(df=traces, col_name=col_name, fields=parsed_fields)
  File "/Users/foo.bar/Desktop/repositories/mlflow/mlflow/tracing/utils.py", line 312, in _extract_from_traces_pandas_df
    raise MlflowException(
mlflow.exceptions.MlflowException: Column 'spans' not found in traces DataFrame. Available columns: Index([], dtype='object')
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
