### PR TITLE
Cast non-string tag/metadata values before sending to tracking server

### DIFF
--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -231,14 +231,14 @@ class RestStore(AbstractStore):
         for key, value in request_metadata.items():
             attr = TraceRequestMetadata()
             attr.key = key
-            attr.value = value
+            attr.value = str(value)
             request_metadata_proto.append(attr)
 
         tags_proto = []
         for key, value in tags.items():
             tag = TraceTag()
             tag.key = key
-            tag.value = value
+            tag.value = str(value)
             tags_proto.append(tag)
 
         req_body = message_to_json(
@@ -280,14 +280,14 @@ class RestStore(AbstractStore):
         for key, value in request_metadata.items():
             attr = TraceRequestMetadata()
             attr.key = key
-            attr.value = value
+            attr.value = str(value)
             request_metadata_proto.append(attr)
 
         tags_proto = []
         for key, value in tags.items():
             tag = TraceTag()
             tag.key = key
-            tag.value = value
+            tag.value = str(value)
             tags_proto.append(tag)
 
         req_body = message_to_json(

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -498,13 +498,16 @@ def test_start_trace():
     request_id = "tr-123"
     experiment_id = "447585625682310"
     timestamp_ms = 123
-    metadata = {"key1": "val1", "key2": "val2"}
-    tags = {"tag1": "tv1", "tag2": "tv2"}
+    # Metadata/tags values should be string, but should not break for other types too
+    metadata = {"key1": "val1", "key2": "val2", "key3": 123}
+    tags = {"tag1": "tv1", "tag2": "tv2", "tag3": None}
     expected_request = StartTrace(
         experiment_id=experiment_id,
         timestamp_ms=123,
-        request_metadata=[ProtoTraceRequestMetadata(key=k, value=v) for k, v in metadata.items()],
-        tags=[ProtoTraceTag(key=k, value=v) for k, v in tags.items()],
+        request_metadata=[
+            ProtoTraceRequestMetadata(key=k, value=str(v)) for k, v in metadata.items()
+        ],
+        tags=[ProtoTraceTag(key=k, value=str(v)) for k, v in tags.items()],
     )
     response = mock.MagicMock()
     response.status_code = 200
@@ -516,8 +519,8 @@ def test_start_trace():
                 "timestamp_ms": timestamp_ms,
                 "execution_time_ms": None,
                 "status": 0,  # Running
-                "request_metadata": [{"key": k, "value": v} for k, v in metadata.items()],
-                "tags": [{"key": k, "value": v} for k, v in tags.items()],
+                "request_metadata": [{"key": k, "value": str(v)} for k, v in metadata.items()],
+                "tags": [{"key": k, "value": str(v)} for k, v in tags.items()],
             }
         }
     )
@@ -535,8 +538,8 @@ def test_start_trace():
         assert res.timestamp_ms == timestamp_ms
         assert res.execution_time_ms == 0
         assert res.status == TraceStatus.UNSPECIFIED
-        assert res.request_metadata == metadata
-        assert res.tags == tags
+        assert res.request_metadata == {k: str(v) for k, v in metadata.items()}
+        assert res.tags == {k: str(v) for k, v in tags.items()}
 
 
 def test_end_trace():

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -41,6 +41,7 @@ from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
 from mlflow.server.handlers import _get_sampled_steps_from_steps
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.tracing.constant import TraceTagKey
 from mlflow.utils import mlflow_tags
 from mlflow.utils.file_utils import TempDir, path_to_local_file_uri
 from mlflow.utils.mlflow_tags import (
@@ -2043,6 +2044,36 @@ def test_start_and_end_trace(mlflow_client):
     }
 
     assert trace_info == client.get_trace_info(trace_info.request_id)
+
+
+def test_start_and_end_trace_non_string_name(mlflow_client):
+    # OpenTelemetry span can accept non-string name like 1234. However, it is problematic
+    # when we use it as a trace name (which is set from a root span name) and log it to
+    # remote tracking server. Trace name is stored as mlflow.traceName tag and tag value
+    # can only be string, otherwise protobuf serialization will fail. Therefore, this test
+    # verifies that non-string span name is correctly handled before sending to the server.
+    mlflow.set_tracking_uri(mlflow_client.tracking_uri)
+    exp_id = mlflow_client.create_experiment("non-string trace")
+
+    span = mlflow_client.start_trace(name=1234, experiment_id=exp_id)
+    child_span = mlflow_client.start_span(
+        name=None, request_id=span.request_id, parent_id=span.span_id
+    )
+    mlflow_client.end_span(
+        request_id=child_span.request_id, span_id=child_span.span_id, status="OK"
+    )
+    mlflow_client.end_trace(request_id=span.request_id, status="OK")
+
+    traces = mlflow_client.search_traces(experiment_ids=[exp_id])
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.info.tags[TraceTagKey.TRACE_NAME] == "1234"
+    assert trace.info.status == TraceStatus.OK
+    assert len(trace.data.spans) == 2
+    assert trace.data.spans[0].name == 1234
+    assert trace.data.spans[0].status.status_code == "OK"
+    assert trace.data.spans[1].name is None
+    assert trace.data.spans[1].status.status_code == "OK"
 
 
 def test_search_traces(mlflow_client):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12199?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12199/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12199
```

</p>
</details>

### What changes are proposed in this pull request?

The trace `tags` and `metadata` should have string value only in theory, but there is no validation at client side. Indeed, file store and sql store works (implicitly convert to string when storing them). 

However, REST store (both OSS and Databricks) does not work because protobuf complains when setting non-string value to string field ([code](https://github.com/mlflow/mlflow/blob/72b256221e48a81e0d0a790f8886b6527756cb13/mlflow/store/tracking/rest_store.py#L234)). This results in weird error like this;

> 2024/05/31 05:55:43 WARNING mlflow.tracing.export.mlflow: Failed to log trace to MLflow backend: bad argument type for built-in operation

There are two options to fix this;
1. Validate type of tag/metadata values in advance and raise with a better error message.
2. Cast tag/metadata before serializing to proto.

This PR takes the second approach - just converting to string similar to how it works in file/SQL store. It is more consistent and also better UX - users don't want to fail entire trace logging by mixing a single int value in tags.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
