### PR TITLE
Fix delete_traces

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1628,14 +1628,10 @@ class FileStore(AbstractStore):
                         exc_info=_logger.isEnabledFor(logging.DEBUG),
                     )
             trace_info_and_paths.sort(key=lambda x: x[0].timestamp_ms)
-            if max_traces is None:
-                max_traces = len(trace_info_and_paths)
+            deleted_traces = min(len(trace_info_and_paths), max_traces or len(trace_info_and_paths))
+            trace_info_and_paths = trace_info_and_paths[:deleted_traces]
             for _, trace_path in trace_info_and_paths:
-                if max_traces == 0:
-                    break
                 shutil.rmtree(trace_path)
-                deleted_traces += 1
-                max_traces -= 1
             return deleted_traces
         if request_ids:
             for request_id in request_ids:

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -99,6 +99,8 @@ from mlflow.utils.validation import (
     _validate_tag_name,
 )
 
+_logger = logging.getLogger(__name__)
+
 
 def _default_root_dir():
     return MLFLOW_TRACKING_DIR.get() or os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
@@ -1577,7 +1579,9 @@ class FileStore(AbstractStore):
             experiment_id: ID of the associated experiment.
             max_timestamp_millis: The maximum timestamp in milliseconds since the UNIX epoch for
                 deleting traces. Traces older than or equal to this timestamp will be deleted.
-            max_traces: The maximum number of traces to delete.
+            max_traces: The maximum number of traces to delete. If max_traces is specified, and
+                it is less than the number of traces that would be deleted based on the
+                max_timestamp_millis, the oldest traces will be deleted first.
             request_ids: A set of request IDs to delete.
 
         Returns:
@@ -1610,24 +1614,28 @@ class FileStore(AbstractStore):
         deleted_traces = 0
         if max_timestamp_millis:
             trace_paths = list_all(traces_path, lambda x: os.path.isdir(x), full_path=True)
-            if max_traces is None:
-                max_traces = len(trace_paths)
+            trace_info_and_paths = []
             for trace_path in trace_paths:
                 try:
                     trace_info = self._get_trace_info_from_dir(trace_path)
                     if trace_info.timestamp_ms <= max_timestamp_millis:
-                        shutil.rmtree(trace_path)
-                        deleted_traces += 1
-                        max_traces -= 1
+                        trace_info_and_paths.append((trace_info, trace_path))
                 except MissingConfigException as e:
                     # trap malformed trace exception and log warning
                     request_id = os.path.basename(trace_path)
-                    logging.warning(
+                    _logger.warning(
                         f"Malformed trace with request_id '{request_id}'. Detailed error {e}",
-                        exc_info=True,
+                        exc_info=_logger.isEnabledFor(logging.DEBUG),
                     )
+            trace_info_and_paths.sort(key=lambda x: x[0].timestamp_ms)
+            if max_traces is None:
+                max_traces = len(trace_info_and_paths)
+            for _, trace_path in trace_info_and_paths:
                 if max_traces == 0:
                     break
+                shutil.rmtree(trace_path)
+                deleted_traces += 1
+                max_traces -= 1
             return deleted_traces
         if request_ids:
             for request_id in request_ids:

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2864,19 +2864,21 @@ def test_delete_trace_tag(store_and_trace_info):
 def test_delete_traces(store):
     exp_id = store.create_experiment("test")
     request_ids = []
-    timestamps = list(range(0, 100, 10))
+    timestamps = list(range(90, -1, -10))
     for i in range(10):
         trace_info = store.start_trace(exp_id, timestamps[i], {}, {})
         request_ids.append(trace_info.request_id)
 
     # delete with max_timestamp_millis
-    assert store.delete_traces(exp_id, 50, 2) == 2
+    # if max_traces < number of traces with timestamp < max_timestamp_millis,
+    # delete older traces first
+    assert store.delete_traces(exp_id, max_timestamp_millis=50, max_traces=2) == 2
     assert len(store.search_traces([exp_id])[0]) == 8
-    assert store.delete_traces(exp_id, 50) == 4
+    assert store.delete_traces(exp_id, max_timestamp_millis=50) == 4
     assert len(store.search_traces([exp_id])[0]) == 4
 
     # delete with request_ids
-    assert store.delete_traces(exp_id, request_ids=[request_ids[6]]) == 1
+    assert store.delete_traces(exp_id, request_ids=[request_ids[3]]) == 1
     assert len(store.search_traces([exp_id])[0]) == 3
     assert store.delete_traces(exp_id, request_ids=["non_existing_request_id"]) == 0
     assert len(store.search_traces([exp_id])[0]) == 3


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12174?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12174/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12174
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix file_store delete_traces --> we should delete older traces first if max_traces < number of traces with timestamp < max_timestamp_millis

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
