### PR TITLE
Skip conversational tests for transformers dev

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1494,12 +1494,16 @@ def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
 
 
 def _try_import_conversational_pipeline():
-    import transformers
+    """
+    Try importing ConversationalPipeline because for version > 4.41.2
+    it is removed from the transformers package.
+    """
+    try:
+        from transformers import ConversationalPipeline
 
-    if Version(transformers.__version__) > Version("4.41.2"):
+        return ConversationalPipeline
+    except ImportError:
         return
-
-    return transformers.ConversationalPipeline
 
 
 @experimental

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1784,9 +1784,7 @@ class _TransformersWrapper:
         data = self._convert_cast_lists_from_np_back_to_list(data)
 
         # Generate inference data with the pipeline object
-        if (conversational_pipeline := _try_import_conversational_pipeline()) and isinstance(
-            self.pipeline, conversational_pipeline
-        ):
+        if (cp := _try_import_conversational_pipeline()) and isinstance(self.pipeline, cp):
             conversation_output = self.pipeline(self._conversation)
             return conversation_output.generated_responses[-1]
         else:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1493,6 +1493,15 @@ def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
     )
 
 
+def _try_import_conversational_pipeline():
+    import transformers
+
+    if Version(transformers.__version__) > Version("4.41.2"):
+        return
+
+    return transformers.ConversationalPipeline
+
+
 @experimental
 def generate_signature_output(pipeline, data, model_config=None, params=None, flavor_config=None):
     """
@@ -1733,9 +1742,12 @@ class _TransformersWrapper:
             output_key = None
             data = self._parse_feature_extraction_input(data)
             data = self._format_prompt_template(data)
-        elif isinstance(self.pipeline, transformers.ConversationalPipeline):
+        elif (conversational_pipeline := _try_import_conversational_pipeline()) and isinstance(
+            self.pipeline, conversational_pipeline
+        ):
             output_key = None
             if not self._conversation:
+                # this import is valid if conversational_pipeline is not None
                 self._conversation = transformers.Conversation()
             self._conversation.add_user_input(data)
         elif type(self.pipeline).__name__ in self._supported_custom_generator_types:
@@ -1768,7 +1780,9 @@ class _TransformersWrapper:
         data = self._convert_cast_lists_from_np_back_to_list(data)
 
         # Generate inference data with the pipeline object
-        if isinstance(self.pipeline, transformers.ConversationalPipeline):
+        if (conversational_pipeline := _try_import_conversational_pipeline()) and isinstance(
+            self.pipeline, conversational_pipeline
+        ):
             conversation_output = self.pipeline(self._conversation)
             return conversation_output.generated_responses[-1]
         else:
@@ -1988,10 +2002,12 @@ class _TransformersWrapper:
             )
 
     def _parse_conversation_input(self, data):
-        import transformers
+        conversational_pipeline = _try_import_conversational_pipeline()
 
-        if not isinstance(self.pipeline, transformers.ConversationalPipeline) or isinstance(
-            data, str
+        if (
+            not conversational_pipeline
+            or not isinstance(self.pipeline, conversational_pipeline)
+            or isinstance(data, str)
         ):
             return data
         elif isinstance(data, list) and all(isinstance(elem, dict) for elem in data):

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -118,6 +118,9 @@ def load_component_multi_modal():
 @prefetch
 @flaky()
 def load_small_conversational_model():
+    # Conversational model is deprecated and removed
+    if Version(transformers.__version__) > Version("4.41.2"):
+        return
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         "microsoft/DialoGPT-small", low_cpu_mem_usage=True
     )
@@ -229,6 +232,9 @@ def load_ner_pipeline_aggregation():
 @prefetch
 @flaky()
 def load_conversational_pipeline():
+    # Conversational model is deprecated and removed
+    if Version(transformers.__version__) > Version("4.41.2"):
+        return
     return transformers.pipeline(
         model="AVeryRealHuman/DialoGPT-small-TonyStark", task="conversational"
     )

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -7,7 +7,7 @@ from functools import wraps
 import transformers
 from packaging.version import Version
 
-from mlflow.transformers import _PEFT_PIPELINE_ERROR_MSG
+from mlflow.transformers import _PEFT_PIPELINE_ERROR_MSG, _try_import_conversational_pipeline
 from mlflow.utils.logging_utils import suppress_logs
 
 _logger = logging.getLogger(__name__)
@@ -118,16 +118,14 @@ def load_component_multi_modal():
 @prefetch
 @flaky()
 def load_small_conversational_model():
-    # Conversational model is deprecated and removed
-    if Version(transformers.__version__) > Version("4.41.2"):
-        return
-    tokenizer = transformers.AutoTokenizer.from_pretrained(
-        "microsoft/DialoGPT-small", low_cpu_mem_usage=True
-    )
-    model = transformers.AutoModelWithLMHead.from_pretrained(
-        "satvikag/chatbot", low_cpu_mem_usage=True
-    )
-    return transformers.pipeline(task="conversational", model=model, tokenizer=tokenizer)
+    if _try_import_conversational_pipeline():
+        tokenizer = transformers.AutoTokenizer.from_pretrained(
+            "microsoft/DialoGPT-small", low_cpu_mem_usage=True
+        )
+        model = transformers.AutoModelWithLMHead.from_pretrained(
+            "satvikag/chatbot", low_cpu_mem_usage=True
+        )
+        return transformers.pipeline(task="conversational", model=model, tokenizer=tokenizer)
 
 
 @prefetch
@@ -232,12 +230,10 @@ def load_ner_pipeline_aggregation():
 @prefetch
 @flaky()
 def load_conversational_pipeline():
-    # Conversational model is deprecated and removed
-    if Version(transformers.__version__) > Version("4.41.2"):
-        return
-    return transformers.pipeline(
-        model="AVeryRealHuman/DialoGPT-small-TonyStark", task="conversational"
-    )
+    if _try_import_conversational_pipeline():
+        return transformers.pipeline(
+            model="AVeryRealHuman/DialoGPT-small-TonyStark", task="conversational"
+        )
 
 
 @prefetch

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -39,6 +39,7 @@ from mlflow.transformers import (
     _is_model_distributed_in_memory,
     _should_add_pyfunc_to_model,
     _TransformersWrapper,
+    _try_import_conversational_pipeline,
     _validate_llm_inference_task_type,
     _write_card_data,
     _write_license_information,
@@ -862,7 +863,7 @@ def test_huggingface_hub_not_installed(small_seq2seq_pipeline, model_path):
 
 
 @pytest.mark.skipif(
-    Version(transformers.__version__) > Version("4.41.2"),
+    _try_import_conversational_pipeline() is None,
     reason="Conversation model is deprecated and removed.",
 )
 def test_save_pipeline_without_defined_components(small_conversational_model, model_path):
@@ -1615,7 +1616,7 @@ def test_ner_pipeline(pipeline_name, model_path, data, result, request):
 
 
 @pytest.mark.skipif(
-    Version(transformers.__version__) > Version("4.41.2"),
+    _try_import_conversational_pipeline() is None,
     reason="Conversation model is deprecated and removed.",
 )
 def test_conversational_pipeline(conversational_pipeline, model_path):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -861,6 +861,10 @@ def test_huggingface_hub_not_installed(small_seq2seq_pipeline, model_path):
         assert license_data.rstrip().endswith("mobilebert")
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__) > Version("4.41.2"),
+    reason="Conversation model is deprecated and removed.",
+)
 def test_save_pipeline_without_defined_components(small_conversational_model, model_path):
     # This pipeline type explicitly does not have a configuration for an image_processor
     with mlflow.start_run():
@@ -1610,6 +1614,10 @@ def test_ner_pipeline(pipeline_name, model_path, data, result, request):
     assert pd_inference == result
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__) > Version("4.41.2"),
+    reason="Conversation model is deprecated and removed.",
+)
 def test_conversational_pipeline(conversational_pipeline, model_path):
     signature = infer_signature(
         "Hi there!",

--- a/tests/transformers/test_transformers_signature.py
+++ b/tests/transformers/test_transformers_signature.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from mlflow.models.signature import ModelSignature
+from mlflow.transformers import _try_import_conversational_pipeline
 from mlflow.transformers.signature import (
     _TEXT2TEXT_SIGNATURE,
     format_input_example_for_special_cases,
@@ -137,6 +138,8 @@ from mlflow.types.schema import ColSpec, DataType, Schema
     ],
 )
 def test_signature_inference(pipeline_name, example, expected_signature, request):
+    if pipeline_name == "conversational_pipeline" and _try_import_conversational_pipeline() is None:
+        return
     pipeline = request.getfixturevalue(pipeline_name)
 
     default_signature = infer_or_get_default_signature(pipeline)

--- a/tests/transformers/test_transformers_signature.py
+++ b/tests/transformers/test_transformers_signature.py
@@ -139,7 +139,7 @@ from mlflow.types.schema import ColSpec, DataType, Schema
 )
 def test_signature_inference(pipeline_name, example, expected_signature, request):
     if pipeline_name == "conversational_pipeline" and _try_import_conversational_pipeline() is None:
-        return
+        pytest.skip("Conversation model is deprecated and removed.")
     pipeline = request.getfixturevalue(pipeline_name)
 
     default_signature = infer_or_get_default_signature(pipeline)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12310?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12310/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12310
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
https://github.com/huggingface/transformers/pull/31165 
Transformers is removing Conversational models in the dev version, so we skip the test if it doesn't exist. 
Updated transformers flavor to try importing the module.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
