### PR TITLE
Support file store search_traces with tags

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1656,7 +1656,7 @@ class FileStore(AbstractStore):
         Args:
             experiment_ids: List of experiment ids to scope the search.
             filter_string: A search filter string. Supported filter keys are `name`,
-                           `status` and `timestamp_ms`.
+                           `status`, `timestamp_ms` and `tags`.
             max_results: Maximum number of traces desired.
             order_by: List of order_by clauses. Supported sort key is `timestamp_ms`. By default
                       we sort by timestamp_ms DESC.

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1547,6 +1547,8 @@ class SearchTraceUtils(SearchUtils):
             lhs = getattr(trace, key)
         elif key in cls.VALID_SEARCH_ATTRIBUTE_KEYS:
             lhs = getattr(trace, key)
+        elif sed.get("type") == cls._TAG_IDENTIFIER:
+            lhs = trace.tags.get(key)
         else:
             raise MlflowException(
                 f"Invalid search key '{key}', supported are {cls.VALID_SEARCH_ATTRIBUTE_KEYS}",
@@ -1625,6 +1627,8 @@ class SearchTraceUtils(SearchUtils):
         if identifier_type == cls._TAG_IDENTIFIER:
             if token.ttype in cls.STRING_VALUE_TYPES or isinstance(token, Identifier):
                 return cls._strip_quotes(token.value, expect_quoted_value=True)
+            elif isinstance(token, Parenthesis):
+                return cls._parse_attribute_lists(token)
             raise MlflowException(
                 "Expected a quoted string value for "
                 f"{identifier_type} (e.g. 'my-value'). Got value "

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -3023,15 +3023,26 @@ def test_search_traces_filter(generate_trace_infos):
     _validate_search_traces(store, [exp_id], "run_id ILIKE 'RUN_5'", [trace_infos[5]])
 
     # filter by tag
-    _validate_search_traces(store, [exp_id], "tags.test_tag = 'tag_0'", [trace_infos[0]])
-    _validate_search_traces(store, [exp_id], "tags.test_tag != 'tag_0'", trace_infos[1:][::-1])
-    _validate_search_traces(store, [exp_id], "tags.test_tag IN ('tag_0')", [trace_infos[0]])
-    _validate_search_traces(
-        store, [exp_id], "tags.test_tag NOT IN ('tag_0')", trace_infos[1:][::-1]
-    )
-    _validate_search_traces(store, [exp_id], "tags.test_tag LIKE 'tag_%'", trace_infos[::-1])
-    _validate_search_traces(store, [exp_id], "tags.test_tag ILIKE 'TAG_%'", trace_infos[::-1])
-    _validate_search_traces(store, [exp_id], "tags.test_tag = '123'", [])
+    for tag_identifier in ["tag", "tags"]:
+        _validate_search_traces(
+            store, [exp_id], f"{tag_identifier}.test_tag = 'tag_0'", [trace_infos[0]]
+        )
+        _validate_search_traces(
+            store, [exp_id], f"{tag_identifier}.test_tag != 'tag_0'", trace_infos[1:][::-1]
+        )
+        _validate_search_traces(
+            store, [exp_id], f"{tag_identifier}.test_tag IN ('tag_0')", [trace_infos[0]]
+        )
+        _validate_search_traces(
+            store, [exp_id], f"{tag_identifier}.test_tag NOT IN ('tag_0')", trace_infos[1:][::-1]
+        )
+        _validate_search_traces(
+            store, [exp_id], f"{tag_identifier}.test_tag LIKE 'tag_%'", trace_infos[::-1]
+        )
+        _validate_search_traces(
+            store, [exp_id], f"{tag_identifier}.test_tag ILIKE 'TAG_%'", trace_infos[::-1]
+        )
+        _validate_search_traces(store, [exp_id], f"{tag_identifier}.test_tag = '123'", [])
 
     # multiple filter conditions
     _validate_search_traces(

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -88,7 +88,7 @@ def generate_trace_infos(store):
             exp_id,
             timestamp,
             {},
-            {TraceTagKey.TRACE_NAME: f"trace_{i}"},
+            {TraceTagKey.TRACE_NAME: f"trace_{i}", "test_tag": f"tag_{i}"},
         )
         trace_infos.append(trace_info)
         request_ids.append(trace_info.request_id)
@@ -3021,6 +3021,17 @@ def test_search_traces_filter(generate_trace_infos):
     _validate_search_traces(store, [exp_id], "run_id NOT IN ('run_5')", trace_infos[6:][::-1])
     _validate_search_traces(store, [exp_id], "run_id LIKE 'run_%'", trace_infos[5:][::-1])
     _validate_search_traces(store, [exp_id], "run_id ILIKE 'RUN_5'", [trace_infos[5]])
+
+    # filter by tag
+    _validate_search_traces(store, [exp_id], "tags.test_tag = 'tag_0'", [trace_infos[0]])
+    _validate_search_traces(store, [exp_id], "tags.test_tag != 'tag_0'", trace_infos[1:][::-1])
+    _validate_search_traces(store, [exp_id], "tags.test_tag IN ('tag_0')", [trace_infos[0]])
+    _validate_search_traces(
+        store, [exp_id], "tags.test_tag NOT IN ('tag_0')", trace_infos[1:][::-1]
+    )
+    _validate_search_traces(store, [exp_id], "tags.test_tag LIKE 'tag_%'", trace_infos[::-1])
+    _validate_search_traces(store, [exp_id], "tags.test_tag ILIKE 'TAG_%'", trace_infos[::-1])
+    _validate_search_traces(store, [exp_id], "tags.test_tag = '123'", [])
 
     # multiple filter conditions
     _validate_search_traces(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12196?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12196/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12196
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We should be able to search traces with filter string "tags.tag_key = 'tag_value'" for file store.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
