### PR TITLE
Introduce log_traces for langchain autologging and deprecate log_inputs_outputs

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -998,11 +998,7 @@ def autolog(
     log_model_signatures=False,
     log_models=False,
     log_datasets=False,
-    # TODO: log_inputs_outputs was originally defaulted to True in the production version of
-    # the LangChain autologging, as it is a common use case to log input/output table for
-    # evaluation. Once tracing is fully launched, this should be supported by the tracer
-    # but we should design it to be compatible with the existing UJ.
-    log_inputs_outputs=False,
+    log_inputs_outputs=None,
     disable=False,
     exclusive=False,
     disable_for_unsupported_versions=True,
@@ -1010,6 +1006,7 @@ def autolog(
     registered_model_name=None,
     extra_tags=None,
     extra_model_classes=None,
+    log_traces=True,
 ):
     """
     Enables (or disables) and configures autologging from Langchain to MLflow.
@@ -1033,7 +1030,11 @@ def autolog(
             are also omitted when ``log_models`` is ``False``.
         log_datasets: If ``True``, dataset information is logged to MLflow Tracking
             if applicable. If ``False``, dataset information is not logged.
-        log_inputs_outputs: If ``True``, inference data and results are combined into a single
+        log_inputs_outputs: **Deprecated** The legacy parameter used for logging inference
+            inputs and outputs. This argument will be removed in a future version of MLflow.
+            The alternative is to use ``log_traces`` which logs traces for Langchain models,
+            including inputs and outputs for each stage.
+            If ``True``, inference data and results are combined into a single
             pandas DataFrame and logged to MLflow Tracking as an artifact.
             If ``False``, inference data and results are not logged.
             Default to ``False``.
@@ -1056,6 +1057,9 @@ def autolog(
             We do not guarantee classes specified in this list can be logged as a model, but tracing
             will be supported. Note that all classes within the list must be subclasses of Runnable,
             and we only patch `invoke`, `batch`, and `stream` methods for tracing.
+        log_traces: If ``True``, traces are logged for Langchain models by using
+            MlflowLangchainTracer as a callback during inference. If ``False``, no traces are
+            collected during inference. Default to ``True``.
     """
     with contextlib.suppress(ImportError):
         import langchain

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -100,7 +100,8 @@ def patched_inference(func_name, original, self, *args, **kwargs):
     else:
         result = _invoke(self, *args, **kwargs)
 
-    mlflow_tracer.flush_tracker()
+    if config.log_traces:
+        mlflow_tracer.flush_tracker()
     return result
 
 

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -55,7 +55,7 @@ class AutoLoggingConfig:
     def init(cls):
         config_dict = AUTOLOGGING_INTEGRATIONS.get(mlflow.langchain.FLAVOR_NAME, {})
         if config_dict.get("log_inputs_outputs"):
-            warnings.warn(
+            _logger.warning(
                 "The log_inputs_outputs option is deprecated and will be removed in a future "
                 "release. Please use the log_traces option in `mlflow.langchain.autolog` "
                 "to log traces (including inputs and outputs) of the model."

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -64,7 +64,7 @@ class AutoLoggingConfig:
             log_models=config_dict.get("log_models", False),
             log_input_examples=config_dict.get("log_input_examples", False),
             log_model_signatures=config_dict.get("log_model_signatures", False),
-            log_traces=config_dict.get("log_traces", False),
+            log_traces=config_dict.get("log_traces", True),
             log_inputs_outputs=config_dict.get("log_inputs_outputs", False),
             extra_tags=config_dict.get("extra_tags", None),
         )

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -36,7 +36,8 @@ class AutoLoggingConfig:
     log_models: bool
     log_input_examples: bool
     log_model_signatures: bool
-    log_inputs_outputs: bool
+    log_traces: bool
+    log_inputs_outputs: Optional[bool] = None
     extra_tags: Optional[dict] = None
 
     def should_log_optional_artifacts(self):
@@ -53,10 +54,17 @@ class AutoLoggingConfig:
     @classmethod
     def init(cls):
         config_dict = AUTOLOGGING_INTEGRATIONS.get(mlflow.langchain.FLAVOR_NAME, {})
+        if config_dict.get("log_inputs_outputs"):
+            warnings.warn(
+                "The log_inputs_outputs option is deprecated and will be removed in a future "
+                "release. Please use the log_traces option in `mlflow.langchain.autolog` "
+                "to log traces (including inputs and outputs) of the model."
+            )
         return cls(
             log_models=config_dict.get("log_models", False),
             log_input_examples=config_dict.get("log_input_examples", False),
             log_model_signatures=config_dict.get("log_model_signatures", False),
+            log_traces=config_dict.get("log_traces", False),
             log_inputs_outputs=config_dict.get("log_inputs_outputs", False),
             extra_tags=config_dict.get("extra_tags", None),
         )
@@ -73,9 +81,10 @@ def patched_inference(func_name, original, self, *args, **kwargs):
     from mlflow.langchain.langchain_tracer import MlflowLangchainTracer
 
     config = AutoLoggingConfig.init()
-    mlflow_tracer = MlflowLangchainTracer()
-    args, kwargs = _inject_mlflow_callbacks(func_name, [mlflow_tracer], args, kwargs)
-    _logger.debug("Injected MLflow callbacks into the model.")
+    if config.log_traces:
+        mlflow_tracer = MlflowLangchainTracer()
+        args, kwargs = _inject_mlflow_callbacks(func_name, [mlflow_tracer], args, kwargs)
+        _logger.debug("Injected MLflow callbacks into the model.")
 
     # NB: Running the original inference with disabling autologging, so we only patch the top-level
     # component and avoid duplicate logging for child components.

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -78,6 +78,7 @@ MLFLOW_EVALUATE_RESTRICT_LANGCHAIN_AUTOLOG_TO_TRACES_CONFIG = {
     "registered_model_name": None,
     "extra_tags": None,
     "extra_model_classes": None,
+    "log_traces": True,
 }
 
 _logger = logging.getLogger(__name__)

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -898,10 +898,16 @@ def test_langchain_autolog_produces_expected_traces_with_streaming(tmp_path):
     assert len(stream_trace.data.spans) == len(invoke_trace.data.spans)
 
 
-def test_langchain_tracer_injection_for_arbitrary_runnables():
+@pytest.mark.parametrize("log_traces", [True, False, None])
+def test_langchain_tracer_injection_for_arbitrary_runnables(log_traces):
     from langchain.schema.runnable import RouterRunnable, RunnableLambda
 
-    mlflow.langchain.autolog()
+    should_log_traces = log_traces is not False
+
+    if log_traces is not None:
+        mlflow.langchain.autolog(log_traces=log_traces)
+    else:
+        mlflow.langchain.autolog()
 
     add = RunnableLambda(func=lambda x: x + 1)
     square = RunnableLambda(func=lambda x: x**2)
@@ -909,10 +915,16 @@ def test_langchain_tracer_injection_for_arbitrary_runnables():
 
     with mock.patch("mlflow.langchain._langchain_autolog._logger.debug") as mock_debug:
         model.invoke({"key": "square", "input": 3})
-        mock_debug.assert_called_once_with("Injected MLflow callbacks into the model.")
+        if should_log_traces:
+            mock_debug.assert_called_once_with("Injected MLflow callbacks into the model.")
+        else:
+            mock_debug.assert_not_called()
     traces = get_traces()
-    assert len(traces) == 1
-    assert traces[0].data.spans[0].attributes[SpanAttributeKey.SPAN_TYPE] == "CHAIN"
+    if should_log_traces:
+        assert len(traces) == 1
+        assert traces[0].data.spans[0].attributes[SpanAttributeKey.SPAN_TYPE] == "CHAIN"
+    else:
+        assert len(traces) == 0
 
 
 def test_langchain_autolog_extra_model_classes_no_duplicate_patching():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12272?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12272/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12272
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Deprecate log_inputs_outputs and add log_traces.
log_traces by default is True, we use MlflowLangchainTracer to collect traces.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
