### PR TITLE
Move trace_schema to request_metadata

### DIFF
--- a/mlflow/tracing/processor/inference_table.py
+++ b/mlflow/tracing/processor/inference_table.py
@@ -72,7 +72,7 @@ class InferenceTableSpanProcessor(SimpleSpanProcessor):
                 )
                 return
         span.set_attribute(SpanAttributeKey.REQUEST_ID, json.dumps(request_id))
-        tags = {TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)}
+        tags = {}
         if depedencies_schema := maybe_get_dependencies_schemas():
             tags.update(depedencies_schema)
 
@@ -83,7 +83,7 @@ class InferenceTableSpanProcessor(SimpleSpanProcessor):
                 timestamp_ms=span.start_time // 1_000_000,  # nanosecond to millisecond
                 execution_time_ms=None,
                 status=TraceStatus.IN_PROGRESS,
-                request_metadata={},
+                request_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
                 tags=tags,
             )
             self._trace_manager.register_trace(span.context.trace_id, trace_info)

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -79,7 +79,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
 
     def _start_trace(self, span: OTelSpan) -> TraceInfo:
         experiment_id = get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID)
-        metadata = {}
+        metadata = {TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)}
         # If the span is started within an active MLflow run, we should record it as a trace tag
         if run := mlflow.active_run():
             metadata[TraceMetadataKey.SOURCE_RUN] = run.info.run_id
@@ -109,7 +109,6 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             for key, value in unfiltered_tags.items()
             if key in TRACE_RESOLVE_TAGS_ALLOWLIST
         }
-        tags.update({TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)})
 
         # If the trace is created in the context of MLflow model evaluation, we extract the request
         # ID from the prediction context. Otherwise, we create a new trace info by calling the

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -40,7 +40,6 @@ from mlflow.store.tracking import (
     SEARCH_TRACES_DEFAULT_MAX_RESULTS,
 )
 from mlflow.tracing.artifact_utils import get_artifact_uri_for_trace
-from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_KEY
 from mlflow.tracing.utils import TraceJSONEncoder, exclude_immutable_tags
 from mlflow.tracking._tracking_service import utils
 from mlflow.tracking.metric_value_conversion_utils import convert_metric_value_to_float_if_possible
@@ -191,7 +190,6 @@ class TrackingServiceClient:
             The created TraceInfo object.
         """
         tags = exclude_immutable_tags(tags or {})
-        tags.update({TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)})
         return self.store.start_trace(
             experiment_id=experiment_id,
             timestamp_ms=timestamp_ms,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -58,8 +58,6 @@ from mlflow.store.model_registry import (
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT, SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing.constant import (
     TRACE_REQUEST_ID_PREFIX,
-    TRACE_SCHEMA_VERSION,
-    TRACE_SCHEMA_VERSION_KEY,
     SpanAttributeKey,
     TraceTagKey,
 )
@@ -617,7 +615,6 @@ class MlflowClient:
                 mlflow_span.set_attributes(attributes)
             trace_manager = InMemoryTraceManager.get_instance()
             tags = exclude_immutable_tags(tags or {})
-            tags.update({TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)})
             if is_in_databricks_model_serving_environment():
                 # Update trace tags for trace in in-memory trace manager
                 with trace_manager.get_trace(request_id) as trace:

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -5,8 +5,6 @@ See the System Tags section in the MLflow Tracking documentation for information
 meaning of these tags.
 """
 
-from mlflow.tracing.constant import TRACE_SCHEMA_VERSION_KEY
-
 MLFLOW_EXPERIMENT_SOURCE_ID = "mlflow.experiment.sourceId"
 MLFLOW_EXPERIMENT_SOURCE_TYPE = "mlflow.experiment.sourceType"
 MLFLOW_RUN_NAME = "mlflow.runName"
@@ -82,7 +80,7 @@ MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER = (
 LATEST_CHECKPOINT_ARTIFACT_TAG_KEY = "mlflow.latest_checkpoint_artifact"
 
 # A set of tags that cannot be updated by the user
-IMMUTABLE_TAGS = {MLFLOW_USER, MLFLOW_ARTIFACT_LOCATION, TRACE_SCHEMA_VERSION_KEY}
+IMMUTABLE_TAGS = {MLFLOW_USER, MLFLOW_ARTIFACT_LOCATION}
 
 # The list of tags generated from resolve_tags() that are required for tracing UI
 TRACE_RESOLVE_TAGS_ALLOWLIST = (

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -62,13 +62,13 @@ def test_json_deserialization(monkeypatch):
             "request_metadata": {
                 "mlflow.traceInputs": '{"x": 2, "y": 5}',
                 "mlflow.traceOutputs": "8",
+                TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
             },
             "tags": {
                 "mlflow.traceName": "predict",
                 "mlflow.source.name": "test",
                 "mlflow.source.type": "LOCAL",
                 "mlflow.artifactLocation": trace.info.tags[MLFLOW_ARTIFACT_LOCATION],
-                TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
             },
         },
         "data": {

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -60,6 +60,7 @@ from mlflow.models.evaluation.default_evaluator import DefaultEvaluator
 from mlflow.models.evaluation.evaluator_registry import _model_evaluation_registry
 from mlflow.pyfunc import _ServedPyFuncModel
 from mlflow.pyfunc.scoring_server.client import ScoringServerClient
+from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracking.artifact_utils import get_artifact_uri
 from mlflow.utils import insecure_hash
@@ -393,7 +394,7 @@ def test_mlflow_evaluate_logs_traces():
             model, eval_data, targets="ground_truth", extra_metrics=[mlflow.metrics.exact_match()]
         )
     assert len(get_traces()) == 1
-    assert run.info.run_id == get_traces()[0].info.request_metadata["mlflow.sourceRun"]
+    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
 
 
 def test_pyfunc_evaluate_logs_traces():
@@ -423,7 +424,7 @@ def test_pyfunc_evaluate_logs_traces():
         )
     assert len(get_traces()) == 1
     assert len(get_traces()[0].data.spans) == 2
-    assert run.info.run_id == get_traces()[0].info.request_metadata["mlflow.sourceRun"]
+    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
 
 
 def test_langchain_evaluate_autologs_traces():
@@ -464,7 +465,7 @@ def test_langchain_evaluate_autologs_traces():
     assert len(get_traces()) == 2
     for trace in get_traces():
         assert len(trace.data.spans) == 3
-    assert run.info.run_id == get_traces()[0].info.request_metadata["mlflow.sourceRun"]
+    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
 
     TRACE_BUFFER.clear()
 
@@ -507,7 +508,7 @@ def test_langchain_pyfunc_autologs_traces():
         )
     assert len(get_traces()) == 1
     assert len(get_traces()[0].data.spans) == 3
-    assert run.info.run_id == get_traces()[0].info.request_metadata["mlflow.sourceRun"]
+    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
 
 
 def test_langchain_evaluate_fails_with_an_exception():

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -29,7 +29,7 @@ from mlflow.models.dependencies_schemas import DependenciesSchemasType, set_retr
 from mlflow.models.signature import infer_signature
 from mlflow.models.utils import _read_example
 from mlflow.pyfunc.context import Context, set_prediction_context
-from mlflow.tracing.constant import SpanAttributeKey, TraceTagKey
+from mlflow.tracing.constant import SpanAttributeKey, TraceMetadataKey, TraceTagKey
 from mlflow.utils.openai_utils import (
     TEST_CONTENT,
     _mock_chat_completion_response,
@@ -439,7 +439,7 @@ def test_loaded_llmchain_within_model_evaluation(mock_get_display, tmp_path):
     assert response == ["test"]
     trace = mlflow.get_trace(request_id)
     assert trace.info.tags[TraceTagKey.EVAL_REQUEST_ID] == request_id
-    assert trace.info.request_metadata["mlflow.sourceRun"] == run_id
+    assert trace.info.request_metadata[TraceMetadataKey.SOURCE_RUN] == run_id
 
     # Trace should not be displayed in the notebook cell if it is in evaluation
     mock_display_handler = mock_get_display.return_value

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -70,6 +70,7 @@ from mlflow.models.dependencies_schemas import DependenciesSchemasType
 from mlflow.models.resources import DatabricksServingEndpoint, DatabricksVectorSearchIndex, Resource
 from mlflow.models.signature import ModelSignature, Schema, infer_signature
 from mlflow.pyfunc.context import Context
+from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_KEY
 from mlflow.tracing.processor.inference_table import _HEADER_REQUEST_ID_KEY
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import Array, ColSpec, DataType, Object, Property
@@ -3007,6 +3008,10 @@ def test_langchain_model_inject_callback_in_model_serving(
     if enable_mlflow_tracing:
         assert len(_TRACE_BUFFER) == 1
         assert _REQUEST_ID in _TRACE_BUFFER
+        trace = _TRACE_BUFFER[_REQUEST_ID]
+        assert trace["info"]["request_metadata"][TRACE_SCHEMA_VERSION_KEY] == str(
+            TRACE_SCHEMA_VERSION
+        )
     else:
         assert len(_TRACE_BUFFER) == 0
 

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -376,7 +376,7 @@ def test_e2e_rag_model_tracing_in_serving(mock_databricks_serving_with_tracing_e
     assert response == [{"text": TEST_CONTENT}]
     trace = Trace.from_dict(trace_dict)
     assert trace.info.request_id == request_id
-    assert trace.info.tags[TRACE_SCHEMA_VERSION_KEY] == "2"
+    assert trace.info.request_metadata[TRACE_SCHEMA_VERSION_KEY] == "2"
     spans = trace.data.spans
     assert len(spans) == 2
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -3212,7 +3212,8 @@ def test_search_traces_raise_errors(generate_trace_infos):
         store.search_traces([exp_id], "", order_by=["name DESC"])
     with pytest.raises(
         MlflowException,
-        match=r"Invalid order_by entity `request_metadata` with key `mlflow.sourceRun`",
+        match=r"Invalid order_by entity `request_metadata` "
+        rf"with key `{TraceMetadataKey.SOURCE_RUN}`",
     ):
         store.search_traces([exp_id], "", order_by=["run_id ASC"])
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -66,6 +66,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlTraceTag,
 )
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore, _get_orderby_clauses
+from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.utils import mlflow_tags
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import (
@@ -3935,7 +3936,7 @@ def store_with_traces(tmp_path):
         execution_time_ms=6,
         status=TraceStatus.OK,
         tags={"mlflow.traceName": "ddd"},
-        request_metadata={"mlflow.sourceRun": "run0"},
+        request_metadata={TraceMetadataKey.SOURCE_RUN: "run0"},
     )
     _create_trace(
         store,
@@ -3945,7 +3946,7 @@ def store_with_traces(tmp_path):
         execution_time_ms=2,
         status=TraceStatus.ERROR,
         tags={"mlflow.traceName": "aaa", "fruit": "apple", "color": "red"},
-        request_metadata={"mlflow.sourceRun": "run1"},
+        request_metadata={TraceMetadataKey.SOURCE_RUN: "run1"},
     )
     _create_trace(
         store,
@@ -4039,11 +4040,11 @@ def test_search_traces_order_by(store_with_traces, order_by, expected_ids):
         ("tags.fruit = 'apple' and tags.color != 'red'", ["tr-2"]),
         # Search by request metadata
         ("run_id = 'run0'", ["tr-0"]),
-        ("request_metadata.mlflow.sourceRun = 'run0'", ["tr-0"]),
-        ("request_metadata.mlflow.sourceRun = 'run1'", ["tr-1"]),
-        ("request_metadata.`mlflow.sourceRun` = 'run0'", ["tr-0"]),
-        ("metadata.mlflow.sourceRun = 'run0'", ["tr-0"]),
-        ("metadata.mlflow.sourceRun != 'run0'", ["tr-1"]),
+        (f"request_metadata.{TraceMetadataKey.SOURCE_RUN} = 'run0'", ["tr-0"]),
+        (f"request_metadata.{TraceMetadataKey.SOURCE_RUN} = 'run1'", ["tr-1"]),
+        (f"request_metadata.`{TraceMetadataKey.SOURCE_RUN}` = 'run0'", ["tr-0"]),
+        (f"metadata.{TraceMetadataKey.SOURCE_RUN} = 'run0'", ["tr-0"]),
+        (f"metadata.{TraceMetadataKey.SOURCE_RUN} != 'run0'", ["tr-1"]),
     ],
 )
 def test_search_traces_with_filter(store_with_traces, filter_string, expected_ids):

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -167,7 +167,7 @@ def test_on_start_during_run(monkeypatch):
         timestamp_ms=5,
         # expect run id to be set
         request_metadata={
-            "mlflow.sourceRun": expected_run_id,
+            TraceMetadataKey.SOURCE_RUN: expected_run_id,
             TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
         },
         tags=mock.ANY,

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -46,12 +46,11 @@ def test_on_start(monkeypatch):
     mock_client._start_tracked_trace.assert_called_once_with(
         experiment_id="0",
         timestamp_ms=5,
-        request_metadata={},
+        request_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
         tags={
             "mlflow.user": "bob",
             "mlflow.source.name": "test",
             "mlflow.source.type": "LOCAL",
-            TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
         },
     )
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
@@ -113,12 +112,11 @@ def test_on_start_with_experiment_id(monkeypatch):
     mock_client._start_tracked_trace.assert_called_once_with(
         experiment_id=experiment_id,
         timestamp_ms=5,
-        request_metadata={},
+        request_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
         tags={
             "mlflow.user": "bob",
             "mlflow.source.name": "test",
             "mlflow.source.type": "LOCAL",
-            TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
         },
     )
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
@@ -168,7 +166,10 @@ def test_on_start_during_run(monkeypatch):
         experiment_id=run_experiment_id,
         timestamp_ms=5,
         # expect run id to be set
-        request_metadata={"mlflow.sourceRun": expected_run_id},
+        request_metadata={
+            "mlflow.sourceRun": expected_run_id,
+            TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
+        },
         tags=mock.ANY,
     )
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -143,15 +143,17 @@ def test_trace_with_databricks_tracking_uri(databricks_tracking_uri, mock_store,
     assert trace_info.request_id == "tr-12345"
     assert trace_info.experiment_id == "test_experiment_id"
     assert trace_info.status == TraceStatus.OK
-    assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
-    assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "64"
+    assert trace_info.request_metadata == {
+        TraceMetadataKey.INPUTS: '{"x": 2, "y": 5}',
+        TraceMetadataKey.OUTPUTS: "64",
+        TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
+    }
     assert trace_info.tags == {
         "mlflow.traceName": "predict",
         "mlflow.artifactLocation": "test",
         "mlflow.source.name": "test",
         "mlflow.source.type": "LOCAL",
         "mlflow.user": "bob",
-        TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
     }
 
     trace_data = traces[0].data
@@ -221,7 +223,7 @@ def test_trace_in_databricks_model_serving(mock_databricks_serving_with_tracing_
     trace_dict = response.json["trace"]
     trace = Trace.from_dict(trace_dict)
     assert trace.info.request_id == databricks_request_id
-    assert trace.info.tags[TRACE_SCHEMA_VERSION_KEY] == "2"
+    assert trace.info.request_metadata[TRACE_SCHEMA_VERSION_KEY] == "2"
     assert len(trace.data.spans) == 3
 
     span_name_to_span = {span.name: span for span in trace.data.spans}
@@ -303,11 +305,11 @@ def test_trace_in_model_evaluation(mock_store, monkeypatch):
         "mlflow.source.type": "LOCAL",
         "mlflow.user": "bob",
         "mlflow.artifactLocation": "test",
-        TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
     }
 
     trace = mlflow.get_trace(request_id_1)
     assert trace.info.request_metadata[TraceMetadataKey.SOURCE_RUN] == run_id
+    assert trace.info.request_metadata[TRACE_SCHEMA_VERSION_KEY] == str(TRACE_SCHEMA_VERSION)
     assert trace.info.tags == {**expected_tags, **{TraceTagKey.EVAL_REQUEST_ID: request_id_1}}
 
     trace = mlflow.get_trace(request_id_2)

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -78,7 +78,7 @@ def test_trace(with_active_run):
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "64"
     if with_active_run:
-        assert trace_info.request_metadata["mlflow.sourceRun"] == run_id
+        assert trace_info.request_metadata[TraceMetadataKey.SOURCE_RUN] == run_id
 
     assert trace.data.request == '{"x": 2, "y": 5}'
     assert trace.data.response == "64"

--- a/tests/tracking/_tracking_service/test_tracking_service_client.py
+++ b/tests/tracking/_tracking_service/test_tracking_service_client.py
@@ -405,8 +405,11 @@ def test_search_traces_with_filestore(tmp_path):
             client.start_trace(
                 exp_id,
                 i * 1000,
-                {SpanAttributeKey.REQUEST_ID: f"request_id_{i}"},
-                {TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
+                {
+                    SpanAttributeKey.REQUEST_ID: f"request_id_{i}",
+                    TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
+                },
+                {},
             )
         )
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -436,7 +436,7 @@ def test_start_and_end_trace(tracking_uri, with_active_run):
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
     assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == '{"output": 25}'
     if with_active_run:
-        assert trace.info.request_metadata["mlflow.sourceRun"] == run_id
+        assert trace.info.request_metadata[TraceMetadataKey.SOURCE_RUN] == run_id
         assert trace.info.experiment_id == run.info.experiment_id
     else:
         assert trace.info.experiment_id == experiment_id

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -625,8 +625,11 @@ def test_log_trace_with_databricks_tracking_uri(
     assert trace_info.request_id == "tr-12345"
     assert trace_info.experiment_id == "test_experiment_id"
     assert trace_info.status == TraceStatus.OK
-    assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
-    assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "5"
+    assert trace_info.request_metadata == {
+        TraceMetadataKey.INPUTS: '{"x": 1, "y": 2}',
+        TraceMetadataKey.OUTPUTS: "5",
+        TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
+    }
     assert trace_info.tags == {
         "mlflow.traceName": "predict",
         "mlflow.artifactLocation": "test",
@@ -634,7 +637,6 @@ def test_log_trace_with_databricks_tracking_uri(
         "mlflow.source.name": "test",
         "mlflow.source.type": "LOCAL",
         "tag": "tag_value",
-        TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION),
     }
 
     trace_data = traces[0].data


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12327?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12327/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12327
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
trace_schema is set by mlflow so we should set it in request_metadata instead of tags

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
