### PR TITLE
Refactor trace state clearance fixture

### DIFF
--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -12,10 +12,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.tracing.provider import _get_tracer, trace_disabled
 from mlflow.tracing.utils import encode_span_id, encode_trace_id
 
-from tests.tracing.conftest import clear_singleton  # noqa: F401
 
-
-def test_create_live_span(clear_singleton):
+def test_create_live_span():
     request_id = "tr-12345"
 
     tracer = _get_tracer("test")
@@ -147,7 +145,7 @@ def test_set_status_raise_for_invalid_value():
             span.set_status("INVALID")
 
 
-def test_dict_conversion(clear_singleton):
+def test_dict_conversion():
     request_id = "tr-12345"
 
     tracer = _get_tracer("test")
@@ -175,7 +173,7 @@ def test_dict_conversion(clear_singleton):
         recovered_span.set_status("OK")
 
 
-def test_to_immutable_span(clear_singleton):
+def test_to_immutable_span():
     request_id = "tr-12345"
 
     tracer = _get_tracer("test")

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -13,7 +13,6 @@ from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_K
 from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.utils.mlflow_tags import MLFLOW_ARTIFACT_LOCATION
 
-from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.helper import create_test_trace_info
 
 
@@ -41,7 +40,7 @@ def _test_model(datetime=datetime.now()):
     return TestModel()
 
 
-def test_json_deserialization(clear_singleton, monkeypatch):
+def test_json_deserialization(monkeypatch):
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
     datetime_now = datetime.now()
@@ -190,7 +189,7 @@ def test_trace_serialize_langchain_base_message():
     assert expected_dict_subset.items() <= loaded.items()
 
 
-def test_trace_to_from_dict_and_json(clear_singleton):
+def test_trace_to_from_dict_and_json():
     model = _test_model()
     model.predict(2, 5)
 

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -6,10 +6,8 @@ import mlflow
 from mlflow.entities import SpanType, TraceData
 from mlflow.entities.span_event import SpanEvent
 
-from tests.tracing.conftest import clear_singleton  # noqa: F401
 
-
-def test_json_deserialization(clear_singleton):
+def test_json_deserialization():
     class TestModel:
         @mlflow.trace()
         def predict(self, x, y):

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -68,7 +68,6 @@ from mlflow.utils.autologging_utils import (
 )
 from mlflow.utils.file_utils import TempDir
 
-from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.helper import create_test_trace_info, get_traces
 from tests.utils.test_file_utils import spark_session  # noqa: F401
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -37,8 +37,6 @@ from mlflow.utils.openai_utils import (
     _MockResponse,
 )
 
-# TODO: This test helper is used outside the tracing module, we should move it to a common utils
-from tests.tracing.conftest import clear_singleton as clear_trace_singleton  # noqa: F401
 from tests.tracing.helper import get_traces
 
 MODEL_DIR = "model"
@@ -245,7 +243,7 @@ def test_resolve_tags():
     }
 
 
-def test_autolog_record_exception(clear_trace_singleton):
+def test_autolog_record_exception():
     from langchain.schema.runnable import RunnableLambda
 
     def always_fail(input):
@@ -266,7 +264,7 @@ def test_autolog_record_exception(clear_trace_singleton):
     assert trace.data.spans[0].name == "always_fail"
 
 
-def test_llmchain_autolog(clear_trace_singleton):
+def test_llmchain_autolog():
     mlflow.langchain.autolog(log_models=True)
     question = "MLflow"
     answer = {"product": "MLflow", "text": TEST_CONTENT}
@@ -300,9 +298,7 @@ def test_llmchain_autolog(clear_trace_singleton):
         assert attrs["invocation_params"]["temperature"] == 0.9
 
 
-def test_llmchain_autolog_should_not_generate_trace_while_saving_models(
-    clear_trace_singleton, tmp_path
-):
+def test_llmchain_autolog_should_not_generate_trace_while_saving_models(tmp_path):
     mlflow.langchain.autolog()
     question = "MLflow"
 
@@ -317,7 +313,7 @@ def test_llmchain_autolog_should_not_generate_trace_while_saving_models(
     assert len(traces) == 0
 
 
-def test_llmchain_autolog_no_optional_artifacts_by_default(clear_trace_singleton):
+def test_llmchain_autolog_no_optional_artifacts_by_default():
     mlflow.langchain.autolog()
     question = "MLflow"
     answer = {"product": "MLflow", "text": TEST_CONTENT}
@@ -443,7 +439,7 @@ def test_loaded_llmchain_within_model_evaluation(mock_get_display, tmp_path):
     mock_display_handler.display_traces.assert_not_called()
 
 
-def test_agent_autolog(clear_trace_singleton):
+def test_agent_autolog():
     mlflow.langchain.autolog(log_models=True)
     model, input, mock_response = create_openai_llmagent()
     with _mock_request(return_value=_MockResponse(200, mock_response)), mock.patch(
@@ -532,7 +528,7 @@ def test_agent_autolog_log_inputs_outputs():
         )
 
 
-def test_runnable_sequence_autolog(clear_trace_singleton):
+def test_runnable_sequence_autolog():
     mlflow.langchain.autolog(log_models=True)
     chain, input_example = create_runnable_sequence()
     with mock.patch("mlflow.langchain.log_model") as log_model_mock:
@@ -614,7 +610,7 @@ def test_runnable_sequence_autolog_log_inputs_outputs():
     )
 
 
-def test_retriever_autolog(tmp_path, clear_trace_singleton):
+def test_retriever_autolog(tmp_path):
     mlflow.langchain.autolog(log_models=True)
     model, query = create_retriever(tmp_path)
     with mock.patch("mlflow.langchain.log_model") as log_model_mock, mock.patch(
@@ -957,7 +953,7 @@ def test_langchain_autolog_extra_model_classes_warning():
 
 
 @pytest.mark.skip(reason="This test is not thread safe, please run locally")
-def test_set_retriever_schema_work_for_langchain_model(clear_trace_singleton):
+def test_set_retriever_schema_work_for_langchain_model():
     set_retriever_schema(
         primary_key="primary-key",
         text_column="text-column",

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -76,7 +76,6 @@ from mlflow.utils.openai_utils import (
 )
 
 from tests.helper_functions import pyfunc_serve_and_score_model
-from tests.tracing.conftest import clear_singleton as clear_trace_singleton  # noqa: F401
 from tests.tracing.export.test_inference_table_exporter import _REQUEST_ID
 
 # this kwarg was added in langchain_community 0.0.27, and
@@ -2970,7 +2969,7 @@ def test_langchain_model_save_load_with_listeners(fake_chat_model):
 
 @pytest.mark.parametrize("enable_mlflow_tracing", [True, False])
 def test_langchain_model_inject_callback_in_model_serving(
-    clear_trace_singleton, monkeypatch, model_path, enable_mlflow_tracing
+    monkeypatch, model_path, enable_mlflow_tracing
 ):
     # Emulate the model serving environment
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
@@ -2999,9 +2998,7 @@ def test_langchain_model_inject_callback_in_model_serving(
 
 
 @pytest.mark.parametrize("env_var", ["MLFLOW_ENABLE_TRACE_IN_SERVING", "ENABLE_MLFLOW_TRACING"])
-def test_langchain_model_not_inject_callback_when_disabled(
-    clear_trace_singleton, monkeypatch, model_path, env_var
-):
+def test_langchain_model_not_inject_callback_when_disabled(monkeypatch, model_path, env_var):
     # Emulate the model serving environment
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
 

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -37,7 +37,6 @@ from mlflow.utils.openai_utils import (
     _mock_request,
 )
 
-from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.helper import get_traces
 
 TEST_CONTENT = "test"
@@ -114,7 +113,7 @@ def _validate_trace_json_serialization(trace):
                 )
 
 
-def test_llm_success(clear_singleton):
+def test_llm_success():
     callback = MlflowLangchainTracer()
     run_id = str(uuid.uuid4())
     callback.on_llm_start(
@@ -147,7 +146,7 @@ def test_llm_success(clear_singleton):
     _validate_trace_json_serialization(trace)
 
 
-def test_llm_error(clear_singleton):
+def test_llm_error():
     callback = MlflowLangchainTracer()
     run_id = str(uuid.uuid4())
     callback.on_llm_start(
@@ -174,7 +173,7 @@ def test_llm_error(clear_singleton):
     _validate_trace_json_serialization(trace)
 
 
-def test_llm_internal_exception(clear_singleton):
+def test_llm_internal_exception():
     callback = MlflowLangchainTracer()
     run_id = str(uuid.uuid4())
     callback.on_llm_start(
@@ -191,7 +190,7 @@ def test_llm_internal_exception(clear_singleton):
         callback.on_llm_end(LLMResult(generations=[[{"text": "generated text"}]]), run_id=run_id)
 
 
-def test_retriever_success(clear_singleton):
+def test_retriever_success():
     callback = MlflowLangchainTracer()
     run_id = str(uuid.uuid4())
     callback.on_retriever_start(
@@ -227,7 +226,7 @@ def test_retriever_success(clear_singleton):
     _validate_trace_json_serialization(trace)
 
 
-def test_retriever_error(clear_singleton):
+def test_retriever_error():
     callback = MlflowLangchainTracer()
     run_id = str(uuid.uuid4())
     callback.on_retriever_start(
@@ -251,7 +250,7 @@ def test_retriever_error(clear_singleton):
     _validate_trace_json_serialization(trace)
 
 
-def test_retriever_internal_exception(clear_singleton):
+def test_retriever_internal_exception():
     callback = MlflowLangchainTracer()
     run_id = str(uuid.uuid4())
     callback.on_retriever_start(
@@ -276,7 +275,7 @@ def test_retriever_internal_exception(clear_singleton):
         )
 
 
-def test_multiple_components(clear_singleton):
+def test_multiple_components():
     callback = MlflowLangchainTracer()
     chain_run_id = str(uuid.uuid4())
     callback.on_chain_start(
@@ -367,9 +366,7 @@ def _predict_with_callbacks(lc_model, request_id, data):
     return response, trace_dict
 
 
-def test_e2e_rag_model_tracing_in_serving(
-    clear_singleton, mock_databricks_serving_with_tracing_env
-):
+def test_e2e_rag_model_tracing_in_serving(mock_databricks_serving_with_tracing_env):
     llm_chain = create_openai_llmchain()
 
     request_id = "test_request_id"
@@ -408,7 +405,7 @@ def test_e2e_rag_model_tracing_in_serving(
     _validate_trace_json_serialization(trace)
 
 
-def test_agent_success(clear_singleton, mock_databricks_serving_with_tracing_env):
+def test_agent_success(mock_databricks_serving_with_tracing_env):
     agent = create_openai_llmagent()
     langchain_input = {"input": "What is 123 raised to the .023 power?"}
     expected_output = {"output": TEST_CONTENT}
@@ -457,7 +454,7 @@ def test_agent_success(clear_singleton, mock_databricks_serving_with_tracing_env
     _validate_trace_json_serialization(trace)
 
 
-def test_tool_success(clear_singleton, mock_databricks_serving_with_tracing_env):
+def test_tool_success(mock_databricks_serving_with_tracing_env):
     prompt = SystemMessagePromptTemplate.from_template("You are a nice assistant.") + "{question}"
     llm = OpenAI(temperature=0.9)
 
@@ -503,7 +500,7 @@ def test_tool_success(clear_singleton, mock_databricks_serving_with_tracing_env)
     _validate_trace_json_serialization(trace)
 
 
-def test_tracer_thread_safe(clear_singleton):
+def test_tracer_thread_safe():
     tracer = MlflowLangchainTracer()
 
     def worker_function(worker_id):
@@ -527,7 +524,7 @@ def test_tracer_thread_safe(clear_singleton):
     Version(langchain.__version__) < Version("0.1.0"),
     reason="ChatPromptTemplate expecting dict input",
 )
-def test_tracer_does_not_add_spans_to_trace_after_root_run_has_finished(clear_singleton):
+def test_tracer_does_not_add_spans_to_trace_after_root_run_has_finished():
     from langchain.callbacks.manager import CallbackManagerForLLMRun
     from langchain.chat_models.base import SimpleChatModel
     from langchain.schema.messages import BaseMessage
@@ -572,7 +569,7 @@ def test_tracer_does_not_add_spans_to_trace_after_root_run_has_finished(clear_si
         tracer.on_chain_end({"output": "test output"}, run_id=run_id_for_on_chain_end, inputs=None)
 
 
-def test_tracer_noop_when_tracing_disabled(clear_singleton, monkeypatch):
+def test_tracer_noop_when_tracing_disabled(monkeypatch):
     llm_chain = create_openai_llmchain()
     model = _LangChainModelWrapper(llm_chain)
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -58,7 +58,6 @@ from tests.helper_functions import (
     assert_register_model_called_with_local_model_path,
     pyfunc_serve_and_score_model,
 )
-from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.helper import get_traces
 
 
@@ -1835,7 +1834,7 @@ def test_pyfunc_as_code_with_dependencies():
 @pytest.mark.parametrize("is_in_db_model_serving", ["true", "false"])
 @pytest.mark.parametrize("stream", [True, False])
 def test_pyfunc_as_code_with_dependencies_store_dependencies_schemas_in_trace(
-    clear_singleton, monkeypatch, is_in_db_model_serving, stream
+    monkeypatch, is_in_db_model_serving, stream
 ):
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", is_in_db_model_serving)
     monkeypatch.setenv("ENABLE_MLFLOW_TRACING", "true")
@@ -1889,7 +1888,7 @@ def test_pyfunc_as_code_with_dependencies_store_dependencies_schemas_in_trace(
 
 @pytest.mark.parametrize("stream", [True, False])
 def test_no_traces_collected_for_pyfunc_as_code_with_dependencies_if_no_tracing_enabled(
-    clear_singleton, monkeypatch, stream
+    monkeypatch, stream
 ):
     # This sets model without trace inside code_with_dependencies.py file
     monkeypatch.setenv("TEST_TRACE", "false")

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -52,7 +52,6 @@ from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.uri import append_to_uri_path
 
 from tests.helper_functions import random_int, random_str, safe_edit_yaml
-from tests.tracing.conftest import clear_singleton  # noqa: F401
 
 FILESTORE_PACKAGE = "mlflow.store.tracking.file_store"
 
@@ -3182,7 +3181,7 @@ def test_search_traces_pagination(generate_trace_infos):
     assert token is None
 
 
-def test_traces_not_listed_as_runs(clear_singleton, tmp_path):
+def test_traces_not_listed_as_runs(tmp_path):
     with _use_tracking_uri(tmp_path.joinpath("mlruns").as_uri()):
         client = mlflow.MlflowClient()
         with mlflow.start_run() as run:

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -6,28 +6,8 @@ import pytest
 import mlflow
 from mlflow.entities import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
-from mlflow.tracing.display import IPythonTraceDisplayHandler
-from mlflow.tracing.export.inference_table import _TRACE_BUFFER
-from mlflow.tracing.fluent import TRACE_BUFFER
-from mlflow.tracing.provider import _TRACER_PROVIDER_INITIALIZED
-from mlflow.tracing.trace_manager import InMemoryTraceManager
 
 from tests.tracing.helper import create_test_trace_info
-
-
-@pytest.fixture(autouse=True)
-def clear_singleton():
-    """
-    Clear the singleton instances after each tests to avoid side effects.
-    """
-    InMemoryTraceManager._instance = None
-    IPythonTraceDisplayHandler._instance = None
-    TRACE_BUFFER.clear()
-    _TRACE_BUFFER.clear()
-
-    # Tracer provider also needs to be reset as it may hold reference to the singleton
-    with _TRACER_PROVIDER_INITIALIZED._lock:
-        _TRACER_PROVIDER_INITIALIZED._done = False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/tracing/processor/test_inference_table_processor.py
+++ b/tests/tracing/processor/test_inference_table_processor.py
@@ -28,7 +28,7 @@ def flask_request():
         yield request
 
 
-def test_on_start(clear_singleton, flask_request):
+def test_on_start(flask_request):
     # Root span should create a new trace on start
     span = create_mock_otel_span(
         trace_id=_TRACE_ID, span_id=1, parent_id=None, start_time=5_000_000
@@ -61,7 +61,7 @@ def test_on_start(clear_singleton, flask_request):
         assert trace.info.timestamp_ms == 5
 
 
-def test_on_end(clear_singleton):
+def test_on_end():
     trace_info = create_test_trace_info(_REQUEST_ID, 0)
     trace_manager = InMemoryTraceManager.get_instance()
     trace_manager.register_trace(_TRACE_ID, trace_info)

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -27,7 +27,7 @@ _TRACE_ID = 12345
 _REQUEST_ID = f"tr-{_TRACE_ID}"
 
 
-def test_on_start(clear_singleton, monkeypatch):
+def test_on_start(monkeypatch):
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
 
@@ -69,7 +69,7 @@ def test_on_start(clear_singleton, monkeypatch):
 
 
 @pytest.mark.skipif(is_windows(), reason="Timestamp is not precise enough on Windows")
-def test_on_start_adjust_span_timestamp_to_exclude_backend_latency(clear_singleton, monkeypatch):
+def test_on_start_adjust_span_timestamp_to_exclude_backend_latency(monkeypatch):
     monkeypatch.setenv("MLFLOW_TESTING", "false")
     trace_info = create_test_trace_info(_REQUEST_ID, 0)
     mock_client = mock.MagicMock()
@@ -93,7 +93,7 @@ def test_on_start_adjust_span_timestamp_to_exclude_backend_latency(clear_singlet
     assert time.time_ns() - span.start_time < 100_000_000  # 0.1 second
 
 
-def test_on_start_with_experiment_id(clear_singleton, monkeypatch):
+def test_on_start_with_experiment_id(monkeypatch):
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
 
@@ -125,7 +125,7 @@ def test_on_start_with_experiment_id(clear_singleton, monkeypatch):
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces
 
 
-def test_on_start_during_model_evaluation(clear_singleton):
+def test_on_start_during_model_evaluation():
     # Root span should create a new trace on start
     span = create_mock_otel_span(trace_id=_TRACE_ID, span_id=1)
     mock_client = mock.MagicMock()
@@ -139,7 +139,7 @@ def test_on_start_during_model_evaluation(clear_singleton):
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
 
 
-def test_on_start_during_run(clear_singleton, monkeypatch):
+def test_on_start_during_run(monkeypatch):
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
 
@@ -173,7 +173,7 @@ def test_on_start_during_run(clear_singleton, monkeypatch):
     )
 
 
-def test_on_start_warns_default_experiment(clear_singleton, monkeypatch):
+def test_on_start_warns_default_experiment(monkeypatch):
     mlflow.set_experiment(experiment_id=DEFAULT_EXPERIMENT_ID)
 
     mock_client = mock.MagicMock()
@@ -193,7 +193,7 @@ def test_on_start_warns_default_experiment(clear_singleton, monkeypatch):
     assert "Creating a trace within the default" in str(warns[0])
 
 
-def test_on_end(clear_singleton):
+def test_on_end():
     trace_info = create_test_trace_info(_REQUEST_ID, 0)
     trace_manager = InMemoryTraceManager.get_instance()
     trace_manager.register_trace(_TRACE_ID, trace_info)

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -59,7 +59,7 @@ def mock_client():
 
 
 @pytest.mark.parametrize("with_active_run", [True, False])
-def test_trace(clear_singleton, with_active_run):
+def test_trace(with_active_run):
     model = DefaultTestModel()
 
     if with_active_run:
@@ -119,9 +119,7 @@ def test_trace(clear_singleton, with_active_run):
     }
 
 
-def test_trace_with_databricks_tracking_uri(
-    databricks_tracking_uri, clear_singleton, mock_store, monkeypatch
-):
+def test_trace_with_databricks_tracking_uri(databricks_tracking_uri, mock_store, monkeypatch):
     monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "test")
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
@@ -166,9 +164,7 @@ def test_trace_with_databricks_tracking_uri(
     mock_upload_trace_data.assert_called_once()
 
 
-def test_trace_in_databricks_model_serving(
-    clear_singleton, mock_databricks_serving_with_tracing_env
-):
+def test_trace_in_databricks_model_serving(mock_databricks_serving_with_tracing_env):
     # Dummy flask app for prediction
     import flask
 
@@ -277,7 +273,7 @@ def test_trace_in_databricks_model_serving(
     assert len(traces) == 0
 
 
-def test_trace_in_model_evaluation(clear_singleton, mock_store, monkeypatch):
+def test_trace_in_model_evaluation(mock_store, monkeypatch):
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
 
@@ -322,7 +318,7 @@ def test_trace_in_model_evaluation(clear_singleton, mock_store, monkeypatch):
     assert mock_store.end_trace.call_count == 2
 
 
-def test_trace_handle_exception_during_prediction(clear_singleton):
+def test_trace_handle_exception_during_prediction():
     # This test is to make sure that the exception raised by the main prediction
     # logic is raised properly and the trace is still logged.
     class TestModel:
@@ -351,7 +347,7 @@ def test_trace_handle_exception_during_prediction(clear_singleton):
     assert len(trace.data.spans) == 2
 
 
-def test_trace_ignore_exception_from_tracing_logic(clear_singleton, monkeypatch):
+def test_trace_ignore_exception_from_tracing_logic(monkeypatch):
     # This test is to make sure that the main prediction logic is not affected
     # by the exception raised by the tracing logic.
     class TestModel:
@@ -394,7 +390,7 @@ def test_trace_ignore_exception_from_tracing_logic(clear_singleton, monkeypatch)
     TRACE_BUFFER.clear()
 
 
-def test_start_span_context_manager(clear_singleton):
+def test_start_span_context_manager():
     datetime_now = datetime.now()
 
     class TestModel:
@@ -471,7 +467,7 @@ def test_start_span_context_manager(clear_singleton):
     assert child_span_2.start_time_ns <= child_span_2.end_time_ns - 0.1 * 1e6
 
 
-def test_start_span_context_manager_with_imperative_apis(clear_singleton):
+def test_start_span_context_manager_with_imperative_apis():
     # This test is to make sure that the spans created with fluent APIs and imperative APIs
     # (via MLflow client) are correctly linked together. This usage is not recommended but
     # should be supported for the advanced use cases like using LangChain callbacks as a
@@ -908,7 +904,7 @@ def test_search_traces_with_span_name(monkeypatch):
         )
 
 
-def test_get_last_active_trace(clear_singleton):
+def test_get_last_active_trace():
     assert mlflow.get_last_active_trace() is None
 
     @mlflow.trace()

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -549,7 +549,9 @@ def test_start_and_end_trace_before_all_span_end():
 
 
 @mock.patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-def test_log_trace_with_databricks_tracking_uri(mock_store_for_tracing, monkeypatch):
+def test_log_trace_with_databricks_tracking_uri(
+    databricks_tracking_uri, mock_store_for_tracing, monkeypatch
+):
     monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "test")
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -56,12 +56,8 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_USER,
 )
 
-from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.conftest import mock_store as mock_store_for_tracing  # noqa: F401
-from tests.tracing.helper import (
-    create_test_trace_info,
-    get_traces,
-)
+from tests.tracing.helper import create_test_trace_info, get_traces
 
 
 @pytest.fixture(autouse=True)
@@ -485,7 +481,7 @@ def test_start_and_end_trace(tracking_uri, with_active_run):
 
 
 @pytest.mark.usefixtures("reset_active_experiment")
-def test_start_and_end_trace_before_all_span_end(clear_singleton):
+def test_start_and_end_trace_before_all_span_end():
     # This test is to verify that the trace is still exported even if some spans are not ended
     exp_id = mlflow.set_experiment("test_experiment_1").experiment_id
 
@@ -553,9 +549,7 @@ def test_start_and_end_trace_before_all_span_end(clear_singleton):
 
 
 @mock.patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-def test_log_trace_with_databricks_tracking_uri(
-    clear_singleton, mock_store_for_tracing, monkeypatch
-):
+def test_log_trace_with_databricks_tracking_uri(mock_store_for_tracing, monkeypatch):
     monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "test")
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
@@ -688,13 +682,13 @@ def test_start_and_end_trace_does_not_log_trace_when_disabled(tracking_uri, monk
     mock_logger.warning.assert_not_called()
 
 
-def test_start_trace_raise_error_when_active_trace_exists(clear_singleton):
+def test_start_trace_raise_error_when_active_trace_exists():
     with mlflow.start_span("fluent_span"):
         with pytest.raises(MlflowException, match=r"Another trace is already set in the global"):
             mlflow.tracking.MlflowClient().start_trace("test")
 
 
-def test_end_trace_raise_error_when_trace_not_exist(clear_singleton):
+def test_end_trace_raise_error_when_trace_not_exist():
     client = mlflow.tracking.MlflowClient()
     mock_tracking_client = mock.MagicMock()
     mock_tracking_client.get_trace.return_value = None
@@ -705,7 +699,7 @@ def test_end_trace_raise_error_when_trace_not_exist(clear_singleton):
 
 
 @pytest.mark.parametrize("status", TraceStatus.pending_statuses())
-def test_end_trace_works_for_trace_in_pending_status(clear_singleton, status):
+def test_end_trace_works_for_trace_in_pending_status(status):
     client = mlflow.tracking.MlflowClient()
     mock_tracking_client = mock.MagicMock()
     mock_tracking_client.get_trace.return_value = Trace(
@@ -718,7 +712,7 @@ def test_end_trace_works_for_trace_in_pending_status(clear_singleton, status):
 
 
 @pytest.mark.parametrize("status", TraceStatus.end_statuses())
-def test_end_trace_raise_error_for_trace_in_end_status(clear_singleton, status):
+def test_end_trace_raise_error_for_trace_in_end_status(status):
     client = mlflow.tracking.MlflowClient()
     mock_tracking_client = mock.MagicMock()
     mock_tracking_client.get_trace.return_value = Trace(
@@ -745,7 +739,7 @@ def test_start_span_raise_error_when_parent_id_is_not_provided():
         mlflow.tracking.MlflowClient().start_span("span_name", request_id="test", parent_id=None)
 
 
-def test_ignore_exception_from_tracing_logic(clear_singleton, monkeypatch):
+def test_ignore_exception_from_tracing_logic(monkeypatch):
     exp_id = mlflow.set_experiment("test_experiment_1").experiment_id
     client = MlflowClient()
     TRACE_BUFFER.clear()
@@ -782,7 +776,7 @@ def test_ignore_exception_from_tracing_logic(clear_singleton, monkeypatch):
     assert len(TRACE_BUFFER) == 0
 
 
-def test_set_and_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
+def test_set_and_delete_trace_tag_on_active_trace(monkeypatch):
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
 
@@ -797,12 +791,12 @@ def test_set_and_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
     assert trace.info.tags["foo"] == "bar"
 
 
-def test_set_trace_tag_on_logged_trace(mock_store, clear_singleton):
+def test_set_trace_tag_on_logged_trace(mock_store):
     mlflow.tracking.MlflowClient().set_trace_tag("test", "foo", "bar")
     mock_store.set_trace_tag.assert_called_once_with("test", "foo", "bar")
 
 
-def test_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
+def test_delete_trace_tag_on_active_trace(monkeypatch):
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "bob")
     monkeypatch.setattr(mlflow.tracking.context.default_context, "_get_source_name", lambda: "test")
 
@@ -817,7 +811,7 @@ def test_delete_trace_tag_on_active_trace(clear_singleton, monkeypatch):
     assert "foo" not in trace.info.tags
 
 
-def test_delete_trace_tag_on_logged_trace(mock_store, clear_singleton):
+def test_delete_trace_tag_on_logged_trace(mock_store):
     mlflow.tracking.MlflowClient().delete_trace_tag("test", "foo")
     mock_store.delete_trace_tag.assert_called_once_with("test", "foo")
 
@@ -1513,7 +1507,7 @@ def test_enable_async_logging(mock_store, setup_async_logging):
     mock_store.log_metric_async.assert_called_once_with("run_id", Metric("key", "val", 1, 1))
 
 
-def test_file_store_download_upload_trace_data(clear_singleton, tmp_path):
+def test_file_store_download_upload_trace_data(tmp_path):
     with _use_tracking_uri(tmp_path.joinpath("mlruns").as_uri()):
         client = MlflowClient()
         span = client.start_trace("test", inputs={"test": 1})


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12232?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12232/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12232
```

</p>
</details>

### What changes are proposed in this pull request?

Refactor the `clear_singleton()` fixture into a new `reset_tracing()` fixture and apply it to all tests to avoid any surprise. The fixture takes less than 0.1 ms so shouldn't degrade the overall test speed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
