### PR TITLE
Add alternative package names for RAG to requirements exclusion validation

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -627,16 +627,28 @@ def warn_dependency_requirement_mismatches(model_requirements: List[str]):
     doesn't satisfy them.
     """
     # Suppress databricks-feature-lookup warning for feature store cases
-    # Suppress databricks-chains warning for RAG Studio cases
+    # Suppress databricks-chains, databricks-rag, and databricks-agents warnings for RAG
+    # Studio cases
+    # NB: When a final name has been decided for GA for the aforementioned
+    # "Databricks RAG Studio" product, remove unrelated names from this listing.
     _DATABRICKS_FEATURE_LOOKUP = "databricks-feature-lookup"
-    _DATABRICKS_RAG_STUDIO = "databricks-chains"
-    ignore_packages = list(
-        map(
-            _normalize_package_name,
-            # TODO: remove databricks-rag-studio once it's EoL
-            [_DATABRICKS_FEATURE_LOOKUP, _DATABRICKS_RAG_STUDIO, "databricks-rag-studio"],
-        )
-    )
+    _DATABRICKS_RAG_STUDIO = "databricks-rag-studio"
+    _DATABRICKS_CHAINS = "databricks-chains"
+    _DATABRICKS_RAG = "databricks-rag"
+    _DATABRICKS_AGENTS = "databricks-agents"
+
+    # List of packages to ignore
+    packages_to_ignore = [
+        _DATABRICKS_FEATURE_LOOKUP,
+        _DATABRICKS_RAG_STUDIO,
+        _DATABRICKS_CHAINS,
+        _DATABRICKS_RAG,
+        _DATABRICKS_AGENTS,
+    ]
+
+    # Normalize package names and create ignore list
+    ignore_packages = list(map(_normalize_package_name, packages_to_ignore))
+
     try:
         mismatch_infos = []
         for req in model_requirements:

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -564,6 +564,12 @@ model's environment and install dependencies using the resulting environment fil
         "databricks.chains",
         "databricks-rag-studio",
         "databricks.rag_studio",
+        "databricks.rag",
+        "databricks-rag",
+        "databricks_rag",
+        "databricks-agents",
+        "databricks_agents",
+        "databricks.agents",
     ],
 )
 def test_suppress_warn_dependency_requirement_mismatches_ignore_some_packages(ignore_package_name):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/12261?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12261/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12261
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds additional alternative names to the requirements validation exclusion list

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [X] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
