### PR TITLE
Add note about 'fork' vs 'spawn' method when using multiprocessing for parallel runs

### DIFF
--- a/docs/source/tracking/tracking-api.rst
+++ b/docs/source/tracking/tracking-api.rst
@@ -258,17 +258,17 @@ MLflow also supports running multiple runs in parallel using `multiprocessing <h
     import multiprocessing as mp
 
 
-    def train_model(params):
+    def train_model(param):
         with mlflow.start_run():
-            mlflow.log_param("p", params)
+            mlflow.log_param("p", param)
             ...
 
 
     if __name__ == "__main__":
         mlflow.set_experiment("multi-process")
         params = [0.01, 0.02, ...]
-        pool = mp.Pool(processes=4)
-        pool.map(train_model, params)
+        with mp.Pool(processes=4) as pool:
+            pool.map(train_model, params)
 
 .. attention::
 
@@ -308,10 +308,10 @@ You can start child runs in each thread by passing ``nested=True`` to :py:func:`
         import threading
 
 
-        def train_model(params):
+        def train_model(param):
             # Create a child run by passing nested=True
             with mlflow.start_run(nested=True):
-                mlflow.log_param("p", params)
+                mlflow.log_param("p", param)
                 ...
 
 

--- a/docs/source/tracking/tracking-api.rst
+++ b/docs/source/tracking/tracking-api.rst
@@ -254,20 +254,49 @@ MLflow also supports running multiple runs in parallel using `multiprocessing <h
 
 .. code-block:: python
 
-        import mlflow
-        import multiprocessing as mp
+    import mlflow
+    import multiprocessing as mp
 
 
-        def train_model(params):
-            with mlflow.start_run():
-                mlflow.log_param("p", params)
-                ...
+    def train_model(params):
+        with mlflow.start_run():
+            mlflow.log_param("p", params)
+            ...
 
 
-        if __name__ == "__main__":
-            params = [0.01, 0.02, ...]
-            pool = mp.Pool(processes=4)
-            pool.map(train_model, params)
+    if __name__ == "__main__":
+        mlflow.set_experiment("multi-process")
+        params = [0.01, 0.02, ...]
+        pool = mp.Pool(processes=4)
+        pool.map(train_model, params)
+
+.. attention::
+
+  The above code will only work if the ``fork`` method is used for creating child processes. If you are using
+  the ``spawn`` method, the child processes will not automatically inherit the global state of the parent process, which includes
+  the active experiment and tracking URI, resulting in the child processes not being able to log to the same experiment. To
+  overcome this limitation, you can set the active experiment and tracking URI explicitly in each child process as shown below.
+  The ``fork`` is the default method on POSIX systems except MacOS, but otherwise ``spawn`` method will be used by default.
+
+  .. code-block:: python
+
+    import mlflow
+    import multiprocessing as mp
+
+
+    def train_model(params):
+        # Set the experiment and tracking URI in each child process
+        mlflow.set_tracking_uri("http://localhost:5000")
+        mlflow.set_experiment("multi-process")
+        with mlflow.start_run():
+            ...
+
+
+    if __name__ == "__main__":
+        params = [0.01, 0.02, ...]
+        pool = mp.get_context("spawn").Pool(processes=4)
+        pool.map(train_model, params)
+
 
 **Multi-threading** is a bit more complicated because MLflow uses a global state to keep track of the currently active run i.e. having multiple active
 runs in the same process may cause data corruption. However, you can avoid this issue and use multi threading by using :ref:`Child Runs <child_runs>`.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12337?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12337/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12337
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/issues/12315

### What changes are proposed in this pull request?

When using multiprocessing for parallel Runs, the start method is important because MLflow uses global variables for keeping track of the current experiment and tracking URI. If using `spawn` start method, global state is not propagated to child processes automatically, so users need to set them explicitly in the child processes to log to the correct experiment.

This does NOT work:
```
import mlflow
import multiprocessing as mp

def train_model(param):
    with mlflow.start_run():
        mlflow.log_param("p", param)

if __name__ == "__main__":
    params = [0.01, 0.02, 0.03, 0.04]
    mp.set_start_method("spawn")

    mlflow.set_tracking_uri("http://localhost:5000")
    mlflow.set_experiment("mptest")

    pool = mp.Pool(processes=4)
    pool.map(train_model, params)
```

Instead, we need to do this:
```
import mlflow
import multiprocessing as mp

def train_model(param):
    # Set tracking URI and experiment in the child processes
    mlflow.set_tracking_uri("http://localhost:5000")
    mlflow.set_experiment("mptest")

    with mlflow.start_run():
        mlflow.log_param("p", param)

if __name__ == "__main__":
    params = [0.01, 0.02, 0.03, 0.04]
    mp.set_start_method("spawn")

    pool = mp.Pool(processes=4)
    pool.map(train_model, params)
```

Since it requires significant architecture change to stop using global variables and auto-propagate them, this PR simply adds a note and above workaround in the documentation.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
