### PR TITLE
Allow Relative Paths in Mlflow Log Model

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -41,7 +41,6 @@ from mlflow.langchain.utils import (
     _MODEL_LOAD_KEY,
     _RUNNABLE_LOAD_KEY,
     _load_base_lcs,
-    _load_from_yaml,
     _save_base_lcs,
     _validate_and_prepare_lc_model_or_path,
     lc_runnables_types,
@@ -93,6 +92,7 @@ from mlflow.utils.model_utils import (
     _validate_and_copy_code_paths,
     _validate_and_copy_file_to_directory,
     _validate_and_prepare_target_save_path,
+    _validate_and_get_model_config_from_file,
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
 
@@ -274,7 +274,7 @@ def save_model(
         if not os.path.isabs(model_config):
             model_config = os.path.abspath(model_config)
         if os.path.exists(model_config):
-            model_config = _load_from_yaml(model_config)
+            model_config = _validate_and_get_model_config_from_file(model_config)
         else:
             raise mlflow.MlflowException.invalid_parameter_value(
                 f"Model config path '{model_config}' provided is not a valid file path. "
@@ -888,7 +888,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
                 local_model_path,
                 os.path.basename(model_config),
             )
-            model_config = _load_from_yaml(config_path)
+            model_config = _validate_and_get_model_config_from_file(config_path)
 
         flavor_code_path = pyfunc_flavor_conf.get(
             MODEL_CODE_PATH, flavor_conf.get(MODEL_CODE_PATH, None)

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -271,14 +271,7 @@ def save_model(
     _validate_and_prepare_target_save_path(path)
 
     if isinstance(model_config, str):
-        model_config = os.path.abspath(model_config)
-        if os.path.exists(model_config):
-            model_config = _validate_and_get_model_config_from_file(model_config)
-        else:
-            raise mlflow.MlflowException.invalid_parameter_value(
-                f"Model config path '{model_config}' provided is not a valid file path. "
-                "Please provide a valid model configuration."
-            )
+        model_config = _validate_and_get_model_config_from_file(model_config)
 
     model_code_path = None
     if isinstance(lc_model_or_path, str):

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -271,6 +271,8 @@ def save_model(
     _validate_and_prepare_target_save_path(path)
 
     if isinstance(model_config, str):
+        if not os.path.isabs(model_config):
+            model_config = os.path.abspath(model_config)
         if os.path.exists(model_config):
             model_config = _load_from_yaml(model_config)
         else:

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -91,8 +91,8 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _validate_and_copy_file_to_directory,
-    _validate_and_prepare_target_save_path,
     _validate_and_get_model_config_from_file,
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
 
@@ -271,8 +271,7 @@ def save_model(
     _validate_and_prepare_target_save_path(path)
 
     if isinstance(model_config, str):
-        if not os.path.isabs(model_config):
-            model_config = os.path.abspath(model_config)
+        model_config = os.path.abspath(model_config)
         if os.path.exists(model_config):
             model_config = _validate_and_get_model_config_from_file(model_config)
         else:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -655,7 +655,7 @@ class Model:
         """
         from mlflow.models.wheeled_model import _ORIGINAL_REQ_FILE_NAME, WheeledModel
         from mlflow.utils.model_utils import _validate_and_get_model_config_from_file
-        
+
         with TempDir() as tmp:
             local_path = tmp.path("model")
             if run_id is None:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -705,6 +705,8 @@ class Model:
                             with open(model_config) as f:
                                 model_config = json.load(f)
                         elif file_extension in [".yaml", ".yml"]:
+                            if not os.path.isabs(model_config):
+                                model_config = os.path.abspath(model_config)
                             with open(model_config) as f:
                                 model_config = yaml.safe_load(f)
                         else:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -705,8 +705,7 @@ class Model:
                             with open(model_config) as f:
                                 model_config = json.load(f)
                         elif file_extension in [".yaml", ".yml"]:
-                            if not os.path.isabs(model_config):
-                                model_config = os.path.abspath(model_config)
+                            model_config = os.path.abspath(model_config)
                             with open(model_config) as f:
                                 model_config = yaml.safe_load(f)
                         else:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -654,7 +654,8 @@ class Model:
             metadata of the logged model.
         """
         from mlflow.models.wheeled_model import _ORIGINAL_REQ_FILE_NAME, WheeledModel
-
+        from mlflow.utils.model_utils import _validate_and_get_model_config_from_file
+        
         with TempDir() as tmp:
             local_path = tmp.path("model")
             if run_id is None:
@@ -705,9 +706,7 @@ class Model:
                             with open(model_config) as f:
                                 model_config = json.load(f)
                         elif file_extension in [".yaml", ".yml"]:
-                            model_config = os.path.abspath(model_config)
-                            with open(model_config) as f:
-                                model_config = yaml.safe_load(f)
+                            model_config = _validate_and_get_model_config_from_file(model_config)
                         else:
                             _logger.warning(
                                 "Unsupported file format for model config: %s. "

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -150,6 +150,8 @@ class _ResourceBuilder:
     def from_yaml_file(path: str) -> Dict[str, Dict[ResourceType, List[Dict]]]:
         if not os.path.exists(path):
             raise OSError(f"No such file or directory: '{path}'")
+        if not os.path.isabs(path):
+            path = os.path.abspath(path)
         with open(path) as file:
             data = yaml.safe_load(file)
             return _ResourceBuilder.from_dict(data)

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -150,8 +150,7 @@ class _ResourceBuilder:
     def from_yaml_file(path: str) -> Dict[str, Dict[ResourceType, List[Dict]]]:
         if not os.path.exists(path):
             raise OSError(f"No such file or directory: '{path}'")
-        if not os.path.isabs(path):
-            path = os.path.abspath(path)
+        path = os.path.abspath(path)
         with open(path) as file:
             data = yaml.safe_load(file)
             return _ResourceBuilder.from_dict(data)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1551,8 +1551,7 @@ def _validate_and_get_model_code_path(model_code_path: str) -> str:
     """
 
     # If the path is not a absolute path then convert it
-    if not os.path.isabs(model_code_path):
-        model_code_path = os.path.abspath(model_code_path)
+    model_code_path = os.path.abspath(model_code_path)
 
     if not os.path.exists(model_code_path):
         raise MlflowException.invalid_parameter_value(

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1549,6 +1549,11 @@ def _validate_and_get_model_code_path(model_code_path: str) -> str:
 
     Returns either `model_code_path` or a temp file path with the contents of the notebook.
     """
+
+    # If the path is not a absolute path then convert it
+    if not os.path.isabs(model_code_path):
+        model_code_path = os.path.abspath(model_code_path)
+
     if not os.path.exists(model_code_path):
         raise MlflowException.invalid_parameter_value(
             f"If the provided model '{model_code_path}' is a string, it must be a valid python "

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -381,6 +381,8 @@ def _get_overridden_pyfunc_model_config(
 
 
 def _validate_and_get_model_config_from_file(model_config):
+    if not os.path.isabs(model_config):
+        model_config = os.path.abspath(model_config)
     if os.path.exists(model_config):
         with open(model_config) as file:
             try:

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -381,8 +381,7 @@ def _get_overridden_pyfunc_model_config(
 
 
 def _validate_and_get_model_config_from_file(model_config):
-    if not os.path.isabs(model_config):
-        model_config = os.path.abspath(model_config)
+    model_config = os.path.abspath(model_config)
     if os.path.exists(model_config):
         with open(model_config) as file:
             try:

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2348,7 +2348,11 @@ def chain_model_signature():
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_save_load_chain_as_code(chain_model_signature):
+@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
+                                        "tests/langchain/../langchain/sample_code/chain.py"])
+@pytest.mark.parametrize("model_config", [os.path.abspath("tests/langchain/sample_code/config.yml"),
+                                          "tests/langchain/../langchain/sample_code/config.yml"])
+def test_save_load_chain_as_code(chain_model_signature, chain_path,model_config, monkeypatch):
     input_example = {
         "messages": [
             {
@@ -2360,11 +2364,11 @@ def test_save_load_chain_as_code(chain_model_signature):
     artifact_path = "model_path"
     with mlflow.start_run() as run:
         model_info = mlflow.langchain.log_model(
-            lc_model="tests/langchain/sample_code/chain.py",
+            lc_model=chain_path,
             artifact_path=artifact_path,
             signature=chain_model_signature,
             input_example=input_example,
-            model_config="tests/langchain/sample_code/config.yml",
+            model_config=model_config,
         )
 
     assert mlflow.models.model_config.__mlflow_model_config__ is None
@@ -2432,7 +2436,9 @@ def test_save_load_chain_as_code(chain_model_signature):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_save_load_chain_as_code_model_config_dict(chain_model_signature):
+@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
+                                        "tests/langchain/../langchain/sample_code/chain.py"])
+def test_save_load_chain_as_code_model_config_dict(chain_model_signature, chain_path):
     input_example = {
         "messages": [
             {
@@ -2443,7 +2449,7 @@ def test_save_load_chain_as_code_model_config_dict(chain_model_signature):
     }
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(
-            lc_model="tests/langchain/sample_code/chain.py",
+            lc_model=chain_path,
             artifact_path="model_path",
             signature=chain_model_signature,
             input_example=input_example,
@@ -2470,7 +2476,11 @@ def test_save_load_chain_as_code_model_config_dict(chain_model_signature):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_save_load_chain_as_code_with_different_names(tmp_path, chain_model_signature):
+@pytest.mark.parametrize("model_config", [os.path.abspath("tests/langchain/sample_code/config.yml"),
+                                          "tests/langchain/../langchain/sample_code/config.yml"])
+def test_save_load_chain_as_code_with_different_names(tmp_path,
+                                                      chain_model_signature,
+                                                      model_config):
     input_example = {
         "messages": [
             {
@@ -2493,7 +2503,7 @@ def test_save_load_chain_as_code_with_different_names(tmp_path, chain_model_sign
             artifact_path="model_path",
             signature=chain_model_signature,
             input_example=input_example,
-            model_config="tests/langchain/sample_code/config.yml",
+            model_config=model_config,
         )
 
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
@@ -2512,8 +2522,11 @@ def test_save_load_chain_as_code_with_different_names(tmp_path, chain_model_sign
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_save_load_chain_as_code_multiple_times(tmp_path, chain_model_signature):
-    config_path = "tests/langchain/sample_code/config.yml"
+@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
+                                        "tests/langchain/../langchain/sample_code/chain.py"])
+@pytest.mark.parametrize("model_config", [os.path.abspath("tests/langchain/sample_code/config.yml"),
+                                          "tests/langchain/../langchain/sample_code/config.yml"])
+def test_save_load_chain_as_code_multiple_times(tmp_path, chain_model_signature, chain_path, model_config):
     input_example = {
         "messages": [
             {
@@ -2524,15 +2537,15 @@ def test_save_load_chain_as_code_multiple_times(tmp_path, chain_model_signature)
     }
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(
-            lc_model="tests/langchain/sample_code/chain.py",
+            lc_model=chain_path,
             artifact_path="model_path",
             signature=chain_model_signature,
             input_example=input_example,
-            model_config=config_path,
+            model_config=model_config,
         )
 
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
-    with open(config_path) as f:
+    with open(model_config) as f:
         base_config = yaml.safe_load(f)
 
     assert loaded_model.middle[0].messages[0].prompt.template == base_config["llm_prompt_template"]
@@ -2547,7 +2560,7 @@ def test_save_load_chain_as_code_multiple_times(tmp_path, chain_model_signature)
 
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(
-            lc_model="tests/langchain/sample_code/chain.py",
+            lc_model=chain_path,
             artifact_path="model_path",
             signature=chain_model_signature,
             input_example=input_example,
@@ -2561,7 +2574,9 @@ def test_save_load_chain_as_code_multiple_times(tmp_path, chain_model_signature)
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_save_load_chain_errors(chain_model_signature):
+@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain1/sample_code/chain.py"),
+                                        "sample_code/chain.py"])
+def test_save_load_chain_errors(chain_model_signature, chain_path):
     input_example = {
         "messages": [
             {
@@ -2571,15 +2586,14 @@ def test_save_load_chain_errors(chain_model_signature):
         ]
     }
     with mlflow.start_run():
-        incorrect_path = "tests/langchain1/sample_code/chain.py"
         with pytest.raises(
             MlflowException,
-            match=f"If the provided model '{incorrect_path}' is a string, it must be a valid "
+            match=f"If the provided model '{chain_path}' is a string, it must be a valid "
             "python file path or a databricks notebook file path containing the code for defining "
             "the chain instance.",
         ):
             mlflow.langchain.log_model(
-                lc_model=incorrect_path,
+                lc_model=chain_path,
                 artifact_path="model_path",
                 signature=chain_model_signature,
                 input_example=input_example,
@@ -2590,7 +2604,9 @@ def test_save_load_chain_errors(chain_model_signature):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_save_load_chain_as_code_optional_code_path(chain_model_signature):
+@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
+                                        "tests/langchain/../langchain/sample_code/chain.py"])
+def test_save_load_chain_as_code_optional_code_path(chain_model_signature, chain_path):
     input_example = {
         "messages": [
             {
@@ -2602,7 +2618,7 @@ def test_save_load_chain_as_code_optional_code_path(chain_model_signature):
     artifact_path = "new_model_path"
     with mlflow.start_run() as run:
         model_info = mlflow.langchain.log_model(
-            lc_model="tests/langchain/sample_code/no_config/chain.py",
+            lc_model=chain_path,
             artifact_path=artifact_path,
             signature=chain_model_signature,
             input_example=input_example,
@@ -2966,13 +2982,15 @@ def test_langchain_model_not_inject_callback_when_disabled(
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_save_model_as_code_correct_streamable(chain_model_signature):
+@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
+                                        "tests/langchain/../langchain/sample_code/chain.py"])
+def test_save_model_as_code_correct_streamable(chain_model_signature, chain_path):
     input_example = {"messages": [{"role": "user", "content": "Who owns MLflow?"}]}
     answer = "Databricks"
     artifact_path = "model_path"
     with mlflow.start_run() as run:
         model_info = mlflow.langchain.log_model(
-            lc_model="tests/langchain/sample_code/no_config/chain.py",
+            lc_model=chain_path,
             artifact_path=artifact_path,
             signature=chain_model_signature,
             input_example=input_example,
@@ -3124,7 +3142,11 @@ def test_langchain_2_12_model_loads():
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_load_chain_with_model_config_overrides_saved_config(chain_model_signature):
+@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
+                                        "tests/langchain/../langchain/sample_code/chain.py"])
+@pytest.mark.parametrize("model_config", [os.path.abspath("tests/langchain/sample_code/config.yml"),
+                                          "tests/langchain/../langchain/sample_code/config.yml"])
+def test_load_chain_with_model_config_overrides_saved_config(chain_model_signature, chain_path, model_config):
     input_example = {
         "messages": [
             {
@@ -3136,11 +3158,11 @@ def test_load_chain_with_model_config_overrides_saved_config(chain_model_signatu
     artifact_path = "model_path"
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(
-            lc_model="tests/langchain/sample_code/chain.py",
+            lc_model=chain_path,
             artifact_path=artifact_path,
             signature=chain_model_signature,
             input_example=input_example,
-            model_config="tests/langchain/sample_code/config.yml",
+            model_config=model_config,
         )
 
     with mock.patch("mlflow.langchain._load_model_code_path") as load_model_code_path_mock:

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2348,11 +2348,21 @@ def chain_model_signature():
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
-                                        "tests/langchain/../langchain/sample_code/chain.py"])
-@pytest.mark.parametrize("model_config", [os.path.abspath("tests/langchain/sample_code/config.yml"),
-                                          "tests/langchain/../langchain/sample_code/config.yml"])
-def test_save_load_chain_as_code(chain_model_signature, chain_path,model_config, monkeypatch):
+@pytest.mark.parametrize(
+    "chain_path",
+    [
+        os.path.abspath("tests/langchain/sample_code/chain.py"),
+        "tests/langchain/../langchain/sample_code/chain.py",
+    ],
+)
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        os.path.abspath("tests/langchain/sample_code/config.yml"),
+        "tests/langchain/../langchain/sample_code/config.yml",
+    ],
+)
+def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config, monkeypatch):
     input_example = {
         "messages": [
             {
@@ -2436,8 +2446,13 @@ def test_save_load_chain_as_code(chain_model_signature, chain_path,model_config,
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
-                                        "tests/langchain/../langchain/sample_code/chain.py"])
+@pytest.mark.parametrize(
+    "chain_path",
+    [
+        os.path.abspath("tests/langchain/sample_code/chain.py"),
+        "tests/langchain/../langchain/sample_code/chain.py",
+    ],
+)
 def test_save_load_chain_as_code_model_config_dict(chain_model_signature, chain_path):
     input_example = {
         "messages": [
@@ -2476,11 +2491,16 @@ def test_save_load_chain_as_code_model_config_dict(chain_model_signature, chain_
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize("model_config", [os.path.abspath("tests/langchain/sample_code/config.yml"),
-                                          "tests/langchain/../langchain/sample_code/config.yml"])
-def test_save_load_chain_as_code_with_different_names(tmp_path,
-                                                      chain_model_signature,
-                                                      model_config):
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        os.path.abspath("tests/langchain/sample_code/config.yml"),
+        "tests/langchain/../langchain/sample_code/config.yml",
+    ],
+)
+def test_save_load_chain_as_code_with_different_names(
+    tmp_path, chain_model_signature, model_config
+):
     input_example = {
         "messages": [
             {
@@ -2522,11 +2542,23 @@ def test_save_load_chain_as_code_with_different_names(tmp_path,
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
-                                        "tests/langchain/../langchain/sample_code/chain.py"])
-@pytest.mark.parametrize("model_config", [os.path.abspath("tests/langchain/sample_code/config.yml"),
-                                          "tests/langchain/../langchain/sample_code/config.yml"])
-def test_save_load_chain_as_code_multiple_times(tmp_path, chain_model_signature, chain_path, model_config):
+@pytest.mark.parametrize(
+    "chain_path",
+    [
+        os.path.abspath("tests/langchain/sample_code/chain.py"),
+        "tests/langchain/../langchain/sample_code/chain.py",
+    ],
+)
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        os.path.abspath("tests/langchain/sample_code/config.yml"),
+        "tests/langchain/../langchain/sample_code/config.yml",
+    ],
+)
+def test_save_load_chain_as_code_multiple_times(
+    tmp_path, chain_model_signature, chain_path, model_config
+):
     input_example = {
         "messages": [
             {
@@ -2574,8 +2606,9 @@ def test_save_load_chain_as_code_multiple_times(tmp_path, chain_model_signature,
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain1/sample_code/chain.py"),
-                                        "sample_code/chain.py"])
+@pytest.mark.parametrize(
+    "chain_path", [os.path.abspath("tests/langchain1/sample_code/chain.py"), "sample_code/chain.py"]
+)
 def test_save_load_chain_errors(chain_model_signature, chain_path):
     input_example = {
         "messages": [
@@ -2604,8 +2637,13 @@ def test_save_load_chain_errors(chain_model_signature, chain_path):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
-                                        "tests/langchain/../langchain/sample_code/chain.py"])
+@pytest.mark.parametrize(
+    "chain_path",
+    [
+        os.path.abspath("tests/langchain/sample_code/chain.py"),
+        "tests/langchain/../langchain/sample_code/chain.py",
+    ],
+)
 def test_save_load_chain_as_code_optional_code_path(chain_model_signature, chain_path):
     input_example = {
         "messages": [
@@ -2982,8 +3020,13 @@ def test_langchain_model_not_inject_callback_when_disabled(
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
-                                        "tests/langchain/../langchain/sample_code/chain.py"])
+@pytest.mark.parametrize(
+    "chain_path",
+    [
+        os.path.abspath("tests/langchain/sample_code/chain.py"),
+        "tests/langchain/../langchain/sample_code/chain.py",
+    ],
+)
 def test_save_model_as_code_correct_streamable(chain_model_signature, chain_path):
     input_example = {"messages": [{"role": "user", "content": "Who owns MLflow?"}]}
     answer = "Databricks"
@@ -3142,11 +3185,23 @@ def test_langchain_2_12_model_loads():
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain/sample_code/chain.py"),
-                                        "tests/langchain/../langchain/sample_code/chain.py"])
-@pytest.mark.parametrize("model_config", [os.path.abspath("tests/langchain/sample_code/config.yml"),
-                                          "tests/langchain/../langchain/sample_code/config.yml"])
-def test_load_chain_with_model_config_overrides_saved_config(chain_model_signature, chain_path, model_config):
+@pytest.mark.parametrize(
+    "chain_path",
+    [
+        os.path.abspath("tests/langchain/sample_code/chain.py"),
+        "tests/langchain/../langchain/sample_code/chain.py",
+    ],
+)
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        os.path.abspath("tests/langchain/sample_code/config.yml"),
+        "tests/langchain/../langchain/sample_code/config.yml",
+    ],
+)
+def test_load_chain_with_model_config_overrides_saved_config(
+    chain_model_signature, chain_path, model_config
+):
     input_example = {
         "messages": [
             {

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2621,7 +2621,7 @@ def test_save_load_chain_errors(chain_model_signature, chain_path):
     with mlflow.start_run():
         with pytest.raises(
             MlflowException,
-            match=f"The provided model path '{incorrect_path}' is not a valid Python file path or "
+            match=f"The provided model path '{chain_path}' is not a valid Python file path or "
             "a Databricks Notebook file path containing the code for defining the chain instance. "
             "Ensure the file path is valid and try again.",
         ):

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2638,8 +2638,8 @@ def test_save_load_chain_errors(chain_model_signature, chain_path):
 @pytest.mark.parametrize(
     "chain_path",
     [
-        os.path.abspath("tests/langchain/sample_code/chain.py"),
-        "tests/langchain/../langchain/sample_code/chain.py",
+        os.path.abspath("tests/langchain/sample_code/no_config/chain.py"),
+        "tests/langchain/../langchain/sample_code/no_config/chain.py",
     ],
 )
 def test_save_load_chain_as_code_optional_code_path(chain_model_signature, chain_path):
@@ -3021,8 +3021,8 @@ def test_langchain_model_not_inject_callback_when_disabled(
 @pytest.mark.parametrize(
     "chain_path",
     [
-        os.path.abspath("tests/langchain/sample_code/chain.py"),
-        "tests/langchain/../langchain/sample_code/chain.py",
+        os.path.abspath("tests/langchain/sample_code/no_config/chain.py"),
+        "tests/langchain/../langchain/sample_code/no_config/chain.py",
     ],
 )
 def test_save_model_as_code_correct_streamable(chain_model_signature, chain_path):

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2606,9 +2606,7 @@ def test_save_load_chain_as_code_multiple_times(
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize(
-    "chain_path", [os.path.abspath("tests/langchain1/sample_code/chain.py"), "sample_code/chain.py"]
-)
+@pytest.mark.parametrize("chain_path", [os.path.abspath("tests/langchain1/sample_code/chain.py")])
 def test_save_load_chain_errors(chain_model_signature, chain_path):
     input_example = {
         "messages": [

--- a/tests/pyfunc/test_pyfunc_model_config.py
+++ b/tests/pyfunc/test_pyfunc_model_config.py
@@ -22,11 +22,6 @@ def model_config():
     }
 
 
-@pytest.fixture
-def model_config_path():
-    return "tests/pyfunc/sample_code/config.yml"
-
-
 def _load_pyfunc(path):
     return TestModel()
 
@@ -53,7 +48,7 @@ def test_save_with_model_config(model_path, model_config):
     assert all(loaded_model.model_config[k] == v for k, v in model_config.items())
     assert all(loaded_model.model_config[k] == v for k, v in loaded_model.predict([[0]]))
 
-
+@pytest.mark.parametrize("model_config_path", [os.path.abspath("tests/pyfunc/sample_code/config.yml"), "tests/pyfunc/../pyfunc/sample_code/config.yml"])
 def test_save_with_model_config_path(model_path, model_config, model_config_path):
     model = InferenceContextModel()
     mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
@@ -76,7 +71,7 @@ def test_override_model_config(model_path, model_config):
     assert loaded_model.model_config["timeout"] == 400
     assert all(loaded_model.model_config[k] == v for k, v in inference_override.items())
 
-
+@pytest.mark.parametrize("model_config_path", [os.path.abspath("tests/pyfunc/sample_code/config.yml"), "tests/pyfunc/../pyfunc/sample_code/config.yml"])
 def test_override_model_config_path(model_path, model_config_path):
     model = TestModel()
     inference_override = {"timeout": 400}
@@ -99,7 +94,7 @@ def test_override_model_config_ignore_invalid(model_path, model_config):
     assert loaded_model.predict([[5]])
     assert all(k not in loaded_model.model_config for k in inference_override.keys())
 
-
+@pytest.mark.parametrize("model_config_path", [os.path.abspath("tests/pyfunc/sample_code/config.yml"), "tests/pyfunc/../pyfunc/sample_code/config.yml"])
 def test_override_model_config_path_ignore_invalid(model_path, model_config_path):
     model = TestModel()
     inference_override = {"invalid_key": 400}

--- a/tests/pyfunc/test_pyfunc_model_config.py
+++ b/tests/pyfunc/test_pyfunc_model_config.py
@@ -48,7 +48,14 @@ def test_save_with_model_config(model_path, model_config):
     assert all(loaded_model.model_config[k] == v for k, v in model_config.items())
     assert all(loaded_model.model_config[k] == v for k, v in loaded_model.predict([[0]]))
 
-@pytest.mark.parametrize("model_config_path", [os.path.abspath("tests/pyfunc/sample_code/config.yml"), "tests/pyfunc/../pyfunc/sample_code/config.yml"])
+
+@pytest.mark.parametrize(
+    "model_config_path",
+    [
+        os.path.abspath("tests/pyfunc/sample_code/config.yml"),
+        "tests/pyfunc/../pyfunc/sample_code/config.yml",
+    ],
+)
 def test_save_with_model_config_path(model_path, model_config, model_config_path):
     model = InferenceContextModel()
     mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
@@ -71,7 +78,14 @@ def test_override_model_config(model_path, model_config):
     assert loaded_model.model_config["timeout"] == 400
     assert all(loaded_model.model_config[k] == v for k, v in inference_override.items())
 
-@pytest.mark.parametrize("model_config_path", [os.path.abspath("tests/pyfunc/sample_code/config.yml"), "tests/pyfunc/../pyfunc/sample_code/config.yml"])
+
+@pytest.mark.parametrize(
+    "model_config_path",
+    [
+        os.path.abspath("tests/pyfunc/sample_code/config.yml"),
+        "tests/pyfunc/../pyfunc/sample_code/config.yml",
+    ],
+)
 def test_override_model_config_path(model_path, model_config_path):
     model = TestModel()
     inference_override = {"timeout": 400}
@@ -94,7 +108,14 @@ def test_override_model_config_ignore_invalid(model_path, model_config):
     assert loaded_model.predict([[5]])
     assert all(k not in loaded_model.model_config for k in inference_override.keys())
 
-@pytest.mark.parametrize("model_config_path", [os.path.abspath("tests/pyfunc/sample_code/config.yml"), "tests/pyfunc/../pyfunc/sample_code/config.yml"])
+
+@pytest.mark.parametrize(
+    "model_config_path",
+    [
+        os.path.abspath("tests/pyfunc/sample_code/config.yml"),
+        "tests/pyfunc/../pyfunc/sample_code/config.yml",
+    ],
+)
 def test_override_model_config_path_ignore_invalid(model_path, model_config_path):
     model = TestModel()
     inference_override = {"invalid_key": 400}


### PR DESCRIPTION
### Related Issues/PRs

Support Relative Paths in Mlflow langchain and pyfunc log model

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` 

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)