### PR TITLE
Block LIKE/ILIKE operator for trace search

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -542,7 +542,8 @@ class SearchUtils:
         if key_type == cls._TAG_IDENTIFIER:
             if comparator not in cls.VALID_TAG_COMPARATORS:
                 raise MlflowException(
-                    f"Invalid comparator '{comparator}' not one of '{cls.VALID_TAG_COMPARATORS}"
+                    f"Invalid comparator '{comparator}' not one of '{cls.VALID_TAG_COMPARATORS}",
+                    error_code=INVALID_PARAMETER_VALUE,
                 )
             return True
         return False
@@ -559,7 +560,8 @@ class SearchUtils:
             if comparator not in cls.VALID_STRING_ATTRIBUTE_COMPARATORS:
                 raise MlflowException(
                     f"Invalid comparator '{comparator}' not one of "
-                    f"'{cls.VALID_STRING_ATTRIBUTE_COMPARATORS}'"
+                    f"'{cls.VALID_STRING_ATTRIBUTE_COMPARATORS}'",
+                    error_code=INVALID_PARAMETER_VALUE,
                 )
             return True
         return False
@@ -570,7 +572,8 @@ class SearchUtils:
             if comparator not in cls.VALID_NUMERIC_ATTRIBUTE_COMPARATORS:
                 raise MlflowException(
                     f"Invalid comparator '{comparator}' not one of "
-                    f"'{cls.VALID_STRING_ATTRIBUTE_COMPARATORS}"
+                    f"'{cls.VALID_STRING_ATTRIBUTE_COMPARATORS}",
+                    error_code=INVALID_PARAMETER_VALUE,
                 )
             return True
         return False
@@ -581,7 +584,8 @@ class SearchUtils:
             if comparator not in cls.VALID_DATASET_COMPARATORS:
                 raise MlflowException(
                     f"Invalid comparator '{comparator}' "
-                    f"not one of '{cls.VALID_DATASET_COMPARATORS}"
+                    f"not one of '{cls.VALID_DATASET_COMPARATORS}",
+                    error_code=INVALID_PARAMETER_VALUE,
                 )
             return True
         return False
@@ -1500,10 +1504,9 @@ class SearchTraceUtils(SearchUtils):
         "execution_time",
     }
 
-    # Databricks backend does not support LIKE/ILIKE operators for trace search
-    # for performance issues, so we don't support them in the OSS either for
-    # consistency. We can revisit this decision if we find a way to support
-    # these operators in a performant way, or users request them.
+    # For now, don't support LIKE/ILIKE operators for trace search because it may
+    # cause performance issues with large attributes and tags. We can revisit this
+    # decision if we find a way to support them efficiently.
     VALID_TAG_COMPARATORS = {"!=", "="}
     VALID_STRING_ATTRIBUTE_COMPARATORS = {"!=", "=", "IN", "NOT IN"}
 
@@ -1612,7 +1615,8 @@ class SearchTraceUtils(SearchUtils):
             # Request metadata accepts the same set of comparators as tags
             if comparator not in cls.VALID_TAG_COMPARATORS:
                 raise MlflowException(
-                    f"Invalid comparator '{comparator}' not one of '{cls.VALID_TAG_COMPARATORS}'"
+                    f"Invalid comparator '{comparator}' not one of '{cls.VALID_TAG_COMPARATORS}'",
+                    error_code=INVALID_PARAMETER_VALUE,
                 )
             return True
         return False

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1500,6 +1500,13 @@ class SearchTraceUtils(SearchUtils):
         "execution_time",
     }
 
+    # Databricks backend does not support LIKE/ILIKE operators for trace search
+    # for performance issues, so we don't support them in the OSS either for
+    # consistency. We can revisit this decision if we find a way to support
+    # these operators in a performant way, or users request them.
+    VALID_TAG_COMPARATORS = {"!=", "="}
+    VALID_STRING_ATTRIBUTE_COMPARATORS = {"!=", "=", "IN", "NOT IN"}
+
     _REQUEST_METADATA_IDENTIFIER = "request_metadata"
     _TAG_IDENTIFIER = "tag"
     _ATTRIBUTE_IDENTIFIER = "attribute"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2930,11 +2930,6 @@ def test_search_traces_filter(generate_trace_infos):
     # filter by name
     _validate_search_traces(store, [exp_id], "name = 'trace_0'", trace_infos[:1])
     _validate_search_traces(store, [exp_id], "name != 'trace_0'", trace_infos[1:][::-1])
-    _validate_search_traces(store, [exp_id], "name LIKE 'trace_%'", trace_infos[::-1])
-    _validate_search_traces(store, [exp_id], "name ILIKE 'Trace_%'", trace_infos[::-1])
-    _validate_search_traces(
-        store, [exp_id], "name ILIKE 'Trace_%' AND name LIKE '%0'", trace_infos[:1]
-    )
 
     # filter by status
     _validate_search_traces(store, [exp_id], "status = 'IN_PROGRESS'", trace_infos[::-1])
@@ -2954,8 +2949,6 @@ def test_search_traces_filter(generate_trace_infos):
     _validate_search_traces(
         store, [exp_id], "status NOT IN ('IN_PROGRESS', 'OK')", trace_infos[2:5][::-1]
     )
-    _validate_search_traces(store, [exp_id], "status LIKE 'O%'", trace_infos[:2][::-1])
-    _validate_search_traces(store, [exp_id], "status ILIKE 'ok'", trace_infos[:2][::-1])
 
     # filter by status w/ attributes. or trace. prefix
     _validate_search_traces(
@@ -2991,8 +2984,6 @@ def test_search_traces_filter(generate_trace_infos):
     _validate_search_traces(
         store, [exp_id], f"request_id NOT IN ('{request_ids[0]}')", trace_infos[1:][::-1]
     )
-    _validate_search_traces(store, [exp_id], "request_id LIKE '%'", trace_infos[::-1])
-    _validate_search_traces(store, [exp_id], "request_id ILIKE '%'", trace_infos[::-1])
 
     # filter by execution_time
     for execution_time_key in ["execution_time", "execution_time_ms"]:
@@ -3025,8 +3016,6 @@ def test_search_traces_filter(generate_trace_infos):
         )
     _validate_search_traces(store, [exp_id], "run_id = 'run_5'", [trace_infos[5]])
     _validate_search_traces(store, [exp_id], "run_id != 'run_5'", trace_infos[6:][::-1])
-    _validate_search_traces(store, [exp_id], "run_id LIKE 'run_%'", trace_infos[5:][::-1])
-    _validate_search_traces(store, [exp_id], "run_id ILIKE 'RUN_5'", [trace_infos[5]])
 
     # filter by tag
     for tag_identifier in ["tag", "tags"]:
@@ -3036,23 +3025,11 @@ def test_search_traces_filter(generate_trace_infos):
         _validate_search_traces(
             store, [exp_id], f"{tag_identifier}.test_tag != 'tag_0'", trace_infos[1:][::-1]
         )
-        _validate_search_traces(
-            store, [exp_id], f"{tag_identifier}.test_tag LIKE 'tag_%'", trace_infos[::-1]
-        )
-        _validate_search_traces(
-            store, [exp_id], f"{tag_identifier}.test_tag ILIKE 'TAG_%'", trace_infos[::-1]
-        )
         _validate_search_traces(store, [exp_id], f"{tag_identifier}.test_tag = '123'", [])
 
     # multiple filter conditions
     _validate_search_traces(
-        store, [exp_id], "name LIKE 'trace_%' AND timestamp <= 10", trace_infos[:2][::-1]
-    )
-    _validate_search_traces(
-        store,
-        [exp_id],
-        "name LIKE 'trace_%' AND status IN ('ERROR') AND timestamp <= 20",
-        [trace_infos[2]],
+        store, [exp_id], "status = 'OK' AND timestamp <= 10", trace_infos[:2][::-1]
     )
 
 
@@ -3066,6 +3043,12 @@ def test_search_traces_filter(generate_trace_infos):
         ("trace.tags.foo = 'bar'", r"Invalid attribute key 'tags\.foo'"),
         ("trace.status < 'OK'", r"Invalid comparator '<'"),
         ("name IN ('foo', 'bar')", r"Invalid comparator 'IN'"),
+        # Databricks backend does not support LIKE/ILIKE operators for trace search
+        # for performance issues, so we don't support them in the FileStore either.
+        ("name LIKE 'trace_%'", r"Invalid comparator 'LIKE'"),
+        ("run_id ILIKE 'run_%'", r"Invalid comparator 'ILIKE'"),
+        ("tag.test_tag LIKE 'tag_%'", r"Invalid comparator 'LIKE'"),
+        ("tags.test_tag ILIKE 'tag_%'", r"Invalid comparator 'ILIKE'"),
     ],
 )
 def test_search_traces_invalid_filter(generate_trace_infos, filter_string, error):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -3043,8 +3043,8 @@ def test_search_traces_filter(generate_trace_infos):
         ("trace.tags.foo = 'bar'", r"Invalid attribute key 'tags\.foo'"),
         ("trace.status < 'OK'", r"Invalid comparator '<'"),
         ("name IN ('foo', 'bar')", r"Invalid comparator 'IN'"),
-        # Databricks backend does not support LIKE/ILIKE operators for trace search
-        # for performance issues, so we don't support them in the FileStore either.
+        # We don't support LIKE/ILIKE operators for trace search because it may
+        # cause performance issues with large attributes and tags.
         ("name LIKE 'trace_%'", r"Invalid comparator 'LIKE'"),
         ("run_id ILIKE 'run_%'", r"Invalid comparator 'ILIKE'"),
         ("tag.test_tag LIKE 'tag_%'", r"Invalid comparator 'LIKE'"),

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4024,8 +4024,6 @@ def test_search_traces_order_by(store_with_traces, order_by, expected_ids):
         # Search by name
         ("name = 'aaa'", ["tr-1"]),
         ("name != 'aaa'", ["tr-4", "tr-3", "tr-2", "tr-0"]),
-        ("name LIKE 'b%'", ["tr-2"]),
-        ("name ILIKE 'd%'", ["tr-4", "tr-0"]),
         # Search by status
         ("status = 'OK'", ["tr-4", "tr-3", "tr-0"]),
         ("status != 'OK'", ["tr-2", "tr-1"]),
@@ -4037,7 +4035,6 @@ def test_search_traces_order_by(store_with_traces, order_by, expected_ids):
         ("`timestamp` >= 1 AND execution_time < 10", ["tr-2", "tr-1"]),
         # Search by tag
         ("tag.fruit = 'apple'", ["tr-2", "tr-1"]),
-        ("tag.color LIKE 're%'", ["tr-1"]),
         # tags is an alias for tag
         ("tags.fruit = 'apple' and tags.color != 'red'", ["tr-2"]),
         # Search by request metadata
@@ -4068,6 +4065,11 @@ def test_search_traces_with_filter(store_with_traces, filter_string, expected_id
         ("trace.tags.foo = 'bar'", r"Invalid attribute key 'tags\.foo'"),
         ("trace.status < 'OK'", r"Invalid comparator '<'"),
         ("name IN ('foo', 'bar')", r"Invalid comparator 'IN'"),
+        # Databricks backend does not support LIKE/ILIKE operators for trace search
+        # for performance issues, so we don't support them in the SQLStore either.
+        ("name LIKE 'b%'", r"Invalid comparator 'LIKE'"),
+        ("name ILIKE 'd%'", r"Invalid comparator 'ILIKE'"),
+        ("tag.color LIKE 're%'", r"Invalid comparator 'LIKE'"),
     ],
 )
 def test_search_traces_with_invalid_filter(store_with_traces, filter_string, error):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4065,8 +4065,8 @@ def test_search_traces_with_filter(store_with_traces, filter_string, expected_id
         ("trace.tags.foo = 'bar'", r"Invalid attribute key 'tags\.foo'"),
         ("trace.status < 'OK'", r"Invalid comparator '<'"),
         ("name IN ('foo', 'bar')", r"Invalid comparator 'IN'"),
-        # Databricks backend does not support LIKE/ILIKE operators for trace search
-        # for performance issues, so we don't support them in the SQLStore either.
+        # We don't support LIKE/ILIKE operators for trace search because it may
+        # cause performance issues with large attributes and tags.
         ("name LIKE 'b%'", r"Invalid comparator 'LIKE'"),
         ("name ILIKE 'd%'", r"Invalid comparator 'ILIKE'"),
         ("tag.color LIKE 're%'", r"Invalid comparator 'LIKE'"),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12221?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12221/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12221
```

</p>
</details>

### What changes are proposed in this pull request?

The `LIKE` / `ILIKE` search operator has some performance issue in current Databricks backend architecture. For consistency, we disable them for OSS store, until we find a solution to make it performant or we receive feature requests.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="600" alt="Screenshot 2024-06-04 at 9 48 27" src="https://github.com/mlflow/mlflow/assets/31463517/98a2a1ca-8d11-406e-9d78-889d560012aa">


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
