### PR TITLE
Suppress trace during signature inference and fix faulty warnings

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, get_type_hin
 import numpy as np
 import pandas as pd
 
-import mlflow
 from mlflow import environment_variables
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
@@ -23,6 +22,7 @@ from mlflow.models.utils import ModelInputExample, _contains_params, _Example
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
+from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_artifact_to_uri
 from mlflow.types.schema import ParamSchema, Schema, convert_dataclass_to_schema
 from mlflow.types.utils import _infer_param_schema, _infer_schema, _infer_schema_from_type_hint
@@ -378,7 +378,7 @@ def _infer_signature_from_input_example(
         input_schema = _infer_schema(input_example)
         params_schema = _infer_param_schema(params) if params else None
         # Avoid rendering traces when inferring the signature
-        with mlflow.tracing.disabled():
+        with trace_disabled():
             prediction = wrapped_model.predict(input_example, params=params)
         # For column-based inputs, 1D numpy arrays likely signify row-based predictions. Thus, we
         # convert them to a Pandas series for inferring as a single ColSpec Schema.

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, get_type_hin
 import numpy as np
 import pandas as pd
 
+import mlflow
 from mlflow import environment_variables
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
@@ -376,7 +377,9 @@ def _infer_signature_from_input_example(
             input_example = deepcopy(example.inference_data)
         input_schema = _infer_schema(input_example)
         params_schema = _infer_param_schema(params) if params else None
-        prediction = wrapped_model.predict(input_example, params=params)
+        # Avoid rendering traces when inferring the signature
+        with mlflow.tracing.disabled():
+            prediction = wrapped_model.predict(input_example, params=params)
         # For column-based inputs, 1D numpy arrays likely signify row-based predictions. Thus, we
         # convert them to a Pandas series for inferring as a single ColSpec Schema.
         if (

--- a/mlflow/tracing/__init__.py
+++ b/mlflow/tracing/__init__.py
@@ -1,3 +1,3 @@
-from mlflow.tracing.provider import disable, disabled, enable
+from mlflow.tracing.provider import disable, enable
 
-__all__ = ["disable", "disabled", "enable"]
+__all__ = ["disable", "enable"]

--- a/mlflow/tracing/__init__.py
+++ b/mlflow/tracing/__init__.py
@@ -1,3 +1,3 @@
-from mlflow.tracing.provider import disable, enable
+from mlflow.tracing.provider import disable, disabled, enable
 
-__all__ = ["disable", "enable"]
+__all__ = ["disable", "disabled", "enable"]

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -11,7 +11,8 @@ from cachetools import TTLCache
 from opentelemetry import trace as trace_api
 
 from mlflow import MlflowClient
-from mlflow.entities import LiveSpan, NoOpSpan, SpanType, Trace
+from mlflow.entities import NoOpSpan, SpanType, Trace
+from mlflow.entities.span import create_mlflow_span
 from mlflow.environment_variables import (
     MLFLOW_TRACE_BUFFER_MAX_SIZE,
     MLFLOW_TRACE_BUFFER_TTL_SECONDS,
@@ -214,9 +215,9 @@ def start_span(
     try:
         otel_span = provider.start_span_in_context(name)
 
-        # Create a new MlflowSpanWrapper and register it to the in-memory trace manager
+        # Create a new MLflow span and register it to the in-memory trace manager
         request_id = get_otel_attribute(otel_span, SpanAttributeKey.REQUEST_ID)
-        mlflow_span = LiveSpan(otel_span, request_id=request_id, span_type=span_type)
+        mlflow_span = create_mlflow_span(otel_span, request_id, span_type)
         mlflow_span.set_attributes(attributes or {})
         InMemoryTraceManager.get_instance().register_span(mlflow_span)
 
@@ -232,7 +233,7 @@ def start_span(
 
     try:
         # Setting end_on_exit = False to suppress the default span
-        # export and instead invoke MlflowSpanWrapper.end()
+        # export and instead invoke MLflow span's end() method.
         with trace_api.use_span(mlflow_span._span, end_on_exit=False):
             yield mlflow_span
     finally:

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -44,10 +44,6 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
 
     def __init__(self, span_exporter: SpanExporter, client: Optional[MlflowClient] = None):
         self.span_exporter = span_exporter
-        # TODO: MlflowClient() does not handle the change of tracking URI after
-        # the client is instantiated. Inherently, this class does not handle it
-        # either. We should consider reset these singleton instances for tracing
-        # when the tracking URI is changed.
         self._client = client or MlflowClient()
         self._trace_manager = InMemoryTraceManager.get_instance()
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -111,9 +111,6 @@ def disable():
     """
     Disable tracing by setting the global tracer provider to NoOpTracerProvider.
     """
-    if not _is_enabled():
-        _logger.info("Tracing is already disabled")
-        return
     reset_tracer_setup()  # Force re-initialization of the tracer provider
     _TRACER_PROVIDER_INITIALIZED.do_once(lambda: _setup_tracer_provider(disabled=True))
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -133,6 +133,8 @@ def enable():
 def trace_disabled():
     """
     Temporarily disable tracing for the duration of the context manager.
+
+    :meta private:
     """
     was_trace_enabled = _is_enabled()
     try:

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -164,7 +164,7 @@ def _is_enabled() -> bool:
     Check if tracing is enabled based on whether the global tracer
     is instantiated or not.
 
-    Trace is considered as "on" if the followings
+    Trace is considered as "enabled" if the followings
     1. The default state (before any tracing operation)
     2. The tracer is not either ProxyTracer or NoOpTracer
     """

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import logging
 from typing import Optional, Tuple
@@ -126,6 +127,18 @@ def enable():
         return
 
     _setup_tracer_provider()
+
+
+@contextlib.contextmanager
+def disabled():
+    """
+    Temporarily disable tracing for the duration of the context manager.
+    """
+    try:
+        disable()
+        yield
+    finally:
+        enable()
 
 
 def reset_tracer_setup():

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -82,7 +82,7 @@ class InMemoryTraceManager:
         """
         with self._lock:
             if trace_info.request_id not in self._traces:
-                _logger.warning(f"Trace data with request ID {trace_info.request_id} not found.")
+                _logger.debug(f"Trace data with request ID {trace_info.request_id} not found.")
                 return
             self._traces[trace_info.request_id].info = trace_info
 
@@ -94,7 +94,7 @@ class InMemoryTraceManager:
             span: The span to be stored.
         """
         if not isinstance(span, LiveSpan):
-            _logger.warning(f"Invalid span object {type(span)} is passed. Skipping.")
+            _logger.debug(f"Invalid span object {type(span)} is passed. Skipping.")
             return
 
         with self._lock:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -37,7 +37,7 @@ from mlflow.entities import (
 )
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
-from mlflow.entities.span import NO_OP_SPAN_REQUEST_ID, LiveSpan, NoOpSpan
+from mlflow.entities.span import NO_OP_SPAN_REQUEST_ID, NoOpSpan, create_mlflow_span
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_LOGGING
 from mlflow.exceptions import MlflowException
@@ -578,7 +578,7 @@ class MlflowClient:
             )
             request_id = get_otel_attribute(otel_span, SpanAttributeKey.REQUEST_ID)
 
-            mlflow_span = LiveSpan(otel_span, request_id, span_type)
+            mlflow_span = create_mlflow_span(otel_span, request_id, span_type)
             if inputs:
                 mlflow_span.set_inputs(inputs)
             if attributes:
@@ -824,7 +824,7 @@ class MlflowClient:
 
         try:
             otel_span = mlflow.tracing.provider.start_detached_span(name, parent=parent_span._span)
-            span = LiveSpan(otel_span, request_id, span_type)
+            span = create_mlflow_span(otel_span, request_id, span_type)
             if attributes:
                 span.set_attributes(attributes)
             if inputs:

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -7,6 +7,7 @@ from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 
 import mlflow
 from mlflow.entities import LiveSpan, Span, SpanEvent, SpanStatus, SpanStatusCode, SpanType
+from mlflow.entities.span import NoOpSpan, create_mlflow_span
 from mlflow.exceptions import MlflowException
 from mlflow.tracing.provider import _get_tracer
 from mlflow.tracing.utils import encode_span_id, encode_trace_id
@@ -14,12 +15,13 @@ from mlflow.tracing.utils import encode_span_id, encode_trace_id
 from tests.tracing.conftest import clear_singleton  # noqa: F401
 
 
-def test_wrap_live_span(clear_singleton):
+def test_create_live_span(clear_singleton):
     request_id = "tr-12345"
 
     tracer = _get_tracer("test")
     with tracer.start_as_current_span("parent") as parent_span:
-        span = LiveSpan(parent_span, request_id=request_id, span_type=SpanType.LLM)
+        span = create_mlflow_span(parent_span, request_id=request_id, span_type=SpanType.LLM)
+        assert isinstance(span, LiveSpan)
         assert span.request_id == request_id
         assert span._trace_id == encode_trace_id(parent_span.context.trace_id)
         assert span.span_id == encode_span_id(parent_span.context.span_id)
@@ -60,12 +62,13 @@ def test_wrap_live_span(clear_singleton):
 
         # Test child span
         with tracer.start_as_current_span("child") as child_span:
-            span = LiveSpan(child_span, request_id=request_id)
+            span = create_mlflow_span(child_span, request_id=request_id)
+            assert isinstance(span, LiveSpan)
             assert span.name == "child"
             assert span.parent_id == encode_span_id(parent_span.context.span_id)
 
 
-def test_wrap_non_live_span():
+def test_create_non_live_span():
     request_id = "tr-12345"
     parent_span_context = trace_api.SpanContext(
         trace_id=12345, span_id=111, is_remote=False, trace_flags=trace_api.TraceFlags(1)
@@ -85,8 +88,11 @@ def test_wrap_non_live_span():
         start_time=99999,
         end_time=100000,
     )
-    span = Span(readable_span)
+    span = create_mlflow_span(readable_span, request_id)
 
+    assert isinstance(span, Span)
+    assert not isinstance(span, LiveSpan)
+    assert not isinstance(span, NoOpSpan)
     assert span.request_id == request_id
     assert span._trace_id == encode_trace_id(12345)
     assert span.span_id == encode_span_id(222)
@@ -104,9 +110,22 @@ def test_wrap_non_live_span():
         span.set_inputs({"input": 1})
 
 
-def test_wrap_raise_for_invalid_otel_span():
-    with pytest.raises(MlflowException, match=r"The `otel_span` argument for the LiveSpan class"):
-        LiveSpan(None, request_id="tr-12345")
+def test_create_noop_span():
+    with mlflow.tracing.disabled():
+        request_id = "tr-12345"
+        tracer = _get_tracer("test")
+        with tracer.start_as_current_span("span") as otel_span:
+            span = create_mlflow_span(otel_span, request_id=request_id)
+        assert isinstance(span, NoOpSpan)
+
+    # create from None
+    span = create_mlflow_span(None, request_id=request_id)
+    assert isinstance(span, NoOpSpan)
+
+
+def test_create_raise_for_invalid_otel_span():
+    with pytest.raises(MlflowException, match=r"The `otel_span` argument must be"):
+        create_mlflow_span(otel_span=123, request_id="tr-12345")
 
 
 @pytest.mark.parametrize(

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -9,7 +9,7 @@ import mlflow
 from mlflow.entities import LiveSpan, Span, SpanEvent, SpanStatus, SpanStatusCode, SpanType
 from mlflow.entities.span import NoOpSpan, create_mlflow_span
 from mlflow.exceptions import MlflowException
-from mlflow.tracing.provider import _get_tracer
+from mlflow.tracing.provider import _get_tracer, trace_disabled
 from mlflow.tracing.utils import encode_span_id, encode_trace_id
 
 from tests.tracing.conftest import clear_singleton  # noqa: F401
@@ -111,7 +111,7 @@ def test_create_non_live_span():
 
 
 def test_create_noop_span():
-    with mlflow.tracing.disabled():
+    with trace_disabled():
         request_id = "tr-12345"
         tracer = _get_tracer("test")
         with tracer.start_as_current_span("span") as otel_span:

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -5,11 +5,11 @@ from typing import List, Optional
 import opentelemetry.trace as trace_api
 from opentelemetry.sdk.trace import ReadableSpan
 
-import mlflow
 from mlflow.entities import Trace, TraceData, TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.processor.mlflow import MlflowSpanProcessor
+from mlflow.tracing.provider import _get_tracer
 
 
 def create_mock_otel_span(
@@ -127,8 +127,7 @@ def get_tracer_tracking_uri() -> Optional[str]:
     """Get current tracking URI configured as the trace export destination."""
     from opentelemetry import trace
 
-    mlflow.tracing.enable()
-    tracer = trace.get_tracer(__name__)
+    tracer = _get_tracer(__name__)
     if isinstance(tracer, trace.ProxyTracer):
         tracer = tracer._tracer
     span_processor = tracer.span_processor._span_processors[0]

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -7,7 +7,12 @@ from mlflow.tracing.export.mlflow import MlflowSpanExporter
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
 from mlflow.tracing.processor.mlflow import MlflowSpanProcessor
-from mlflow.tracing.provider import _TRACER_PROVIDER_INITIALIZED, _get_tracer, _is_enabled, trace_disabled
+from mlflow.tracing.provider import (
+    _TRACER_PROVIDER_INITIALIZED,
+    _get_tracer,
+    _is_enabled,
+    trace_disabled,
+)
 
 
 # Mock client getter just to count the number of calls

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1,3 +1,4 @@
+import pytest
 from opentelemetry import trace
 
 import mlflow
@@ -6,7 +7,7 @@ from mlflow.tracing.export.mlflow import MlflowSpanExporter
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
 from mlflow.tracing.processor.mlflow import MlflowSpanProcessor
-from mlflow.tracing.provider import _TRACER_PROVIDER_INITIALIZED, _get_tracer
+from mlflow.tracing.provider import _TRACER_PROVIDER_INITIALIZED, _get_tracer, _is_enabled, trace_disabled
 
 
 # Mock client getter just to count the number of calls
@@ -62,3 +63,47 @@ def test_disable_enable_tracing():
     assert len(TRACE_BUFFER) == 1
     assert isinstance(_get_tracer(__name__), trace.Tracer)
     TRACE_BUFFER.clear()
+
+
+@pytest.mark.parametrize("enabled_initially", [True, False])
+def test_trace_disabled_context_manager(enabled_initially):
+    if not enabled_initially:
+        mlflow.tracing.disable()
+    assert _is_enabled() == enabled_initially
+
+    @mlflow.trace
+    def test_fn():
+        pass
+
+    with trace_disabled():
+        test_fn()
+        assert len(TRACE_BUFFER) == 0
+        assert not _is_enabled()
+
+    # Recover the initial state
+    assert _is_enabled() == enabled_initially
+
+
+def test_is_enabled():
+    # Before doing anything -> tracing is considered as "on"
+    assert _is_enabled()
+
+    # Generate a trace -> tracing is still "on"
+    @mlflow.trace
+    def foo():
+        pass
+
+    foo()
+    assert _is_enabled()
+
+    # Disable tracing
+    mlflow.tracing.disable()
+    assert not _is_enabled()
+
+    # Try to generate a trace -> tracing is still "off"
+    foo()
+    assert not _is_enabled()
+
+    # Re-enable tracing
+    mlflow.tracing.enable()
+    assert _is_enabled()

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -376,7 +376,6 @@ def test_set_tracking_uri_with_path(tmp_path, monkeypatch, absolute):
 def test_set_tracking_uri_update_trace_provider():
     default_uri = mlflow.get_tracking_uri()
     try:
-        mlflow.tracing.enable()
         assert get_tracer_tracking_uri() != "file:///tmp"
 
         set_tracking_uri("file:///tmp")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12167?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12167/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12167
```

</p>
</details>

### What changes are proposed in this pull request?

When logging a model with an input example, MLflow runs model prediction once to infer the output signature. When trace is enabled, this generates and renders a new trace, which is confusing as users won't know why it runs prediction. 

**Before**
<img width="687" alt="Screenshot 2024-05-29 at 10 02 39" src="https://github.com/mlflow/mlflow/assets/31463517/215daf6a-e507-4394-bc4e-0eed904e79ea">

**After**
<img width="689" alt="Screenshot 2024-05-29 at 12 47 14" src="https://github.com/mlflow/mlflow/assets/31463517/1eca70f4-1608-4dd4-b588-b6f4096a92c3">

(Not sure where `Setuptools is replacing distutils.` comes from. I will investigate and if it's related to tracing, will address in a separate PR).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
