### PR TITLE
Fix `mlflow.evaluate` with `baseline_model` and `thresholds`

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -14,7 +14,7 @@ import warnings
 from collections import namedtuple
 from contextlib import contextmanager
 from functools import partial
-from typing import Callable, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Callable, List, NamedTuple, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -140,8 +140,8 @@ def _extract_raw_model(model):
 
 
 def _extract_predict_fn(
-    model: Optional[object],
-    raw_model: Optional[object],
+    model: Any,
+    raw_model: Any,
 ) -> Tuple[Optional[Callable], Optional[Callable]]:
     """
     Extracts the predict function from the given model or raw_model.

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -188,6 +188,7 @@ def restrict_langchain_autologging_to_traces_only(pred_fn):
         return None
 
     # In non-langchain environments, nothing would be autologged.
+    @functools.wraps(pred_fn)
     def new_pred_fn(*args, **kwargs):
         with mlflow.utils.autologging_utils.restrict_langchain_autologging_to_traces_only():
             return pred_fn(*args, **kwargs)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -183,7 +183,7 @@ def _extract_predict_fn(
     return predict_fn, predict_proba_fn
 
 
-def restrict_langchain_autologging_to_traces_only(pred_fn):
+def _restrict_langchain_autologging_to_traces_only(pred_fn):
     if pred_fn is None:
         return None
 
@@ -1901,8 +1901,8 @@ class DefaultEvaluator(ModelEvaluator):
                 # model is constructed from a user specified function or not provided
                 self.model_loader_module, self.raw_model = None, None
             self.predict_fn, self.predict_proba_fn = _extract_predict_fn(model, self.raw_model)
-            self.predict_fn = restrict_langchain_autologging_to_traces_only(self.predict_fn)
-            self.predict_proba_fn = restrict_langchain_autologging_to_traces_only(
+            self.predict_fn = _restrict_langchain_autologging_to_traces_only(self.predict_fn)
+            self.predict_proba_fn = _restrict_langchain_autologging_to_traces_only(
                 self.predict_proba_fn
             )
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1444,7 +1444,7 @@ class DefaultEvaluator(ModelEvaluator):
                 i, row_data = row
                 single_input = row_data.to_frame().T if is_dataframe else row_data
                 start_time = time.time()
-                y_pred = self.model_predict_fn(single_input)
+                y_pred = self.predict_fn(single_input)
                 end_time = time.time()
                 pred_latencies.append(end_time - start_time)
                 y_pred_list.append(y_pred)
@@ -1476,7 +1476,7 @@ class DefaultEvaluator(ModelEvaluator):
             if compute_latency:
                 model_predictions = predict_with_latency(X_copy)
             else:
-                model_predictions = self.model_predict_fn(X_copy)
+                model_predictions = self.predict_fn(X_copy)
         else:
             if self.dataset.predictions_data is None:
                 raise MlflowException(
@@ -1970,7 +1970,6 @@ class DefaultEvaluator(ModelEvaluator):
                     return model.predict(x)
 
         self.model_predict_fn = model_predict_func
-
         self.dataset = dataset
         self.run_id = run_id
         self.model_type = model_type

--- a/tests/evaluate/test_validation.py
+++ b/tests/evaluate/test_validation.py
@@ -1,7 +1,9 @@
+import random
 from unittest import mock
 
 import pytest
 
+import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation import (
     EvaluationResult,
@@ -935,3 +937,33 @@ def test_validation_multi_thresholds_should_fail(
                     validation_thresholds=validation_thresholds,
                     baseline_model=multiclass_logistic_regressor_model_uri,
                 )
+
+
+def test_validation_thresholds_validation_thresholds_no_mock():
+    targets = [0, 1, 1, 1]
+    data = [[random.random()] for _ in targets]
+
+    class BaseModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input):
+            return len(model_input) * [0]
+
+    class CandidateModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input):
+            return len(model_input) * [1]
+
+    with mlflow.start_run():
+        base = mlflow.pyfunc.log_model("base", python_model=BaseModel())
+        candidate = mlflow.pyfunc.log_model("candidate", python_model=CandidateModel())
+        evaluate(
+            candidate.model_uri,
+            data=data,
+            model_type="classifier",
+            targets=targets,
+            validation_thresholds={
+                "recall_score": MetricThreshold(
+                    min_absolute_change=0.1,
+                    greater_is_better=True,
+                ),
+            },
+            baseline_model=base.model_uri,
+        )

--- a/tests/evaluate/test_validation.py
+++ b/tests/evaluate/test_validation.py
@@ -939,7 +939,7 @@ def test_validation_multi_thresholds_should_fail(
                 )
 
 
-def test_validation_thresholds_validation_thresholds_no_mock():
+def test_validation_thresholds_no_mock():
     targets = [0, 1, 1, 1]
     data = [[random.random()] for _ in targets]
 

--- a/tests/evaluate/test_validation.py
+++ b/tests/evaluate/test_validation.py
@@ -954,8 +954,28 @@ def test_validation_thresholds_no_mock():
     with mlflow.start_run():
         base = mlflow.pyfunc.log_model("base", python_model=BaseModel())
         candidate = mlflow.pyfunc.log_model("candidate", python_model=CandidateModel())
+
+    evaluate(
+        candidate.model_uri,
+        data=data,
+        model_type="classifier",
+        targets=targets,
+        validation_thresholds={
+            "recall_score": MetricThreshold(
+                threshold=0.9,
+                min_absolute_change=0.1,
+                greater_is_better=True,
+            ),
+        },
+        baseline_model=base.model_uri,
+    )
+
+    with pytest.raises(
+        ModelValidationFailedException,
+        match="recall_score value threshold check failed",
+    ):
         evaluate(
-            candidate.model_uri,
+            base.model_uri,
             data=data,
             model_type="classifier",
             targets=targets,
@@ -966,5 +986,5 @@ def test_validation_thresholds_no_mock():
                     greater_is_better=True,
                 ),
             },
-            baseline_model=base.model_uri,
+            baseline_model=candidate.model_uri,
         )

--- a/tests/evaluate/test_validation.py
+++ b/tests/evaluate/test_validation.py
@@ -961,6 +961,7 @@ def test_validation_thresholds_no_mock():
             targets=targets,
             validation_thresholds={
                 "recall_score": MetricThreshold(
+                    threshold=0.9,
                     min_absolute_change=0.1,
                     greater_is_better=True,
                 ),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12215?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12215/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12215
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix a bug introduced in #11911:

https://github.com/mlflow-automation/mlflow/actions/runs/9338523457/job/25701739320:

```
mlflow.models.evaluation.validation.ModelValidationFailedException: Metric recall_score minimum absolute change check failed: candidate model recall_score = 0.659607843137255, baseline model recall_score = 0.659607843137255, recall_score minimum absolute change threshold = 0.1. Metric recall_score minimum relative change check failed: candidate model recall_score = 0.659607843137255, baseline model recall_score = 0.659607843137255, recall_score minimum relative change threshold = 0.1.
```

This traceback indicates that `evaluate` compares the same model, not base and candidate models. The fact that #11911 could be merged means there is no test that can detect the issue. This PR fixes it and adds a test.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
