### PR TITLE
Fix `test_spark_udf_spark_connect`

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2071,6 +2071,8 @@ Compound types:
                         tempfile.gettempdir(),
                         "mlflow",
                         insecure_hash.sha1(model_uri.encode()).hexdigest(),
+                        # Use pid to avoid conflict when multiple spark UDF tasks
+                        str(os.getpid()),
                     )
                     try:
                         loaded_model = mlflow.pyfunc.load_model(model_path)

--- a/tests/pyfunc/test_spark_connect.py
+++ b/tests/pyfunc/test_spark_connect.py
@@ -24,12 +24,14 @@ def spark():
     spark.stop()
 
 
-def test_spark_udf_spark_connect(spark, tmp_path):
+@pytest.mark.parametrize("x", range(100))
+def test_spark_udf_spark_connect(x, spark):
     X, y = load_iris(return_X_y=True)
     model = LogisticRegression().fit(X, y)
-    mlflow.sklearn.save_model(model, tmp_path)
+    with mlflow.start_run():
+        info = mlflow.sklearn.log_model(model, "model")
     sdf = spark.createDataFrame(pd.DataFrame(X, columns=list("abcd")))
-    udf = mlflow.pyfunc.spark_udf(spark, str(tmp_path), env_manager="local")
+    udf = mlflow.pyfunc.spark_udf(spark, info.model_uri, env_manager="local")
     result = sdf.select(udf(*sdf.columns).alias("preds")).toPandas()
     np.testing.assert_almost_equal(result["preds"].to_numpy(), model.predict(X))
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12291?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12291/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12291
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow/mlflow/actions/runs/9413544522/job/25930511211

```
  An exception was thrown from the Python worker. Please see the stack trace below.
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/mlflow/pyfunc/__init__.py", line 2108, in udf
    os.kill(scoring_server_proc.pid, signal.SIGTERM)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/tracing/provider.py", line 255, in wrapper
    return f(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/pyfunc/__init__.py", line 1032, in load_model
    _clear_dependencies_schemas()
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/sklearn/__init__.py", line 494, in _load_pyfunc
    pyfunc_flavor_conf = _get_flavor_configuration(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/utils/model_utils.py", line 63, in _get_flavor_configuration
    raise MlflowException(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/models/model.py", line 614, in load
    return cls.from_dict(yaml.safe_load(f.read()))
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/models/model.py", line 622, in from_dict
    model_dict = model_dict.copy()
AttributeError: 'NoneType' object has no attribute 'copy'
```

https://github.com/mlflow/mlflow/actions/runs/9413095217/job/25929173931?pr=12288

```
FAILED | MEM 1.9/15.6 GB | DISK 44.8/72.5 GB tests/pyfunc/test_spark_connect.py::test_spark_udf_spark_connect - pyspark.errors.exceptions.connect.PythonException: 
  An exception was thrown from the Python worker. Please see the stack trace below.
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/mlflow/pyfunc/__init__.py", line 2108, in udf
    os.kill(scoring_server_proc.pid, signal.SIGTERM)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/tracing/provider.py", line 255, in wrapper
    return f(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/pyfunc/__init__.py", line 979, in load_model
    local_path = _download_artifact_from_uri(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/tracking/artifact_utils.py", line 116, in _download_artifact_from_uri
    return repo.download_artifacts(artifact_path=artifact_path, dst_path=output_path)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/store/artifact/local_artifact_repo.py", line 85, in download_artifacts
    return super().download_artifacts(artifact_path, dst_path)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/store/artifact/artifact_repo.py", line 274, in download_artifacts
    raise MlflowException(
mlflow.exceptions.MlflowException: The following failures occurred while downloading one or more artifacts from /tmp/pytest-of-runner/pytest-1:
##### File test_spark_udf_spark_connect0/69572efd70e24a679784e3f51de9386c.sqlite-journal #####
[Errno 2] No such file or directory: '/tmp/pytest-of-runner/pytest-1/test_spark_udf_spark_connect0/69572efd70e24a679784e3f51de9386c.sqlite-journal'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
