### PR TITLE
Fix advice for DCO check

### DIFF
--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -61,17 +61,16 @@ gh pr checkout ${issue_number}
     });
   }
 
-  // TODO: Uncomment this once https://github.com/dcoapp/app/issues/211 is resolved
-  // const dcoCheck = await getDcoCheck(github, owner, repo, sha);
-  // if (dcoCheck.conclusion !== "success") {
-  //   messages.push(
-  //     "#### &#x26a0; DCO check\n\n" +
-  //       "The DCO check failed. " +
-  //       `Please sign off your commit(s) by following the instructions [here](${dcoCheck.html_url}). ` +
-  //       "See https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#sign-your-work for more " +
-  //       "details."
-  //   );
-  // }
+  const dcoCheck = await getDcoCheck(github, owner, repo, sha);
+  if (dcoCheck?.conclusion !== "success") {
+    messages.push(
+      "#### &#x26a0; DCO check\n\n" +
+        "The DCO check failed. " +
+        `Please sign off your commit(s) by following the instructions [here](${dcoCheck.html_url}). ` +
+        "See https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#sign-your-work for more " +
+        "details."
+    );
+  }
 
   if (label.endsWith(":master")) {
     messages.push(

--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -61,16 +61,17 @@ gh pr checkout ${issue_number}
     });
   }
 
-  const dcoCheck = await getDcoCheck(github, owner, repo, sha);
-  if (dcoCheck.conclusion !== "success") {
-    messages.push(
-      "#### &#x26a0; DCO check\n\n" +
-        "The DCO check failed. " +
-        `Please sign off your commit(s) by following the instructions [here](${dcoCheck.html_url}). ` +
-        "See https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#sign-your-work for more " +
-        "details."
-    );
-  }
+  // TODO: Uncomment this once https://github.com/dcoapp/app/issues/211 is resolved
+  // const dcoCheck = await getDcoCheck(github, owner, repo, sha);
+  // if (dcoCheck.conclusion !== "success") {
+  //   messages.push(
+  //     "#### &#x26a0; DCO check\n\n" +
+  //       "The DCO check failed. " +
+  //       `Please sign off your commit(s) by following the instructions [here](${dcoCheck.html_url}). ` +
+  //       "See https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#sign-your-work for more " +
+  //       "details."
+  //   );
+  // }
 
   if (label.endsWith(":master")) {
     messages.push(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12242?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12242/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12242
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

I marked the DCO as option (as it's broken), which caused the following error:

```
[Attempt 1/5] The DCO check hasn't completed yet.
[Attempt 2/5] The DCO check hasn't completed yet.
[Attempt 3/5] The DCO check hasn't completed yet.
[Attempt 4/5] The DCO check hasn't completed yet.
[Attempt 5/5] The DCO check hasn't completed yet.
TypeError: Cannot read properties of undefined (reading 'conclusion')
    at module.exports (/home/runner/work/mlflow/mlflow/.github/workflows/advice.js:65:[16](https://github.com/mlflow/mlflow/actions/runs/9376534925/job/25816824258?pr=12240#step:3:17))
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This PR fixes it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
