### PR TITLE
Provide a way to set urllib's connection number and max size

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -618,8 +618,13 @@ MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT", int, 500
 )
 
-#: The number of urllib3 connection pools to cache.
+
+#: Specifies the number of connection pools to cache in urllib3. This environment variable sets the
+#: `pool_connections` parameter in the `requests.adapters.HTTPAdapter` constructor. By adjusting
+#: this variable, users can enhance the concurrency of HTTP requests made by MLflow.
 MLFLOW_HTTP_POOL_CONNECTIONS = _EnvironmentVariable("MLFLOW_HTTP_POOL_CONNECTIONS", int, 10)
 
-#: The number of urllib3 connection pools to cache.
+#: Specifies the maximum number of connections to keep in the HTTP connection pool. This environment
+#: variable sets the `pool_maxsize` parameter in the `requests.adapters.HTTPAdapter` constructor.
+#: By adjusting this variable, users can enhance the concurrency of HTTP requests made by MLflow.
 MLFLOW_HTTP_POOL_MAXSIZE = _EnvironmentVariable("MLFLOW_HTTP_POOL_MAXSIZE", int, 10)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -617,3 +617,9 @@ MLFLOW_BOTO_CLIENT_ADDRESSING_STYLE = _EnvironmentVariable(
 MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT", int, 500
 )
+
+#: The number of urllib3 connection pools to cache.
+MLFLOW_HTTP_POOL_CONNECTIONS = _EnvironmentVariable("MLFLOW_HTTP_POOL_CONNECTIONS", int, 10)
+
+#: The number of urllib3 connection pools to cache.
+MLFLOW_HTTP_POOL_MAXSIZE = _EnvironmentVariable("MLFLOW_HTTP_POOL_MAXSIZE", int, 10)

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -12,6 +12,11 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
 from urllib3.util import Retry
 
+from mlflow.environment_variables import (
+    MLFLOW_HTTP_POOL_CONNECTIONS,
+    MLFLOW_HTTP_POOL_MAXSIZE,
+)
+
 # Response codes that generally indicate transient network failures and merit client retries,
 # based on guidance from cloud service providers
 # (https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#general-rest-and-retry-guidelines)
@@ -137,7 +142,11 @@ def _cached_get_request_session(
         retry = JitteredRetry(**retry_kwargs)
     else:
         retry = Retry(**retry_kwargs)
-    adapter = HTTPAdapter(max_retries=retry)
+    adapter = HTTPAdapter(
+        pool_connections=MLFLOW_HTTP_POOL_CONNECTIONS.get(),
+        pool_maxsize=MLFLOW_HTTP_POOL_MAXSIZE.get(),
+        max_retries=retry,
+    )
     session = requests.Session()
     session.mount("https://", adapter)
     session.mount("http://", adapter)

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -12,11 +12,6 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
 from urllib3.util import Retry
 
-from mlflow.environment_variables import (
-    MLFLOW_HTTP_POOL_CONNECTIONS,
-    MLFLOW_HTTP_POOL_MAXSIZE,
-)
-
 # Response codes that generally indicate transient network failures and merit client retries,
 # based on guidance from cloud service providers
 # (https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#general-rest-and-retry-guidelines)
@@ -142,6 +137,11 @@ def _cached_get_request_session(
         retry = JitteredRetry(**retry_kwargs)
     else:
         retry = Retry(**retry_kwargs)
+    from mlflow.environment_variables import (
+        MLFLOW_HTTP_POOL_CONNECTIONS,
+        MLFLOW_HTTP_POOL_MAXSIZE,
+    )
+
     adapter = HTTPAdapter(
         pool_connections=MLFLOW_HTTP_POOL_CONNECTIONS.get(),
         pool_maxsize=MLFLOW_HTTP_POOL_MAXSIZE.get(),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/12227?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12227/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12227
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Provide a way to set urllib's connection number and max size. People are reporting to see warning as below:

```
	 Train loss/train/total: 2.5931
	 Train loss/train/loss: 2.5786
	 Train loss/train/lbl: 0.0145
	 Train lr-DecoupledLionW/group0: 0.0002
	 Train time/train: 10.1496
	 Train time/val: 0.0000
	 Train time/total: 10.1496
2024-06-03 15:58:38,311: rank0[84][MLflowBatchLoggingWorkerPool_9]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 15:58:59,009: rank0[84][MLflowBatchLoggingWorkerPool_8]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 15:59:09,137: rank0[84][SystemMetricsMonitor]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 15:59:09,579: rank0[84][MLflowBatchLoggingWorkerPool_4]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 15:59:31,188: rank0[84][MLflowBatchLoggingWorkerPool_9]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 15:59:41,214: rank0[84][MLflowBatchLoggingWorkerPool_9]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:00:01,703: rank0[84][MLflowBatchLoggingWorkerPool_2]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:00:12,217: rank0[84][MLflowBatchLoggingWorkerPool_4]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:00:22,339: rank0[84][SystemMetricsMonitor]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:00:22,826: rank0[84][MLflowBatchLoggingWorkerPool_9]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:00:33,248: rank0[84][MLflowBatchLoggingWorkerPool_2]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:00:43,803: rank0[84][MLflowBatchLoggingWorkerPool_3]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:00:53,814: rank0[84][SystemMetricsMonitor]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:00:54,285: rank0[84][MLflowBatchLoggingWorkerPool_7]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:01:04,377: rank0[84][SystemMetricsMonitor]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:01:04,818: rank0[84][MLflowBatchLoggingWorkerPool_9]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:01:25,359: rank0[84][MLflowBatchLoggingWorkerPool_5]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:01:45,883: rank0[84][MLflowBatchLoggingWorkerPool_9]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:01:56,447: rank0[84][MLflowBatchLoggingWorkerPool_6]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connection pool size: 10
2024-06-03 16:02:06,527: rank0[84][SystemMetricsMonitor]: WARNING: urllib3.connectionpool: Connection pool is full, discarding connection: dbc-559ffd80-2bfc.cloud.databricks.com. Connecti
```

Although no data is lost, it's scary to see a tsunami of warnings like this. Since this is a rarely incurred issue, we just make this as an environment variable similar to [`MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE`](https://github.com/mlflow/mlflow/blob/72df4a2a0f44c52179dfbdc7d47ad10f58ceec39/mlflow/environment_variables.py#L545)


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
