### PR TITLE
Fix cross version test failure for tensorflow 2.6.5

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -120,7 +120,7 @@ tensorflow:
     requirements:
       # Requirements to run tests for keras
       ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1"]
-      "< 2.7.0": ["pandas>=1.3.5,<2.0"]
+      "< 2.7.0": ["pandas>=1.3.5,<3.0"]
       ">= 2.7.0": ["pandas<2.0"]
       # TensorFlow == 2.6.5 are incompatible with SQLAlchemy 2.x due to
       # transitive dependency version conflicts with the `typing-extensions` package

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import uuid
@@ -284,7 +285,13 @@ def _create_virtualenv(
                 tmp_req_file = f"requirements.{uuid.uuid4().hex}.txt"
                 Path(tmpdir).joinpath(tmp_req_file).write_text("\n".join(deps))
                 cmd = _join_commands(activate_cmd, f"python -m pip install -r {tmp_req_file}")
-                _exec_cmd(cmd, capture_output=capture_output, cwd=tmpdir, extra_env=extra_env)
+                _exec_cmd(
+                    cmd,
+                    capture_output=capture_output,
+                    cwd=tmpdir,
+                    extra_env=extra_env,
+                    stdout=subprocess.DEVNULL,
+                )
 
     return activate_cmd
 

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -283,9 +283,7 @@ def _create_virtualenv(
 
                 tmp_req_file = f"requirements.{uuid.uuid4().hex}.txt"
                 Path(tmpdir).joinpath(tmp_req_file).write_text("\n".join(deps))
-                cmd = _join_commands(
-                    activate_cmd, f"python -m pip install --quiet -r {tmp_req_file}"
-                )
+                cmd = _join_commands(activate_cmd, f"python -m pip install -r {tmp_req_file}")
                 _exec_cmd(cmd, capture_output=capture_output, cwd=tmpdir, extra_env=extra_env)
 
     return activate_cmd

--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -25,7 +25,7 @@ dependencies = [
   "cachetools<6,>=5.0.0",
   "click<9,>=7.0",
   "cloudpickle<4",
-  "databricks-sdk<1,>=0.20.0",
+  "databricks-sdk<1",
   "entrypoints<1",
   "gitpython<4,>=3.1.9",
   "importlib_metadata<8,>=3.7.0,!=4.7.0",

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -16,4 +16,4 @@ sqlparse<1,>=0.4.0
 cachetools<6,>=5.0.0
 opentelemetry-api<3,>=1.9.0
 opentelemetry-sdk<3,>=1.9.0
-databricks-sdk<1,>=0.20.0
+databricks-sdk<1

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -80,5 +80,4 @@ opentelemetry-sdk:
 
 databricks-sdk:
   pip_release: databricks-sdk
-  minimum: "0.20.0"
   max_major_version: 0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12208?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12208/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12208
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #12011 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow-automation/mlflow/actions/runs/9338574434/job/25709716248#step:12:2827

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.18/x64/bin/mlflow", line 8, in <module>
    sys.exit(cli())
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/models/cli.py", line 103, in serve
    return get_flavor_backend(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/pyfunc/backend.py", line 285, in serve
    return self.prepare_env(local_path).execute(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/pyfunc/backend.py", line 131, in prepare_env
    activate_cmd = _get_or_create_virtualenv(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/utils/virtualenv.py", line 379, in _get_or_create_virtualenv
    activate_cmd = _create_virtualenv(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/utils/virtualenv.py", line 289, in _create_virtualenv
    _exec_cmd(cmd, capture_output=capture_output, cwd=tmpdir, extra_env=extra_env)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/utils/process.py", line 120, in _exec_cmd
    raise ShellCommandException.from_completed_process(comp_process)
mlflow.utils.process.ShellCommandException: Non-zero exit code: 1
Command: ['bash', '-c', 'source /home/runner/.mlflow/envs/mlflow-e99db9c66bfe61bedd347d62bd4f0f84a81e770c/bin/activate && python -m pip install --quiet -r requirements.aed95cf807c7447ab22744f883552bde.txt']
```

pip failed with the following error:

```
ERROR: Cannot install mlflow and tensorflow because these package versions have conflicting dependencies.

The conflict is caused by:
    databricks-sdk 0.20.0 depends on google-auth~=2.0
    tensorboard 2.6.0 depends on google-auth<2 and >=1.6.3
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
