### PR TITLE
Add tracing section in 'mlflow.' Python API page for better visibility

### DIFF
--- a/docs/source/python_api/mlflow.rst
+++ b/docs/source/python_api/mlflow.rst
@@ -20,7 +20,7 @@ The ``mlflow`` module provides a set of high-level APIs for `MLflow Tracing <../
 guidance on how to use these tracing APIs, please refer to the `Tracing Fluent APIs Guide <../llms/tracing/index.html#tracing-fluent-apis>`_.
 
 For some advanced use cases such as multi-threaded application, instrumentation via callbacks, you may need to use
-the low-level tracing APIs implemented in the :py:class:`MlflowClient <mlflow.client.MlflowClient>` class.
+the low-level tracing APIs :py:class:`MlflowClient <mlflow.client.MlflowClient>` provides.
 For detailed guidance on how to use the low-level tracing APIs, please refer to the `Tracing Client APIs Guide <../llms/tracing/index.html#tracing-client-apis>`_.
 
 .. autofunction:: mlflow.trace

--- a/docs/source/python_api/mlflow.rst
+++ b/docs/source/python_api/mlflow.rst
@@ -4,7 +4,7 @@ mlflow
 .. automodule:: mlflow
     :members:
     :undoc-members:
-    :exclude-members: MlflowClient
+    :exclude-members: MlflowClient, trace, start_span, get_trace, search_traces, get_current_active_span, get_last_active_trace
 
 
 .. _mlflow-tracing-fluent-python-apis:
@@ -24,17 +24,11 @@ the low-level tracing APIs :py:class:`MlflowClient <mlflow.client.MlflowClient>`
 For detailed guidance on how to use the low-level tracing APIs, please refer to the `Tracing Client APIs Guide <../llms/tracing/index.html#tracing-client-apis>`_.
 
 .. autofunction:: mlflow.trace
-    :noindex:
 .. autofunction:: mlflow.start_span
-    :noindex:
 .. autofunction:: mlflow.get_trace
-    :noindex:
 .. autofunction:: mlflow.search_traces
-    :noindex:
 .. autofunction:: mlflow.get_current_active_span
-    :noindex:
 .. autofunction:: mlflow.get_last_active_trace
-    :noindex:
 .. automodule:: mlflow.tracing
     :members:
     :undoc-members:

--- a/docs/source/python_api/mlflow.rst
+++ b/docs/source/python_api/mlflow.rst
@@ -5,3 +5,37 @@ mlflow
     :members:
     :undoc-members:
     :exclude-members: MlflowClient
+
+
+.. _mlflow-tracing-fluent-python-apis:
+
+MLflow Tracing APIs
+===================
+
+.. warning::
+
+    The tracing functionality is experimental and currently only available in Databricks. The feature will be fully supported in open-source MLflow in next major release.
+
+The ``mlflow`` module provides a set of high-level APIs for `MLflow Tracing <../llms/tracing/index.html>`_. For the detailed
+guidance on how to use these tracing APIs, please refer to the `Tracing Fluent APIs Guide <../llms/tracing/index.html#tracing-fluent-apis>`_.
+
+For some advanced use cases such as multi-threaded application, instrumentation via callbacks, you may need to use
+the low-level tracing APIs implemented in the :py:class:`MlflowClient <mlflow.client.MlflowClient>` class.
+For detailed guidance on how to use the low-level tracing APIs, please refer to the `Tracing Client APIs Guide <../llms/tracing/index.html#tracing-client-apis>`_.
+
+.. autofunction:: mlflow.trace
+    :noindex:
+.. autofunction:: mlflow.start_span
+    :noindex:
+.. autofunction:: mlflow.get_trace
+    :noindex:
+.. autofunction:: mlflow.search_traces
+    :noindex:
+.. autofunction:: mlflow.get_current_active_span
+    :noindex:
+.. autofunction:: mlflow.get_last_active_trace
+    :noindex:
+.. automodule:: mlflow.tracing
+    :members:
+    :undoc-members:
+    :noindex:

--- a/docs/source/python_api/mlflow.rst
+++ b/docs/source/python_api/mlflow.rst
@@ -14,7 +14,7 @@ MLflow Tracing APIs
 
 .. warning::
 
-    The tracing functionality is experimental and currently only available in Databricks. The feature will be fully supported in open-source MLflow in next major release.
+    The tracing functionality is experimental and currently only available in Databricks. The feature will be fully supported in open-source MLflow in 2.14.0.
 
 The ``mlflow`` module provides a set of high-level APIs for `MLflow Tracing <../llms/tracing/index.html>`_. For the detailed
 guidance on how to use these tracing APIs, please refer to the `Tracing Fluent APIs Guide <../llms/tracing/index.html#tracing-fluent-apis>`_.

--- a/docs/source/python_api/mlflow.tracing.rst
+++ b/docs/source/python_api/mlflow.tracing.rst
@@ -1,6 +1,16 @@
 mlflow.tracing
 ==============
 
+.. warning::
+
+    The tracing functionality is experimental and currently only available in Databricks. The feature will be fully supported in open-source MLflow in next major release.
+
+.. attention::
+
+    The ``mlflow.tracing`` namespace only contains a few utility functions fo managing traces. The main entry point for MLflow
+    Tracing is :ref:`Tracing Fluent APIs <mlflow-tracing-fluent-python-apis>` defined directly under the
+    :py:mod:`mlflow` namespace, or the low-level `Tracing Client APIs <../llms/tracing/index.html#tracing-client-apis>`_
+
 .. automodule:: mlflow.tracing
     :members:
     :undoc-members:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12281?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12281/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12281
```

</p>
</details>

### What changes are proposed in this pull request?

Currently, `mlflow.tracing` Python API doc only shows `mlflow.tracing.enable()` and `mlflow.tracing.disable()`, because other fluent API are under `mlflow` namespace. To provide better visibility and visual cohesion for the tracing Python APIs, this PR adds (1) Tracing API section in the `mlflow` module page (2) Add a quick note and link to the page from `mlflow.tracing` module page.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
