### PR TITLE
Avoid creating a trace when saving chat models

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -462,6 +462,7 @@ from mlflow.pyfunc.model import (
     get_default_conda_env,  # noqa: F401
     get_default_pip_requirements,
 )
+from mlflow.tracing.provider import trace_disabled
 from mlflow.tracing.utils import _try_get_prediction_context
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -2447,7 +2448,8 @@ def save_model(
             _logger.info("Predicting on input example to validate output")
             context = PythonModelContext(artifacts, model_config)
             python_model.load_context(context)
-            output = python_model.predict(context, messages, params)
+            with trace_disabled():  # Avoid generating a trace from this predict call
+                output = python_model.predict(context, messages, params)
             if not isinstance(output, ChatResponse):
                 raise MlflowException(
                     "Failed to save ChatModel. Please ensure that the model's predict() method "

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -10,6 +10,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models.model import Model
 from mlflow.models.signature import ModelSignature
 from mlflow.pyfunc.loaders.chat_model import _ChatModelPyfuncWrapper
+from mlflow.tracing.constant import TraceTagKey
 from mlflow.types.llm import (
     CHAT_MODEL_INPUT_SCHEMA,
     CHAT_MODEL_OUTPUT_SCHEMA,
@@ -20,6 +21,7 @@ from mlflow.types.llm import (
 from mlflow.types.schema import ColSpec, DataType, Schema
 
 from tests.helper_functions import expect_status_code, pyfunc_serve_and_score_model
+from tests.tracing.helper import get_traces
 
 # `None`s (`max_tokens` and `stop`) are excluded
 DEFAULT_PARAMS = {
@@ -75,6 +77,13 @@ class ChatModelWithContext(mlflow.pyfunc.ChatModel):
         return ChatResponse(**get_mock_response([message], params))
 
 
+class ChatModelWithTrace(mlflow.pyfunc.ChatModel):
+    @mlflow.trace
+    def predict(self, context, messages: List[ChatMessage], params: ChatParams) -> ChatResponse:
+        mock_response = get_mock_response(messages, params)
+        return ChatResponse(**mock_response)
+
+
 def test_chat_model_save_load(tmp_path):
     model = TestChatModel()
     mlflow.pyfunc.save_model(python_model=model, path=tmp_path)
@@ -85,6 +94,28 @@ def test_chat_model_save_load(tmp_path):
     output_schema = loaded_model.metadata.get_output_schema()
     assert input_schema == CHAT_MODEL_INPUT_SCHEMA
     assert output_schema == CHAT_MODEL_OUTPUT_SCHEMA
+
+
+def test_chat_model_with_trace(tmp_path):
+    model = ChatModelWithTrace()
+    mlflow.pyfunc.save_model(python_model=model, path=tmp_path)
+
+    # predict() call during saving chat model should not generate a trace
+    assert len(get_traces()) == 0
+
+    loaded_model = mlflow.pyfunc.load_model(tmp_path)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant"},
+        {"role": "user", "content": "Hello!"},
+    ]
+    loaded_model.predict({"messages": messages})
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.tags[TraceTagKey.TRACE_NAME] == "predict"
+    request = json.loads(traces[0].data.request)
+    assert request["messages"] == [str(ChatMessage(**msg)) for msg in messages]
+    assert request["params"] == str(ChatParams(**DEFAULT_PARAMS))
 
 
 def test_chat_model_save_throws_with_signature(tmp_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12197?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12197/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12197
```

</p>
</details>

### What changes are proposed in this pull request?

We disabled tracing during model logging in https://github.com/mlflow/mlflow/pull/12167, to avoid generating a trace of the internal prediction for inferring model signature. For ChatModel specifically, there is one more place that runs prediction, so we should also suppress it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Validated that saving chat model doesn't generate traces.

<img width="803" alt="Screenshot 2024-05-31 at 15 35 30" src="https://github.com/mlflow/mlflow/assets/31463517/c6c95bc8-702b-42fd-99a7-f8f3fe30b7b7">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
