### PR TITLE
Exclude irrelevant tags from resolve_tags() for tracing

### DIFF
--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -34,3 +34,16 @@ TRACE_SCHEMA_VERSION = 2
 # Key for the trace schema version in the trace. This key is also used in
 # Databricks model serving to be careful when modifying it.
 TRACE_SCHEMA_VERSION_KEY = "mlflow.trace_schema.version"
+
+# The list of tags generated from resolve_tags that are required for tracing UI
+TRACE_RESOLVE_TAGS_ALLOWLIST = (
+    "mlflow.databricks.notebook.commandID",
+    "mlflow.databricks.notebookID",
+    "mlflow.databricks.notebookPath",
+    "mlflow.databricks.webappURL",
+    "mlflow.databricks.workspaceID",
+    "mlflow.databricks.workspaceURL",
+    "mlflow.source.name",
+    "mlflow.source.type",
+    "mlflow.user",
+)

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -34,16 +34,3 @@ TRACE_SCHEMA_VERSION = 2
 # Key for the trace schema version in the trace. This key is also used in
 # Databricks model serving to be careful when modifying it.
 TRACE_SCHEMA_VERSION_KEY = "mlflow.trace_schema.version"
-
-# The list of tags generated from resolve_tags that are required for tracing UI
-TRACE_RESOLVE_TAGS_ALLOWLIST = (
-    "mlflow.databricks.notebook.commandID",
-    "mlflow.databricks.notebookID",
-    "mlflow.databricks.notebookPath",
-    "mlflow.databricks.webappURL",
-    "mlflow.databricks.workspaceID",
-    "mlflow.databricks.workspaceURL",
-    "mlflow.source.name",
-    "mlflow.source.type",
-    "mlflow.user",
-)

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -13,6 +13,7 @@ from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
+    TRACE_RESOLVE_TAGS_ALLOWLIST,
     TRACE_SCHEMA_VERSION,
     TRACE_SCHEMA_VERSION_KEY,
     TRUNCATION_SUFFIX,
@@ -102,7 +103,12 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             )
             self._issued_default_exp_warning = True
 
-        tags = resolve_tags()
+        unfiltered_tags = resolve_tags()
+        tags = {
+            key: value
+            for key, value in unfiltered_tags.items()
+            if key in TRACE_RESOLVE_TAGS_ALLOWLIST
+        }
         tags.update({TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)})
 
         # If the trace is created in the context of MLflow model evaluation, we extract the request

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -13,7 +13,6 @@ from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
-    TRACE_RESOLVE_TAGS_ALLOWLIST,
     TRACE_SCHEMA_VERSION,
     TRACE_SCHEMA_VERSION_KEY,
     TRUNCATION_SUFFIX,
@@ -32,6 +31,7 @@ from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.context.registry import resolve_tags
 from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 from mlflow.tracking.fluent import _get_experiment_id
+from mlflow.utils.mlflow_tags import TRACE_RESOLVE_TAGS_ALLOWLIST
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -84,6 +84,19 @@ LATEST_CHECKPOINT_ARTIFACT_TAG_KEY = "mlflow.latest_checkpoint_artifact"
 # A set of tags that cannot be updated by the user
 IMMUTABLE_TAGS = {MLFLOW_USER, MLFLOW_ARTIFACT_LOCATION, TRACE_SCHEMA_VERSION_KEY}
 
+# The list of tags generated from resolve_tags() that are required for tracing UI
+TRACE_RESOLVE_TAGS_ALLOWLIST = (
+    MLFLOW_DATABRICKS_NOTEBOOK_COMMAND_ID,
+    MLFLOW_DATABRICKS_NOTEBOOK_ID,
+    MLFLOW_DATABRICKS_NOTEBOOK_PATH,
+    MLFLOW_DATABRICKS_WEBAPP_URL,
+    MLFLOW_DATABRICKS_WORKSPACE_ID,
+    MLFLOW_DATABRICKS_WORKSPACE_URL,
+    MLFLOW_SOURCE_NAME,
+    MLFLOW_SOURCE_TYPE,
+    MLFLOW_USER,
+)
+
 
 def _get_run_name_from_tags(tags):
     for tag in tags:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/xq-yin/mlflow/pull/12330?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12330/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12330
```

</p>
</details>

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Initial issue is that trace logging fails from databricks notebooks because an irrelevant tag sparkDataSourceInfo exceeds limits.

After discussing with @daniellok-db and @B-Step62, it seems that resolve_tags() was introduced originally to render the traces table in UI. And not all tags are needed for the UI.
this is the current list of tags that's passed to frontend for react component to render the table. 
![image](https://github.com/mlflow/mlflow/assets/171547006/31d02c70-3ce0-497d-8898-241032adbd22)
among these, mlflow.databricks.cluster.id is not used by UI, mlflow.trace_schema.version and mlflow.artifactLocation are not generated from resolve_tags(). Based on this info, this PR makes the rest of the tags an allowlist, and remove irrelevant tags if it's not in the list.

The original issue should be solved because the sparkDataSourceInfo isn't in the new allowlist

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

pytest tests/tracing/processor/test_mlflow_processor.py
tested in notebook
Verified the traces UI, especially the "source" column still renders, and the link can point to the right notebook
![image](https://github.com/mlflow/mlflow/assets/171547006/e8ea38ee-f2e1-4fd0-bcf4-21a99039b537)

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
