### PR TITLE
Ignore databricks_rag_studio in package mismatch

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -627,11 +627,15 @@ def warn_dependency_requirement_mismatches(model_requirements: List[str]):
     doesn't satisfy them.
     """
     # Suppress databricks-feature-lookup warning for feature store cases
-    # Suppress databricks_rag_studio warning for RAG Studio cases
+    # Suppress databricks-chains warning for RAG Studio cases
     _DATABRICKS_FEATURE_LOOKUP = "databricks-feature-lookup"
-    _DATABRICKS_RAG_STUDIO = "databricks_rag_studio"
+    _DATABRICKS_RAG_STUDIO = "databricks-chains"
     ignore_packages = list(
-        map(_normalize_package_name, [_DATABRICKS_FEATURE_LOOKUP, _DATABRICKS_RAG_STUDIO])
+        map(
+            _normalize_package_name,
+            # TODO: remove databricks-rag-studio once it's EoL
+            [_DATABRICKS_FEATURE_LOOKUP, _DATABRICKS_RAG_STUDIO, "databricks-rag-studio"],
+        )
     )
     try:
         mismatch_infos = []

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -626,19 +626,19 @@ def warn_dependency_requirement_mismatches(model_requirements: List[str]):
     Inspects the model's dependencies and prints a warning if the current Python environment
     doesn't satisfy them.
     """
+    # Suppress databricks-feature-lookup warning for feature store cases
+    # Suppress databricks_rag_studio warning for RAG Studio cases
     _DATABRICKS_FEATURE_LOOKUP = "databricks-feature-lookup"
     _DATABRICKS_RAG_STUDIO = "databricks_rag_studio"
+    ignore_packages = list(
+        map(_normalize_package_name, [_DATABRICKS_FEATURE_LOOKUP, _DATABRICKS_RAG_STUDIO])
+    )
     try:
         mismatch_infos = []
         for req in model_requirements:
             mismatch_info = _check_requirement_satisfied(req)
             if mismatch_info is not None:
-                # Suppress databricks-feature-lookup warning for feature store cases
-                # Suppress databricks_rag_studio warning for RAG Studio cases
-                if mismatch_info.package_name in [
-                    _DATABRICKS_FEATURE_LOOKUP,
-                    _DATABRICKS_RAG_STUDIO,
-                ]:
+                if _normalize_package_name(mismatch_info.package_name) in ignore_packages:
                     continue
                 mismatch_infos.append(str(mismatch_info))
 

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -627,13 +627,18 @@ def warn_dependency_requirement_mismatches(model_requirements: List[str]):
     doesn't satisfy them.
     """
     _DATABRICKS_FEATURE_LOOKUP = "databricks-feature-lookup"
+    _DATABRICKS_RAG_STUDIO = "databricks_rag_studio"
     try:
         mismatch_infos = []
         for req in model_requirements:
             mismatch_info = _check_requirement_satisfied(req)
             if mismatch_info is not None:
                 # Suppress databricks-feature-lookup warning for feature store cases
-                if mismatch_info.package_name == _DATABRICKS_FEATURE_LOOKUP:
+                # Suppress databricks_rag_studio warning for RAG Studio cases
+                if mismatch_info.package_name in [
+                    _DATABRICKS_FEATURE_LOOKUP,
+                    _DATABRICKS_RAG_STUDIO,
+                ]:
                     continue
                 mismatch_infos.append(str(mismatch_info))
 

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -555,7 +555,10 @@ model's environment and install dependencies using the resulting environment fil
         mock_warning.assert_not_called()
 
 
-def test_suppress_warn_dependency_requirement_mismatches_feature_store(tmp_path):
+@pytest.mark.parametrize(
+    "ignore_package_name", ["databricks-feature-lookup", "databricks_rag_studio"]
+)
+def test_suppress_warn_dependency_requirement_mismatches_ignore_some_packages(ignore_package_name):
     with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warning:
         original_get_installed_version_fn = mlflow.utils.requirements_utils._get_installed_version
 
@@ -573,7 +576,7 @@ def test_suppress_warn_dependency_requirement_mismatches_feature_store(tmp_path)
             "mlflow.utils.requirements_utils._get_installed_version",
             gen_mock_get_installed_version_fn(
                 {
-                    "databricks-feature-lookup": "9.99.11",
+                    ignore_package_name: "9.99.11",
                     "cloudpickle": "999.99.22",
                 }
             ),
@@ -581,7 +584,7 @@ def test_suppress_warn_dependency_requirement_mismatches_feature_store(tmp_path)
             warn_dependency_requirement_mismatches(
                 model_requirements=[
                     f"cloudpickle=={cloudpickle.__version__}",
-                    "databricks-feature-lookup==999.1.1",
+                    f"{ignore_package_name}==999.1.1",
                 ]
             )
             mock_warning.assert_called_once_with(

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -559,10 +559,11 @@ model's environment and install dependencies using the resulting environment fil
     "ignore_package_name",
     [
         "databricks-feature-lookup",
-        "databricks_rag_studio",
+        "databricks-chains",
+        "databricks_chains",
+        "databricks.chains",
         "databricks-rag-studio",
-        "databricks.rag.studio",
-        "Databricks-rag-studio",
+        "databricks.rag_studio",
     ],
 )
 def test_suppress_warn_dependency_requirement_mismatches_ignore_some_packages(ignore_package_name):

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -556,7 +556,8 @@ model's environment and install dependencies using the resulting environment fil
 
 
 @pytest.mark.parametrize(
-    "ignore_package_name", ["databricks-feature-lookup", "databricks_rag_studio"]
+    "ignore_package_name",
+    ["databricks-feature-lookup", "databricks_rag_studio", "databricks-rag-studio"],
 )
 def test_suppress_warn_dependency_requirement_mismatches_ignore_some_packages(ignore_package_name):
     with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warning:

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -557,7 +557,13 @@ model's environment and install dependencies using the resulting environment fil
 
 @pytest.mark.parametrize(
     "ignore_package_name",
-    ["databricks-feature-lookup", "databricks_rag_studio", "databricks-rag-studio"],
+    [
+        "databricks-feature-lookup",
+        "databricks_rag_studio",
+        "databricks-rag-studio",
+        "databricks.rag.studio",
+        "Databricks-rag-studio",
+    ],
 )
 def test_suppress_warn_dependency_requirement_mismatches_ignore_some_packages(ignore_package_name):
     with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warning:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12231?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12231/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12231
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Ignore databricks_rag_studio package to avoid emitting warning

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
