### PR TITLE
Attache model version in ModelInfo returned by 'log_model'

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -497,7 +497,7 @@ class Model:
             serialized_resource = value
         self._resources = serialized_resource
 
-    def get_model_info(self):
+    def get_model_info(self, model_version=None):
         """
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
         model metadata.
@@ -514,6 +514,7 @@ class Model:
             utc_time_created=self.utc_time_created,
             mlflow_version=self.mlflow_version,
             metadata=self.metadata,
+            model_version=model_version,
         )
 
     def to_dict(self):
@@ -737,14 +738,16 @@ class Model:
                 # older tracking servers. Only print out a warning for now.
                 _logger.warning(_LOG_MODEL_METADATA_WARNING_TEMPLATE, mlflow.get_artifact_uri())
                 _logger.debug("", exc_info=True)
+
+            model_version = None
             if registered_model_name is not None:
-                mlflow.tracking._model_registry.fluent._register_model(
+                model_version = mlflow.tracking._model_registry.fluent._register_model(
                     f"runs:/{run_id}/{mlflow_model.artifact_path}",
                     registered_model_name,
                     await_registration_for=await_registration_for,
                     local_model_path=local_path,
-                )
-        return mlflow_model.get_model_info()
+                ).version
+        return mlflow_model.get_model_info(model_version=model_version)
 
 
 def get_model_info(model_uri: str) -> ModelInfo:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -509,7 +509,7 @@ class Model:
             serialized_resource = value
         self._resources = serialized_resource
 
-    def get_model_info(self, model_version=None):
+    def get_model_info(self):
         """
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
         model metadata.
@@ -526,7 +526,6 @@ class Model:
             utc_time_created=self.utc_time_created,
             mlflow_version=self.mlflow_version,
             metadata=self.metadata,
-            model_version=model_version,
         )
 
     def to_dict(self):
@@ -759,7 +758,10 @@ class Model:
                     await_registration_for=await_registration_for,
                     local_model_path=local_path,
                 ).version
-        return mlflow_model.get_model_info(model_version=model_version)
+        model_info = mlflow_model.get_model_info()
+        if model_version is not None:
+            model_info._model_version = model_version
+        return model_info
 
 
 def get_model_info(model_uri: str) -> ModelInfo:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -87,6 +87,7 @@ class ModelInfo:
         mlflow_version: str,
         signature_dict: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        model_version: Optional[int] = None,
     ):
         self._artifact_path = artifact_path
         self._flavors = flavors
@@ -99,6 +100,7 @@ class ModelInfo:
         self._utc_time_created = utc_time_created
         self._mlflow_version = mlflow_version
         self._metadata = metadata
+        self._model_version = model_version
 
     @property
     def artifact_path(self):
@@ -275,6 +277,16 @@ class ModelInfo:
             assert model_info.metadata["metadata_key"] == "metadata_value"
         """
         return self._metadata
+
+    @property
+    def model_version(self) -> Optional[int]:
+        """
+        The registered model version, if the model is registered.
+
+        :getter: Gets the registered model version if the model is registered.
+        :type: Optional[int]
+        """
+        return self._model_version
 
 
 class Model:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -231,9 +231,11 @@ def test_model_info_with_model_version(tmp_path):
     experiment_id = mlflow.create_experiment("test", artifact_location=str(tmp_path))
     with mlflow.start_run(experiment_id=experiment_id):
         model_info = Model.log("some/path", TestFlavor, registered_model_name="model_abc")
-        assert model_info.model_version == 1
+        assert model_info.registered_model_version == 1
         model_info = Model.log("some/path", TestFlavor, registered_model_name="model_abc")
-        assert model_info.model_version == 2
+        assert model_info.registered_model_version == 2
+        model_info = Model.log("some/path", TestFlavor)
+        assert model_info.registered_model_version is None
 
 
 def test_model_metadata():

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -227,14 +227,13 @@ def test_model_info():
         assert model_info_fetched.mlflow_version == loaded_model.mlflow_version
 
 
-def test_model_info_with_model_version():
-    with TempDir() as tmp:
-        experiment_id = mlflow.create_experiment("test", artifact_location=tmp.path())
-        with mlflow.start_run(experiment_id=experiment_id):
-            model_info = Model.log("some/path", TestFlavor, registered_model_name="model_abc")
-            assert model_info.model_version == 1
-            model_info = Model.log("some/path", TestFlavor, registered_model_name="model_abc")
-            assert model_info.model_version == 2
+def test_model_info_with_model_version(tmp_path):
+    experiment_id = mlflow.create_experiment("test", artifact_location=str(tmp_path))
+    with mlflow.start_run(experiment_id=experiment_id):
+        model_info = Model.log("some/path", TestFlavor, registered_model_name="model_abc")
+        assert model_info.model_version == 1
+        model_info = Model.log("some/path", TestFlavor, registered_model_name="model_abc")
+        assert model_info.model_version == 2
 
 
 def test_model_metadata():

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -227,6 +227,16 @@ def test_model_info():
         assert model_info_fetched.mlflow_version == loaded_model.mlflow_version
 
 
+def test_model_info_with_model_version():
+    with TempDir(chdr=True):
+        experiment_id = mlflow.create_experiment("test")
+        with mlflow.start_run(experiment_id=experiment_id):
+            model_info = Model.log("some/path", TestFlavor, registered_model_name="model_abc")
+            assert model_info.model_version == 1
+            model_info = Model.log("some/path", TestFlavor, registered_model_name="model_abc")
+            assert model_info.model_version == 2
+
+
 def test_model_metadata():
     with TempDir(chdr=True) as tmp:
         metadata = {"metadata_key": "metadata_value"}

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -228,8 +228,8 @@ def test_model_info():
 
 
 def test_model_info_with_model_version():
-    with TempDir(chdr=True):
-        experiment_id = mlflow.create_experiment("test")
+    with TempDir() as tmp:
+        experiment_id = mlflow.create_experiment("test", artifact_location=tmp.path())
         with mlflow.start_run(experiment_id=experiment_id):
             model_info = Model.log("some/path", TestFlavor, registered_model_name="model_abc")
             assert model_info.model_version == 1


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12246?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12246/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12246
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> Closes #12217

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Because currently databricks-UC backend can't support search_model_versions by run_id (it requires lots of engineering efforts), as a workaround of the [use-case](https://github.com/mlflow/mlflow/issues/12217) , we decide to attach model version in ModelInfo returned by 'log_model' .

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
