### PR TITLE
Add doc and clearer error message for MLflow Deployment Server on Windows

### DIFF
--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -11,6 +11,10 @@ MLflow Deployments Server (Experimental)
    MLflow AI Gateway should refer to the new documentation for migration guidelines and familiarize
    themselves with the updated API structure. See :ref:`gateway-migration` for migration.
 
+.. warning::
+
+    MLflow Deployments Server does not support Windows.
+
 The MLflow Deployments Server is a powerful tool designed to streamline the usage and management of
 various large language model (LLM) providers, such as OpenAI and Anthropic, within an organization.
 It offers a high-level interface that simplifies the interaction with these services by providing

--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -8,6 +8,7 @@ from mlflow.deployments import interface
 from mlflow.environment_variables import MLFLOW_DEPLOYMENTS_CONFIG
 from mlflow.utils import cli_args
 from mlflow.utils.annotations import experimental
+from mlflow.utils.os import is_windows
 from mlflow.utils.proto_json_utils import NumpyEncoder, _get_jsonable_obj
 
 
@@ -495,6 +496,9 @@ def validate_config_path(_ctx, _param, value):
     help="The number of workers.",
 )
 def start_server(config_path: str, host: str, port: str, workers: int):
+    if is_windows():
+        raise RuntimeError("MLflow Deployments Server does not support Windows.")
+
     from mlflow.deployments.server.runner import run_app
 
     run_app(config_path=config_path, host=host, port=port, workers=workers)

--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -497,7 +497,7 @@ def validate_config_path(_ctx, _param, value):
 )
 def start_server(config_path: str, host: str, port: str, workers: int):
     if is_windows():
-        raise RuntimeError("MLflow Deployments Server does not support Windows.")
+        raise click.ClickException("MLflow Deployments Server does not support Windows.")
 
     from mlflow.deployments.server.runner import run_app
 

--- a/tests/deployments/server/test_server_cli.py
+++ b/tests/deployments/server/test_server_cli.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import time
+from unittest import mock
 
 import pytest
 import requests
@@ -11,6 +12,17 @@ from mlflow.deployments import cli
 from tests.helper_functions import get_safe_port
 
 pytest.importorskip("mlflow.gateway")
+
+_TEST_CONFIG = """
+routes:
+  - name: chat
+    route_type: llm/v1/chat
+    model:
+      provider: openai
+      name: gpt-3.5-turbo
+      config:
+        openai_api_key: sk-openai
+"""
 
 
 def test_start_help():
@@ -61,18 +73,7 @@ routes:
 
 def test_start_server(tmp_path):
     config = tmp_path.joinpath("config.yml")
-    config.write_text(
-        """
-routes:
-  - name: chat
-    route_type: llm/v1/chat
-    model:
-      provider: openai
-      name: gpt-3.5-turbo
-      config:
-        openai_api_key: sk-openai
-"""
-    )
+    config.write_text(_TEST_CONFIG)
     port = get_safe_port()
     with subprocess.Popen(
         [
@@ -98,3 +99,15 @@ routes:
                 raise Exception("Server did not start in time")
         finally:
             prc.terminate()
+
+
+def test_start_server_fail_on_windows(tmp_path):
+    config = tmp_path.joinpath("config.yml")
+    config.write_text(_TEST_CONFIG)
+
+    runner = CliRunner()
+    with mock.patch("mlflow.deployments.cli.is_windows", return_value=True):
+        with pytest.raises(
+            RuntimeError, match="MLflow Deployments Server does not support Windows."
+        ):
+            runner.invoke(cli.start_server, ["--config-path", config], catch_exceptions=False)

--- a/tests/deployments/server/test_server_cli.py
+++ b/tests/deployments/server/test_server_cli.py
@@ -107,7 +107,6 @@ def test_start_server_fail_on_windows(tmp_path):
 
     runner = CliRunner()
     with mock.patch("mlflow.deployments.cli.is_windows", return_value=True):
-        with pytest.raises(
-            RuntimeError, match="MLflow Deployments Server does not support Windows."
-        ):
-            runner.invoke(cli.start_server, ["--config-path", config], catch_exceptions=False)
+        result = runner.invoke(cli.start_server, ["--config-path", config], catch_exceptions=True)
+        assert result.exit_code == 1
+        assert "MLflow Deployments Server does not support Windows" in result.output


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12339?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12339/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12339
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/issues/12334

### What changes are proposed in this pull request?

Deployments Server does not support Windows now. Adding a note on doc and also add a check to fail early.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
