### PR TITLE
Suppress trace display while loading model-as-code langchain model that includes invoke()

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -929,7 +929,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
 
 
 @experimental
-@trace_disabled # Suppress traces while loading model
+@trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):
     """
     Load a LangChain model from a local file or a run.

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -929,6 +929,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
 
 
 @experimental
+@trace_disabled # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):
     """
     Load a LangChain model from a local file or a run.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -922,6 +922,7 @@ def _get_pip_requirements_from_model_path(model_path: str):
     return [req.req_str for req in _parse_requirements(req_file_path, is_constraint=False)]
 
 
+@trace_disabled # Suppress traces while loading model
 def load_model(
     model_uri: str,
     suppress_warnings: bool = False,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -922,7 +922,7 @@ def _get_pip_requirements_from_model_path(model_path: str):
     return [req.req_str for req in _parse_requirements(req_file_path, is_constraint=False)]
 
 
-@trace_disabled # Suppress traces while loading model
+@trace_disabled  # Suppress traces while loading model
 def load_model(
     model_uri: str,
     suppress_warnings: bool = False,

--- a/tests/langchain/sample_code/chain.py
+++ b/tests/langchain/sample_code/chain.py
@@ -56,6 +56,7 @@ def get_fake_chat_model(endpoint="fake-endpoint"):
 
     return FakeChatModel(endpoint=endpoint)
 
+
 # No need to define the model, but simulating common practice in dev notebooks
 mlflow.langchain.autolog()
 

--- a/tests/langchain/sample_code/chain.py
+++ b/tests/langchain/sample_code/chain.py
@@ -12,6 +12,7 @@ from langchain.schema.runnable import RunnablePassthrough
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.vectorstores import FAISS
 
+import mlflow
 from mlflow.models import ModelConfig, set_model, set_retriever_schema
 
 base_config = ModelConfig(development_config="tests/langchain/config.yml")
@@ -55,6 +56,8 @@ def get_fake_chat_model(endpoint="fake-endpoint"):
 
     return FakeChatModel(endpoint=endpoint)
 
+# No need to define the model, but simulating common practice in dev notebooks
+mlflow.langchain.autolog()
 
 text_path = "tests/langchain/state_of_the_union.txt"
 loader = TextLoader(text_path)
@@ -84,3 +87,5 @@ set_retriever_schema(
     doc_uri="doc-uri",
     other_columns=["column1", "column2"],
 )
+
+retrieval_chain.invoke({"question": "What is the capital of Japan?"})

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -12,6 +12,7 @@ import langchain
 import numpy as np
 import openai
 import pytest
+from tests.tracing.helper import get_traces
 import transformers
 import yaml
 from langchain import SQLDatabase
@@ -2400,6 +2401,12 @@ def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config
 
     assert mlflow.models.model_config.__mlflow_model_config__ is None
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
+
+    # During the loading process, MLflow executes the chain.py file to
+    # load the model class. It should not generate any traces even if
+    # the code enables autologging and invoke chain.
+    assert len(get_traces()) == 0
+
     assert mlflow.models.model_config.__mlflow_model_config__ is None
     answer = "Databricks"
     assert loaded_model.invoke(input_example) == answer

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -12,7 +12,6 @@ import langchain
 import numpy as np
 import openai
 import pytest
-from tests.tracing.helper import get_traces
 import transformers
 import yaml
 from langchain import SQLDatabase
@@ -31,6 +30,8 @@ from langchain.document_loaders import TextLoader
 from langchain.embeddings.base import Embeddings
 from langchain.embeddings.fake import FakeEmbeddings
 from langchain.evaluation.qa import QAEvalChain
+
+from tests.tracing.helper import get_traces
 
 try:
     from langchain_huggingface import HuggingFacePipeline

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -112,8 +112,7 @@ def test_trace_disabled_decorator(enabled_initially):
 
     # @trace_disabled should not block the decorated function even
     # if it fails to disable tracing
-    with mock.patch("mlflow.tracing.provider.disable",
-                    side_effect=ValueError("error")):
+    with mock.patch("mlflow.tracing.provider.disable", side_effect=ValueError("error")):
         assert 0 == test_fn()
         assert call_count == 3
 

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -72,6 +72,14 @@ def test_disable_enable_tracing():
     assert isinstance(_get_tracer(__name__), trace.Tracer)
     TRACE_BUFFER.clear()
 
+    # enable() / disable() should not raise an exception
+    with mock.patch(
+        "mlflow.tracing.provider._is_enabled", side_effect=ValueError("error")
+    ) as is_enabled_mock:
+        mlflow.tracing.disable()
+        mlflow.tracing.enable()
+        assert is_enabled_mock.call_count == 2
+
 
 @pytest.mark.parametrize("enabled_initially", [True, False])
 def test_trace_disabled_decorator(enabled_initially):
@@ -112,9 +120,12 @@ def test_trace_disabled_decorator(enabled_initially):
 
     # @trace_disabled should not block the decorated function even
     # if it fails to disable tracing
-    with mock.patch("mlflow.tracing.provider.disable", side_effect=ValueError("error")):
+    with mock.patch(
+        "mlflow.tracing.provider._setup_tracer_provider", side_effect=ValueError("error")
+    ) as setup_mock:
         assert 0 == test_fn()
         assert call_count == 3
+        assert setup_mock.call_count == (2 if enabled_initially else 0)
 
 
 def test_is_enabled():
@@ -140,6 +151,13 @@ def test_is_enabled():
     # Re-enable tracing
     mlflow.tracing.enable()
     assert _is_enabled()
+
+    # _is_enabled() should not raise an exception
+    with mock.patch(
+        "mlflow.tracing.provider.trace.get_tracer", side_effect=ValueError("error")
+    ) as get_tracer_mock:
+        assert not _is_enabled()
+        assert get_tracer_mock.call_count == 1
 
 
 @pytest.mark.parametrize("enable_mlflow_tracing", [True, False, None])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12268?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12268/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12268
```

</p>
</details>

### What changes are proposed in this pull request?

LangChain flavor supports loading a notebook or `.py` file as a model code. When loading that model, MLflow [execute the code once](https://github.com/mlflow/mlflow/blob/master/mlflow/models/utils.py#L1655) to extract the chain class.

If the user's code/notebook enables tracing there, this will also generates a trace, which is confusing UX. For example, it is common that the dev notebook enables autologging like this and test invocation. Let's say user has the following notebook for model definition (say "chain.ipynb").
```
# User's notebook (chain.ipynb)
mlflow.langchain.autolog()

chain.invoke(...)
```
Then loading this notebook as model will generate a trace
``` 
# We already suppressed trace while logging
info = mlflow.langchain.log_model(lc_model="chain.ipynb", ....)

# But this also generates trace
loaded_model = mlflow.langchain.load_model(info.model_uri)
```
<img width="400" alt="Screenshot 2024-06-06 at 15 46 42" src="https://github.com/mlflow/mlflow/assets/31463517/14d1affd-52cd-4daf-ba91-8c4f87da4529">


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Trace is no longer shown when loading the model.

<img width="400" alt="Screenshot 2024-06-06 at 16 01 00" src="https://github.com/mlflow/mlflow/assets/31463517/b40607e9-e4b6-43e2-b523-b343cc12773d">



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
