### PR TITLE
Refactor dev/dev-env-setup.sh to separate mandatory and optional setup

### DIFF
--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -237,7 +237,7 @@ check_and_install_min_py_version() {
 }
 
 # Check if the virtualenv already exists at the specified path
-set_up_virtualenv() {
+create_virtualenv() {
   if [[ -d "$directory" ]]; then
     if [ -z "$GITHUB_ACTIONS" ]; then
       read -p "A virtual environment is already located at $directory. Do you wish to replace it? $(
@@ -295,7 +295,7 @@ install_mlflow() {
   )A docker installation cannot be found. Please ensure that docker is installed to run all tests locally.$(tput sgr0)"
 }
 
-# check if pandoc with required version is installed and offer to install it if not present
+# Check if pandoc with required version is installed and offer to install it if not present
 check_and_install_pandoc() {
   pandoc_version=$(pandoc --version | grep "pandoc" | awk '{print $2}')
   if [[ -z "$pandoc_version" ]] || ! version_gt "$pandoc_version" "2.2.1"; then
@@ -310,7 +310,7 @@ check_and_install_pandoc() {
         check_and_install_brew "pandoc"
         brew install pandoc
       elif [[ "$machine" == linux ]]; then
-        # install pandoc via deb package as `apt-get` gives too old version
+        # Install pandoc via deb package as `apt-get` gives too old version
         TEMP_DEB=$(mktemp) &&
           wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb &&
           sudo dpkg --install $(find $TEMP_DEB -name '*.deb') &&
@@ -323,7 +323,7 @@ check_and_install_pandoc() {
   fi
 }
 
-# Setup git environment configuration for proper signing of commits
+# Set up git environment configuration for proper signing of commits
 set_up_git_signoff() {
   git_user=$(git config user.name)
   git_email=$(git config user.email)
@@ -351,12 +351,12 @@ set_up_git_signoff() {
 # Main env setup starts
 check_and_install_pyenv
 check_and_install_min_py_version
-set_up_virtualenv
+create_virtualenv
 install_mlflow
 check_and_install_pandoc
 set_up_git_signoff
 
-# setup pre-commit hooks
+# Set up pre-commit hooks
 pre-commit install -t pre-commit -t prepare-commit-msg
 
 echo "$(tput setaf 2)Your MLflow development environment can be activated by running: $(tput bold)source $VENV_DIR$(tput sgr0)"

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -49,7 +49,6 @@ MLFLOW_HOME="$(pwd)"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 rd="$REPO_ROOT/requirements"
 VENV_DIR="$directory/bin/activate"
-
 while :
 do
   case "$1" in
@@ -93,9 +92,9 @@ fi
 
 # Acquire the OS for this environment
 case "$(uname -s)" in
-  Darwin*) machine=mac ;;
-  Linux*) machine=linux ;;
-  *) machine=unknown ;;
+  Darwin*)                       machine=mac;;
+  Linux*)                        machine=linux;;
+  *)                             machine=unknown;;
 esac
 
 quiet_command(){

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -46,6 +46,10 @@ EOF
 
 directory="$(pwd)/.venvs/mlflow-dev"
 MLFLOW_HOME="$(pwd)"
+REPO_ROOT=$(git rev-parse --show-toplevel)
+rd="$REPO_ROOT/requirements"
+VENV_DIR="$directory/bin/activate"
+
 while :; do
   case "$1" in
   -d | --directory)
@@ -186,160 +190,171 @@ check_and_install_pyenv() {
   fi
 }
 
-check_and_install_pyenv
+check_and_install_min_py_version() {
+  # Get the minimum supported version for development purposes
+  min_py_version="3.8"
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-rd="$REPO_ROOT/requirements"
+  echo "The minimum version of Python to ensure backwards compatibility for MLflow development is: $(
+    tput bold
+    tput setaf 3
+  )$min_py_version$(tput sgr0)"
 
-# Get the minimum supported version for development purposes
-min_py_version="3.8"
-
-echo "The minimum version of Python to ensure backwards compatibility for MLflow development is: $(
-  tput bold
-  tput setaf 3
-)$min_py_version$(tput sgr0)"
-
-if [[ -n "$override_py_ver" ]]; then
-  version_levels=$(grep -o '\.' <<<"$override_py_ver" | wc -l)
-  if [[ $version_levels -eq 1 ]]; then
-    PY_INSTALL_VERSION=$(minor_to_micro $override_py_ver)
-  elif [[ $version_levels -eq 2 ]]; then
-    PY_INSTALL_VERSION=$override_py_ver
-  else
-    echo "You must supply a python override version with either minor (e.g., '3.9') or micro (e.g., '3.9.5'). '$override_py_ver' is invalid."
-    exit 1
-  fi
-else
-  PY_INSTALL_VERSION=$(minor_to_micro $min_py_version)
-fi
-
-echo "The top-level dependencies that will be installed are: "
-
-if [[ -n "$full" ]]; then
-  files=("$rd/extra-ml-requirements.txt" "$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
-  echo "Files:"
-  echo "MLflow test plugin: $MLFLOW_HOME/tests/resources/mlflow-test-plugin"
-  echo "The local development branch of MLflow installed in editable mode with 'extras' requirements"
-  echo "The following packages: "
-else
-  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
-fi
-tail -n +1 "${files[@]}" | grep "^[^#= ]" | sort | cat
-
-echo "$(tput setaf 2) Installing Python version $(tput bold)$PY_INSTALL_VERSION$(tput sgr0)"
-
-# Install the Python version if it cannot be found
-pyenv install -s "$PY_INSTALL_VERSION"
-pyenv local "$PY_INSTALL_VERSION"
-pyenv exec pip install $(quiet_command) --upgrade pip
-pyenv exec pip install $(quiet_command) virtualenv
-pyenv exec pip install $(quiet_command) pre-commit
-
-VENV_DIR="$directory/bin/activate"
-
-# Check if the virtualenv already exists at the specified path
-if [[ -d "$directory" ]]; then
-  if [ -z "$GITHUB_ACTIONS" ]; then
-    read -p "A virtual environment is already located at $directory. Do you wish to replace it? $(
-      tput bold
-      tput setaf 2
-    )(y/n) $(tput sgr0)" -n 1 -r
-    echo
-  fi
-  if [[ $REPLY =~ ^[Yy]$ || -n "$GITHUB_ACTIONS" ]]; then
-    echo "Replacing Virtual environment in '$directory'. Installing new instance."
-    pyenv exec virtualenv --clear "$directory"
-  fi
-else
-  # Create a virtual environment with the specified Python version
-  pyenv exec virtualenv --python "$PY_INSTALL_VERSION" "$directory"
-fi
-
-# Activate the virtual environment
-# shellcheck disable=SC1090
-source "$VENV_DIR"
-
-echo "$(tput setaf 2)Current Python version: $(tput bold)$(python --version)$(tput sgr0)"
-echo "$(tput setaf 3)Activated environment is located: $(tput bold) $directory/bin/activate$(tput sgr0)"
-
-echo "Installing pip dependencies for development environment."
-
-# Install current checked out version of MLflow (local)
-pip install $(quiet_command) -e .[extras]
-pip install pre-commit
-
-if [[ -n "$full" ]]; then
-  # Install dev requirements and test plugin
-  pip install $(quiet_command) -r "$rd/dev-requirements.txt"
-  # Install test plugin
-  pip install $(quiet_command) -e "$MLFLOW_HOME/tests/resources//mlflow-test-plugin"
-  echo "Finished installing pip dependencies."
-else
-  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
-  for r in "${files[@]}"; do
-    pip install $(quiet_command) -r "$r"
-  done
-fi
-
-echo "$(
-  tput setaf 2
-  tput smul
-)Python packages that have been installed:$(tput rmul)"
-echo "$(pip freeze)$(tput sgr0)"
-
-command -v docker >/dev/null 2>&1 || echo "$(
-  tput bold
-  tput setaf 1
-)A docker installation cannot be found. Please ensure that docker is installed to run all tests locally.$(tput sgr0)"
-
-# check if pandoc with required version is installed and offer to install it if not present
-pandoc_version=$(pandoc --version | grep "pandoc" | awk '{print $2}')
-if [[ -z "$pandoc_version" ]] || ! version_gt "$pandoc_version" "2.2.1"; then
-  if [ -z "$GITHUB_ACTIONS" ]; then
-    read -p "Pandoc version 2.2.1 or above is required to generate documentation. Would you like to install it? $(tput bold)(y/n)$(tput sgr0): " -n 1 -r
-    echo
-  fi
-
-  if [[ $REPLY =~ ^[Yy]$ || -n "$GITHUB_ACTIONS" ]]; then
-    echo "Installing Pandoc..."
-    if [[ "$machine" == mac ]]; then
-      check_and_install_brew "pandoc"
-      brew install pandoc
-    elif [[ "$machine" == linux ]]; then
-      # install pandoc via deb package as `apt-get` gives too old version
-      TEMP_DEB=$(mktemp) &&
-        wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb &&
-        sudo dpkg --install $(find $TEMP_DEB -name '*.deb') &&
-        rm -rf $TEMP_DEB
+  if [[ -n "$override_py_ver" ]]; then
+    version_levels=$(grep -o '\.' <<<"$override_py_ver" | wc -l)
+    if [[ $version_levels -eq 1 ]]; then
+      PY_INSTALL_VERSION=$(minor_to_micro $override_py_ver)
+    elif [[ $version_levels -eq 2 ]]; then
+      PY_INSTALL_VERSION=$override_py_ver
     else
-      echo "Unknown operating system environment: $machine exiting."
+      echo "You must supply a python override version with either minor (e.g., '3.9') or micro (e.g., '3.9.5'). '$override_py_ver' is invalid."
       exit 1
     fi
+  else
+    PY_INSTALL_VERSION=$(minor_to_micro $min_py_version)
   fi
-fi
+
+  echo "The top-level dependencies that will be installed are: "
+
+  if [[ -n "$full" ]]; then
+    files=("$rd/extra-ml-requirements.txt" "$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
+    echo "Files:"
+    echo "MLflow test plugin: $MLFLOW_HOME/tests/resources/mlflow-test-plugin"
+    echo "The local development branch of MLflow installed in editable mode with 'extras' requirements"
+    echo "The following packages: "
+  else
+    files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
+  fi
+  tail -n +1 "${files[@]}" | grep "^[^#= ]" | sort | cat
+
+  echo "$(tput setaf 2) Installing Python version $(tput bold)$PY_INSTALL_VERSION$(tput sgr0)"
+
+  # Install the Python version if it cannot be found
+  pyenv install -s "$PY_INSTALL_VERSION"
+  pyenv local "$PY_INSTALL_VERSION"
+  pyenv exec pip install $(quiet_command) --upgrade pip
+  pyenv exec pip install $(quiet_command) virtualenv
+  pyenv exec pip install $(quiet_command) pre-commit
+}
+
+# Check if the virtualenv already exists at the specified path
+set_up_virtualenv() {
+  if [[ -d "$directory" ]]; then
+    if [ -z "$GITHUB_ACTIONS" ]; then
+      read -p "A virtual environment is already located at $directory. Do you wish to replace it? $(
+        tput bold
+        tput setaf 2
+      )(y/n) $(tput sgr0)" -n 1 -r
+      echo
+    fi
+    if [[ $REPLY =~ ^[Yy]$ || -n "$GITHUB_ACTIONS" ]]; then
+      echo "Replacing Virtual environment in '$directory'. Installing new instance."
+      pyenv exec virtualenv --clear "$directory"
+    fi
+  else
+    # Create a virtual environment with the specified Python version
+    pyenv exec virtualenv --python "$PY_INSTALL_VERSION" "$directory"
+  fi
+
+  # Activate the virtual environment
+  # shellcheck disable=SC1090
+  source "$VENV_DIR"
+
+  echo "$(tput setaf 2)Current Python version: $(tput bold)$(python --version)$(tput sgr0)"
+  echo "$(tput setaf 3)Activated environment is located: $(tput bold) $directory/bin/activate$(tput sgr0)"
+}
+
+# Install current checked out version of MLflow (local)
+install_mlflow() {
+  echo "Installing pip dependencies for development environment."
+
+  pip install $(quiet_command) -e .[extras]
+  pip install pre-commit
+
+  if [[ -n "$full" ]]; then
+    # Install dev requirements and test plugin
+    pip install $(quiet_command) -r "$rd/dev-requirements.txt"
+    # Install test plugin
+    pip install $(quiet_command) -e "$MLFLOW_HOME/tests/resources//mlflow-test-plugin"
+    echo "Finished installing pip dependencies."
+  else
+    files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
+    for r in "${files[@]}"; do
+      pip install $(quiet_command) -r "$r"
+    done
+  fi
+
+  echo "$(
+    tput setaf 2
+    tput smul
+  )Python packages that have been installed:$(tput rmul)"
+  echo "$(pip freeze)$(tput sgr0)"
+
+  command -v docker >/dev/null 2>&1 || echo "$(
+    tput bold
+    tput setaf 1
+  )A docker installation cannot be found. Please ensure that docker is installed to run all tests locally.$(tput sgr0)"
+}
+
+# check if pandoc with required version is installed and offer to install it if not present
+check_and_install_pandoc() {
+  pandoc_version=$(pandoc --version | grep "pandoc" | awk '{print $2}')
+  if [[ -z "$pandoc_version" ]] || ! version_gt "$pandoc_version" "2.2.1"; then
+    if [ -z "$GITHUB_ACTIONS" ]; then
+      read -p "Pandoc version 2.2.1 or above is required to generate documentation. Would you like to install it? $(tput bold)(y/n)$(tput sgr0): " -n 1 -r
+      echo
+    fi
+
+    if [[ $REPLY =~ ^[Yy]$ || -n "$GITHUB_ACTIONS" ]]; then
+      echo "Installing Pandoc..."
+      if [[ "$machine" == mac ]]; then
+        check_and_install_brew "pandoc"
+        brew install pandoc
+      elif [[ "$machine" == linux ]]; then
+        # install pandoc via deb package as `apt-get` gives too old version
+        TEMP_DEB=$(mktemp) &&
+          wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb &&
+          sudo dpkg --install $(find $TEMP_DEB -name '*.deb') &&
+          rm -rf $TEMP_DEB
+      else
+        echo "Unknown operating system environment: $machine exiting."
+        exit 1
+      fi
+    fi
+  fi
+}
 
 # Setup git environment configuration for proper signing of commits
-git_user=$(git config user.name)
-git_email=$(git config user.email)
+set_up_git_signoff() {
+  git_user=$(git config user.name)
+  git_email=$(git config user.email)
 
-if [[ -z "$git_email" || -z "$git_user" ]]; then
-  read -p "Your git environment is not setup to automatically sign your commits. Would you like to configure it? $(
-    tput bold
-    tput setaf 2
-  )(y/n): $(tput sgr0)" -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    read -p "Enter the user name you would like to have associated with your commit signature: " -r git_user_name
+  if [[ -z "$git_email" || -z "$git_user" ]]; then
+    read -p "Your git environment is not setup to automatically sign your commits. Would you like to configure it? $(
+      tput bold
+      tput setaf 2
+    )(y/n): $(tput sgr0)" -n 1 -r
     echo
-    git config --global user.name "$git_user_name"
-    echo "Git user name set as: $(git config user.name)"
-    read -p "Enter your email address for your commit signature: " -r git_user_email
-    git config --global user.email "$git_user_email"
-    echo "Git user email set as: $(git config user.email)"
-  else
-    echo "Failing to set git 'user.name' and 'user.email' will result in unsigned commits. Ensure that you sign commits manually for CI checks to pass."
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      read -p "Enter the user name you would like to have associated with your commit signature: " -r git_user_name
+      echo
+      git config --global user.name "$git_user_name"
+      echo "Git user name set as: $(git config user.name)"
+      read -p "Enter your email address for your commit signature: " -r git_user_email
+      git config --global user.email "$git_user_email"
+      echo "Git user email set as: $(git config user.email)"
+    else
+      echo "Failing to set git 'user.name' and 'user.email' will result in unsigned commits. Ensure that you sign commits manually for CI checks to pass."
+    fi
   fi
-fi
+}
+
+# Main env setup starts
+check_and_install_pyenv
+check_and_install_min_py_version
+set_up_virtualenv
+install_mlflow
+check_and_install_pandoc
+set_up_git_signoff
 
 # setup pre-commit hooks
 pre-commit install -t pre-commit -t prepare-commit-msg

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -177,7 +177,7 @@ check_and_install_pyenv() {
           echo "PYENV_ROOT=$PYENV_ROOT" >>"$GITHUB_ENV"
         fi
       else
-        echo "Unknown operating system environment: $machine exiting."
+        echo "Unsupported operating system environment: $machine. This setup script only supports MacOS and Linux. For other operating systems, please follow the manual setup instruction here: https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#manual-python-development-environment-configuration "
         exit 1
       fi
     else
@@ -248,21 +248,21 @@ create_virtualenv() {
   echo "$(tput setaf 3)Activated environment is located: $(tput bold) $directory/bin/activate$(tput sgr0)"
 }
 
-# Install Mlflow dev version and required dependencies
+# Install mlflow dev version and required dependencies
 install_mlflow_and_dependencies() {
-  # Install current checked out version of Mlflow (local)
-  pip install $(quiet_command) -e .[extras]
+  # Install current checked out version of mlflow (local)
+  pip install -e .[extras]
   
   echo "Installing pip dependencies for development environment."
   if [[ -n "$full" ]]; then
     # Install dev requirements
-    pip install $(quiet_command) -r "$rd/dev-requirements.txt"
+    pip install -r "$rd/dev-requirements.txt"
     # Install test plugin
-    pip install $(quiet_command) -e "$MLFLOW_HOME/tests/resources//mlflow-test-plugin"
+    pip install -e "$MLFLOW_HOME/tests/resources//mlflow-test-plugin"
   else
     files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
     for r in "${files[@]}"; do
-      pip install $(quiet_command) -r "$r"
+      pip install -r "$r"
     done
   fi
   echo "Finished installing pip dependencies."
@@ -278,7 +278,7 @@ check_docker() {
    command -v docker >/dev/null 2>&1 || echo "$(
     tput bold
     tput setaf 1
-  )A docker installation cannot be found. Please ensure that docker is installed to run all tests locally.$(tput sgr0)"
+  )A docker installation cannot be found. Docker is optional but you may need it for developing some features and running all tests locally. $(tput sgr0)"
 }
 
 # Check if pandoc with required version is installed and offer to install it if not present
@@ -286,7 +286,7 @@ check_and_install_pandoc() {
   pandoc_version=$(pandoc --version | grep "pandoc" | awk '{print $2}')
   if [[ -z "$pandoc_version" ]] || ! version_gt "$pandoc_version" "2.2.1"; then
     if [ -z "$GITHUB_ACTIONS" ]; then
-      read -p "Pandoc version 2.2.1 or above is required to generate documentation. Would you like to install it? $(tput bold)(y/n)$(tput sgr0): " -n 1 -r
+      read -p "Pandoc version 2.2.1 or above is an optional requirement for compiling documentation. Would you like to install it? $(tput bold)(y/n)$(tput sgr0): " -n 1 -r
       echo
     fi
 
@@ -302,7 +302,7 @@ check_and_install_pandoc() {
           sudo dpkg --install $(find $TEMP_DEB -name '*.deb') &&
           rm -rf $TEMP_DEB
       else
-        echo "Unknown operating system environment: $machine exiting."
+        echo "Unsupported operating system environment: $machine. This setup script only supports MacOS and Linux. For other operating systems, please follow the manual setup instruction here: https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#manual-python-development-environment-configuration "
         exit 1
       fi
     fi

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -3,7 +3,7 @@
 set +exv
 
 showHelp() {
-  cat <<EOF
+cat << EOF
 Usage: ./install-dev-env.sh [-d] [directory to install virtual environment] [-v] [-q] [-f] [-o] [override python version]
 Development environment setup script for Python in linux-based Operating Systems (including OSX).
 Note: this script will not work on Windows or MacOS M1 arm64 chipsets.
@@ -50,39 +50,40 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 rd="$REPO_ROOT/requirements"
 VENV_DIR="$directory/bin/activate"
 
-while :; do
+while :
+do
   case "$1" in
-  -d | --directory)
-    directory="$2"
-    shift 2
-    ;;
-  -f | --full)
-    full="full"
-    shift
-    ;;
-  -q | --quiet)
-    quiet="quiet"
-    shift
-    ;;
-  -o | --override)
-    override_py_ver="$2"
-    shift 2
-    ;;
-  -h | --help)
-    showHelp
-    exit 0
-    ;;
-  --)
-    shift
-    break
-    ;;
-  -*)
-    echo "Error: unknown option: $1" >&2
-    exit 1
-    ;;
-  *)
-    break
-    ;;
+    -d | --directory)
+      directory="$2"
+      shift 2
+      ;;
+    -f | --full)
+      full="full"
+      shift
+      ;;
+    -q | --quiet)
+      quiet="quiet"
+      shift
+      ;;
+    -o | --override)
+      override_py_ver="$2"
+      shift 2
+      ;;
+    -h | --help)
+      showHelp
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
   esac
 done
 
@@ -92,21 +93,21 @@ fi
 
 # Acquire the OS for this environment
 case "$(uname -s)" in
-Darwin*) machine=mac ;;
-Linux*) machine=linux ;;
-*) machine=unknown ;;
+  Darwin*) machine=mac ;;
+  Linux*) machine=linux ;;
+  *) machine=unknown ;;
 esac
 
-quiet_command() {
-  echo $([[ -n $quiet ]] && printf %s '-q')
+quiet_command(){
+  echo $( [[ -n $quiet ]] && printf %s '-q' )
 }
 
 minor_to_micro() {
   case $1 in
-  "3.7") echo "3.7.14" ;;
-  "3.8") echo "3.8.13" ;;
-  "3.9") echo "3.9.13" ;;
-  "3.10") echo "3.10.4" ;;
+    "3.7") echo "3.7.14" ;;
+    "3.8") echo "3.8.13" ;;
+    "3.9") echo "3.9.13" ;;
+    "3.10") echo "3.10.4" ;;
   esac
 }
 
@@ -126,26 +127,26 @@ check_and_install_brew() {
 # Usage: version_gt version1 version2
 # Returns 0 (true) if version1 > version2, 1 (false) otherwise
 version_gt() {
-  IFS='.' read -ra VER1 <<<"$1"
-  IFS='.' read -ra VER2 <<<"$2"
+    IFS='.' read -ra VER1 <<< "$1"
+    IFS='.' read -ra VER2 <<< "$2"
 
-  # Compare each segment of the version numbers
-  for ((i = 0; i < "${#VER1[@]}"; i++)); do
-    # If VER2 is shorter and we haven't found a difference yet, VER1 is greater
-    if [[ -z ${VER2[i]} ]]; then
-      return 0
-    fi
+    # Compare each segment of the version numbers
+    for (( i=0; i<"${#VER1[@]}"; i++ )); do
+        # If VER2 is shorter and we haven't found a difference yet, VER1 is greater
+        if [[ -z ${VER2[i]} ]]; then
+            return 0
+        fi
 
-    # If some segments are not equal, return their comparison result
-    if ((${VER1[i]} > ${VER2[i]})); then
-      return 0
-    elif ((${VER1[i]} < ${VER2[i]})); then
-      return 1
-    fi
-  done
+        # If some segments are not equal, return their comparison result
+        if (( ${VER1[i]} > ${VER2[i]} )); then
+            return 0
+        elif (( ${VER1[i]} < ${VER2[i]} )); then
+            return 1
+        fi
+    done
 
-  # If all common length segments are same, the one with more segments is greater
-  return $((${#VER1[@]} <= ${#VER2[@]}))
+    # If all common length segments are same, the one with more segments is greater
+    return $(( ${#VER1[@]} <= ${#VER2[@]} ))
 }
 
 # Check if pyenv is installed and offer to install it if not present

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -248,9 +248,9 @@ create_virtualenv() {
   echo "$(tput setaf 3)Activated environment is located: $(tput bold) $directory/bin/activate$(tput sgr0)"
 }
 
-# Install MLFlow dev version and required dependencies
+# Install Mlflow dev version and required dependencies
 install_mlflow_and_dependencies() {
-  # Install current checked out version of MLflow (local)
+  # Install current checked out version of Mlflow (local)
   pip install $(quiet_command) -e .[extras]
   
   echo "Installing pip dependencies for development environment."


### PR DESCRIPTION
### What changes are proposed in this pull request?

[dev/dev-env-setup.sh](https://github.com/mlflow/mlflow/blob/master/dev/dev-env-setup.sh) is a one-stop script for setting up development environment for MLflow. This is the most convenient way to set up and we recommend it in [the contribution guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#automated-python-development-environment-configuration).

However, as the script gets longer, the fact that it can only be executed all at once becomes a friction. The motivation of this PR is to refactor the script to make it resumable from where it errored out. 

This first PR only contains the refactoring change, which divides the script into different sections, wrap them with functions, and group them by mandatory vs optional. The following PR will implement the checkpoints to actually save the progress.

This PR also touches the logic of the original script by removing https://github.com/mlflow/mlflow/blob/master/dev/dev-env-setup.sh#L213-L222 , reason being it only prints out the dependencies without actually installing them. https://github.com/mlflow/mlflow/blob/master/dev/dev-env-setup.sh#L263-L278 has already covered both the printout and installation.

### How is this PR tested?
- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

Passed `pytest tests/tracking/test_client.py tests/tracking/test_rest_tracking.py `
Passed `pre-commit run --all-files`

Ran `dev/dev-env-setup.sh -d .venvs/mlflow-dev -q ` without commenting out https://github.com/mlflow/mlflow/blob/master/requirements/doc-requirements.txt#L2 on my local macOS, which fails the mandatory setup
Verified the script exited on error
<img width="1471" alt="image" src="https://github.com/mlflow/mlflow/assets/171547006/eef8e143-b621-4be4-abb6-fabd9aaa6a88">

Ran `dev/dev-env-setup.sh -d .venvs/mlflow-dev -q ` when 
1. correctly commenting out https://github.com/mlflow/mlflow/blob/master/requirements/doc-requirements.txt#L2 on my local macOS -> all mandatory setup should pass AND
2. making docker installation fail (it's an optional setup)
Verified the script can finish
<img width="1349" alt="image" src="https://github.com/mlflow/mlflow/assets/171547006/10b11181-4448-409b-b945-8b225d9e8d93">

and `source .venvs/mlflow-dev/bin/activate` can run successfully

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)

