### PR TITLE
Add params check in abstract store for delete_traces

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -300,29 +300,6 @@ class AbstractStore:
                 max_timestamp_millis, the oldest traces will be deleted first.
             request_ids: A set of request IDs to delete.
 
-            Example usage:
-
-                .. code-block:: python
-
-                    import mlflow
-                    import time
-
-                    client = mlflow.MlflowClient()
-
-                    # Delete all traces in the experiment
-                    client.delete_traces(
-                        experiment_id="0", max_timestamp_millis=time.time_ns() // 1_000_000
-                    )
-
-                    # Delete traces based on max_timestamp_millis and max_traces
-                    # Older traces will be deleted first.
-                    client.delete_traces(
-                        experiment_id="0", max_timestamp_millis=some_timestamp, max_traces=2
-                    )
-
-                    # Delete traces based on request_ids
-                    client.delete_traces(experiment_id="0", request_ids=["id_1", "id_2"])
-
         Returns:
             The number of traces deleted.
         """

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -8,6 +8,7 @@ from mlflow.entities import (
 )
 from mlflow.entities.metric import MetricWithRunId
 from mlflow.entities.trace_status import TraceStatus
+from mlflow.exceptions import MlflowException
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT, SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.utils.annotations import developer_stable
@@ -294,12 +295,64 @@ class AbstractStore:
             experiment_id: ID of the associated experiment.
             max_timestamp_millis: The maximum timestamp in milliseconds since the UNIX epoch for
                 deleting traces. Traces older than or equal to this timestamp will be deleted.
-            max_traces: The maximum number of traces to delete.
+            max_traces: The maximum number of traces to delete. If max_traces is specified, and
+                it is less than the number of traces that would be deleted based on the
+                max_timestamp_millis, the oldest traces will be deleted first.
             request_ids: A set of request IDs to delete.
+
+            Example usage:
+
+                .. code-block:: python
+
+                    import mlflow
+                    import time
+
+                    client = mlflow.MlflowClient()
+
+                    # Delete all traces in the experiment
+                    client.delete_traces(
+                        experiment_id="0", max_timestamp_millis=time.time_ns() // 1_000_000
+                    )
+
+                    # Delete traces based on max_timestamp_millis and max_traces
+                    # Older traces will be deleted first.
+                    client.delete_traces(
+                        experiment_id="0", max_timestamp_millis=some_timestamp, max_traces=2
+                    )
+
+                    # Delete traces based on request_ids
+                    client.delete_traces(experiment_id="0", request_ids=["id_1", "id_2"])
 
         Returns:
             The number of traces deleted.
         """
+        # request_ids can't be an empty list of string
+        if max_timestamp_millis is None and not request_ids:
+            raise MlflowException.invalid_parameter_value(
+                "Either `max_timestamp_millis` or `request_ids` must be specified.",
+            )
+        if max_timestamp_millis and request_ids:
+            raise MlflowException.invalid_parameter_value(
+                "Only one of `max_timestamp_millis` and `request_ids` can be specified.",
+            )
+        if request_ids and max_traces is not None:
+            raise MlflowException.invalid_parameter_value(
+                "`max_traces` can't be specified if `request_ids` is specified.",
+            )
+        if max_traces is not None and max_traces <= 0:
+            raise MlflowException.invalid_parameter_value(
+                f"`max_traces` must be a positive integer, received {max_traces}.",
+            )
+        return self._delete_traces(experiment_id, max_timestamp_millis, max_traces, request_ids)
+
+    @abstractmethod
+    def _delete_traces(
+        self,
+        experiment_id: str,
+        max_timestamp_millis: Optional[int] = None,
+        max_traces: Optional[int] = None,
+        request_ids: Optional[List[str]] = None,
+    ) -> int:
         raise NotImplementedError
 
     def get_trace_info(self, request_id: str) -> TraceInfo:

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -322,7 +322,6 @@ class AbstractStore:
             )
         return self._delete_traces(experiment_id, max_timestamp_millis, max_traces, request_ids)
 
-    @abstractmethod
     def _delete_traces(
         self,
         experiment_id: str,

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1562,7 +1562,7 @@ class FileStore(AbstractStore):
             )
         os.remove(tag_path)
 
-    def delete_traces(
+    def _delete_traces(
         self,
         experiment_id: str,
         max_timestamp_millis: Optional[int] = None,
@@ -1587,28 +1587,6 @@ class FileStore(AbstractStore):
         Returns:
             The number of traces deleted.
         """
-        # request_ids can't be an empty list of string
-        if max_timestamp_millis is None and not request_ids:
-            raise MlflowException(
-                "Either `max_timestamp_millis` or `request_ids` must be specified.",
-                INVALID_PARAMETER_VALUE,
-            )
-        if max_timestamp_millis and request_ids:
-            raise MlflowException(
-                "Only one of `max_timestamp_millis` and `request_ids` can be specified.",
-                INVALID_PARAMETER_VALUE,
-            )
-        if request_ids and max_traces is not None:
-            raise MlflowException(
-                "`max_traces` can't be specified if `request_ids` is specified.",
-                INVALID_PARAMETER_VALUE,
-            )
-        if max_traces is not None and max_traces <= 0:
-            raise MlflowException(
-                f"`max_traces` must be a positive integer, received {max_traces}.",
-                INVALID_PARAMETER_VALUE,
-            )
-
         experiment_path = self._get_experiment_path(experiment_id, assert_exists=True)
         traces_path = os.path.join(experiment_path, FileStore.TRACES_FOLDER_NAME)
         deleted_traces = 0
@@ -1628,6 +1606,7 @@ class FileStore(AbstractStore):
                         exc_info=_logger.isEnabledFor(logging.DEBUG),
                     )
             trace_info_and_paths.sort(key=lambda x: x[0].timestamp_ms)
+            # if max_traces is not None then it must > 0
             deleted_traces = min(len(trace_info_and_paths), max_traces or len(trace_info_and_paths))
             trace_info_and_paths = trace_info_and_paths[:deleted_traces]
             for _, trace_path in trace_info_and_paths:

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -304,7 +304,7 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(EndTrace, req_body, endpoint=endpoint)
         return TraceInfo.from_proto(response_proto.trace_info)
 
-    def delete_traces(
+    def _delete_traces(
         self,
         experiment_id: str,
         max_timestamp_millis: Optional[int] = None,

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1750,7 +1750,7 @@ class SqlAlchemyStore(AbstractStore):
                 )
             tags.delete()
 
-    def delete_traces(
+    def _delete_traces(
         self,
         experiment_id: str,
         max_timestamp_millis: Optional[int] = None,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -415,8 +415,35 @@ class MlflowClient:
             experiment_id: ID of the associated experiment.
             max_timestamp_millis: The maximum timestamp in milliseconds since the UNIX epoch for
                 deleting traces. Traces older than or equal to this timestamp will be deleted.
-            max_traces: The maximum number of traces to delete.
+            max_traces: The maximum number of traces to delete. If max_traces is specified, and
+                it is less than the number of traces that would be deleted based on the
+                max_timestamp_millis, the oldest traces will be deleted first.
             request_ids: A set of request IDs to delete.
+
+            Example usage:
+
+                .. code-block:: python
+                    :test:
+
+                    import mlflow
+                    import time
+
+                    client = mlflow.MlflowClient()
+
+                    # Delete all traces in the experiment
+                    client.delete_traces(
+                        experiment_id="0", max_timestamp_millis=time.time_ns() // 1_000_000
+                    )
+
+                    # Delete traces based on max_timestamp_millis and max_traces
+                    # Older traces will be deleted first.
+                    some_timestamp = time.time_ns() // 1_000_000
+                    client.delete_traces(
+                        experiment_id="0", max_timestamp_millis=some_timestamp, max_traces=2
+                    )
+
+                    # Delete traces based on request_ids
+                    client.delete_traces(experiment_id="0", request_ids=["id_1", "id_2"])
 
         Returns:
             The number of traces deleted.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -420,33 +420,33 @@ class MlflowClient:
                 max_timestamp_millis, the oldest traces will be deleted first.
             request_ids: A set of request IDs to delete.
 
-            Example usage:
-
-                .. code-block:: python
-                    :test:
-
-                    import mlflow
-                    import time
-
-                    client = mlflow.MlflowClient()
-
-                    # Delete all traces in the experiment
-                    client.delete_traces(
-                        experiment_id="0", max_timestamp_millis=time.time_ns() // 1_000_000
-                    )
-
-                    # Delete traces based on max_timestamp_millis and max_traces
-                    # Older traces will be deleted first.
-                    some_timestamp = time.time_ns() // 1_000_000
-                    client.delete_traces(
-                        experiment_id="0", max_timestamp_millis=some_timestamp, max_traces=2
-                    )
-
-                    # Delete traces based on request_ids
-                    client.delete_traces(experiment_id="0", request_ids=["id_1", "id_2"])
-
         Returns:
             The number of traces deleted.
+
+        Example:
+
+        .. code-block:: python
+            :test:
+
+            import mlflow
+            import time
+
+            client = mlflow.MlflowClient()
+
+            # Delete all traces in the experiment
+            client.delete_traces(
+                experiment_id="0", max_timestamp_millis=time.time_ns() // 1_000_000
+            )
+
+            # Delete traces based on max_timestamp_millis and max_traces
+            # Older traces will be deleted first.
+            some_timestamp = time.time_ns() // 1_000_000
+            client.delete_traces(
+                experiment_id="0", max_timestamp_millis=some_timestamp, max_traces=2
+            )
+
+            # Delete traces based on request_ids
+            client.delete_traces(experiment_id="0", request_ids=["id_1", "id_2"])
         """
         return self._tracking_client.delete_traces(
             experiment_id=experiment_id,

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -645,21 +645,21 @@ def test_search_traces():
 
 
 @pytest.mark.parametrize(
-    "delete_traces_request",
+    "delete_traces_kwargs",
     [
         {"experiment_id": "0", "request_ids": ["tr-1234"]},
         {"experiment_id": "0", "max_timestamp_millis": 1, "max_traces": 2},
     ],
 )
-def test_delete_traces(delete_traces_request):
+def test_delete_traces(delete_traces_kwargs):
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)
     response = mock.MagicMock()
     response.status_code = 200
-    request = DeleteTraces(**delete_traces_request)
+    request = DeleteTraces(**delete_traces_kwargs)
     response.text = json.dumps({"traces_deleted": 1})
     with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
-        res = store.delete_traces(**delete_traces_request)
+        res = store.delete_traces(**delete_traces_kwargs)
         _verify_requests(mock_http, creds, "traces/delete-traces", "POST", message_to_json(request))
         assert res == 1
 

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -644,25 +644,22 @@ def test_search_traces():
         assert token == "token"
 
 
-def test_delete_traces():
+@pytest.mark.parametrize(
+    "delete_traces_request",
+    [
+        {"experiment_id": "0", "request_ids": ["tr-1234"]},
+        {"experiment_id": "0", "max_timestamp_millis": 1, "max_traces": 2},
+    ],
+)
+def test_delete_traces(delete_traces_request):
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)
     response = mock.MagicMock()
     response.status_code = 200
-    request = DeleteTraces(
-        experiment_id="0",
-        max_timestamp_millis=1,
-        max_traces=2,
-        request_ids=["tr-1234"],
-    )
+    request = DeleteTraces(**delete_traces_request)
     response.text = json.dumps({"traces_deleted": 1})
     with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
-        res = store.delete_traces(
-            experiment_id=request.experiment_id,
-            max_timestamp_millis=request.max_timestamp_millis,
-            max_traces=request.max_traces,
-            request_ids=request.request_ids,
-        )
+        res = store.delete_traces(**delete_traces_request)
         _verify_requests(mock_http, creds, "traces/delete-traces", "POST", message_to_json(request))
         assert res == 1
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4162,6 +4162,7 @@ def test_set_tag_truncate_too_long_tag(store: SqlAlchemyStore):
 def test_delete_traces(store):
     exp1 = store.create_experiment("exp1")
     exp2 = store.create_experiment("exp2")
+    now = int(time.time() * 1000)
 
     for i in range(10):
         _create_trace(
@@ -4174,19 +4175,19 @@ def test_delete_traces(store):
     traces, _ = store.search_traces([exp1, exp2])
     assert len(traces) == 20
 
-    deleted = store.delete_traces(experiment_id=exp1)
+    deleted = store.delete_traces(experiment_id=exp1, max_timestamp_millis=now)
     assert deleted == 10
     traces, _ = store.search_traces([exp1, exp2])
     assert len(traces) == 10
     for trace in traces:
         assert trace.experiment_id == exp2
 
-    deleted = store.delete_traces(experiment_id=exp2)
+    deleted = store.delete_traces(experiment_id=exp2, max_timestamp_millis=now)
     assert deleted == 10
     traces, _ = store.search_traces([exp1, exp2])
     assert len(traces) == 0
 
-    deleted = store.delete_traces(experiment_id=exp1)
+    deleted = store.delete_traces(experiment_id=exp1, max_timestamp_millis=now)
     assert deleted == 0
 
 
@@ -4213,7 +4214,7 @@ def test_delete_traces_with_max_count(store):
     for i in range(10):
         _create_trace(store, f"tr-{i}", exp1, timestamp_ms=i)
 
-    deleted = store.delete_traces(exp1, max_traces=4)
+    deleted = store.delete_traces(exp1, max_traces=4, max_timestamp_millis=10)
     assert deleted == 4
     traces, _ = store.search_traces([exp1])
     assert len(traces) == 6
@@ -4237,3 +4238,25 @@ def test_delete_traces_with_request_ids(store):
     traces, _ = store.search_traces([exp1])
     assert len(traces) == 2
     assert [trace.request_id for trace in traces] == ["tr-9", "tr-8"]
+
+
+def test_delete_traces_raises_error(store):
+    exp_id = store.create_experiment("test")
+
+    with pytest.raises(
+        MlflowException, match=r"Either `max_timestamp_millis` or `request_ids` must be specified."
+    ):
+        store.delete_traces(exp_id)
+    with pytest.raises(
+        MlflowException,
+        match=r"Only one of `max_timestamp_millis` and `request_ids` can be specified.",
+    ):
+        store.delete_traces(exp_id, max_timestamp_millis=100, request_ids=["request_id"])
+    with pytest.raises(
+        MlflowException, match=r"`max_traces` can't be specified if `request_ids` is specified."
+    ):
+        store.delete_traces(exp_id, max_traces=2, request_ids=["request_id"])
+    with pytest.raises(
+        MlflowException, match=r"`max_traces` must be a positive integer, received 0"
+    ):
+        store.delete_traces(exp_id, 100, max_traces=0)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12194?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12194/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12194
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Move param checks to abstract store for delete_traces.
Currently we persist databricks behavior -- explained in docstring and added example.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
