### PR TITLE
Silence traces when logging langchain models

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -63,6 +63,7 @@ from mlflow.models.utils import (
 )
 from mlflow.pyfunc import FLAVOR_NAME as PYFUNC_FLAVOR_NAME
 from mlflow.pyfunc.context import get_prediction_context
+from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import ColSpec, DataType, Schema
@@ -146,6 +147,7 @@ def _infer_signature_from_input_example_for_lc_model(
 
 @experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
+@trace_disabled  # Suppress traces for internal predict calls while saving model
 def save_model(
     lc_model,
     path,
@@ -415,6 +417,7 @@ def save_model(
 
 @experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
+@trace_disabled  # Suppress traces for internal predict calls while logging model
 def log_model(
     lc_model,
     artifact_path,

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -22,7 +22,6 @@ from mlflow.models.utils import ModelInputExample, _contains_params, _Example
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
-from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_artifact_to_uri
 from mlflow.types.schema import ParamSchema, Schema, convert_dataclass_to_schema
 from mlflow.types.utils import _infer_param_schema, _infer_schema, _infer_schema_from_type_hint
@@ -377,9 +376,7 @@ def _infer_signature_from_input_example(
             input_example = deepcopy(example.inference_data)
         input_schema = _infer_schema(input_example)
         params_schema = _infer_param_schema(params) if params else None
-        # Avoid rendering traces when inferring the signature
-        with trace_disabled():
-            prediction = wrapped_model.predict(input_example, params=params)
+        prediction = wrapped_model.predict(input_example, params=params)
         # For column-based inputs, 1D numpy arrays likely signify row-based predictions. Thus, we
         # convert them to a Pandas series for inferring as a single ColSpec Schema.
         if (

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -462,6 +462,7 @@ from mlflow.pyfunc.model import (
     get_default_conda_env,  # noqa: F401
     get_default_pip_requirements,
 )
+from mlflow.tracing.provider import trace_disabled
 from mlflow.tracing.utils import _try_get_prediction_context
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -2160,6 +2161,7 @@ def _validate_function_python_model(python_model):
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
+@trace_disabled  # Suppress traces for internal predict calls while saving model
 def save_model(
     path,
     loader_module=None,
@@ -2529,6 +2531,7 @@ def save_model(
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
+@trace_disabled  # Suppress traces for internal predict calls while logging model
 def log_model(
     artifact_path,
     loader_module=None,

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -1,4 +1,4 @@
-import contextlib
+import functools
 import json
 import logging
 from typing import Optional, Tuple
@@ -136,20 +136,38 @@ def enable():
     _setup_tracer_provider()
 
 
-@contextlib.contextmanager
-def trace_disabled():
+def trace_disabled(f):
     """
-    Temporarily disable tracing for the duration of the context manager.
+    A decorator that temporarily disables tracing for the duration of the decorated function.
+
+    .. code-block:: python
+
+            @trace_disabled
+            def f():
+                with mlflow.start_span("my_span") as span:
+                    span.set_attribute("my_key", "my_value")
+
+                return
+
+            # This function will not generate any trace
+            f()
 
     :meta private:
     """
-    was_trace_enabled = _is_enabled()
-    try:
-        disable()
-        yield
-    finally:
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        was_trace_enabled = _is_enabled()
         if was_trace_enabled:
-            enable()
+            disable()
+            try:
+                return f(*args, **kwargs)
+            finally:
+                enable()
+        else:
+            return f(*args, **kwargs)
+
+    return wrapper
 
 
 def reset_tracer_setup():

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -142,15 +142,16 @@ def trace_disabled(f):
 
     .. code-block:: python
 
-            @trace_disabled
-            def f():
-                with mlflow.start_span("my_span") as span:
-                    span.set_attribute("my_key", "my_value")
+        @trace_disabled
+        def f():
+            with mlflow.start_span("my_span") as span:
+                span.set_attribute("my_key", "my_value")
 
-                return
+            return
 
-            # This function will not generate any trace
-            f()
+
+        # This function will not generate any trace
+        f()
 
     :meta private:
     """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -578,8 +578,12 @@ class MlflowClient:
                 name, experiment_id=experiment_id
             )
             request_id = get_otel_attribute(otel_span, SpanAttributeKey.REQUEST_ID)
-
             mlflow_span = create_mlflow_span(otel_span, request_id, span_type)
+
+            # # If the span is a no-op span i.e. tracing is disabled, do nothing
+            if isinstance(mlflow_span, NoOpSpan):
+                return mlflow_span
+
             if inputs:
                 mlflow_span.set_inputs(inputs)
             if attributes:

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -111,8 +111,10 @@ def test_create_non_live_span():
 
 
 def test_create_noop_span():
-    with trace_disabled():
-        request_id = "tr-12345"
+    request_id = "tr-12345"
+
+    @trace_disabled
+    def f():
         tracer = _get_tracer("test")
         with tracer.start_as_current_span("span") as otel_span:
             span = create_mlflow_span(otel_span, request_id=request_id)

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -74,19 +74,18 @@ def test_disable_enable_tracing():
 
 
 @pytest.mark.parametrize("enabled_initially", [True, False])
-def test_trace_disabled_context_manager(enabled_initially):
+def test_trace_disabled_decorator(enabled_initially):
     if not enabled_initially:
         mlflow.tracing.disable()
     assert _is_enabled() == enabled_initially
 
-    @mlflow.trace
+    @trace_disabled()
     def test_fn():
-        pass
+        with mlflow.start_span(name="test_span") as span:
+            span.set_attribute("key", "value")
 
-    with trace_disabled():
-        test_fn()
-        assert len(TRACE_BUFFER) == 0
-        assert not _is_enabled()
+    test_fn()
+    assert len(TRACE_BUFFER) == 0
 
     # Recover the initial state
     assert _is_enabled() == enabled_initially

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -72,6 +72,16 @@ def test_disable_enable_tracing():
     assert isinstance(_get_tracer(__name__), trace.Tracer)
     TRACE_BUFFER.clear()
 
+    # Tracing should be enabled back even if the function raises an exception
+    @trace_disabled
+    def test_fn_raise():
+        raise ValueError("error")
+
+    with pytest.raises(ValueError, match="error"):
+        test_fn_raise()
+
+    assert len(TRACE_BUFFER) == 1
+
 
 @pytest.mark.parametrize("enabled_initially", [True, False])
 def test_trace_disabled_decorator(enabled_initially):

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -79,7 +79,7 @@ def test_trace_disabled_decorator(enabled_initially):
         mlflow.tracing.disable()
     assert _is_enabled() == enabled_initially
 
-    @trace_disabled()
+    @trace_disabled
     def test_fn():
         with mlflow.start_span(name="test_span") as span:
             span.set_attribute("key", "value")

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -72,16 +72,6 @@ def test_disable_enable_tracing():
     assert isinstance(_get_tracer(__name__), trace.Tracer)
     TRACE_BUFFER.clear()
 
-    # Tracing should be enabled back even if the function raises an exception
-    @trace_disabled
-    def test_fn_raise():
-        raise ValueError("error")
-
-    with pytest.raises(ValueError, match="error"):
-        test_fn_raise()
-
-    assert len(TRACE_BUFFER) == 1
-
 
 @pytest.mark.parametrize("enabled_initially", [True, False])
 def test_trace_disabled_decorator(enabled_initially):
@@ -98,6 +88,17 @@ def test_trace_disabled_decorator(enabled_initially):
     assert len(TRACE_BUFFER) == 0
 
     # Recover the initial state
+    assert _is_enabled() == enabled_initially
+
+    # Tracing should be enabled back even if the function raises an exception
+    @trace_disabled
+    def test_fn_raise():
+        raise ValueError("error")
+
+    with pytest.raises(ValueError, match="error"):
+        test_fn_raise()
+
+    assert len(TRACE_BUFFER) == 0
     assert _is_enabled() == enabled_initially
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -38,7 +38,7 @@ from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore as SqlAlchemyTrackingStore
 from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_KEY, TraceMetadataKey
 from mlflow.tracing.fluent import TRACE_BUFFER
-from mlflow.tracing.provider import _get_tracer
+from mlflow.tracing.provider import _get_tracer, trace_disabled
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracking import set_registry_uri
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
@@ -650,6 +650,43 @@ def test_log_trace_with_databricks_tracking_uri(
     mock_store_for_tracing.start_trace.assert_called_once()
     mock_store_for_tracing.end_trace.assert_called_once()
     mock_upload_trace_data.assert_called_once()
+
+
+def test_start_and_end_trace_does_not_log_trace_when_disabled(tracking_uri, monkeypatch):
+    client = MlflowClient(tracking_uri)
+    experiment_id = client.create_experiment("test_experiment")
+
+    @trace_disabled
+    def func():
+        span = client.start_trace(
+            name="predict",
+            experiment_id=experiment_id,
+            inputs={"x": 1, "y": 2},
+            attributes={"attr": "value"},
+            tags={"tag": "tag_value"},
+        )
+        child_span = client.start_span(
+            "child_span_1",
+            request_id=span.request_id,
+            parent_id=span.span_id,
+        )
+        client.end_span(
+            request_id=span.request_id,
+            span_id=child_span.span_id,
+            outputs={"output": 5},
+        )
+        client.end_trace(span.request_id, outputs=5, status="OK")
+        return "done"
+
+    mock_logger = mock.MagicMock()
+    monkeypatch.setattr(mlflow.tracking.client, "_logger", mock_logger)
+
+    res = func()
+
+    assert res == "done"
+    assert client.search_traces(experiment_ids=[experiment_id]) == []
+    # No warning should be issued
+    mock_logger.warning.assert_not_called()
 
 
 def test_start_trace_raise_error_when_active_trace_exists(clear_singleton):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12210?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12210/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12210
```

</p>
</details>

### What changes are proposed in this pull request?

This is an extension of https://github.com/mlflow/mlflow/pull/12167, where we disable trace during signature inference for logging models. While it worked well for normal pyfunc models, we observed a few traces were still generated when saving some particular model types such as LangChain model-as-code models and Chat Models. These models require a few additional prediction calls during logging, not only the one for signature inference.

To ensure the coverage of the suppression, this PR implements `@trace_disabled` decorator instead of context manager, and apply it to the entire `log_model()` and `save_model()` function.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests 


### Before
<img width="500" alt="Screenshot 2024-06-03 at 13 58 00" src="https://github.com/mlflow/mlflow/assets/31463517/e35ed623-bc64-4a4c-8411-af6a7690b693">


### After 

<img width="500" alt="Screenshot 2024-06-03 at 13 58 53" src="https://github.com/mlflow/mlflow/assets/31463517/ba4628fa-fba6-442d-97e3-73ca4319a406">



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
