### PR TITLE
Use unique temp dir for model code

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -321,8 +321,8 @@ def save_model(
                 ]
                 output_schema = Schema(output_columns)
             else:
-                # TODO: empty output schema if multiple output_keys or is a retriever.
-                # fix later! https://databricks.atlassian.net/browse/ML-34706
+                # TODO: empty output schema if multiple output_keys or is a retriever. fix later!
+                # https://databricks.atlassian.net/browse/ML-34706
                 output_schema = None
 
             signature = (
@@ -375,9 +375,7 @@ def save_model(
 
     if Version(langchain.__version__) >= Version("0.0.311"):
         if databricks_resources := _detect_databricks_dependencies(lc_model):
-            serialized_databricks_resources = _ResourceBuilder.from_resources(
-                databricks_resources
-            )
+            serialized_databricks_resources = _ResourceBuilder.from_resources(databricks_resources)
             mlflow_model.resources = serialized_databricks_resources
 
     mlflow_model.add_flavor(

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -293,128 +293,128 @@ def save_model(
         else:
             lc_model = lc_model_or_path
 
-        code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
+    code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
-        if signature is None:
-            if input_example is not None:
-                wrapped_model = _LangChainModelWrapper(lc_model)
-                signature = _infer_signature_from_input_example_for_lc_model(
-                    input_example, wrapped_model, example_no_conversion=example_no_conversion
-                )
-            else:
-                if hasattr(lc_model, "input_keys"):
-                    input_columns = [
-                        ColSpec(type=DataType.string, name=input_key)
-                        for input_key in lc_model.input_keys
-                    ]
-                    input_schema = Schema(input_columns)
-                else:
-                    input_schema = None
-                if (
-                    hasattr(lc_model, "output_keys")
-                    and len(lc_model.output_keys) == 1
-                    and not isinstance(lc_model, BaseRetriever)
-                ):
-                    output_columns = [
-                        ColSpec(type=DataType.string, name=output_key)
-                        for output_key in lc_model.output_keys
-                    ]
-                    output_schema = Schema(output_columns)
-                else:
-                    # TODO: empty output schema if multiple output_keys or is a retriever.
-                    # fix later! https://databricks.atlassian.net/browse/ML-34706
-                    output_schema = None
-
-                signature = (
-                    ModelSignature(input_schema, output_schema)
-                    if input_schema or output_schema
-                    else None
-                )
-
-        if mlflow_model is None:
-            mlflow_model = Model()
-        if signature is not None:
-            mlflow_model.signature = signature
-
+    if signature is None:
         if input_example is not None:
-            _save_example(mlflow_model, input_example, path, example_no_conversion)
-        if metadata is not None:
-            mlflow_model.metadata = metadata
-
-        with _get_dependencies_schemas() as dependencies_schemas:
-            schema = dependencies_schemas.to_dict()
-            if schema is not None:
-                if mlflow_model.metadata is None:
-                    mlflow_model.metadata = {}
-                mlflow_model.metadata.update(schema)
-
-        if streamable is None:
-            streamable = hasattr(lc_model, "stream")
-
-        model_data_kwargs = {}
-        flavor_conf = {}
-        if not isinstance(model_code_path, str):
-            model_data_kwargs = _save_model(lc_model, path, loader_fn, persist_dir)
-            flavor_conf = {
-                _MODEL_TYPE_KEY: lc_model.__class__.__name__,
-                **model_data_kwargs,
-            }
-
-        pyfunc.add_to_model(
-            mlflow_model,
-            loader_module="mlflow.langchain",
-            conda_env=_CONDA_ENV_FILE_NAME,
-            python_env=_PYTHON_ENV_FILE_NAME,
-            code=code_dir_subpath,
-            predict_stream_fn="predict_stream",
-            streamable=streamable,
-            model_code_path=model_code_path,
-            model_config=model_config,
-            **model_data_kwargs,
-        )
-
-        if Version(langchain.__version__) >= Version("0.0.311"):
-            if databricks_resources := _detect_databricks_dependencies(lc_model):
-                serialized_databricks_resources = _ResourceBuilder.from_resources(
-                    databricks_resources
-                )
-                mlflow_model.resources = serialized_databricks_resources
-
-        mlflow_model.add_flavor(
-            FLAVOR_NAME,
-            langchain_version=langchain.__version__,
-            code=code_dir_subpath,
-            streamable=streamable,
-            **flavor_conf,
-        )
-        if size := get_total_file_size(path):
-            mlflow_model.model_size_bytes = size
-        mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
-
-        if conda_env is None:
-            if pip_requirements is None:
-                default_reqs = get_default_pip_requirements()
-                inferred_reqs = mlflow.models.infer_pip_requirements(
-                    str(path), FLAVOR_NAME, fallback=default_reqs
-                )
-                default_reqs = sorted(set(inferred_reqs).union(default_reqs))
-            else:
-                default_reqs = None
-            conda_env, pip_requirements, pip_constraints = _process_pip_requirements(
-                default_reqs, pip_requirements, extra_pip_requirements
+            wrapped_model = _LangChainModelWrapper(lc_model)
+            signature = _infer_signature_from_input_example_for_lc_model(
+                input_example, wrapped_model, example_no_conversion=example_no_conversion
             )
         else:
-            conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+            if hasattr(lc_model, "input_keys"):
+                input_columns = [
+                    ColSpec(type=DataType.string, name=input_key)
+                    for input_key in lc_model.input_keys
+                ]
+                input_schema = Schema(input_columns)
+            else:
+                input_schema = None
+            if (
+                hasattr(lc_model, "output_keys")
+                and len(lc_model.output_keys) == 1
+                and not isinstance(lc_model, BaseRetriever)
+            ):
+                output_columns = [
+                    ColSpec(type=DataType.string, name=output_key)
+                    for output_key in lc_model.output_keys
+                ]
+                output_schema = Schema(output_columns)
+            else:
+                # TODO: empty output schema if multiple output_keys or is a retriever.
+                # fix later! https://databricks.atlassian.net/browse/ML-34706
+                output_schema = None
 
-        with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
-            yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
+            signature = (
+                ModelSignature(input_schema, output_schema)
+                if input_schema or output_schema
+                else None
+            )
 
-        if pip_constraints:
-            write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+    if mlflow_model is None:
+        mlflow_model = Model()
+    if signature is not None:
+        mlflow_model.signature = signature
 
-        write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    if input_example is not None:
+        _save_example(mlflow_model, input_example, path, example_no_conversion)
+    if metadata is not None:
+        mlflow_model.metadata = metadata
 
-        _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
+    with _get_dependencies_schemas() as dependencies_schemas:
+        schema = dependencies_schemas.to_dict()
+        if schema is not None:
+            if mlflow_model.metadata is None:
+                mlflow_model.metadata = {}
+            mlflow_model.metadata.update(schema)
+
+    if streamable is None:
+        streamable = hasattr(lc_model, "stream")
+
+    model_data_kwargs = {}
+    flavor_conf = {}
+    if not isinstance(model_code_path, str):
+        model_data_kwargs = _save_model(lc_model, path, loader_fn, persist_dir)
+        flavor_conf = {
+            _MODEL_TYPE_KEY: lc_model.__class__.__name__,
+            **model_data_kwargs,
+        }
+
+    pyfunc.add_to_model(
+        mlflow_model,
+        loader_module="mlflow.langchain",
+        conda_env=_CONDA_ENV_FILE_NAME,
+        python_env=_PYTHON_ENV_FILE_NAME,
+        code=code_dir_subpath,
+        predict_stream_fn="predict_stream",
+        streamable=streamable,
+        model_code_path=model_code_path,
+        model_config=model_config,
+        **model_data_kwargs,
+    )
+
+    if Version(langchain.__version__) >= Version("0.0.311"):
+        if databricks_resources := _detect_databricks_dependencies(lc_model):
+            serialized_databricks_resources = _ResourceBuilder.from_resources(
+                databricks_resources
+            )
+            mlflow_model.resources = serialized_databricks_resources
+
+    mlflow_model.add_flavor(
+        FLAVOR_NAME,
+        langchain_version=langchain.__version__,
+        code=code_dir_subpath,
+        streamable=streamable,
+        **flavor_conf,
+    )
+    if size := get_total_file_size(path):
+        mlflow_model.model_size_bytes = size
+    mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
+
+    if conda_env is None:
+        if pip_requirements is None:
+            default_reqs = get_default_pip_requirements()
+            inferred_reqs = mlflow.models.infer_pip_requirements(
+                str(path), FLAVOR_NAME, fallback=default_reqs
+            )
+            default_reqs = sorted(set(inferred_reqs).union(default_reqs))
+        else:
+            default_reqs = None
+        conda_env, pip_requirements, pip_constraints = _process_pip_requirements(
+            default_reqs, pip_requirements, extra_pip_requirements
+        )
+    else:
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+
+    with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
+
+    if pip_constraints:
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+
+    _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
 @experimental

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -287,7 +287,8 @@ def _get_supported_llms():
     return supported_llms
 
 
-def _validate_and_prepare_lc_model_or_path(lc_model, loader_fn):
+# temp_dir is only required when lc_model could be a file path
+def _validate_and_prepare_lc_model_or_path(lc_model, loader_fn, temp_dir=None):
     import langchain.agents.agent
     import langchain.chains.base
     import langchain.chains.llm
@@ -297,7 +298,7 @@ def _validate_and_prepare_lc_model_or_path(lc_model, loader_fn):
 
     # lc_model is a file path
     if isinstance(lc_model, str):
-        return _validate_and_get_model_code_path(lc_model)
+        return _validate_and_get_model_code_path(lc_model, temp_dir)
 
     if not isinstance(lc_model, supported_lc_types()):
         raise mlflow.MlflowException.invalid_parameter_value(

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1517,7 +1517,9 @@ def _convert_llm_input_data(data):
     return _convert_llm_ndarray_to_list(data)
 
 
-def _get_temp_file_with_content(temp_dir: str, file_name: str, content: Union[str, bytes], content_format) -> str:
+def _get_temp_file_with_content(
+    temp_dir: str, file_name: str, content: Union[str, bytes], content_format
+) -> str:
     """
     Write the contents to a temporary file and return the path to that file.
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1579,7 +1579,7 @@ def _validate_and_get_model_code_path(model_code_path: str) -> str:
             )
 
         _validate_model_code_from_notebook(decoded_content.decode("utf-8"))
-        return _get_temp_file_with_content("model.py", decoded_content, "wb")
+        return _get_temp_file_with_content(f"model_{uuid.uuid4().hex}.py", decoded_content, "wb")
 
 
 @contextmanager

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -7,7 +7,6 @@ import logging
 import os
 import re
 import sys
-import tempfile
 import uuid
 from contextlib import contextmanager
 from copy import deepcopy
@@ -1518,20 +1517,18 @@ def _convert_llm_input_data(data):
     return _convert_llm_ndarray_to_list(data)
 
 
-def _get_temp_file_with_content(file_name: str, content: str, content_format) -> str:
+def _get_temp_file_with_content(temp_dir: str, file_name: str, content: str, content_format) -> str:
     """
     Write the contents to a temporary file and return the path to that file.
 
     Args:
+        temp_dir: The name of the temporary directory where the file will be created.
         file_name: The name of the file to be created.
         content: The contents to be written to the file.
 
     Returns:
         The string path to the file where the chain model is build.
     """
-    # Get the temporary directory path
-    temp_dir = tempfile.gettempdir()
-
     # Construct the full path where the temporary file will be created
     temp_file_path = os.path.join(temp_dir, file_name)
 
@@ -1542,10 +1539,10 @@ def _get_temp_file_with_content(file_name: str, content: str, content_format) ->
     return temp_file_path
 
 
-def _validate_and_get_model_code_path(model_code_path: str) -> str:
+def _validate_and_get_model_code_path(model_code_path: str, temp_dir: str) -> str:
     """
-    Validate model code path exists. Creates a temp file and validate its contents if it's a
-    notebook.
+    Validate model code path exists. Creates a temp file in temp_dir and validate its contents if
+    it's a notebook.
 
     Returns either `model_code_path` or a temp file path with the contents of the notebook.
     """
@@ -1579,7 +1576,7 @@ def _validate_and_get_model_code_path(model_code_path: str) -> str:
             )
 
         _validate_model_code_from_notebook(decoded_content.decode("utf-8"))
-        return _get_temp_file_with_content(f"model_{uuid.uuid4().hex}.py", decoded_content, "wb")
+        return _get_temp_file_with_content(temp_dir, "model.py", decoded_content, "wb")
 
 
 @contextmanager

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1517,7 +1517,7 @@ def _convert_llm_input_data(data):
     return _convert_llm_ndarray_to_list(data)
 
 
-def _get_temp_file_with_content(temp_dir: str, file_name: str, content: str, content_format) -> str:
+def _get_temp_file_with_content(temp_dir: str, file_name: str, content: Union[str, bytes], content_format) -> str:
     """
     Write the contents to a temporary file and return the path to that file.
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2327,11 +2327,11 @@ def save_model(
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
     """
-    with tempfile.TemporaryDirectory() as temp_dir:
-        _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
-        _validate_pyfunc_model_config(model_config)
-        _validate_and_prepare_target_save_path(path)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_pyfunc_model_config(model_config)
+    _validate_and_prepare_target_save_path(path)
 
+    with tempfile.TemporaryDirectory() as temp_dir:
         model_code_path = None
         if python_model:
             if isinstance(model_config, Path):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2357,180 +2357,180 @@ def save_model(
                     "`pip_requirements`, or `extra_pip_requirements` must be specified."
                 )
 
-        mlflow_model = kwargs.pop("model", mlflow_model)
-        if len(kwargs) > 0:
-            raise TypeError(f"save_model() got unexpected keyword arguments: {kwargs}")
+    mlflow_model = kwargs.pop("model", mlflow_model)
+    if len(kwargs) > 0:
+        raise TypeError(f"save_model() got unexpected keyword arguments: {kwargs}")
 
-        if code_path is not None and code_paths is not None:
-            raise MlflowException(
-                "Both `code_path` and `code_paths` have been specified, which is not permitted."
-            )
-        if code_path is not None:
-            # Alias for `code_path` deprecation
-            code_paths = code_path
-            warnings.warn(
-                "The `code_path` argument is replaced by `code_paths` and is deprecated "
-                "as of MLflow version 2.12.0. This argument will be removed in a future "
-                "release of MLflow."
-            )
-
-        if code_paths is not None:
-            if not isinstance(code_paths, list):
-                raise TypeError(f"Argument code_path should be a list, not {type(code_paths)}")
-
-        first_argument_set = {
-            "loader_module": loader_module,
-            "data_path": data_path,
-        }
-        second_argument_set = {
-            "artifacts": artifacts,
-            "python_model": python_model,
-        }
-        first_argument_set_specified = any(item is not None for item in first_argument_set.values())
-        second_argument_set_specified = any(
-            item is not None for item in second_argument_set.values()
+    if code_path is not None and code_paths is not None:
+        raise MlflowException(
+            "Both `code_path` and `code_paths` have been specified, which is not permitted."
         )
-        if first_argument_set_specified and second_argument_set_specified:
+    if code_path is not None:
+        # Alias for `code_path` deprecation
+        code_paths = code_path
+        warnings.warn(
+            "The `code_path` argument is replaced by `code_paths` and is deprecated "
+            "as of MLflow version 2.12.0. This argument will be removed in a future "
+            "release of MLflow."
+        )
+
+    if code_paths is not None:
+        if not isinstance(code_paths, list):
+            raise TypeError(f"Argument code_path should be a list, not {type(code_paths)}")
+
+    first_argument_set = {
+        "loader_module": loader_module,
+        "data_path": data_path,
+    }
+    second_argument_set = {
+        "artifacts": artifacts,
+        "python_model": python_model,
+    }
+    first_argument_set_specified = any(item is not None for item in first_argument_set.values())
+    second_argument_set_specified = any(
+        item is not None for item in second_argument_set.values()
+    )
+    if first_argument_set_specified and second_argument_set_specified:
+        raise MlflowException(
+            message=(
+                f"The following sets of parameters cannot be specified together:"
+                f" {first_argument_set.keys()}  and {second_argument_set.keys()}."
+                " All parameters in one set must be `None`. Instead, found"
+                f" the following values: {first_argument_set} and {second_argument_set}"
+            ),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+    elif (loader_module is None) and (python_model is None):
+        msg = (
+            "Either `loader_module` or `python_model` must be specified. A `loader_module` "
+            "should be a python module. A `python_model` should be a subclass of PythonModel"
+        )
+        raise MlflowException(message=msg, error_code=INVALID_PARAMETER_VALUE)
+
+    if mlflow_model is None:
+        mlflow_model = Model()
+
+    hints = None
+    if signature is not None:
+        if isinstance(python_model, ChatModel):
             raise MlflowException(
-                message=(
-                    f"The following sets of parameters cannot be specified together:"
-                    f" {first_argument_set.keys()}  and {second_argument_set.keys()}."
-                    " All parameters in one set must be `None`. Instead, found"
-                    f" the following values: {first_argument_set} and {second_argument_set}"
-                ),
+                "ChatModel subclasses have a standard signature that is set "
+                "automatically. Please remove the `signature` parameter from "
+                "the call to log_model() or save_model().",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        elif (loader_module is None) and (python_model is None):
-            msg = (
-                "Either `loader_module` or `python_model` must be specified. A `loader_module` "
-                "should be a python module. A `python_model` should be a subclass of PythonModel"
+        mlflow_model.signature = signature
+    elif python_model is not None:
+        if callable(python_model):
+            input_arg_index = 0  # first argument
+            if signature := _infer_signature_from_type_hints(
+                python_model, input_arg_index, input_example=input_example
+            ):
+                mlflow_model.signature = signature
+        elif isinstance(python_model, ChatModel):
+            mlflow_model.signature = ModelSignature(
+                CHAT_MODEL_INPUT_SCHEMA,
+                CHAT_MODEL_OUTPUT_SCHEMA,
             )
-            raise MlflowException(message=msg, error_code=INVALID_PARAMETER_VALUE)
+            input_example = input_example or CHAT_MODEL_INPUT_EXAMPLE
 
-        if mlflow_model is None:
-            mlflow_model = Model()
-
-        hints = None
-        if signature is not None:
-            if isinstance(python_model, ChatModel):
-                raise MlflowException(
-                    "ChatModel subclasses have a standard signature that is set "
-                    "automatically. Please remove the `signature` parameter from "
-                    "the call to log_model() or save_model().",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
-            mlflow_model.signature = signature
-        elif python_model is not None:
-            if callable(python_model):
-                input_arg_index = 0  # first argument
-                if signature := _infer_signature_from_type_hints(
-                    python_model, input_arg_index, input_example=input_example
-                ):
-                    mlflow_model.signature = signature
-            elif isinstance(python_model, ChatModel):
-                mlflow_model.signature = ModelSignature(
-                    CHAT_MODEL_INPUT_SCHEMA,
-                    CHAT_MODEL_OUTPUT_SCHEMA,
-                )
-                input_example = input_example or CHAT_MODEL_INPUT_EXAMPLE
-
-                if isinstance(input_example, list):
-                    params = ChatParams()
-                    messages = [
-                        each_message
-                        for each_message in input_example
-                        if isinstance(each_message, ChatMessage)
-                    ]
-                else:
-                    # If the input example is a dictionary, convert it to ChatMessage format
-                    messages = [ChatMessage(**m) for m in input_example["messages"]]
-                    params = ChatParams(
-                        **{k: v for k, v in input_example.items() if k != "messages"}
-                    )
-
-                # call load_context() first, as predict may depend on it
-                _logger.info("Predicting on input example to validate output")
-                context = PythonModelContext(artifacts, model_config)
-                python_model.load_context(context)
-                output = python_model.predict(context, messages, params)
-                if not isinstance(output, ChatResponse):
-                    raise MlflowException(
-                        "Failed to save ChatModel. Please ensure that the model's predict() method "
-                        "returns a ChatResponse object. If your predict() method currently returns "
-                        "a dict, you can instantiate a ChatResponse by unpacking the output, e.g. "
-                        "`ChatResponse(**output)`",
-                    )
-            elif isinstance(python_model, PythonModel):
-                input_arg_index = 1  # second argument
-                if signature := _infer_signature_from_type_hints(
-                    python_model.predict,
-                    input_arg_index=input_arg_index,
-                    input_example=input_example,
-                ):
-                    mlflow_model.signature = signature
-                elif input_example is not None:
-                    try:
-                        context = PythonModelContext(artifacts, model_config)
-                        python_model.load_context(context)
-                        mlflow_model.signature = _infer_signature_from_input_example(
-                            input_example,
-                            _PythonModelPyfuncWrapper(python_model, None, None),
-                            no_conversion=example_no_conversion,
-                        )
-                    except Exception as e:
-                        _logger.warning(f"Failed to infer model signature from input example. {e}")
-
-        if input_example is not None:
-            _save_example(mlflow_model, input_example, path, example_no_conversion)
-        if metadata is not None:
-            mlflow_model.metadata = metadata
-
-        with _get_dependencies_schemas() as dependencies_schemas:
-            schema = dependencies_schemas.to_dict()
-            if schema is not None:
-                if mlflow_model.metadata is None:
-                    mlflow_model.metadata = {}
-                mlflow_model.metadata.update(schema)
-
-        if resources is not None:
-            if isinstance(resources, (Path, str)):
-                serialized_resource = _ResourceBuilder.from_yaml_file(resources)
+            if isinstance(input_example, list):
+                params = ChatParams()
+                messages = [
+                    each_message
+                    for each_message in input_example
+                    if isinstance(each_message, ChatMessage)
+                ]
             else:
-                serialized_resource = _ResourceBuilder.from_resources(resources)
+                # If the input example is a dictionary, convert it to ChatMessage format
+                messages = [ChatMessage(**m) for m in input_example["messages"]]
+                params = ChatParams(
+                    **{k: v for k, v in input_example.items() if k != "messages"}
+                )
 
-            mlflow_model.resources = serialized_resource
+            # call load_context() first, as predict may depend on it
+            _logger.info("Predicting on input example to validate output")
+            context = PythonModelContext(artifacts, model_config)
+            python_model.load_context(context)
+            output = python_model.predict(context, messages, params)
+            if not isinstance(output, ChatResponse):
+                raise MlflowException(
+                    "Failed to save ChatModel. Please ensure that the model's predict() method "
+                    "returns a ChatResponse object. If your predict() method currently returns "
+                    "a dict, you can instantiate a ChatResponse by unpacking the output, e.g. "
+                    "`ChatResponse(**output)`",
+                )
+        elif isinstance(python_model, PythonModel):
+            input_arg_index = 1  # second argument
+            if signature := _infer_signature_from_type_hints(
+                python_model.predict,
+                input_arg_index=input_arg_index,
+                input_example=input_example,
+            ):
+                mlflow_model.signature = signature
+            elif input_example is not None:
+                try:
+                    context = PythonModelContext(artifacts, model_config)
+                    python_model.load_context(context)
+                    mlflow_model.signature = _infer_signature_from_input_example(
+                        input_example,
+                        _PythonModelPyfuncWrapper(python_model, None, None),
+                        no_conversion=example_no_conversion,
+                    )
+                except Exception as e:
+                    _logger.warning(f"Failed to infer model signature from input example. {e}")
 
-        if first_argument_set_specified:
-            return _save_model_with_loader_module_and_data_path(
-                path=path,
-                loader_module=loader_module,
-                data_path=data_path,
-                code_paths=code_paths,
-                conda_env=conda_env,
-                mlflow_model=mlflow_model,
-                pip_requirements=pip_requirements,
-                extra_pip_requirements=extra_pip_requirements,
-                model_config=model_config,
-                streamable=streamable,
-                infer_code_paths=infer_code_paths,
-            )
-        elif second_argument_set_specified:
-            return mlflow.pyfunc.model._save_model_with_class_artifacts_params(
-                path=path,
-                signature=signature,
-                hints=hints,
-                python_model=python_model,
-                artifacts=artifacts,
-                conda_env=conda_env,
-                code_paths=code_paths,
-                mlflow_model=mlflow_model,
-                pip_requirements=pip_requirements,
-                extra_pip_requirements=extra_pip_requirements,
-                model_config=model_config,
-                streamable=streamable,
-                model_code_path=model_code_path,
-                infer_code_paths=infer_code_paths,
-            )
+    if input_example is not None:
+        _save_example(mlflow_model, input_example, path, example_no_conversion)
+    if metadata is not None:
+        mlflow_model.metadata = metadata
+
+    with _get_dependencies_schemas() as dependencies_schemas:
+        schema = dependencies_schemas.to_dict()
+        if schema is not None:
+            if mlflow_model.metadata is None:
+                mlflow_model.metadata = {}
+            mlflow_model.metadata.update(schema)
+
+    if resources is not None:
+        if isinstance(resources, (Path, str)):
+            serialized_resource = _ResourceBuilder.from_yaml_file(resources)
+        else:
+            serialized_resource = _ResourceBuilder.from_resources(resources)
+
+        mlflow_model.resources = serialized_resource
+
+    if first_argument_set_specified:
+        return _save_model_with_loader_module_and_data_path(
+            path=path,
+            loader_module=loader_module,
+            data_path=data_path,
+            code_paths=code_paths,
+            conda_env=conda_env,
+            mlflow_model=mlflow_model,
+            pip_requirements=pip_requirements,
+            extra_pip_requirements=extra_pip_requirements,
+            model_config=model_config,
+            streamable=streamable,
+            infer_code_paths=infer_code_paths,
+        )
+    elif second_argument_set_specified:
+        return mlflow.pyfunc.model._save_model_with_class_artifacts_params(
+            path=path,
+            signature=signature,
+            hints=hints,
+            python_model=python_model,
+            artifacts=artifacts,
+            conda_env=conda_env,
+            code_paths=code_paths,
+            mlflow_model=mlflow_model,
+            pip_requirements=pip_requirements,
+            extra_pip_requirements=extra_pip_requirements,
+            model_config=model_config,
+            streamable=streamable,
+            model_code_path=model_code_path,
+            infer_code_paths=infer_code_paths,
+        )
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2387,9 +2387,7 @@ def save_model(
         "python_model": python_model,
     }
     first_argument_set_specified = any(item is not None for item in first_argument_set.values())
-    second_argument_set_specified = any(
-        item is not None for item in second_argument_set.values()
-    )
+    second_argument_set_specified = any(item is not None for item in second_argument_set.values())
     if first_argument_set_specified and second_argument_set_specified:
         raise MlflowException(
             message=(
@@ -2444,9 +2442,7 @@ def save_model(
             else:
                 # If the input example is a dictionary, convert it to ChatMessage format
                 messages = [ChatMessage(**m) for m in input_example["messages"]]
-                params = ChatParams(
-                    **{k: v for k, v in input_example.items() if k != "messages"}
-                )
+                params = ChatParams(**{k: v for k, v in input_example.items() if k != "messages"})
 
             # call load_context() first, as predict may depend on it
             _logger.info("Predicting on input example to validate output")

--- a/tests/pyfunc/test_pyfunc_model_config.py
+++ b/tests/pyfunc/test_pyfunc_model_config.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 import pytest
 import yaml
@@ -87,15 +88,18 @@ def test_override_model_config(model_path, model_config):
     ],
 )
 def test_override_model_config_path(model_path, model_config_path):
-    model = TestModel()
-    inference_override = {"timeout": 400}
-    config_path = _get_temp_file_with_content("config.yml", yaml.dump(inference_override), "w")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        model = TestModel()
+        inference_override = {"timeout": 400}
+        config_path = _get_temp_file_with_content(
+            temp_dir, "config.yml", yaml.dump(inference_override), "w"
+        )
 
-    mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
-    loaded_model = mlflow.pyfunc.load_model(model_uri=model_path, model_config=config_path)
+        mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
+        loaded_model = mlflow.pyfunc.load_model(model_uri=model_path, model_config=config_path)
 
-    assert loaded_model.model_config["timeout"] == 400
-    assert all(loaded_model.model_config[k] == v for k, v in inference_override.items())
+        assert loaded_model.model_config["timeout"] == 400
+        assert all(loaded_model.model_config[k] == v for k, v in inference_override.items())
 
 
 def test_override_model_config_ignore_invalid(model_path, model_config):
@@ -117,15 +121,18 @@ def test_override_model_config_ignore_invalid(model_path, model_config):
     ],
 )
 def test_override_model_config_path_ignore_invalid(model_path, model_config_path):
-    model = TestModel()
-    inference_override = {"invalid_key": 400}
-    config_path = _get_temp_file_with_content("config.yml", yaml.dump(inference_override), "w")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        model = TestModel()
+        inference_override = {"invalid_key": 400}
+        config_path = _get_temp_file_with_content(
+            temp_dir, "config.yml", yaml.dump(inference_override), "w"
+        )
 
-    mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
-    loaded_model = mlflow.pyfunc.load_model(model_uri=model_path, model_config=config_path)
+        mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
+        loaded_model = mlflow.pyfunc.load_model(model_uri=model_path, model_config=config_path)
 
-    assert loaded_model.predict([[5]])
-    assert all(k not in loaded_model.model_config for k in inference_override.keys())
+        assert loaded_model.predict([[5]])
+        assert all(k not in loaded_model.model_config for k in inference_override.keys())
 
 
 def test_pyfunc_without_model_config(model_path, model_config):

--- a/tests/pyfunc/test_pyfunc_model_config.py
+++ b/tests/pyfunc/test_pyfunc_model_config.py
@@ -87,19 +87,18 @@ def test_override_model_config(model_path, model_config):
         "tests/pyfunc/../pyfunc/sample_code/config.yml",
     ],
 )
-def test_override_model_config_path(model_path, model_config_path):
-    with tempfile.TemporaryDirectory() as temp_dir:
-        model = TestModel()
-        inference_override = {"timeout": 400}
-        config_path = _get_temp_file_with_content(
-            temp_dir, "config.yml", yaml.dump(inference_override), "w"
-        )
+def test_override_model_config_path(tmp_path, model_path, model_config_path):
+    model = TestModel()
+    inference_override = {"timeout": 400}
+    config_path = _get_temp_file_with_content(
+        str(tmp_path), "config.yml", yaml.dump(inference_override), "w"
+    )
 
-        mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
-        loaded_model = mlflow.pyfunc.load_model(model_uri=model_path, model_config=config_path)
+    mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
+    loaded_model = mlflow.pyfunc.load_model(model_uri=model_path, model_config=config_path)
 
-        assert loaded_model.model_config["timeout"] == 400
-        assert all(loaded_model.model_config[k] == v for k, v in inference_override.items())
+    assert loaded_model.model_config["timeout"] == 400
+    assert all(loaded_model.model_config[k] == v for k, v in inference_override.items())
 
 
 def test_override_model_config_ignore_invalid(model_path, model_config):
@@ -120,19 +119,18 @@ def test_override_model_config_ignore_invalid(model_path, model_config):
         "tests/pyfunc/../pyfunc/sample_code/config.yml",
     ],
 )
-def test_override_model_config_path_ignore_invalid(model_path, model_config_path):
-    with tempfile.TemporaryDirectory() as temp_dir:
-        model = TestModel()
-        inference_override = {"invalid_key": 400}
-        config_path = _get_temp_file_with_content(
-            temp_dir, "config.yml", yaml.dump(inference_override), "w"
-        )
+def test_override_model_config_path_ignore_invalid(tmp_path model_path, model_config_path):
+    model = TestModel()
+    inference_override = {"invalid_key": 400}
+    config_path = _get_temp_file_with_content(
+        str(tmp_path), "config.yml", yaml.dump(inference_override), "w"
+    )
 
-        mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
-        loaded_model = mlflow.pyfunc.load_model(model_uri=model_path, model_config=config_path)
+    mlflow.pyfunc.save_model(model_path, python_model=model, model_config=model_config_path)
+    loaded_model = mlflow.pyfunc.load_model(model_uri=model_path, model_config=config_path)
 
-        assert loaded_model.predict([[5]])
-        assert all(k not in loaded_model.model_config for k in inference_override.keys())
+    assert loaded_model.predict([[5]])
+    assert all(k not in loaded_model.model_config for k in inference_override.keys())
 
 
 def test_pyfunc_without_model_config(model_path, model_config):

--- a/tests/pyfunc/test_pyfunc_model_config.py
+++ b/tests/pyfunc/test_pyfunc_model_config.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 
 import pytest
 import yaml
@@ -119,7 +118,7 @@ def test_override_model_config_ignore_invalid(model_path, model_config):
         "tests/pyfunc/../pyfunc/sample_code/config.yml",
     ],
 )
-def test_override_model_config_path_ignore_invalid(tmp_path model_path, model_config_path):
+def test_override_model_config_path_ignore_invalid(tmp_path, model_path, model_config_path):
     model = TestModel()
     inference_override = {"invalid_key": 400}
     config_path = _get_temp_file_with_content(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/12223?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12223/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12223
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Use a unique/new temp dir for code models from databricks notebooks so that logging multiple models does not collide to the same file tmp/model.py and so that tmp_dir/model.py is cleaned up.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manually testing:
Before (on shared cluster with MLflow 2.13.1):
<img width="2064" alt="Screenshot 2024-06-03 at 4 42 24 PM" src="https://github.com/mlflow/mlflow/assets/105813440/27504f23-637e-426b-98bc-ea343ba16880">
- one of the notebooks will fail if run at the same time on shared cluster

After (installing this PR):
<img width="2050" alt="Screenshot 2024-06-03 at 4 43 32 PM" src="https://github.com/mlflow/mlflow/assets/105813440/b3da6cf5-a022-49a2-9c91-38ffffa8d0b5">
- both succeed when run at the same time on shared cluster

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
