### PR TITLE
Fix` test_trace_ignore_exception_from_tracing_logic` test

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -135,7 +135,10 @@ def trace(
 
             with start_span(name=span_name, span_type=span_type, attributes=attributes) as span:
                 span.set_attribute(SpanAttributeKey.FUNCTION_NAME, fn.__name__)
-                span.set_inputs(capture_function_input_args(fn, args, kwargs))
+                try:
+                    span.set_inputs(capture_function_input_args(fn, args, kwargs))
+                except Exception:
+                    _logger.warning(f"Failed to capture inputs for function {fn.__name__}.")
                 result = fn(*args, **kwargs)
                 span.set_outputs(result)
                 return result

--- a/mlflow/tracing/utils.py
+++ b/mlflow/tracing/utils.py
@@ -28,20 +28,16 @@ if TYPE_CHECKING:
 
 
 def capture_function_input_args(func, args, kwargs) -> Dict[str, Any]:
-    try:
-        # Avoid capturing `self`
-        func_signature = inspect.signature(func)
-        bound_arguments = func_signature.bind(*args, **kwargs)
-        bound_arguments.apply_defaults()
+    # Avoid capturing `self`
+    func_signature = inspect.signature(func)
+    bound_arguments = func_signature.bind(*args, **kwargs)
+    bound_arguments.apply_defaults()
 
-        # Remove `self` from bound arguments if it exists
-        if bound_arguments.arguments.get("self"):
-            del bound_arguments.arguments["self"]
+    # Remove `self` from bound arguments if it exists
+    if bound_arguments.arguments.get("self"):
+        del bound_arguments.arguments["self"]
 
-        return bound_arguments.arguments
-    except Exception:
-        _logger.warning(f"Failed to capture inputs for function {func.__name__}.")
-        return {}
+    return bound_arguments.arguments
 
 
 class TraceJSONEncoder(json.JSONEncoder):

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -370,12 +370,14 @@ def test_trace_ignore_exception_from_tracing_logic(clear_singleton, monkeypatch)
     TRACE_BUFFER.clear()
 
     # Exception during inspecting inputs: trace is logged without inputs field
-    with mock.patch("mlflow.tracing.utils.inspect.signature", side_effect=ValueError("Some error")):
+    with mock.patch(
+        "mlflow.tracing.fluent.capture_function_input_args", side_effect=ValueError("Some error")
+    ):
         output = model.predict(2, 5)
 
     assert output == 7
     trace = mlflow.get_last_active_trace()
-    assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == "{}"
+    assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == ""
     assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == "7"
     TRACE_BUFFER.clear()
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -372,8 +372,9 @@ def test_trace_ignore_exception_from_tracing_logic(clear_singleton, monkeypatch)
     # Exception during inspecting inputs: trace is logged without inputs field
     with mock.patch(
         "mlflow.tracing.fluent.capture_function_input_args", side_effect=ValueError("Some error")
-    ):
+    ) as mock_input_args:
         output = model.predict(2, 5)
+        mock_input_args.assert_called_once()
 
     assert output == 7
     trace = mlflow.get_last_active_trace()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12233?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12233/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12233
```

</p>
</details>

### What changes are proposed in this pull request?

We observed a weird behavior in `tests/tracing/test_fluent.py::test_trace_ignore_exception_from_tracing_logic` test. The test passes when executed along with other tests, but fails when executed independently.
```
    trace = mlflow.get_last_active_trace()
    assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == "{}"

   >> E               AttributeError: 'NoneType' object has no attribute '__name__'
```

This assertion failure means that the trace is no generated. This tests validates that the trace is generated even when MLflow fails to capture function input, and thus we mock `inspect.signature` call raises an exception here. The exception is expected to be caught by fluent API and it should emit a trace without input.

After some investigation, we found that the dummy error `Some error` is raised from surprising place.

```
    return builder(store_uri=resolved_store_uri, artifact_uri=artifact_uri)
  File "/home/yuki.watanabe/mlflow/mlflow/tracking/_tracking_service/utils.py", line 134, in _get_sqlalchemy_store
    from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
  File "/home/yuki.watanabe/mlflow/mlflow/store/tracking/sqlalchemy_store.py", line 11, in <module>
    import sqlalchemy
  File "/home/yuki.watanabe/mlflow/.venv/mlflow-remote/lib/python3.9/site-packages/sqlalchemy/__init__.py", line 13, in <module>
    from .engine import AdaptedConnection as AdaptedConnection
  File "/home/yuki.watanabe/mlflow/.venv/mlflow-remote/lib/python3.9/site-packages/sqlalchemy/engine/__init__.py", line 43, in <module>
    from .reflection import Inspector as Inspector
  File "/home/yuki.watanabe/mlflow/.venv/mlflow-remote/lib/python3.9/site-packages/sqlalchemy/engine/reflection.py", line 2070, in <module>
    class _ReflectionInfo:
  File "/home/yuki.watanabe/.pyenv/versions/3.9.8/lib/python3.9/dataclasses.py", line 1021, in dataclass
    return wrap(cls)
  File "/home/yuki.watanabe/.pyenv/versions/3.9.8/lib/python3.9/dataclasses.py", line 1013, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen)
  File "/home/yuki.watanabe/.pyenv/versions/3.9.8/lib/python3.9/dataclasses.py", line 993, in _process_class
    str(inspect.signature(cls)).replace(' -> None', ''))
  File "/home/yuki.watanabe/.pyenv/versions/3.9.8/lib/python3.9/unittest/mock.py", line 1092, in __call__
    return self._mock_call(*args, **kwargs)
  File "/home/yuki.watanabe/.pyenv/versions/3.9.8/lib/python3.9/unittest/mock.py", line 1096, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
  File "/home/yuki.watanabe/.pyenv/versions/3.9.8/lib/python3.9/unittest/mock.py", line 1151, in _execute_mock_call
    raise effect
ValueError: Some error
```

This error log says that the exception is raised from  `inspect.signature` call **within sqlalchemy library**. It appears that sqlalchemy uses that function to inspect the signature of data models when initializing the engine. Since this instantiation only happens once in a process, we didn't see the failure when the test is executed with other tests.

One mysterious thing is that "why unittest mocks the call within sqlalchemy?" - but it's not worthwhile digging into. Therefore, this PR just change how we simulate the exception, which is sufficient to fix the test behavior.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
