### PR TITLE
Mock dbutils when loading model code path

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1598,7 +1598,7 @@ def _config_context(config: Optional[Union[str, Dict[str, Any]]] = None):
 
 
 class MockDbutils:
-    def __init__(self, real_dbutils):
+    def __init__(self, real_dbutils=None):
         self.real_dbutils = real_dbutils
 
     def __getattr__(self, name):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1651,6 +1651,7 @@ def _load_model_code_path(code_path: str, config: Optional[Union[str, Dict[str, 
             spec = importlib.util.spec_from_file_location(new_module_name, code_path)
             module = importlib.util.module_from_spec(spec)
             sys.modules[new_module_name] = module
+            # Since dbutils will only work in databricks environment, we need to mock it
             with _mock_dbutils(module.__dict__):
                 spec.loader.exec_module(module)
         except ImportError as e:

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1598,10 +1598,15 @@ def _config_context(config: Optional[Union[str, Dict[str, Any]]] = None):
 
 
 class MockDbutils:
-    def __init__(self):
-        pass
+    def __init__(self, real_dbutils):
+        self.real_dbutils = real_dbutils
 
     def __getattr__(self, name):
+        try:
+            if self.real_dbutils:
+                return getattr(self.real_dbutils, name)
+        except AttributeError:
+            pass
         return MockDbutils()
 
     def __call__(self, *args, **kwargs):

--- a/tests/langchain/sample_code/chain.py
+++ b/tests/langchain/sample_code/chain.py
@@ -1,4 +1,5 @@
 import dbutils
+
 dbutils.library.restartPython()
 
 from typing import Any, List, Optional

--- a/tests/langchain/sample_code/chain.py
+++ b/tests/langchain/sample_code/chain.py
@@ -1,3 +1,6 @@
+import dbutils
+dbutils.library.restartPython()
+
 from typing import Any, List, Optional
 
 from langchain.document_loaders import TextLoader

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -456,7 +456,7 @@ def test_model_code_validation():
             "functions correctly, make sure that it does not rely on these magic commands for "
             "correctness."
         )
-    
+
     # Code with commented pip magic commands does not warn
     warning_code = "# MAGIC %pip install mlflow"
     with mock.patch("mlflow.models.utils._logger.warning") as mock_warning:

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -438,12 +438,15 @@ def test_model_code_validation():
     # Invalid code with dbutils
     invalid_code = "dbutils.library.restartPython()\nsome_python_variable = 5"
 
-    with pytest.raises(
-        ValueError, match="The model file uses 'dbutils' command which is not supported."
-    ):
+    with mock.patch("mlflow.models.utils._logger.warning") as mock_warning:
         _validate_model_code_from_notebook(invalid_code)
+        mock_warning.assert_called_once_with(
+            "The model file uses 'dbutils' commands which are not supported. To ensure your "
+            "code functions correctly, make sure that it does not rely on these dbutils "
+            "commands for correctness."
+        )
 
-    # Code with commended magic commands displays warning
+    # Code with commented magic commands displays warning
     warning_code = "# dbutils.library.restartPython()\n# MAGIC %run ../wheel_installer"
 
     with mock.patch("mlflow.models.utils._logger.warning") as mock_warning:
@@ -453,6 +456,12 @@ def test_model_code_validation():
             "functions correctly, make sure that it does not rely on these magic commands for "
             "correctness."
         )
+    
+    # Code with commented pip magic commands does not warn
+    warning_code = "# MAGIC %pip install mlflow"
+    with mock.patch("mlflow.models.utils._logger.warning") as mock_warning:
+        _validate_model_code_from_notebook(warning_code)
+        mock_warning.assert_not_called()
 
     # Test valid code
     valid_code = "some_valid_python_code = 'valid'"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/12226?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12226/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12226
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Don't error out if using dbutils - warn that it will be mocked to a no-op
- Exclude %pip from magic command warning

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="991" alt="Screenshot 2024-06-04 at 1 15 11 PM" src="https://github.com/mlflow/mlflow/assets/105813440/befdb738-79eb-405c-8f28-64ade766a3e1">

https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/2728230779498259 

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
