### PR TITLE
Avoid showing repeated warnings for tracing default experiment usage

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -12,7 +12,7 @@ from opentelemetry import trace as trace_api
 
 from mlflow import MlflowClient
 from mlflow.entities import NoOpSpan, SpanType, Trace
-from mlflow.entities.span import create_mlflow_span
+from mlflow.entities.span import LiveSpan, create_mlflow_span
 from mlflow.environment_variables import (
     MLFLOW_TRACE_BUFFER_MAX_SIZE,
     MLFLOW_TRACE_BUFFER_TTL_SECONDS,

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -48,9 +48,10 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         self._trace_manager = InMemoryTraceManager.get_instance()
 
         # We issue a warning when a trace is created under the default experiment.
-        # We only want to issue it once, but de-duplication of warnings module does
-        # not work in notebooks (https://github.com/ipython/ipython/issues/11207).
-        # Therefore, we keep track of the warning issuance state manually.
+        # We only want to issue it once, and typically it can be achieved by using
+        # warnings.warn() with filterwarnings setting. However, the de-duplication does
+        # not work in notebooks (https://github.com/ipython/ipython/issues/11207),
+        # so we instead keep track of the warning issuance state manually.
         self._issued_default_exp_warning = False
 
     def on_start(self, span: OTelSpan, parent_context: Optional[Context] = None):

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -47,6 +47,12 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         self._client = client or MlflowClient()
         self._trace_manager = InMemoryTraceManager.get_instance()
 
+        # We issue a warning when a trace is created under the default experiment.
+        # We only want to issue it once, but de-duplication of warnings module does
+        # not work in notebooks (https://github.com/ipython/ipython/issues/11207).
+        # Therefore, we keep track of the warning issuance state manually.
+        self._issued_default_exp_warning = False
+
     def on_start(self, span: OTelSpan, parent_context: Optional[Context] = None):
         """
         Handle the start of a span. This method is called when an OpenTelemetry span is started.
@@ -82,7 +88,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             # take precendence over the environment experiment id
             experiment_id = run.info.experiment_id
 
-        if experiment_id == DEFAULT_EXPERIMENT_ID:
+        if experiment_id == DEFAULT_EXPERIMENT_ID and not self._issued_default_exp_warning:
             _logger.warning(
                 "Creating a trace within the default experiment with id "
                 f"'{DEFAULT_EXPERIMENT_ID}'. It is strongly recommended to not use "
@@ -92,6 +98,8 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                 "To avoid performance and disambiguation issues, set the experiment for "
                 "your environment using `mlflow.set_experiment()` API."
             )
+            self._issued_default_exp_warning = True
+
         tags = resolve_tags()
         tags.update({TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)})
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12175?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12175/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12175
```

</p>
</details>

### What changes are proposed in this pull request?

When users create a trace under the default experiment, we issues a warning because it might result in performance issue as the trace volume increases. 

> WARNING mlflow.tracing.processor.mlflow: Creating a trace within the default experiment with id '0'. It is strongly recommended to not use the default experiment to log traces due to ambiguous search results and probable performance issues over time due to directory table listing performance degradation with high volumes of directories within a specific path. To avoid performance and disambiguation issues, set the experiment for your environment using `mlflow.set_experiment()` API.

Currently, this warning is emitted whenever users create a new trace, which is annoying. This PR fixes the issue to only show the warning once in a process.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="999" alt="Screenshot 2024-05-29 at 22 21 26" src="https://github.com/mlflow/mlflow/assets/31463517/cd3568ca-78fb-4167-9f61-1e2198955156">


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
