### PR TITLE
Fix `_get_trace_info_from_dir` to return None if info file is missing

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1498,7 +1498,7 @@ class FileStore(AbstractStore):
     def _get_trace_info_and_dir(self, request_id: str) -> Tuple[TraceInfo, str]:
         trace_dir = self._find_trace_dir(request_id, assert_exists=True)
         trace_info = self._get_trace_info_from_dir(trace_dir)
-        if trace_info.request_id != request_id:
+        if trace_info and trace_info.request_id != request_id:
             raise MlflowException(
                 f"Trace with request ID '{request_id}' metadata is in invalid state.",
                 databricks_pb2.INVALID_STATE,
@@ -1519,7 +1519,9 @@ class FileStore(AbstractStore):
                 RESOURCE_DOES_NOT_EXIST,
             )
 
-    def _get_trace_info_from_dir(self, trace_dir) -> TraceInfo:
+    def _get_trace_info_from_dir(self, trace_dir) -> Optional[TraceInfo]:
+        if not os.path.exists(os.path.join(trace_dir, FileStore.TRACE_INFO_FILE_NAME)):
+            return None
         trace_info_dict = FileStore._read_yaml(trace_dir, FileStore.TRACE_INFO_FILE_NAME)
         trace_info = TraceInfo.from_dict(trace_info_dict)
         trace_info.request_metadata = self._get_dict_from_trace_sub_folder(
@@ -1596,7 +1598,7 @@ class FileStore(AbstractStore):
             for trace_path in trace_paths:
                 try:
                     trace_info = self._get_trace_info_from_dir(trace_path)
-                    if trace_info.timestamp_ms <= max_timestamp_millis:
+                    if trace_info and trace_info.timestamp_ms <= max_timestamp_millis:
                         trace_info_and_paths.append((trace_info, trace_path))
                 except MissingConfigException as e:
                     # trap malformed trace exception and log warning
@@ -1674,8 +1676,8 @@ class FileStore(AbstractStore):
         trace_infos = []
         for trace_path in trace_paths:
             try:
-                trace_info = self._get_trace_info_from_dir(trace_path)
-                trace_infos.append(trace_info)
+                if trace_info := self._get_trace_info_from_dir(trace_path):
+                    trace_infos.append(trace_info)
             except MissingConfigException as e:
                 # trap malformed trace exception and log warning
                 request_id = os.path.basename(trace_path)

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1683,6 +1683,6 @@ class FileStore(AbstractStore):
                 request_id = os.path.basename(trace_path)
                 logging.warning(
                     f"Malformed trace with request_id '{request_id}'. Detailed error {e}",
-                    exc_info=True,
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
         return trace_infos


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12241?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12241/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12241
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix `_get_trace_info_from_dir` to return None if trace info file is missing and suppress verbose warning messages.

```
WARNING:root:Malformed trace with request_id 'fc7ed15afbbc4a72b6649bb475bf5575'. Detailed error Yaml file '/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlruns/1/traces/fc7ed15afbbc4a72b6649bb475bf5575/trace_info.yaml' does not exist.
Traceback (most recent call last):
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/store/tracking/file_store.py", line 1677, in _list_trace_infos
    trace_info = self._get_trace_info_from_dir(trace_path)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/store/tracking/file_store.py", line 1523, in _get_trace_info_from_dir
    trace_info_dict = FileStore._read_yaml(trace_dir, FileStore.TRACE_INFO_FILE_NAME)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/store/tracking/file_store.py", line 1341, in _read_yaml
    return _read_helper(root, file_name, attempts_remaining=retries)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/store/tracking/file_store.py", line 1334, in _read_helper
    result = read_yaml(root, file_name)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 312, in read_yaml
    raise MissingConfigException(f"Yaml file '{file_path}' does not exist.")
mlflow.exceptions.MissingConfigException: Yaml file '/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlruns/1/traces/fc7ed15afbbc4a72b6649bb475bf5575/trace_info.yaml' does not exist.
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
