### PR TITLE
Gate model metadata copy for UC sharing to only Databricks env

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -87,6 +87,11 @@ When logging a model, model metadata files (``MLmodel``, ``conda.yaml``, ``pytho
     This file contains the name and version of the model referenced in the MLflow Model Registry,
     and will be used for deployment and other purposes.
 
+.. attention::
+
+    If you log a model within Databricks, MLflow also creates a ``metadata`` subdirectory within
+    the model directory. This subdirectory contains the lightweight copy of aforementioned
+    metadata files for internal use.
 
 .. toctree::
     :maxdepth: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,3 +184,11 @@ def tmp_sqlite_uri(tmp_path):
 def mock_databricks_serving_with_tracing_env(monkeypatch):
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("ENABLE_MLFLOW_TRACING", "true")
+
+
+@pytest.fixture(params=[True, False])
+def mock_is_in_databricks(request):
+    with mock.patch(
+        "mlflow.models.model.is_in_databricks_runtime", return_value=request.param
+    ) as mock_databricks:
+        yield mock_databricks

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3840,51 +3840,44 @@ def test_persist_pretrained_model(mock_tmpdir, small_seq2seq_pipeline):
     mock_tmpdir.assert_not_called()
 
 
-@pytest.mark.parametrize("is_in_databricks", [True, False])
 def test_small_qa_pipeline_copy_metadata_in_databricks(
-    is_in_databricks, small_qa_pipeline, tmp_path
+    mock_is_in_databricks, small_qa_pipeline, tmp_path
 ):
     artifact_path = "transformers"
-
     with mlflow.start_run():
-        with mock.patch(
-            "mlflow.models.model.is_in_databricks_runtime", return_value=is_in_databricks
-        ):
-            model_info = mlflow.transformers.log_model(
-                transformers_model=small_qa_pipeline,
-                artifact_path=artifact_path,
-            )
-        artifact_path = mlflow.artifacts.download_artifacts(
-            artifact_uri=model_info.model_uri, dst_path=tmp_path.as_posix()
+        model_info = mlflow.transformers.log_model(
+            transformers_model=small_qa_pipeline,
+            artifact_path=artifact_path,
         )
+    artifact_path = mlflow.artifacts.download_artifacts(
+        artifact_uri=model_info.model_uri, dst_path=tmp_path.as_posix()
+    )
 
-        # Metadata should be copied only in Databricks
-        metadata_path = os.path.join(artifact_path, "metadata")
-        if is_in_databricks:
-            assert set(os.listdir(metadata_path)) == set(METADATA_FILES)
-        else:
-            assert not os.path.exists(metadata_path)
+    # Metadata should be copied only in Databricks
+    metadata_path = os.path.join(artifact_path, "metadata")
+    if mock_is_in_databricks.return_value:
+        assert set(os.listdir(metadata_path)) == set(METADATA_FILES)
+    else:
+        assert not os.path.exists(metadata_path)
+    mock_is_in_databricks.assert_called_once()
 
 
-@pytest.mark.parametrize("is_in_databricks", [True, False])
-def test_peft_pipeline_copy_metadata_in_databricks(is_in_databricks, peft_pipeline, tmp_path):
+def test_peft_pipeline_copy_metadata_in_databricks(mock_is_in_databricks, peft_pipeline, tmp_path):
     artifact_path = "transformers"
-
     with mlflow.start_run():
-        with mock.patch(
-            "mlflow.models.model.is_in_databricks_runtime", return_value=is_in_databricks
-        ):
-            model_info = mlflow.transformers.log_model(
-                transformers_model=peft_pipeline,
-                artifact_path=artifact_path,
-            )
-        artifact_path = mlflow.artifacts.download_artifacts(
-            artifact_uri=model_info.model_uri, dst_path=tmp_path.as_posix()
+        model_info = mlflow.transformers.log_model(
+            transformers_model=peft_pipeline,
+            artifact_path=artifact_path,
         )
 
-        # Metadata should be copied only in Databricks
-        metadata_path = os.path.join(artifact_path, "metadata")
-        if is_in_databricks:
-            assert set(os.listdir(metadata_path)) == set(METADATA_FILES)
-        else:
-            assert not os.path.exists(metadata_path)
+    artifact_path = mlflow.artifacts.download_artifacts(
+        artifact_uri=model_info.model_uri, dst_path=tmp_path.as_posix()
+    )
+
+    # Metadata should be copied only in Databricks
+    metadata_path = os.path.join(artifact_path, "metadata")
+    if mock_is_in_databricks.return_value:
+        assert set(os.listdir(metadata_path)) == set(METADATA_FILES)
+    else:
+        assert not os.path.exists(metadata_path)
+    mock_is_in_databricks.assert_called_once()

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3840,29 +3840,51 @@ def test_persist_pretrained_model(mock_tmpdir, small_seq2seq_pipeline):
     mock_tmpdir.assert_not_called()
 
 
-def test_small_qa_pipeline_copy_metadata(small_qa_pipeline, tmp_path):
+@pytest.mark.parametrize("is_in_databricks", [True, False])
+def test_small_qa_pipeline_copy_metadata_in_databricks(
+    is_in_databricks, small_qa_pipeline, tmp_path
+):
     artifact_path = "transformers"
 
     with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=small_qa_pipeline,
-            artifact_path=artifact_path,
-        )
+        with mock.patch(
+            "mlflow.models.model.is_in_databricks_runtime", return_value=is_in_databricks
+        ):
+            model_info = mlflow.transformers.log_model(
+                transformers_model=small_qa_pipeline,
+                artifact_path=artifact_path,
+            )
         artifact_path = mlflow.artifacts.download_artifacts(
             artifact_uri=model_info.model_uri, dst_path=tmp_path.as_posix()
         )
-        assert set(os.listdir(os.path.join(artifact_path, "metadata"))) == set(METADATA_FILES)
+
+        # Metadata should be copied only in Databricks
+        metadata_path = os.path.join(artifact_path, "metadata")
+        if is_in_databricks:
+            assert set(os.listdir(metadata_path)) == set(METADATA_FILES)
+        else:
+            assert not os.path.exists(metadata_path)
 
 
-def test_peft_pipeline_copy_metadata(peft_pipeline, tmp_path):
+@pytest.mark.parametrize("is_in_databricks", [True, False])
+def test_peft_pipeline_copy_metadata_in_databricks(is_in_databricks, peft_pipeline, tmp_path):
     artifact_path = "transformers"
 
     with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=peft_pipeline,
-            artifact_path=artifact_path,
-        )
+        with mock.patch(
+            "mlflow.models.model.is_in_databricks_runtime", return_value=is_in_databricks
+        ):
+            model_info = mlflow.transformers.log_model(
+                transformers_model=peft_pipeline,
+                artifact_path=artifact_path,
+            )
         artifact_path = mlflow.artifacts.download_artifacts(
             artifact_uri=model_info.model_uri, dst_path=tmp_path.as_posix()
         )
-        assert set(os.listdir(os.path.join(artifact_path, "metadata"))) == set(METADATA_FILES)
+
+        # Metadata should be copied only in Databricks
+        metadata_path = os.path.join(artifact_path, "metadata")
+        if is_in_databricks:
+            assert set(os.listdir(metadata_path)) == set(METADATA_FILES)
+        else:
+            assert not os.path.exists(metadata_path)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12320?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12320/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12320
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/issues/12254

### What changes are proposed in this pull request?

The `metadata` subdirectory contains copy of metadata files such as `MLModel`, which was added in https://github.com/mlflow/mlflow/pull/11357 for supporting UC sharing. However, it has been causing confusion to OSS users.

This PR gates the copying to Databricks environment only, and add a quick note in the documentation to avoid further confusion.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
