### PR TITLE
Remove old warning for object/array signature

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -238,30 +238,6 @@ def _infer_schema(data: Any) -> Schema:
     """
     from scipy.sparse import csc_matrix, csr_matrix
 
-    # List[Dict[str, Union[DataType, List, Dict]]]
-    # e.g.
-    # [{'output': 'some sentence', 'ids': ['id1', 'id2'], 'dict': {'key': 'value'}},
-    #  {'output': 'some sentence', 'ids': ['id1', 'id2'], 'dict':
-    # {'key': 'value', 'key2': 'value2'}}]
-    # The corresponding pandas DataFrame representation should be `pd.DataFrame(data)`
-    #           output         ids                                dict
-    # 0  some sentence  [id1, id2]                    {'key': 'value'}
-    # 1  some sentence  [id1, id2]  {'key': 'value', 'key2': 'value2'}
-    # inferred schema -->
-    # Schema([ColSpec(type=DataType.string, name='output'),
-    #        ColSpec(type=Array(dtype=DataType.string), name='ids'),
-    #        ColSpec(type=Object([Property(name='key', dtype=DataType.string),
-    #                             Property(name='key2', dtype=DataType.string, required=False)]
-    #               ), name='dict')])
-    if isinstance(data, dict) and any(not isinstance(value, str) for value in data.values()):
-        # TODO: Add a link to docs/examples
-        _logger.info(
-            "MLflow 2.9.0 introduces model signature with new data types for "
-            "lists and dictionaries. For input such as "
-            "Dict[str, Union[scalars, List, Dict]], we infer dictionary values "
-            "types as `List -> Array` and `Dict -> Object`. "
-        )
-
     # To keep backward compatibility with < 2.9.0, an empty list is inferred as string.
     #   ref: https://github.com/mlflow/mlflow/pull/10125#discussion_r1372751487
     if isinstance(data, list) and data == []:

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -227,6 +227,42 @@ def _infer_schema(data: Any) -> Schema:
       - Dict[str, Union[DataType, List, Dict]]
       - List[Dict[str, Union[DataType, List, Dict]]]
 
+    The last two formats are used to represent complex data structures. For example,
+
+        Input Data:
+            [
+                {
+                    'text': 'some sentence',
+                    'ids': ['id1'],
+                    'dict': {'key': 'value'}
+                },
+                {
+                    'text': 'some sentence',
+                    'ids': ['id1', 'id2'],
+                    'dict': {'key': 'value', 'key2': 'value2'}
+                },
+            ]
+
+        The corresponding pandas DataFrame representation should look like this:
+
+                    output         ids                                dict
+            0  some sentence  [id1, id2]                    {'key': 'value'}
+            1  some sentence  [id1, id2]  {'key': 'value', 'key2': 'value2'}
+
+        The inferred schema should look like this:
+
+            Schema([
+                ColSpec(type=DataType.string, name='output'),
+                ColSpec(type=Array(dtype=DataType.string), name='ids'),
+                ColSpec(
+                    type=Object([
+                        Property(name='key', dtype=DataType.string),
+                        Property(name='key2', dtype=DataType.string, required=False)
+                    ]),
+                    name='dict')]
+                ),
+            ])
+
     The element types should be mappable to one of :py:class:`mlflow.models.signature.DataType` for
     dataframes and to one of numpy types for tensors.
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12212?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12212/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12212
```

</p>
</details>

### What changes are proposed in this pull request?

Split from: https://github.com/mlflow/mlflow/pull/12210

The arrays/object signature has been there for a while. We no longer need a message for it.

> 2024/06/03 04:57:21 INFO mlflow.types.utils: MLflow 2.9.0 introduces model signature with new data types for lists and dictionaries. For input such as Dict[str, Union[scalars, List, Dict]], we infer dictionary values types as `List -> Array` and `Dict -> Object`. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
