### PR TITLE
Add ENABLE_MLFLOW_TRACING to control tracing in serving

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -73,7 +73,10 @@ from mlflow.utils.autologging_utils import (
     autologging_is_disabled,
     safe_patch,
 )
-from mlflow.utils.databricks_utils import is_in_databricks_model_serving_environment
+from mlflow.utils.databricks_utils import (
+    enable_mlflow_tracing_in_model_serving,
+    is_in_databricks_model_serving_environment,
+)
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -641,7 +644,12 @@ class _LangChainModelWrapper:
         # TODO: We don't automatically turn tracing on in OSS model serving, because we haven't
         # implemented storage option for traces in OSS model serving (counterpart to the
         # Inference Table in Databricks model serving).
-        if is_in_databricks_model_serving_environment() and MLFLOW_ENABLE_TRACE_IN_SERVING.get():
+        if (
+            is_in_databricks_model_serving_environment()
+            and MLFLOW_ENABLE_TRACE_IN_SERVING.get()
+            # if this is False, tracing is disabled and we shouldn't inject the tracer
+            and enable_mlflow_tracing_in_model_serving()
+        ):
             from mlflow.langchain.langchain_tracer import MlflowLangchainTracer
 
             callbacks = [MlflowLangchainTracer()]

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -74,8 +74,8 @@ from mlflow.utils.autologging_utils import (
     safe_patch,
 )
 from mlflow.utils.databricks_utils import (
-    enable_mlflow_tracing_in_model_serving,
     is_in_databricks_model_serving_environment,
+    is_mlflow_tracing_enabled_in_model_serving,
 )
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
@@ -648,7 +648,7 @@ class _LangChainModelWrapper:
             is_in_databricks_model_serving_environment()
             and MLFLOW_ENABLE_TRACE_IN_SERVING.get()
             # if this is False, tracing is disabled and we shouldn't inject the tracer
-            and enable_mlflow_tracing_in_model_serving()
+            and is_mlflow_tracing_enabled_in_model_serving()
         ):
             from mlflow.langchain.langchain_tracer import MlflowLangchainTracer
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -9,8 +9,8 @@ from opentelemetry.util._once import Once
 
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.utils.databricks_utils import (
-    enable_mlflow_tracing_in_model_serving,
     is_in_databricks_model_serving_environment,
+    is_mlflow_tracing_enabled_in_model_serving,
 )
 
 # Once() object ensures a function is executed only once in a process.
@@ -81,7 +81,7 @@ def _setup_tracer_provider(disabled=False):
         return
 
     if is_in_databricks_model_serving_environment():
-        if not enable_mlflow_tracing_in_model_serving():
+        if not is_mlflow_tracing_enabled_in_model_serving():
             _force_set_otel_tracer_provider(trace.NoOpTracerProvider())
             return
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -187,7 +187,7 @@ def is_in_databricks_model_serving_environment():
     return val.lower() == "true"
 
 
-def enable_mlflow_tracing_in_model_serving() -> bool:
+def is_mlflow_tracing_enabled_in_model_serving() -> bool:
     """
     This environment variable guards tracing behaviors for models in databricks
     model serving. Tracing in serving is only enabled when this env var is true.

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -187,6 +187,14 @@ def is_in_databricks_model_serving_environment():
     return val.lower() == "true"
 
 
+def enable_mlflow_tracing() -> bool:
+    """
+    This environment variable guards tracing behaviors for models in databricks
+    model serving. Tracing in serving is only enabled when this env var is true.
+    """
+    return os.environ.get("ENABLE_MLFLOW_TRACING", "false").lower() == "true"
+
+
 # this should only be the case when we are in model serving environment
 # and OAuth token file exists in specified path
 def should_fetch_model_serving_environment_oauth():

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -187,7 +187,7 @@ def is_in_databricks_model_serving_environment():
     return val.lower() == "true"
 
 
-def enable_mlflow_tracing() -> bool:
+def enable_mlflow_tracing_in_model_serving() -> bool:
     """
     This environment variable guards tracing behaviors for models in databricks
     model serving. Tracing in serving is only enabled when this env var is true.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,3 +153,9 @@ def monkeypatch():
 def tmp_sqlite_uri(tmp_path):
     path = tmp_path.joinpath("mlflow.db").as_uri()
     return ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
+
+
+@pytest.fixture
+def mock_databricks_serving_with_tracing_env(monkeypatch):
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("ENABLE_MLFLOW_TRACING", "true")

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2936,17 +2936,15 @@ def test_langchain_model_inject_callback_in_model_serving(
         assert len(_TRACE_BUFFER) == 0
 
 
-@pytest.mark.parametrize(
-    "control_param", ["MLFLOW_ENABLE_TRACE_IN_SERVING", "ENABLE_MLFLOW_TRACING"]
-)
+@pytest.mark.parametrize("env_var", ["MLFLOW_ENABLE_TRACE_IN_SERVING", "ENABLE_MLFLOW_TRACING"])
 def test_langchain_model_not_inject_callback_when_disabled(
-    clear_trace_singleton, monkeypatch, model_path, control_param
+    clear_trace_singleton, monkeypatch, model_path, env_var
 ):
     # Emulate the model serving environment
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
 
     # Disable tracing
-    monkeypatch.setenv(control_param, "false")
+    monkeypatch.setenv(env_var, "false")
 
     model = create_openai_llmchain()
     mlflow.langchain.save_model(model, model_path)

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2906,12 +2906,14 @@ def test_langchain_model_save_load_with_listeners(fake_chat_model):
     }
 
 
+@pytest.mark.parametrize("enable_mlflow_tracing", [True, False])
 def test_langchain_model_inject_callback_in_model_serving(
-    clear_trace_singleton, monkeypatch, model_path
+    clear_trace_singleton, monkeypatch, model_path, enable_mlflow_tracing
 ):
     # Emulate the model serving environment
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("MLFLOW_ENABLE_TRACE_IN_SERVING", "true")
+    monkeypatch.setenv("ENABLE_MLFLOW_TRACING", str(enable_mlflow_tracing).lower())
 
     model = create_openai_llmchain()
     mlflow.langchain.save_model(model, model_path)
@@ -2927,18 +2929,24 @@ def test_langchain_model_inject_callback_in_model_serving(
     # Trace should be logged to the inference table
     from mlflow.tracing.export.inference_table import _TRACE_BUFFER
 
-    assert len(_TRACE_BUFFER) == 1
-    assert _REQUEST_ID in _TRACE_BUFFER
+    if enable_mlflow_tracing:
+        assert len(_TRACE_BUFFER) == 1
+        assert _REQUEST_ID in _TRACE_BUFFER
+    else:
+        assert len(_TRACE_BUFFER) == 0
 
 
+@pytest.mark.parametrize(
+    "control_param", ["MLFLOW_ENABLE_TRACE_IN_SERVING", "ENABLE_MLFLOW_TRACING"]
+)
 def test_langchain_model_not_inject_callback_when_disabled(
-    clear_trace_singleton, monkeypatch, model_path
+    clear_trace_singleton, monkeypatch, model_path, control_param
 ):
     # Emulate the model serving environment
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
 
     # Disable tracing
-    monkeypatch.setenv("MLFLOW_ENABLE_TRACE_IN_SERVING", "false")
+    monkeypatch.setenv(control_param, "false")
 
     model = create_openai_llmchain()
     mlflow.langchain.save_model(model, model_path)

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -364,9 +364,9 @@ def _predict_with_callbacks(lc_model, request_id, data):
     return response, trace_dict
 
 
-def test_e2e_rag_model_tracing_in_serving(clear_singleton, monkeypatch):
-    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
-
+def test_e2e_rag_model_tracing_in_serving(
+    clear_singleton, mock_databricks_serving_with_tracing_env
+):
     llm_chain = create_openai_llmchain()
 
     request_id = "test_request_id"
@@ -405,9 +405,7 @@ def test_e2e_rag_model_tracing_in_serving(clear_singleton, monkeypatch):
     _validate_trace_json_serialization(trace)
 
 
-def test_agent_success(clear_singleton, monkeypatch):
-    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
-
+def test_agent_success(clear_singleton, mock_databricks_serving_with_tracing_env):
     agent = create_openai_llmagent()
     langchain_input = {"input": "What is 123 raised to the .023 power?"}
     expected_output = {"output": TEST_CONTENT}
@@ -456,8 +454,7 @@ def test_agent_success(clear_singleton, monkeypatch):
     _validate_trace_json_serialization(trace)
 
 
-def test_tool_success(clear_singleton, monkeypatch):
-    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
+def test_tool_success(clear_singleton, mock_databricks_serving_with_tracing_env):
     prompt = SystemMessagePromptTemplate.from_template("You are a nice assistant.") + "{question}"
     llm = OpenAI(temperature=0.9)
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1838,6 +1838,7 @@ def test_pyfunc_as_code_with_dependencies_store_dependencies_schemas_in_trace(
     clear_singleton, monkeypatch, is_in_db_model_serving, stream
 ):
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", is_in_db_model_serving)
+    monkeypatch.setenv("ENABLE_MLFLOW_TRACING", "true")
     is_in_db_model_serving = is_in_db_model_serving == "true"
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -166,9 +166,9 @@ def test_trace_with_databricks_tracking_uri(
     mock_upload_trace_data.assert_called_once()
 
 
-def test_trace_in_databricks_model_serving(clear_singleton, monkeypatch):
-    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
-
+def test_trace_in_databricks_model_serving(
+    clear_singleton, mock_databricks_serving_with_tracing_env
+):
     # Dummy flask app for prediction
     import flask
 

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -42,10 +42,7 @@ def test_span_processor_and_exporter_default():
     assert isinstance(processors[0].span_exporter, MlflowSpanExporter)
 
 
-def test_span_processor_and_exporter_model_serving(monkeypatch):
-    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "True")
-    monkeypatch.setenv("ENABLE_MLFLOW_TRACING", "true")
-
+def test_span_processor_and_exporter_model_serving(mock_databricks_serving_with_tracing_env):
     _TRACER_PROVIDER_INITIALIZED._done = False
     tracer = _get_tracer("test")
     processors = tracer.span_processor._span_processors
@@ -137,8 +134,7 @@ def test_enable_mlflow_tracing_switch_in_serving_fluent(monkeypatch, enable_mlfl
             foo()
 
     if enable_mlflow_tracing:
-        assert len(_TRACE_BUFFER) == 3
-        assert all(request_id in _TRACE_BUFFER for request_id in request_ids)
+        assert sorted(_TRACE_BUFFER) == request_ids
     else:
         assert len(_TRACE_BUFFER) == 0
 
@@ -167,7 +163,6 @@ def test_enable_mlflow_tracing_switch_in_serving_client(monkeypatch, enable_mlfl
             client.end_trace(request_id="123")
 
     if enable_mlflow_tracing:
-        assert len(_TRACE_BUFFER) == 2
-        assert all(request_id in _TRACE_BUFFER for request_id in request_ids)
+        assert sorted(_TRACE_BUFFER) == request_ids
     else:
         assert len(_TRACE_BUFFER) == 0

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -117,9 +117,12 @@ def test_is_enabled():
     assert _is_enabled()
 
 
-@pytest.mark.parametrize("enable_mlflow_tracing", [True, False])
+@pytest.mark.parametrize("enable_mlflow_tracing", [True, False, None])
 def test_enable_mlflow_tracing_switch_in_serving_fluent(monkeypatch, enable_mlflow_tracing):
-    monkeypatch.setenv("ENABLE_MLFLOW_TRACING", str(enable_mlflow_tracing).lower())
+    if enable_mlflow_tracing is None:
+        monkeypatch.delenv("ENABLE_MLFLOW_TRACING", raising=False)
+    else:
+        monkeypatch.setenv("ENABLE_MLFLOW_TRACING", str(enable_mlflow_tracing).lower())
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
 
     @mlflow.trace


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12180?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12180/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12180
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add ENABLE_MLFLOW_TRACING to determine whether we enable tracing in serving for databricks.
If ENABLE_MLFLOW_TRACING is true, we use inference_table processor, otherwise there's no-op even though the model is traced.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
