### PR TITLE
Avoid importing `mlflow.gateway` at the top level of `mlflow.deployment` module.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -352,7 +352,7 @@ nitpick_ignore = [
     ("py:class", "plotly.graph_objects.Figure"),
     ("py:class", "PIL.Image.Image"),
     ("py:class", "mlflow.deployments.base.BaseDeploymentClient"),
-    ("py:class", "mlflow.deployments.server.config.Endpoint"),
+    ("py:class", "Endpoint"),
     ("py:class", "mlflow.types.schema.Array"),
     ("py:class", "mlflow.types.schema.DataType"),
     ("py:class", "mlflow.types.schema.ColSpec"),

--- a/mlflow/deployments/mlflow/__init__.py
+++ b/mlflow/deployments/mlflow/__init__.py
@@ -7,7 +7,6 @@ from mlflow.deployments import BaseDeploymentClient
 from mlflow.deployments.constants import (
     MLFLOW_DEPLOYMENT_CLIENT_REQUEST_RETRY_CODES,
 )
-from mlflow.deployments.server.config import Endpoint
 from mlflow.deployments.server.constants import (
     MLFLOW_DEPLOYMENTS_CRUD_ENDPOINT_BASE,
     MLFLOW_DEPLOYMENTS_ENDPOINTS_BASE,
@@ -167,6 +166,9 @@ class MlflowDeploymentClient(BaseDeploymentClient):
                 "endpoint_url": "http://localhost:5000/gateway/chat/invocations",
             }
         """
+        # Delayed import to avoid importing mlflow.gateway in the module scope
+        from mlflow.deployments.server.config import Endpoint
+
         route = join_paths(MLFLOW_DEPLOYMENTS_CRUD_ENDPOINT_BASE, endpoint)
         response = self._call_endpoint("GET", route)
         return Endpoint(
@@ -177,6 +179,9 @@ class MlflowDeploymentClient(BaseDeploymentClient):
         )
 
     def _list_endpoints(self, page_token=None) -> "PagedList[Endpoint]":
+        # Delayed import to avoid importing mlflow.gateway in the module scope
+        from mlflow.deployments.server.config import Endpoint
+
         params = None if page_token is None else {"page_token": page_token}
         response_json = self._call_endpoint(
             "GET", MLFLOW_DEPLOYMENTS_CRUD_ENDPOINT_BASE, json_body=params

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -428,10 +428,22 @@ def test_capture_imported_modules_include_deps_by_params():
     assert "sklearn" in captured_modules
 
 
-def test_capture_imported_modules_includes_gateway_extra():
+@pytest.mark.parametrize(
+    ("module_to_import", "should_capture_extra"),
+    [
+        ("mlflow.gateway", True),
+        ("mlflow.deployments.server.app", True),
+        # The `mlflow[gateway]`` extra includes requirements for starting the deployment server,
+        # but it is not required when the model only uses the deployment client. These test
+        # cases validate that importing the deployment client alone does not add the extra.
+        ("mlflow.deployments", False),
+        ("mlflow.deployments.get_deploy_client", False),
+    ],
+)
+def test_capture_imported_modules_includes_gateway_extra(module_to_import, should_capture_extra):
     class MyModel(mlflow.pyfunc.PythonModel):
         def predict(self, _, inputs, params=None):
-            import mlflow.gateway  # noqa: F401
+            importlib.import_module(module_to_import)
 
             return inputs
 
@@ -443,10 +455,10 @@ def test_capture_imported_modules_includes_gateway_extra():
         )
 
     captured_modules = _capture_imported_modules(model_info.model_uri, "pyfunc")
-    assert "mlflow.gateway" in captured_modules
+    assert ("mlflow.gateway" in captured_modules) == should_capture_extra
 
     pip_requirements = infer_pip_requirements(model_info.model_uri, "pyfunc")
-    assert f"mlflow[gateway]=={mlflow.__version__}" in pip_requirements
+    assert (f"mlflow[gateway]=={mlflow.__version__}" in pip_requirements) == should_capture_extra
 
 
 def test_warn_dependency_requirement_mismatches():

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -432,7 +432,7 @@ def test_capture_imported_modules_include_deps_by_params():
     ("module_to_import", "should_capture_extra"),
     [
         ("mlflow.gateway", True),
-        ("mlflow.deployments.server.app", True),
+        ("mlflow.deployments.server.config", True),
         # The `mlflow[gateway]`` extra includes requirements for starting the deployment server,
         # but it is not required when the model only uses the deployment client. These test
         # cases validate that importing the deployment client alone does not add the extra.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12264?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12264/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12264
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow[gateway]` extra contains dependencies for launching the deployment server, such as pydantic, fastapi, etc. It is not required for every module under `mlflow.deployments`. This causes false positive in dependency capturing for a model.

For example, LangChain `ChatDatabricks` chain uses `mlflow.deployment.get_deploy_client` to access Databricks endpoint. The deployment client does not need `mlflow[gatewa]` extra dependencies as it's just a client. However, since importing that module also indirectly import `mlflow.gateway`, MLflow adds the extra to the model dependency. When the user doesn't install the extra in their notebook, they will see the following false warning:

```
2024/06/06 03:40:45 WARNING mlflow.utils.requirements_utils: Detected one or more mismatches between the model's dependencies and the current Python environment:
 - mlflow[gateway] (current: uninstalled, required: mlflow[gateway]==2.13.1)
To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` to fetch the model's environment and install dependencies using the resulting environment file.
```

To fix this, this PR updates the import statement to only import `mlflow.gateway.xxx` if it is actually used.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested saving a lancghain model includes `ChatDatabricks`

**Before Fix**

![Screenshot 2024-06-06 at 12 43 58](https://github.com/mlflow/mlflow/assets/31463517/24d827d8-b2fa-441e-b6a9-cf3d0b0a259d)

**After Fix**
![Screenshot 2024-06-06 at 12 46 12](https://github.com/mlflow/mlflow/assets/31463517/0e03afdc-796f-42e0-a7c3-20b7b1952989)

Also validated the `requirements.txt` file doesn't include `mlflow[gateway]` and the model can be deployed to the serving endpoint.


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix dependency capturing for deployment client so it won't add `mlflow[gateway]` extra to the model dependency.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
