### PR TITLE
Reject invalid comparators for `attribute.status` in FileStore

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1535,7 +1535,7 @@ class SearchTraceUtils(SearchUtils):
         """Filters a set of traces based on a search filter string."""
         if not filter_string:
             return traces
-        parsed = cls.parse_search_filter(filter_string)
+        parsed = cls.parse_search_filter_for_search_traces(filter_string)
 
         def trace_matches(trace):
             return all(cls._does_trace_match_clause(trace, s) for s in parsed)
@@ -1544,20 +1544,16 @@ class SearchTraceUtils(SearchUtils):
 
     @classmethod
     def _does_trace_match_clause(cls, trace, sed):
+        type_ = sed.get("type")
         key = sed.get("key")
         value = sed.get("value")
         comparator = sed.get("comparator").upper()
 
-        if key in cls.SEARCH_KEY_TO_TAG:
-            key = cls.SEARCH_KEY_TO_TAG[key]
+        if cls.is_tag(type_, comparator):
             lhs = trace.tags.get(key)
-        elif key in cls.SEARCH_KEY_TO_METADATA:
-            key = cls.SEARCH_KEY_TO_METADATA[key]
+        elif cls.is_request_metadata(type_, comparator):
             lhs = trace.request_metadata.get(key)
-        elif key in cls.SEARCH_KEY_TO_ATTRIBUTE:
-            key = cls.SEARCH_KEY_TO_ATTRIBUTE[key]
-            lhs = getattr(trace, key)
-        elif key in cls.VALID_SEARCH_ATTRIBUTE_KEYS:
+        elif cls.is_attribute(type_, key, comparator):
             lhs = getattr(trace, key)
         elif sed.get("type") == cls._TAG_IDENTIFIER:
             lhs = trace.tags.get(key)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2930,12 +2930,6 @@ def test_search_traces_filter(generate_trace_infos):
     # filter by name
     _validate_search_traces(store, [exp_id], "name = 'trace_0'", trace_infos[:1])
     _validate_search_traces(store, [exp_id], "name != 'trace_0'", trace_infos[1:][::-1])
-    _validate_search_traces(
-        store, [exp_id], "name IN ('trace_0', 'trace_1')", trace_infos[:2][::-1]
-    )
-    _validate_search_traces(
-        store, [exp_id], "name NOT IN ('trace_0', 'trace_1')", trace_infos[2:][::-1]
-    )
     _validate_search_traces(store, [exp_id], "name LIKE 'trace_%'", trace_infos[::-1])
     _validate_search_traces(store, [exp_id], "name ILIKE 'Trace_%'", trace_infos[::-1])
     _validate_search_traces(
@@ -3031,8 +3025,6 @@ def test_search_traces_filter(generate_trace_infos):
         )
     _validate_search_traces(store, [exp_id], "run_id = 'run_5'", [trace_infos[5]])
     _validate_search_traces(store, [exp_id], "run_id != 'run_5'", trace_infos[6:][::-1])
-    _validate_search_traces(store, [exp_id], "run_id IN ('run_5')", [trace_infos[5]])
-    _validate_search_traces(store, [exp_id], "run_id NOT IN ('run_5')", trace_infos[6:][::-1])
     _validate_search_traces(store, [exp_id], "run_id LIKE 'run_%'", trace_infos[5:][::-1])
     _validate_search_traces(store, [exp_id], "run_id ILIKE 'RUN_5'", [trace_infos[5]])
 
@@ -3078,8 +3070,8 @@ def test_search_traces_filter(generate_trace_infos):
         ("foo.bar = 'baz'", r"Invalid entity type 'foo'"),
         ("invalid = 'foo'", r"Invalid attribute key 'invalid'"),
         ("trace.tags.foo = 'bar'", r"Invalid attribute key 'tags\.foo'"),
-        # TODO: This should raise
-        # ("trace.status < 'OK'", r"Invalid comparator '<'"),
+        ("trace.status < 'OK'", r"Invalid comparator '<'"),
+        ("name IN ('foo', 'bar')", r"Invalid comparator 'IN'"),
     ],
 )
 def test_search_traces_invalid_filter(generate_trace_infos, filter_string, error):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -3037,12 +3037,6 @@ def test_search_traces_filter(generate_trace_infos):
             store, [exp_id], f"{tag_identifier}.test_tag != 'tag_0'", trace_infos[1:][::-1]
         )
         _validate_search_traces(
-            store, [exp_id], f"{tag_identifier}.test_tag IN ('tag_0')", [trace_infos[0]]
-        )
-        _validate_search_traces(
-            store, [exp_id], f"{tag_identifier}.test_tag NOT IN ('tag_0')", trace_infos[1:][::-1]
-        )
-        _validate_search_traces(
             store, [exp_id], f"{tag_identifier}.test_tag LIKE 'tag_%'", trace_infos[::-1]
         )
         _validate_search_traces(

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4067,6 +4067,7 @@ def test_search_traces_with_filter(store_with_traces, filter_string, expected_id
         ("invalid = 'foo'", r"Invalid attribute key 'invalid'"),
         ("trace.tags.foo = 'bar'", r"Invalid attribute key 'tags\.foo'"),
         ("trace.status < 'OK'", r"Invalid comparator '<'"),
+        ("name IN ('foo', 'bar')", r"Invalid comparator 'IN'"),
     ],
 )
 def test_search_traces_with_invalid_filter(store_with_traces, filter_string, error):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12203?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12203/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12203
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`FileStore.search_traces` doesn't throw when `filter_string` contains  `attribute.status < "OK"`, but it should.


### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
