### PR TITLE
Support async logging per X seconds

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -624,6 +624,6 @@ MLFLOW_HTTP_POOL_MAXSIZE = _EnvironmentVariable("MLFLOW_HTTP_POOL_MAXSIZE", int,
 
 #: Specifies the length of time in seconds for the asynchronous logging thread to wait before
 #: logging a batch.
-MLFLOW_ASYNC_LOGGING_WAITING_TIME = _EnvironmentVariable(
-    "MLFLOW_ASYNC_LOGGING_WAITING_TIME", int, None
+MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS = _EnvironmentVariable(
+    "MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS", int, None
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -621,3 +621,9 @@ MLFLOW_HTTP_POOL_CONNECTIONS = _EnvironmentVariable("MLFLOW_HTTP_POOL_CONNECTION
 #: variable sets the `pool_maxsize` parameter in the `requests.adapters.HTTPAdapter` constructor.
 #: By adjusting this variable, users can enhance the concurrency of HTTP requests made by MLflow.
 MLFLOW_HTTP_POOL_MAXSIZE = _EnvironmentVariable("MLFLOW_HTTP_POOL_MAXSIZE", int, 10)
+
+#: Specifies the length of time in seconds for the asynchronous logging thread to wait before
+#: logging a batch.
+MLFLOW_ASYNC_LOGGING_WAITING_TIME = _EnvironmentVariable(
+    "MLFLOW_ASYNC_LOGGING_WAITING_TIME", int, None
+)

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -618,6 +618,15 @@ class AbstractStore:
             run_id=run_id, metrics=metrics, params=params, tags=tags
         )
 
+    def end_async_logging(self):
+        """
+        Ends the async logging queue. This method is a no-op if the queue is not active. This is
+        different from flush as it just stops the async logging queue from accepting new data, but
+        flush will ensure all data is processed before returning.
+        """
+        if self._async_logging_queue.is_active():
+            self._async_logging_queue.end_async_logging()
+
     def flush_async_logging(self):
         """
         Flushes the async logging queue. This method is a no-op if the queue is not active.

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -885,7 +885,8 @@ class TrackingServiceClient:
         end_time = end_time if end_time else get_current_time_millis()
         status = status if status else RunStatus.to_string(RunStatus.FINISHED)
         # Tell the store to stop async logging: stop accepting new data and log already enqueued
-        # data in the background. This call is non-blocking.
+        # data in the background. This call is making sure every async logging data has been
+        # submitted for logging, but not necessarily finished logging.
         self.store.end_async_logging()
         self.store.update_run_info(
             run_id,

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -884,6 +884,7 @@ class TrackingServiceClient:
         """
         end_time = end_time if end_time else get_current_time_millis()
         status = status if status else RunStatus.to_string(RunStatus.FINISHED)
+        self.store.end_async_logging()
         self.store.update_run_info(
             run_id,
             run_status=RunStatus.from_string(status),

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -884,6 +884,8 @@ class TrackingServiceClient:
         """
         end_time = end_time if end_time else get_current_time_millis()
         status = status if status else RunStatus.to_string(RunStatus.FINISHED)
+        # Tell the store to stop async logging: stop accepting new data and log already enqueued
+        # data in the background. This call is non-blocking.
         self.store.end_async_logging()
         self.store.update_run_info(
             run_id,

--- a/mlflow/utils/async_logging/async_logging_queue.py
+++ b/mlflow/utils/async_logging/async_logging_queue.py
@@ -14,8 +14,8 @@ from mlflow.entities.metric import Metric
 from mlflow.entities.param import Param
 from mlflow.entities.run_tag import RunTag
 from mlflow.environment_variables import (
+    MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS,
     MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE,
-    MLFLOW_ASYNC_LOGGING_WAITING_TIME,
 )
 from mlflow.utils.async_logging.run_batch import RunBatch
 from mlflow.utils.async_logging.run_operations import RunOperations
@@ -143,11 +143,10 @@ class AsyncLoggingQueue:
 
         Returns: None
         """
-        async_logging_waiting_time = MLFLOW_ASYNC_LOGGING_WAITING_TIME.get()
-        run_batches = None  # type: RunBatch
+        async_logging_buffer_seconds = MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS.get()
         try:
-            if async_logging_waiting_time:
-                self._stop_data_logging_thread_event.wait(async_logging_waiting_time)
+            if async_logging_buffer_seconds:
+                self._stop_data_logging_thread_event.wait(async_logging_buffer_seconds)
                 run_batches = self._fetch_batch_from_queue()
             else:
                 run_batches = [self._queue.get(timeout=1)]

--- a/mlflow/utils/async_logging/run_batch.py
+++ b/mlflow/utils/async_logging/run_batch.py
@@ -1,5 +1,5 @@
 import threading
-from typing import List
+from typing import List, Optional
 
 from mlflow.entities.metric import Metric
 from mlflow.entities.param import Param
@@ -9,20 +9,20 @@ from mlflow.entities.run_tag import RunTag
 class RunBatch:
     def __init__(
         self,
-        run_id: str,
-        params: List[Param],
-        tags: List[RunTag],
-        metrics: List[Metric],
-        completion_event: threading.Event,
-    ) -> None:
+        run_id: Optional[str] = None,
+        params: Optional[List["Param"]] = None,
+        tags: Optional[List["RunTag"]] = None,
+        metrics: Optional[List["Metric"]] = None,
+        completion_event: Optional[threading.Event] = None,
+    ):
         """Initializes an instance of `RunBatch`.
 
         Args:
-            run_id: The ID of the run.
-            params: A list of parameters.
-            tags: A list of tags.
-            metrics: A list of metrics.
-            completion_event: A threading.Event object.
+            run_id (Optional[str]): The ID of the run. Default is None.
+            params (Optional[List[Param]]): A list of parameters. Default is None.
+            tags (Optional[List[RunTag]]): A list of tags. Default is None.
+            metrics (Optional[List[Metric]]): A list of metrics. Default is None.
+            completion_event (Optional[threading.Event]): A threading.Event object. Default is None.
         """
         self.run_id = run_id
         self.params = params or []
@@ -30,6 +30,7 @@ class RunBatch:
         self.metrics = metrics or []
         self.completion_event = completion_event
         self._exception = None
+        self.child_batches = []
 
     @property
     def exception(self):
@@ -39,3 +40,9 @@ class RunBatch:
     @exception.setter
     def exception(self, exception):
         self._exception = exception
+
+    def is_full(self):
+        return len(self.tags) >= 100 or len(self.params) >= 100 or len(self.metrics) >= 1000
+
+    def add_child_batch(self, child_batch):
+        self.child_batches.append(child_batch)

--- a/mlflow/utils/async_logging/run_batch.py
+++ b/mlflow/utils/async_logging/run_batch.py
@@ -41,11 +41,10 @@ class RunBatch:
     def exception(self, exception):
         self._exception = exception
 
-    def is_full(self):
-        return len(self.tags) >= 100 or len(self.params) >= 100 or len(self.metrics) >= 1000
-
     def add_child_batch(self, child_batch):
-        self.child_batches.append(child_batch)
+        """Add a child batch to the current batch.
 
-    def __str__(self):
-        return f"RunBatch(run_id={self.run_id}, metrics={self.metrics})"
+        This is useful when merging child batches into a parent batch. Child batches are kept so
+        that we can properly notify the system when child batches have been processed.
+        """
+        self.child_batches.append(child_batch)

--- a/mlflow/utils/async_logging/run_batch.py
+++ b/mlflow/utils/async_logging/run_batch.py
@@ -46,3 +46,6 @@ class RunBatch:
 
     def add_child_batch(self, child_batch):
         self.child_batches.append(child_batch)
+
+    def __str__(self):
+        return f"RunBatch(run_id={self.run_id}, metrics={self.metrics})"

--- a/mlflow/utils/async_logging/run_batch.py
+++ b/mlflow/utils/async_logging/run_batch.py
@@ -9,7 +9,7 @@ from mlflow.entities.run_tag import RunTag
 class RunBatch:
     def __init__(
         self,
-        run_id: Optional[str] = None,
+        run_id: Optional[str],
         params: Optional[List["Param"]] = None,
         tags: Optional[List["RunTag"]] = None,
         metrics: Optional[List["Metric"]] = None,
@@ -18,11 +18,11 @@ class RunBatch:
         """Initializes an instance of `RunBatch`.
 
         Args:
-            run_id (Optional[str]): The ID of the run. Default is None.
-            params (Optional[List[Param]]): A list of parameters. Default is None.
-            tags (Optional[List[RunTag]]): A list of tags. Default is None.
-            metrics (Optional[List[Metric]]): A list of metrics. Default is None.
-            completion_event (Optional[threading.Event]): A threading.Event object. Default is None.
+            run_id: The ID of the run.
+            params: A list of parameters. Default is None.
+            tags: A list of tags. Default is None.
+            metrics: A list of metrics. Default is None.
+            completion_event: A threading.Event object. Default is None.
         """
         self.run_id = run_id
         self.params = params or []

--- a/mlflow/utils/async_logging/run_batch.py
+++ b/mlflow/utils/async_logging/run_batch.py
@@ -9,7 +9,7 @@ from mlflow.entities.run_tag import RunTag
 class RunBatch:
     def __init__(
         self,
-        run_id: Optional[str],
+        run_id: str,
         params: Optional[List["Param"]] = None,
         tags: Optional[List["RunTag"]] = None,
         metrics: Optional[List["Metric"]] = None,

--- a/tests/utils/test_async_logging_queue.py
+++ b/tests/utils/test_async_logging_queue.py
@@ -43,10 +43,8 @@ class RunData:
         self.received_tags.extend(tags or [])
 
 
-def test_single_thread_publish_consume_queue():
-    from mlflow.environment_variables import MLFLOW_ASYNC_LOGGING_WAITING_TIME
-
-    MLFLOW_ASYNC_LOGGING_WAITING_TIME.set("3")
+def test_single_thread_publish_consume_queue(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS", "3")
 
     with patch.object(
         AsyncLoggingQueue, "_batch_logging_worker_threadpool", create=True
@@ -64,23 +62,14 @@ def test_single_thread_publish_consume_queue():
         async_logging_queue.activate()
         async_logging_queue._batch_logging_worker_threadpool = mock_worker_threadpool
         async_logging_queue._batch_status_check_threadpool = mock_check_threadpool
-        metrics_sent = []
-        tags_sent = []
-        params_sent = []
 
         for params, tags, metrics in _get_run_data():
             async_logging_queue.log_batch_async(
                 run_id=run_id, metrics=metrics, tags=tags, params=params
             )
-            metrics_sent += metrics
-            tags_sent += tags
-            params_sent += params
-
         async_logging_queue.flush()
-
+        # 2 batches are sent to the worker thread pool due to grouping, otherwise it would be 5.
         assert mock_worker_threadpool.submit.call_count == 2
-
-    MLFLOW_ASYNC_LOGGING_WAITING_TIME.unset()
 
 
 def test_grouping_batch_in_time_window():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/12324?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12324/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12324
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

In this PR we are making it possible for Mlflow client to group batches in a certain time window before logging to Mlflow, which could significantly reduce the QPS. 

Users can set the environment variable `MLFLOW_ASYNC_LOGGING_WAITING_TIME` to control the frequency of async logging.  See code below for reference:

```
import time
import mlflow
import random

last_time = time.time()

mlflow.set_tracking_uri("databricks")
mlflow.set_experiment("/mlflow-speed-test")


with mlflow.start_run():
    max_step = 100000
    for i in range(max_step):
        accuracy = random.randint(-100, 100)
        loss = random.random()
        if i % 100 == 0:
            current_time = time.time()
            print(f"BATCH {i / 100}/{max_step / 100} TAKE {current_time - last_time} seconds!")
            last_time = current_time
        if i % 10000 == 0:
            multiplier = -1 if random.random() > 0.5 else 1
            accuracy = 10000 * multiplier
            loss = 10 * multiplier
        mlflow.log_metrics({"acc": accuracy, "loss": loss}, step=i, synchronous=False)

```


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
