### PR TITLE
Fix docstring order for ChatResponse class and make object field immutable

### DIFF
--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -311,6 +311,7 @@ class ChatResponse(_BaseDataclass):
             raise AttributeError("object must be 'chat.completion'")
         return super().__setattr__(name, value)
 
+
 CHAT_MODEL_INPUT_SCHEMA = Schema(
     [
         ColSpec(

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -292,7 +292,7 @@ class ChatResponse(_BaseDataclass):
     object: Literal["chat.completion"] = "chat.completion"
     created: int = field(default_factory=lambda: int(time.time()))
     # A temporary hack to disallow users to overwrite 'object' field during runtime
-    # Revisit the solution after we move to pydantic
+    # TODO: Revisit the solution after we move to pydantic
     _object: str = field(init=False)
 
     def __post_init__(self):
@@ -314,8 +314,8 @@ class ChatResponse(_BaseDataclass):
 
     @object.setter
     def object(self, value: str):
-        if hasattr(self, '_object'):
-            raise ValueError("Cannot modify 'object' after initialization")
+        if hasattr(self, "_object"):
+            raise ValueError("Cannot modify 'object' field")
         self._object = value
 
 

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -276,13 +276,13 @@ class ChatResponse(_BaseDataclass):
 
     Args:
         id (str): The ID of the response.
-        object (str): The object type.
-        created (int): The time the response was created.
-            **Optional**, defaults to the current time.
         model (str): The name of the model used.
         choices (List[:py:class:`ChatChoice`]): A list of :py:class:`ChatChoice` objects
             containing the generated responses
         usage (:py:class:`TokenUsageStats`): An object describing the tokens used by the request.
+        object (str): The object type.
+        created (int): The time the response was created.
+            **Optional**, defaults to the current time.
     """
 
     id: str

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -308,7 +308,7 @@ class ChatResponse(_BaseDataclass):
     def __setattr__(self, name, value):
         # A hack to ensure users cannot overwrite 'object' field
         if name == "object" and value != "chat.completion":
-            raise AttributeError("object must be 'chat.completion'")
+            raise ValueError("`object` field must be 'chat.completion'")
         return super().__setattr__(name, value)
 
 

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import asdict, dataclass, field
-from typing import List, Literal, Optional
+from typing import List, Optional
 
 from mlflow.types.schema import Array, ColSpec, DataType, Object, Property, Schema
 
@@ -280,7 +280,7 @@ class ChatResponse(_BaseDataclass):
         choices (List[:py:class:`ChatChoice`]): A list of :py:class:`ChatChoice` objects
             containing the generated responses
         usage (:py:class:`TokenUsageStats`): An object describing the tokens used by the request.
-        object (str): The object type.
+        _object (str): The object type. The value should always be 'chat.completion'
         created (int): The time the response was created.
             **Optional**, defaults to the current time.
     """
@@ -289,7 +289,6 @@ class ChatResponse(_BaseDataclass):
     model: str
     choices: List[ChatChoice]
     usage: TokenUsageStats
-    # object: Literal["chat.completion"] = "chat.completion"
     _object: str = field(init=False, repr=False, default="chat.completion")
     created: int = field(default_factory=lambda: int(time.time()))
 
@@ -309,14 +308,6 @@ class ChatResponse(_BaseDataclass):
             raise ValueError(
                 f"Expected `usage` to be of type TokenUsageStats or dict, got {type(self.usage)}"
             )
-
-    '''
-    def __setattr__(self, name, value):
-        # A hack to ensure users cannot overwrite 'object' field
-        if name == "object" and value != "chat.completion":
-            raise AttributeError("object must be 'chat.completion'")
-        return super().__setattr__(name, value)
-    '''
 
 
 CHAT_MODEL_INPUT_SCHEMA = Schema(

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -315,7 +315,7 @@ class ChatResponse(_BaseDataclass):
     @object.setter
     def object(self, value: str):
         if hasattr(self, "_object"):
-            raise ValueError("Cannot modify 'object' field")
+            raise AttributeError("Cannot modify 'object' field")
         self._object = value
 
 

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -289,12 +289,17 @@ class ChatResponse(_BaseDataclass):
     model: str
     choices: List[ChatChoice]
     usage: TokenUsageStats
-    object: Literal["chat.completion"] = "chat.completion"
+    # object: Literal["chat.completion"] = "chat.completion"
+    _object: str = field(init=False, repr=False, default="chat.completion")
     created: int = field(default_factory=lambda: int(time.time()))
+
+    @property
+    def object(self):
+        return self._object
 
     def __post_init__(self):
         self._validate_field("id", str, True)
-        self._validate_field("object", str, True)
+        self._validate_field("_object", str, True)
         self._validate_field("created", int, True)
         self._validate_field("model", str, True)
         self._convert_dataclass_list("choices", ChatChoice)
@@ -305,11 +310,13 @@ class ChatResponse(_BaseDataclass):
                 f"Expected `usage` to be of type TokenUsageStats or dict, got {type(self.usage)}"
             )
 
+    '''
     def __setattr__(self, name, value):
         # A hack to ensure users cannot overwrite 'object' field
         if name == "object" and value != "chat.completion":
             raise AttributeError("object must be 'chat.completion'")
         return super().__setattr__(name, value)
+    '''
 
 
 CHAT_MODEL_INPUT_SCHEMA = Schema(

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -380,3 +380,15 @@ def test_chat_model_predict_stream(tmp_path):
 
     response = next(loaded_model.predict_stream({"messages": messages}))
     assert response["choices"][0]["message"]["content"] == json.dumps(messages)
+
+
+# test that users cannot overwrite the 'object' field in ChatResponse
+def test_chat_model_response_cannot_overwrite_object():
+    message = ChatMessage(role="user", content="Hello!")
+    params = ChatParams(**DEFAULT_PARAMS)
+    mock_response = get_mock_response([message], params)
+
+    response = ChatResponse(**mock_response)
+    assert response.object == "chat.completion"
+    with pytest.raises(AttributeError, match="object must be 'chat.completion'"):
+        response.object = "other"

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -390,5 +390,5 @@ def test_chat_model_response_cannot_overwrite_object():
 
     response = ChatResponse(**mock_response)
     assert response.object == "chat.completion"
-    with pytest.raises(AttributeError, match="object must be 'chat.completion'"):
+    with pytest.raises(AttributeError, match="can't set attribute"):
         response.object = "other"

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -391,12 +391,17 @@ def test_chat_model_response_cannot_overwrite_object():
     # test initialization without setting the property 'object'
     response = ChatResponse(**mock_response)
     assert response.object == "chat.completion"
-    with pytest.raises(AttributeError, match="object must be 'chat.completion'"):
+    with pytest.raises(ValueError, match="`object` field must be 'chat.completion'"):
         response.object = "other"
 
-    # test to set the property 'object' when initializing ChatResponse
+    # test to set correct value for 'object' when initializing ChatResponse
     mock_response["object"] = "chat.completion"
     response = ChatResponse(**mock_response)
     assert response.object == "chat.completion"
-    with pytest.raises(AttributeError, match="object must be 'chat.completion'"):
+    with pytest.raises(ValueError, match="`object` field must be 'chat.completion'"):
         response.object = "other"
+
+    # test to set incorrect value for 'object' when initializing ChatResponse
+    mock_response["object"] = "invalid.value"
+    with pytest.raises(ValueError, match="`object` field must be 'chat.completion'"):
+        response = ChatResponse(**mock_response)

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -388,7 +388,15 @@ def test_chat_model_response_cannot_overwrite_object():
     params = ChatParams(**DEFAULT_PARAMS)
     mock_response = get_mock_response([message], params)
 
+    # test initialization without setting the property 'object'
     response = ChatResponse(**mock_response)
     assert response.object == "chat.completion"
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError, match="object must be 'chat.completion'"):
+        response.object = "other"
+
+    # test to set the property 'object' when initializing ChatResponse
+    mock_response["object"] = "chat.completion"
+    response = ChatResponse(**mock_response)
+    assert response.object == "chat.completion"
+    with pytest.raises(AttributeError, match="object must be 'chat.completion'"):
         response.object = "other"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/xq-yin/mlflow/pull/12305?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12305/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12305
```

</p>
</details>

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
[ChatResponse](https://github.com/mlflow/mlflow/blob/62be195b529a88e11ffec1aca720d86399e0e488/mlflow/types/llm.py#L186) is a pydantic class that defines a schema for OpenAI-compatible chat request/response. Currently, there are two small issues in this class:
1. The order of parameters in the docstring does not match with the actual order.
2. Object field should always be "chat.completion" to be compatible with OpenAI. But current implementation allows users to overwrite the value during runtime

This PR fixes these two issues

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Existing unit test: pytest tests/pyfunc/test_chat_model.py
Added a new test case: pytest tests/pyfunc/test_chat_model.py::test_chat_model_response_cannot_overwrite_object
Manually test that error will be raised if users try to overwrite the field in notebook
<img width="1109" alt="image" src="https://github.com/mlflow/mlflow/assets/171547006/a024b2ce-990d-478d-b9c7-518b531aac66">

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
