### PR TITLE
Clean up `__pycache__` generated when loading model code

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -682,6 +682,8 @@ class Model:
                 artifact_path=artifact_path, run_id=run_id, metadata=metadata, resources=resources
             )
             flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
+            # `save_model` calls `load_model` to infer the model requirements, which may result in
+            # __pycache__ directories being created in the model directory.
             for pycache in Path(local_path).rglob("__pycache__"):
                 shutil.rmtree(pycache, ignore_errors=True)
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -682,6 +682,8 @@ class Model:
                 artifact_path=artifact_path, run_id=run_id, metadata=metadata, resources=resources
             )
             flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
+            for pycache in Path(local_path).rglob("__pycache__"):
+                shutil.rmtree(pycache, ignore_errors=True)
 
             # Copy model metadata files to a sub-directory 'metadata',
             # For UC sharing use-cases.

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1968,7 +1968,7 @@ def test_predict_as_code_with_config():
     assert loaded_model.predict(model_input) == expected_output
 
 
-def test_model_as_code_pycache_cleaned_up(tmp_path):
+def test_model_as_code_pycache_cleaned_up():
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(
             python_model="tests/pyfunc/sample_code/python_model.py",

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1976,4 +1976,4 @@ def test_model_as_code_pycache_cleaned_up(tmp_path):
         )
 
     path = _download_artifact_from_uri(model_info.model_uri)
-    assert not any(p.name == "__pycache__" for p in Path(path).rglob("*"))
+    assert list(Path(path).rglob("__pycache__")) == []

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1966,3 +1966,14 @@ def test_predict_as_code_with_config():
     model_input = "asdf"
     expected_output = f"This was the input: {model_input}, timeout 300"
     assert loaded_model.predict(model_input) == expected_output
+
+
+def test_model_as_code_pycache_cleaned_up(tmp_path):
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model="tests/pyfunc/sample_code/python_model.py",
+            artifact_path="model",
+        )
+
+    path = _download_artifact_from_uri(model_info.model_uri)
+    assert not any(p.name == "__pycache__" for p in Path(path).rglob("*"))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12288?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12288/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12288
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The following code fails on master because loading the model code in `log_model` generates `__pycache__`. This PR fixes it.

```python
def test_model_as_code_pycache_cleaned_up(tmp_path):
    with mlflow.start_run():
        model_info = mlflow.pyfunc.log_model(
            python_model="tests/pyfunc/sample_code/python_model.py",
            artifact_path="model",
        )

    path = _download_artifact_from_uri(model_info.model_uri)
    assert not any(p.name == "__pycache__" for p in Path(path).rglob("*"))
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
