### PR TITLE
Make dev/dev-env-setup.sh resumable for mandatory setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ ENV/
 env.bak/
 venv.bak/
 .python-version
+dev-env-setup-progress
 
 # Editor files
 .*project

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 
+# Progress file to resume the script from where it exited previously
+PROGRESS_FILE="$HOME/.dev-env-setup-progress"
+touch "$PROGRESS_FILE"
+
+save_progress() {
+  echo "$1" > "$PROGRESS_FILE"
+}
+
+load_progress() {
+  if [ -f "$PROGRESS_FILE" ]; then
+    cat "$PROGRESS_FILE"
+  else 
+    echo "0"
+  fi
+}
+
+PROGRESS=$(load_progress)
+
 showHelp() {
 cat << EOF
 Usage: ./install-dev-env.sh [-d] [directory to install virtual environment] [-v] [-q] [-f] [-o] [override python version]
@@ -339,17 +357,40 @@ set_pre_commit_and_git_signoff() {
 
 # Execute mandatory setups with strict error handling
 set +xv && set -e
+
 # Mandatory setups
-check_and_install_pyenv
-check_and_install_min_py_version
-create_virtualenv
-install_mlflow_and_dependencies
-set_pre_commit_and_git_signoff
+if [ "$PROGRESS" -lt "1" ]; then
+  check_and_install_pyenv
+  save_progress 1
+fi
+if [ "$PROGRESS" -lt "2" ]; then
+  check_and_install_min_py_version
+  save_progress 2
+fi
+if [ "$PROGRESS" -lt "3" ]; then
+  create_virtualenv
+  save_progress 3
+fi
+if [ "$PROGRESS" -lt "4" ]; then
+  install_mlflow_and_dependencies
+  save_progress 4
+fi
+if [ "$PROGRESS" -lt "5" ]; then
+  set_pre_commit_and_git_signoff
+  save_progress 5
+fi
 
 # Execute optional setups without strict error handling
 set +exv
+
 # Optional setups
-check_and_install_pandoc
-check_docker
+if [ "$PROGRESS" -lt "6" ]; then
+  check_and_install_pandoc
+  save_progress 6
+fi
+if [ "$PROGRESS" -lt "7" ]; then
+  check_docker
+  save_progress 7
+fi
 
 echo "$(tput setaf 2)Your MLflow development environment can be activated by running: $(tput bold)source $VENV_DIR$(tput sgr0)"

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
+directory="$(pwd)/.venvs/mlflow-dev"
+MLFLOW_HOME="$(pwd)"
+REPO_ROOT=$(git rev-parse --show-toplevel)
+rd="$REPO_ROOT/requirements"
+VENV_DIR="$directory/bin/activate"
 # Progress file to resume the script from where it exited previously
-PROGRESS_FILE="$MLFLOW_HOME/.mlflow-dev-env-setup-progress"
+PROGRESS_FILE="$MLFLOW_HOME/.dev-env-setup-progress"
 
 load_progress() {
   if [[ ! -f "$PROGRESS_FILE" ]]; then
@@ -61,11 +66,6 @@ This script will:
 EOF
 }
 
-directory="$(pwd)/.venvs/mlflow-dev"
-MLFLOW_HOME="$(pwd)"
-REPO_ROOT=$(git rev-parse --show-toplevel)
-rd="$REPO_ROOT/requirements"
-VENV_DIR="$directory/bin/activate"
 while :
 do
   case "$1" in

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Progress file to resume the script from where it exited previously
-PROGRESS_FILE="$HOME/.dev-env-setup-progress"
+PROGRESS_FILE="$MLFLOW_HOME/.mlflow-dev-env-setup-progress"
 
 load_progress() {
   if [[ ! -f "$PROGRESS_FILE" ]]; then
@@ -56,6 +56,8 @@ This script will:
 
 -o,     --override    Override the python version
 
+-r,     --restart     Discard the previous installation progress and restart the setup from scratch
+
 EOF
 }
 
@@ -86,6 +88,10 @@ do
     -h | --help)
       showHelp
       exit 0
+      ;;
+    -r | --restart)
+      rm $PROGRESS_FILE
+      shift
       ;;
     --)
       shift

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -2,21 +2,17 @@
 
 # Progress file to resume the script from where it exited previously
 PROGRESS_FILE="$HOME/.dev-env-setup-progress"
-touch "$PROGRESS_FILE"
 
 save_progress() {
-  echo "$1" > "$PROGRESS_FILE"
+  echo $1 > $PROGRESS_FILE
 }
 
 load_progress() {
-  if [ -f "$PROGRESS_FILE" ]; then
-    cat "$PROGRESS_FILE"
-  else 
-    echo "0"
+  if [ ! -f $PROGRESS_FILE ]; then
+    echo 0 > $PROGRESS_FILE
   fi
+  cat $PROGRESS_FILE
 }
-
-PROGRESS=$(load_progress)
 
 showHelp() {
 cat << EOF
@@ -355,42 +351,43 @@ set_pre_commit_and_git_signoff() {
   pre-commit install -t pre-commit -t prepare-commit-msg
 }
 
+PROGRESS=$(load_progress)
+
 # Execute mandatory setups with strict error handling
 set +xv && set -e
 
 # Mandatory setups
-if [ "$PROGRESS" -lt "1" ]; then
-  check_and_install_pyenv
-  save_progress 1
-fi
-if [ "$PROGRESS" -lt "2" ]; then
-  check_and_install_min_py_version
-  save_progress 2
-fi
-if [ "$PROGRESS" -lt "3" ]; then
-  create_virtualenv
-  save_progress 3
-fi
-if [ "$PROGRESS" -lt "4" ]; then
-  install_mlflow_and_dependencies
-  save_progress 4
-fi
-if [ "$PROGRESS" -lt "5" ]; then
-  set_pre_commit_and_git_signoff
-  save_progress 5
-fi
+case "$PROGRESS" in
+  0)
+    check_and_install_pyenv
+    save_progress 1
+    ;&
+  1)
+    check_and_install_min_py_version
+    save_progress 2
+    ;&
+  2)
+    create_virtualenv
+    save_progress 3
+    ;&
+  3)
+    install_mlflow_and_dependencies
+    save_progress 4
+    ;&
+  4)
+    set_pre_commit_and_git_signoff
+    save_progress 5
+    ;&
+  5)
+    # Clear progress file if all mandatory steps are executed successfully
+    rm $PROGRESS_FILE
+    ;;
+esac
 
 # Execute optional setups without strict error handling
 set +exv
-
 # Optional setups
-if [ "$PROGRESS" -lt "6" ]; then
-  check_and_install_pandoc
-  save_progress 6
-fi
-if [ "$PROGRESS" -lt "7" ]; then
-  check_docker
-  save_progress 7
-fi
+check_and_install_pandoc
+check_docker
 
 echo "$(tput setaf 2)Your MLflow development environment can be activated by running: $(tput bold)source $VENV_DIR$(tput sgr0)"

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -1,26 +1,12 @@
 #!/usr/bin/env bash
 
-directory="$(pwd)/.venvs/mlflow-dev"
 MLFLOW_HOME="$(pwd)"
+directory="$MLFLOW_HOME/.venvs/mlflow-dev"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 rd="$REPO_ROOT/requirements"
 VENV_DIR="$directory/bin/activate"
 # Progress file to resume the script from where it exited previously
-PROGRESS_FILE="$MLFLOW_HOME/.dev-env-setup-progress"
-
-load_progress() {
-  if [[ ! -f "$PROGRESS_FILE" ]]; then
-    echo "0" > "$PROGRESS_FILE"
-  fi
-  cat "$PROGRESS_FILE"
-}
-
-PROGRESS=$(load_progress)
-
-save_progress() {
-  echo "$1" > "$PROGRESS_FILE"
-  PROGRESS=$(load_progress)
-}
+PROGRESS_FILE="$MLFLOW_HOME/dev-env-setup-progress"
 
 showHelp() {
 cat << EOF
@@ -61,7 +47,7 @@ This script will:
 
 -o,     --override    Override the python version
 
--r,     --restart     Discard the previous installation progress and restart the setup from scratch
+-c,     --clean       Discard the previous installation progress and restart the setup from scratch
 
 EOF
 }
@@ -89,7 +75,7 @@ do
       showHelp
       exit 0
       ;;
-    -r | --restart)
+    -c | --clean)
       rm $PROGRESS_FILE
       shift
       ;;
@@ -117,6 +103,20 @@ case "$(uname -s)" in
   Linux*)                        machine=linux;;
   *)                             machine=unknown;;
 esac
+
+load_progress() {
+  if [[ ! -f "$PROGRESS_FILE" ]]; then
+    echo "0" > "$PROGRESS_FILE"
+  fi
+  cat "$PROGRESS_FILE"
+}
+
+PROGRESS=$(load_progress)
+
+save_progress() {
+  echo "$1" > "$PROGRESS_FILE"
+  PROGRESS=$(load_progress)
+}
 
 quiet_command(){
   echo $( [[ -n $quiet ]] && printf %s '-q' )

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -3,15 +3,18 @@
 # Progress file to resume the script from where it exited previously
 PROGRESS_FILE="$HOME/.dev-env-setup-progress"
 
-save_progress() {
-  echo $1 > $PROGRESS_FILE
+load_progress() {
+  if [[ ! -f "$PROGRESS_FILE" ]]; then
+    echo "0" > "$PROGRESS_FILE"
+  fi
+  cat "$PROGRESS_FILE"
 }
 
-load_progress() {
-  if [ ! -f $PROGRESS_FILE ]; then
-    echo 0 > $PROGRESS_FILE
-  fi
-  cat $PROGRESS_FILE
+PROGRESS=$(load_progress)
+
+save_progress() {
+  echo "$1" > "$PROGRESS_FILE"
+  PROGRESS=$(load_progress)
 }
 
 showHelp() {
@@ -351,38 +354,33 @@ set_pre_commit_and_git_signoff() {
   pre-commit install -t pre-commit -t prepare-commit-msg
 }
 
-PROGRESS=$(load_progress)
-
 # Execute mandatory setups with strict error handling
 set +xv && set -e
-
 # Mandatory setups
-case "$PROGRESS" in
-  0)
-    check_and_install_pyenv
-    save_progress 1
-    ;&
-  1)
-    check_and_install_min_py_version
-    save_progress 2
-    ;&
-  2)
-    create_virtualenv
-    save_progress 3
-    ;&
-  3)
-    install_mlflow_and_dependencies
-    save_progress 4
-    ;&
-  4)
-    set_pre_commit_and_git_signoff
-    save_progress 5
-    ;&
-  5)
-    # Clear progress file if all mandatory steps are executed successfully
-    rm $PROGRESS_FILE
-    ;;
-esac
+if [[ "$PROGRESS" -eq "0" ]]; then
+  check_and_install_pyenv
+  save_progress 1
+fi
+if [[ "$PROGRESS" -eq "1" ]]; then
+  check_and_install_min_py_version
+  save_progress 2
+fi
+if [[ "$PROGRESS" -eq "2" ]]; then
+  create_virtualenv
+  save_progress 3
+fi
+if [[ "$PROGRESS" -eq "3" ]]; then
+  install_mlflow_and_dependencies
+  save_progress 4
+fi
+if [[ "$PROGRESS" -eq "4" ]]; then
+  set_pre_commit_and_git_signoff
+  save_progress 5
+fi
+if [[ "$PROGRESS" -eq "5" ]]; then
+  # Clear progress file if all mandatory steps are executed successfully
+  rm $PROGRESS_FILE
+fi
 
 # Execute optional setups without strict error handling
 set +exv


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/xq-yin/mlflow/pull/12289?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12289/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12289
```

</p>
</details>

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
See context from the previous [PR](https://github.com/mlflow/mlflow/pull/12253). This PR introduces the change to checkpoint the progress to a local file and resume the script from where it errored out previously for MANDATORY steps only.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Passed pytest tests/tracking/test_client.py tests/tracking/test_rest_tracking.py 
Passed pre-commit run --all-files

Ran dev/dev-env-setup.sh -d .venvs/mlflow-dev -q  and made it fail the mandatory dependency tensorflow-cpu version
<img width="1623" alt="Screenshot 2024-06-07 at 3 00 01 PM" src="https://github.com/mlflow/mlflow/assets/171547006/1ec2167f-bba1-4497-8f82-8aacc2c30995">
re-run the script again, verified the script resume from the dependency step directly 
also printed out + checked the local progress file to ensure the index bumps correctly

verified the progress file is removed once the script runs successfully (meaning all mandatory steps passed) - so re-run the script will install everything all over again
[UPDATE]
verified that adding -c option will clean up the progress and restart the setup
<img width="1013" alt="image" src="https://github.com/mlflow/mlflow/assets/171547006/93e9bed9-873d-4028-a0b2-b2ccef603cc0">


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
