### PR TITLE
Add get_last_active_trace() API

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -108,6 +108,7 @@ from mlflow.models import evaluate
 from mlflow.projects import run
 from mlflow.tracing.fluent import (
     get_current_active_span,
+    get_last_active_trace,
     get_trace,
     search_traces,
     start_span,
@@ -182,6 +183,7 @@ __all__ = [
     "get_artifact_uri",
     "get_experiment",
     "get_experiment_by_name",
+    "get_last_active_trace",
     "get_parent_run",
     "get_registry_uri",
     "get_run",

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -18,6 +18,7 @@ from mlflow.environment_variables import (
     MLFLOW_TRACE_BUFFER_TTL_SECONDS,
 )
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing import provider
 from mlflow.tracing.constant import SpanAttributeKey
@@ -34,6 +35,7 @@ from mlflow.tracing.utils import (
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.annotations import experimental
+from mlflow.utils.databricks_utils import is_in_databricks_model_serving_environment
 
 _logger = logging.getLogger(__name__)
 
@@ -426,14 +428,26 @@ def get_current_active_span() -> Optional[LiveSpan]:
 @experimental
 def get_last_active_trace() -> Optional[Trace]:
     """
-    Get the last active trace in the same process if exists. If there is an active trace,
-    it will return the trace object as **an immutable copy**.
+    Get the last active trace in the same process if exists.
+
+    .. warning::
+
+        This function DOES NOT work in the model deployed in Databricks model serving.
 
     .. note::
 
         The last active trace is only stored in-memory for the time defined by the TTL
         (Time To Live) configuration. By default, the TTL is 1 hour and can be configured
         using the environment variable ``MLFLOW_TRACE_BUFFER_TTL_SECONDS``.
+
+    .. note::
+
+        This function returns an immutable copy of the original trace that is logged
+        in the tracking store. Any changes made to the returned object will not be reflected
+        in the original trace. To modify the already ended trace (while most of the data is
+        immutable after the trace is ended, you can still edit some fields such as `tags`),
+        please use the respective MlflowClient APIs with the request ID of the trace, as
+        shown in the example below.
 
     .. code-block:: python
         :test:
@@ -450,47 +464,19 @@ def get_last_active_trace() -> Optional[Trace]:
 
         trace = mlflow.get_last_active_trace()
 
-    .. attention::
 
-        This function returns an immutable copy of the original trace that is active or logged
-        in the tracking store. Any changes made to the returned object will not be reflected
-        in the original trace.
-
-        - To mutate the active trace, use :py:func:`mlflow.get_current_active_span` instead.
-        - To modify the already ended trace (while most of the data is immutable after the
-          trace is ended, you can still edit some fields like tags), please use the
-          respective MlflowClient APIs with the request ID of the trace.
-
-        .. code-block:: python
-            :test:
-
-            import mlflow
-
-
-            @mlflow.trace
-            def f():
-                # Use get_current_active_span() to mutate the active trace
-                span = mlflow.get_current_active_span()
-                span.set_attribute("key", "value")
-                pass
-
-
-            f()
-
-            trace = mlflow.get_last_active_trace()
-
-            # Use MlflowClient APIs to mutate the ended trace
-            mlflow.MlflowClient().set_trace_tag(trace.info.request_id, "key", "value")
+        # Use MlflowClient APIs to mutate the ended trace
+        mlflow.MlflowClient().set_trace_tag(trace.info.request_id, "key", "value")
 
     Returns:
         The last active trace if exists, otherwise None.
     """
-    # If there is an active trace, return it as an immutable trace object.
-    if active_span := get_current_active_span():
-        trace_manager = InMemoryTraceManager.get_instance()
-        with trace_manager.get_trace(active_span.request_id) as trace:
-            if trace:
-                return trace.to_mlflow_trace()
+    if is_in_databricks_model_serving_environment():
+        raise MlflowException(
+            "The function `mlflow.get_last_active_trace` is not supported in "
+            "Databricks model serving.",
+            error_code=BAD_REQUEST,
+        )
 
     if len(TRACE_BUFFER) > 0:
         last_active_request_id = list(TRACE_BUFFER.keys())[-1]

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -458,8 +458,8 @@ def get_last_active_trace() -> Optional[Trace]:
 
         - To mutate the active trace, use :py:func:`mlflow.get_current_active_span` instead.
         - To modify the already ended trace (while most of the data is immutable after the
-            trace is ended, you can still edit some fields like tags), please use the
-            respective MlflowClient APIs with the request ID of the trace.
+          trace is ended, you can still edit some fields like tags), please use the
+          respective MlflowClient APIs with the request ID of the trace.
 
         .. code-block:: python
             :test:

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -14,7 +14,7 @@ from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.utils.mlflow_tags import MLFLOW_ARTIFACT_LOCATION
 
 from tests.tracing.conftest import clear_singleton  # noqa: F401
-from tests.tracing.helper import create_test_trace_info, get_first_trace
+from tests.tracing.helper import create_test_trace_info
 
 
 def _test_model(datetime=datetime.now()):
@@ -49,7 +49,7 @@ def test_json_deserialization(clear_singleton, monkeypatch):
     model = _test_model(datetime_now)
     model.predict(2, 5)
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     trace_json = trace.to_json()
 
     trace_json_as_dict = json.loads(trace_json)
@@ -194,7 +194,7 @@ def test_trace_to_from_dict_and_json(clear_singleton):
     model = _test_model()
     model.predict(2, 5)
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     trace_dict = trace.to_dict()
     trace_from_dict = Trace.from_dict(trace_dict)
     trace_json = trace.to_json()

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -7,7 +7,6 @@ from mlflow.entities import SpanType, TraceData
 from mlflow.entities.span_event import SpanEvent
 
 from tests.tracing.conftest import clear_singleton  # noqa: F401
-from tests.tracing.helper import get_first_trace
 
 
 def test_json_deserialization(clear_singleton):
@@ -32,7 +31,7 @@ def test_json_deserialization(clear_singleton):
     with pytest.raises(Exception, match="Error!"):
         model.predict(2, 5)
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     trace_data = trace.data
 
     # Compare events separately as it includes exception stacktrace which is hard to hardcode

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -39,7 +39,7 @@ from mlflow.utils.openai_utils import (
 
 # TODO: This test helper is used outside the tracing module, we should move it to a common utils
 from tests.tracing.conftest import clear_singleton as clear_trace_singleton  # noqa: F401
-from tests.tracing.helper import get_first_trace, get_traces
+from tests.tracing.helper import get_traces
 
 MODEL_DIR = "model"
 TEST_CONTENT = "test"
@@ -958,5 +958,5 @@ def test_set_retriever_schema_work_for_langchain_model(clear_trace_singleton):
         pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
         pyfunc_model.predict("MLflow")
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert DependenciesSchemasType.RETRIEVERS.value in trace.info.tags

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -19,6 +19,7 @@ from langchain_core.outputs import LLMResult
 from langchain_core.tools import tool
 from packaging.version import Version
 
+import mlflow
 from mlflow.entities import Trace
 from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatus, SpanStatusCode
@@ -35,7 +36,7 @@ from mlflow.utils.openai_utils import (
 )
 
 from tests.tracing.conftest import clear_singleton  # noqa: F401
-from tests.tracing.helper import get_first_trace, get_traces
+from tests.tracing.helper import get_traces
 
 TEST_CONTENT = "test"
 
@@ -124,7 +125,7 @@ def test_llm_success(clear_singleton):
     callback.on_llm_new_token("test", run_id=run_id)
 
     callback.on_llm_end(LLMResult(generations=[[{"text": "generated text"}]]), run_id=run_id)
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert len(trace.data.spans) == 1
     llm_span = trace.data.spans[0]
 
@@ -156,7 +157,7 @@ def test_llm_error(clear_singleton):
     mock_error = Exception("mock exception")
     callback.on_llm_error(error=mock_error, run_id=run_id)
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     error_event = SpanEvent.from_exception(mock_error)
     assert len(trace.data.spans) == 1
     llm_span = trace.data.spans[0]
@@ -209,7 +210,7 @@ def test_retriever_success(clear_singleton):
         ),
     ]
     callback.on_retriever_end(documents, run_id=run_id)
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert len(trace.data.spans) == 1
     retriever_span = trace.data.spans[0]
 
@@ -235,7 +236,7 @@ def test_retriever_error(clear_singleton):
     )
     mock_error = Exception("mock exception")
     callback.on_retriever_error(error=mock_error, run_id=run_id)
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert len(trace.data.spans) == 1
     retriever_span = trace.data.spans[0]
     assert retriever_span.attributes[SpanAttributeKey.INPUTS] == "test query"
@@ -319,7 +320,7 @@ def test_multiple_components(clear_singleton):
         outputs={"output": "test output"},
         run_id=chain_run_id,
     )
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert len(trace.data.spans) == 5
     chain_span = trace.data.spans[0]
     assert chain_span.start_time_ns is not None

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -118,11 +118,6 @@ def get_traces() -> List[Trace]:
     return list(TRACE_BUFFER.values())
 
 
-def get_first_trace() -> Optional[Trace]:
-    if traces := get_traces():
-        return traces[0]
-
-
 def get_tracer_tracking_uri() -> Optional[str]:
     """Get current tracking URI configured as the trace export destination."""
     from opentelemetry import trace

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -30,7 +30,7 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.provider import _get_tracer
 
-from tests.tracing.helper import create_test_trace_info, create_trace, get_first_trace, get_traces
+from tests.tracing.helper import create_test_trace_info, create_trace, get_traces
 
 
 class DefaultTestModel:
@@ -69,7 +69,7 @@ def test_trace(clear_singleton, with_active_run):
     else:
         model.predict(2, 5)
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     trace_info = trace.info
     assert trace_info.request_id is not None
     assert trace_info.experiment_id == "0"  # default experiment
@@ -340,7 +340,7 @@ def test_trace_handle_exception_during_prediction(clear_singleton):
         model.predict(2, 5)
 
     # Trace should be logged even if the function fails, with status code ERROR
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert trace.info.request_id is not None
     assert trace.info.status == TraceStatus.ERROR
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
@@ -374,7 +374,7 @@ def test_trace_ignore_exception_from_tracing_logic(clear_singleton, monkeypatch)
         output = model.predict(2, 5)
 
     assert output == 7
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == "{}"
     assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == "7"
     TRACE_BUFFER.clear()
@@ -424,7 +424,7 @@ def test_start_span_context_manager(clear_singleton):
     model = TestModel()
     model.predict(1, 2)
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert trace.info.request_id is not None
     assert trace.info.experiment_id == "0"  # default experiment
     assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
@@ -506,7 +506,7 @@ def test_start_span_context_manager_with_imperative_apis(clear_singleton):
     model = TestModel()
     model.predict(1, 2)
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert trace.info.request_id is not None
     assert trace.info.experiment_id == "0"  # default experiment
     assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
@@ -906,3 +906,29 @@ def test_search_traces_with_span_name(monkeypatch):
         mlflow.search_traces(
             extract_fields=["span.llm.inputs", "span.invalidname.outputs", "span.llm.inputs.x"]
         )
+
+
+def test_get_last_active_trace(clear_singleton):
+    assert mlflow.get_last_active_trace() is None
+
+    @mlflow.trace()
+    def predict(x, y):
+        return x + y
+
+    predict(1, 2)
+    predict(2, 5)
+    predict(3, 6)
+
+    trace = mlflow.get_last_active_trace()
+    assert trace.info.request_id is not None
+    assert trace.data.request == '{"x": 3, "y": 6}'
+
+    # Mutation of the copy should not affect the original trace logged in the backend
+    trace.info.status = TraceStatus.ERROR
+    original_trace = mlflow.MlflowClient().get_trace(trace.info.request_id)
+    assert original_trace.info.status == TraceStatus.OK
+
+    # It should return active trace if there is
+    with mlflow.start_span() as span:
+        trace = mlflow.get_last_active_trace()
+        assert trace.info.request_id == span.request_id

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -927,8 +927,3 @@ def test_get_last_active_trace(clear_singleton):
     trace.info.status = TraceStatus.ERROR
     original_trace = mlflow.MlflowClient().get_trace(trace.info.request_id)
     assert original_trace.info.status == TraceStatus.OK
-
-    # It should return active trace if there is
-    with mlflow.start_span() as span:
-        trace = mlflow.get_last_active_trace()
-        assert trace.info.request_id == span.request_id

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -60,7 +60,6 @@ from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.conftest import mock_store as mock_store_for_tracing  # noqa: F401
 from tests.tracing.helper import (
     create_test_trace_info,
-    get_first_trace,
     get_traces,
 )
 
@@ -429,7 +428,7 @@ def test_start_and_end_trace(tracking_uri, with_active_run):
     else:
         model.predict(1, 2)
 
-    request_id = get_first_trace().info.request_id
+    request_id = mlflow.get_last_active_trace().info.request_id
 
     # Validate that trace is logged to the backend
     trace = client.get_trace(request_id)
@@ -757,7 +756,7 @@ def test_set_and_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
     client.set_trace_tag(request_id, "foo", "bar")
     client.end_trace(request_id)
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert trace.info.tags["foo"] == "bar"
 
 
@@ -776,7 +775,7 @@ def test_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
     client.delete_trace_tag(request_id, "foo")
     client.end_trace(request_id)
 
-    trace = get_first_trace()
+    trace = mlflow.get_last_active_trace()
     assert "baz" in trace.info.tags
     assert "foo" not in trace.info.tags
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add `get_last_active_trace()` fluent API for users to access the most recent generated trace easier.

Previously, user needs to go to the trace UI to check request_id, or use `mlflow.MlflowClient(experiment_ids=[...], ...).search_traces(...)` to fetch traces and find the latest one (the fluent `search_traces()` API returns pandas dataframe so not applicable for this purpose).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
