### PR TITLE
Update ChatModel response with defaults

### DIFF
--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -228,7 +228,7 @@ class ChatChoice(_BaseDataclass):
 
     index: int
     message: ChatMessage
-    finish_reason: str
+    finish_reason: str = "stop"
     logprobs: Optional[ChatChoiceLogProbs] = None
 
     def __post_init__(self):
@@ -259,14 +259,14 @@ class TokenUsageStats(_BaseDataclass):
         total_tokens (int): The total number of tokens used.
     """
 
-    prompt_tokens: int
-    completion_tokens: int
-    total_tokens: int
+    prompt_tokens: int = None
+    completion_tokens: int = None
+    total_tokens: int = None
 
     def __post_init__(self):
-        self._validate_field("prompt_tokens", int, True)
-        self._validate_field("completion_tokens", int, True)
-        self._validate_field("total_tokens", int, True)
+        self._validate_field("prompt_tokens", int, False)
+        self._validate_field("completion_tokens", int, False)
+        self._validate_field("total_tokens", int, False)
 
 
 @dataclass
@@ -285,18 +285,18 @@ class ChatResponse(_BaseDataclass):
             **Optional**, defaults to the current time.
     """
 
-    id: str
-    model: str
+    id: str = None
+    model: str = None
     choices: List[ChatChoice]
     usage: TokenUsageStats
     object: Literal["chat.completion"] = "chat.completion"
     created: int = field(default_factory=lambda: int(time.time()))
 
     def __post_init__(self):
-        self._validate_field("id", str, True)
+        self._validate_field("id", str, False)
         self._validate_field("object", str, True)
         self._validate_field("created", int, True)
-        self._validate_field("model", str, True)
+        self._validate_field("model", str, False)
         self._convert_dataclass_list("choices", ChatChoice)
         if isinstance(self.usage, dict):
             self.usage = TokenUsageStats(**self.usage)

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -285,10 +285,10 @@ class ChatResponse(_BaseDataclass):
             **Optional**, defaults to the current time.
     """
 
-    id: str = None
-    model: str = None
     choices: List[ChatChoice]
     usage: TokenUsageStats
+    id: str = None
+    model: str = None
     object: Literal["chat.completion"] = "chat.completion"
     created: int = field(default_factory=lambda: int(time.time()))
 

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -223,6 +223,7 @@ class ChatChoice(_BaseDataclass):
         index (int): The index of the response in the list of responses.
         message (:py:class:`ChatMessage`): The message that was generated.
         finish_reason (str): The reason why generation stopped.
+            **Optional**, defaults to ``"stop"``
         logprobs (:py:class:`ChatChoiceLogProbs`): Log probability information for the choice.
     """
 
@@ -255,13 +256,16 @@ class TokenUsageStats(_BaseDataclass):
 
     Args:
         prompt_tokens (int): The number of tokens in the prompt.
+            **Optional**, defaults to ``None``
         completion_tokens (int): The number of tokens in the generated completion.
+            **Optional**, defaults to ``None``
         total_tokens (int): The total number of tokens used.
+            **Optional**, defaults to ``None``
     """
 
-    prompt_tokens: int = None
-    completion_tokens: int = None
-    total_tokens: int = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
 
     def __post_init__(self):
         self._validate_field("prompt_tokens", int, False)
@@ -275,11 +279,11 @@ class ChatResponse(_BaseDataclass):
     The full response object returned by the chat endpoint.
 
     Args:
-        id (str): The ID of the response.
-        model (str): The name of the model used.
         choices (List[:py:class:`ChatChoice`]): A list of :py:class:`ChatChoice` objects
             containing the generated responses
         usage (:py:class:`TokenUsageStats`): An object describing the tokens used by the request.
+        id (str): The ID of the response. **Optional**, defaults to ``None``
+        model (str): The name of the model used. **Optional**, defaults to ``None``
         object (str): The object type. The value should always be 'chat.completion'
         created (int): The time the response was created.
             **Optional**, defaults to the current time.
@@ -287,8 +291,8 @@ class ChatResponse(_BaseDataclass):
 
     choices: List[ChatChoice]
     usage: TokenUsageStats
-    id: str = None
-    model: str = None
+    id: Optional[str] = None
+    model: Optional[str] = None
     object: Literal["chat.completion"] = "chat.completion"
     created: int = field(default_factory=lambda: int(time.time()))
 

--- a/tests/pyfunc/test_chat_model_validation.py
+++ b/tests/pyfunc/test_chat_model_validation.py
@@ -168,3 +168,17 @@ def test_to_dict_converts_nested_dataclasses(sample_output):
 def test_to_dict_excludes_nones():
     response = ChatResponse(**MOCK_RESPONSE).to_dict()
     assert "name" not in response["choices"][0]["message"]
+
+
+def test_chat_response_defaults():
+    tokens = TokenUsageStats()
+    message = ChatMessage("user", "Hello")
+    choice = ChatChoice(0, message)
+    response = ChatResponse([choice], tokens)
+
+    assert response.usage.prompt_tokens is None
+    assert response.usage.completion_tokens is None
+    assert response.usage.total_tokens is None
+    assert response.model is None
+    assert response.id is None
+    assert response.choices[0].finish_reason == "stop"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/12298?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12298/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12298
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Addressing recent feedback that ChatModel responses contain required fields that users might not be able to fill out. This PR updates the types with the suggested defaults.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
