### PR TITLE
Fix agent executor predict

### DIFF
--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Literal, Optional, Set, Union
 
 import langchain.chains
 import pydantic
+from langchain.agents import AgentExecutor
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.schema import AgentAction, AIMessage, HumanMessage, SystemMessage
 from langchain.schema import ChatMessage as LangChainChatMessage
@@ -344,6 +345,11 @@ class APIRequest:
                 2. A boolean indicating whether or not the request was transformed from the OpenAI
                 chat format.
         """
+        # Avoid converting the request to LangChain's Message format if the chain
+        # is an AgentExecutor, as LangChainChatMessage might not be accepted by the chain
+        if isinstance(lc_model, AgentExecutor):
+            return request_json, False
+
         input_fields = APIRequest._get_lc_model_input_fields(lc_model)
         if "messages" in input_fields:
             # If the chain accepts a "messages" field directly, don't attempt to convert

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -338,6 +338,11 @@ class APIRequest:
     @staticmethod
     def _transform_request_json_for_chat_if_necessary(request_json, lc_model):
         """
+        Convert the input request JSON to LangChain's Message format if the LangChain model
+        accepts ChatMessage objects (e.g. AIMessage, HumanMessage, SystemMessage) as input.
+        # TODO: this function should identify if the lc_model accepts ChatMessage objects,
+        # and only converts if it does. ChatModels inputs should be converted.
+
         Returns:
             A 2-element tuple containing:
 

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -314,6 +314,7 @@ def _validate_and_prepare_lc_model_or_path(lc_model, loader_fn, temp_dir=None):
             type(lc_model.llm).__name__,
         )
 
+    # warn if the agent executor contains an unsupported LLM
     if (
         isinstance(lc_model, langchain.agents.agent.AgentExecutor)
         # 'RunnableMultiActionAgent' object has no attribute 'llm_chain'

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -287,6 +287,20 @@ def _get_supported_llms():
     return supported_llms
 
 
+def _agent_executor_contains_unsupported_llm(lc_model, _SUPPORTED_LLMS):
+    import langchain.agents.agent
+
+    return (
+        isinstance(lc_model, langchain.agents.agent.AgentExecutor)
+        # 'RunnableMultiActionAgent' object has no attribute 'llm_chain'
+        and hasattr(lc_model.agent, "llm_chain")
+        and not any(
+            isinstance(lc_model.agent.llm_chain.llm, supported_llm)
+            for supported_llm in _SUPPORTED_LLMS
+        )
+    )
+
+
 # temp_dir is only required when lc_model could be a file path
 def _validate_and_prepare_lc_model_or_path(lc_model, loader_fn, temp_dir=None):
     import langchain.agents.agent
@@ -314,16 +328,7 @@ def _validate_and_prepare_lc_model_or_path(lc_model, loader_fn, temp_dir=None):
             type(lc_model.llm).__name__,
         )
 
-    # warn if the agent executor contains an unsupported LLM
-    if (
-        isinstance(lc_model, langchain.agents.agent.AgentExecutor)
-        # 'RunnableMultiActionAgent' object has no attribute 'llm_chain'
-        and hasattr(lc_model.agent, "llm_chain")
-        and not any(
-            isinstance(lc_model.agent.llm_chain.llm, supported_llm)
-            for supported_llm in _SUPPORTED_LLMS
-        )
-    ):
+    if _agent_executor_contains_unsupported_llm(lc_model, _SUPPORTED_LLMS):
         logger.warning(
             _UNSUPPORTED_LLM_WARNING_MESSAGE,
             type(lc_model.agent.llm_chain.llm).__name__,

--- a/tests/langchain/agent_executor/chain.py
+++ b/tests/langchain/agent_executor/chain.py
@@ -1,0 +1,70 @@
+from operator import itemgetter
+from typing import Any, List, Optional
+
+from langchain.agents import AgentExecutor, tool
+from langchain.agents.output_parsers.tools import ToolsAgentOutputParser
+from langchain.callbacks.manager import CallbackManagerForLLMRun
+from langchain.chat_models.base import SimpleChatModel
+from langchain.prompts import PromptTemplate
+from langchain.schema.messages import BaseMessage
+from langchain.schema.runnable import RunnableLambda
+
+from mlflow.models import ModelConfig, set_model
+
+base_config = ModelConfig(development_config="tests/langchain/agent_executor/config.yml")
+
+prompt_with_history = PromptTemplate(
+    input_variables=["chat_history", "question"],
+    template=base_config.get("prompt_with_history_str"),
+)
+
+
+def extract_question(input):
+    return input[-1]["content"]
+
+
+def extract_history(input):
+    return input[:-1]
+
+
+@tool
+def custom_tool(query: str):
+    """
+    Mock a tool
+    """
+    return "Databricks"
+
+
+class FakeChatModel(SimpleChatModel):
+    """Fake Chat Model wrapper for testing purposes."""
+
+    endpoint_name: str = "fake-endpoint"
+
+    def _call(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        return "Databricks"
+
+    @property
+    def _llm_type(self) -> str:
+        return "fake chat model"
+
+
+fake_chat_model = FakeChatModel()
+llm_with_tools = fake_chat_model.bind(tools=[custom_tool])
+agent = (
+    {
+        "question": itemgetter("messages") | RunnableLambda(extract_question),
+        "chat_history": itemgetter("messages") | RunnableLambda(extract_history),
+    }
+    | prompt_with_history
+    | llm_with_tools
+    | ToolsAgentOutputParser()
+)
+
+model = AgentExecutor(agent=agent, tools=[custom_tool])
+set_model(model)

--- a/tests/langchain/agent_executor/config.yml
+++ b/tests/langchain/agent_executor/config.yml
@@ -1,0 +1,1 @@
+prompt_with_history_str: "Here is a history between you and a human: {chat_history}\nNow, please answer this question: {question}"

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3321,7 +3321,7 @@ def test_langchain_model_streamable_param_in_log_model_for_lc_runnable_types(
 
 
 @pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+    Version(langchain.__version__) < Version("0.1.20"), reason="feature not existing"
 )
 def test_agent_executor_model_with_messages_input():
     question = {"messages": [{"role": "user", "content": "Who owns MLflow?"}]}

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3320,6 +3320,9 @@ def test_langchain_model_streamable_param_in_log_model_for_lc_runnable_types(
         assert model_info.flavors["langchain"]["streamable"] is bool(streamable)
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
 def test_agent_executor_model_with_messages_input():
     question = {"messages": [{"role": "user", "content": "Who owns MLflow?"}]}
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12286?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12286/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12286
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix input data parsing for AgentExecutors. We don't convert it to ChatRequest format as some agents might not support those types. 


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
