### PR TITLE
Fix async logging zombie thread issue

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -621,17 +621,19 @@ class AbstractStore:
     def end_async_logging(self):
         """
         Ends the async logging queue. This method is a no-op if the queue is not active. This is
-        different from flush as it just stops the async logging queue from accepting new data, but
-        flush will ensure all data is processed before returning.
+        different from flush as it just stops the async logging queue from accepting
+        new data (moving the queue state TEAR_DOWN state), but flush will ensure all data
+        is processed before returning (moving the queue to TERMINATED state).
         """
         if self._async_logging_queue.is_active():
             self._async_logging_queue.end_async_logging()
 
     def flush_async_logging(self):
         """
-        Flushes the async logging queue. This method is a no-op if the queue is not active.
+        Flushes the async logging queue. This method is a no-op if the queue is already
+        at TERMINATED state. This methods also shutdown the logging worker threads.
         """
-        if self._async_logging_queue.is_active():
+        if not self._async_logging_queue.is_terminated():
             self._async_logging_queue.flush()
 
     @abstractmethod

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -633,7 +633,7 @@ class AbstractStore:
         Flushes the async logging queue. This method is a no-op if the queue is already
         at TERMINATED state. This methods also shutdown the logging worker threads.
         """
-        if not self._async_logging_queue.is_terminated():
+        if not self._async_logging_queue.is_idle():
             self._async_logging_queue.flush()
 
     @abstractmethod

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -623,7 +623,7 @@ class AbstractStore:
         Ends the async logging queue. This method is a no-op if the queue is not active. This is
         different from flush as it just stops the async logging queue from accepting
         new data (moving the queue state TEAR_DOWN state), but flush will ensure all data
-        is processed before returning (moving the queue to TERMINATED state).
+        is processed before returning (moving the queue to IDLE state).
         """
         if self._async_logging_queue.is_active():
             self._async_logging_queue.end_async_logging()
@@ -631,7 +631,7 @@ class AbstractStore:
     def flush_async_logging(self):
         """
         Flushes the async logging queue. This method is a no-op if the queue is already
-        at TERMINATED state. This methods also shutdown the logging worker threads.
+        at IDLE state. This methods also shutdown the logging worker threads.
         """
         if not self._async_logging_queue.is_idle():
             self._async_logging_queue.flush()

--- a/mlflow/utils/async_logging/async_logging_queue.py
+++ b/mlflow/utils/async_logging/async_logging_queue.py
@@ -4,6 +4,7 @@ queue based approach.
 """
 
 import atexit
+import enum
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -21,6 +22,22 @@ from mlflow.utils.async_logging.run_batch import RunBatch
 from mlflow.utils.async_logging.run_operations import RunOperations
 
 _logger = logging.getLogger(__name__)
+
+
+ASYNC_LOGGING_WORKER_THREAD_PREFIX = "MLflowBatchLoggingWorkerPool"
+ASYNC_LOGGING_STATUS_CHECK_THREAD_PREFIX = "MLflowAsyncLoggingStatusCheck"
+
+
+class QueueStatus(enum.Enum):
+    """Status of the async queue"""
+
+    # The queue is running worker threads to consume the new data.
+    ACTIVE = 1
+    # The queue is still running work threads, but does not accept
+    # new data. The queue still processes the remaining data.
+    TEAR_DOWN = 2
+    # The queue is not running worker threads at all.
+    TERMINATED = 3
 
 
 class AsyncLoggingQueue:
@@ -42,7 +59,7 @@ class AsyncLoggingQueue:
         self._logging_func = logging_func
 
         self._stop_data_logging_thread_event = threading.Event()
-        self._is_activated = False
+        self._status = QueueStatus.TERMINATED
 
     def _at_exit_callback(self) -> None:
         """Callback function to be executed when the program is exiting.
@@ -66,7 +83,9 @@ class AsyncLoggingQueue:
             self._stop_data_logging_thread_event.set()
             # Waits till logging queue is drained.
             self._batch_logging_thread.join()
-            self._is_activated = False
+            # Set the status to tear down. The worker threads will still process
+            # the remaining data.
+            self._status = QueueStatus.TEAR_DOWN
 
     def flush(self) -> None:
         """Flush the async logging queue.
@@ -76,6 +95,7 @@ class AsyncLoggingQueue:
         self.end_async_logging()
         self._batch_logging_worker_threadpool.shutdown(wait=True)
         self._batch_status_check_threadpool.shutdown(wait=True)
+        self._status = QueueStatus.TERMINATED
 
         # Restart the thread to listen to incoming data after flushing.
         self._stop_data_logging_thread_event.clear()
@@ -205,7 +225,7 @@ class AsyncLoggingQueue:
         state = self.__dict__.copy()
         del state["_queue"]
         del state["_lock"]
-        del state["_is_activated"]
+        del state["_status"]
 
         if "_run_data_logging_thread" in state:
             del state["_run_data_logging_thread"]
@@ -234,7 +254,7 @@ class AsyncLoggingQueue:
         self.__dict__.update(state)
         self._queue = Queue()
         self._lock = threading.RLock()
-        self._is_activated = False
+        self._status = QueueStatus.TERMINATED
         self._batch_logging_thread = None
         self._batch_logging_worker_threadpool = None
         self._batch_status_check_threadpool = None
@@ -260,7 +280,7 @@ class AsyncLoggingQueue:
         """
         from mlflow import MlflowException
 
-        if not self._is_activated:
+        if not self._status == QueueStatus.ACTIVE:
             raise MlflowException("AsyncLoggingQueue is not activated.")
         batch = RunBatch(
             run_id=run_id,
@@ -274,7 +294,10 @@ class AsyncLoggingQueue:
         return RunOperations(operation_futures=[operation_future])
 
     def is_active(self) -> bool:
-        return self._is_activated
+        return self._status == QueueStatus.ACTIVE
+
+    def is_terminated(self) -> bool:
+        return self._status == QueueStatus.TERMINATED
 
     def _set_up_logging_thread(self) -> None:
         """Sets up the logging thread.
@@ -289,12 +312,12 @@ class AsyncLoggingQueue:
             )
             self._batch_logging_worker_threadpool = ThreadPoolExecutor(
                 max_workers=MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.get() or 10,
-                thread_name_prefix="MLflowBatchLoggingWorkerPool",
+                thread_name_prefix=ASYNC_LOGGING_WORKER_THREAD_PREFIX,
             )
 
             self._batch_status_check_threadpool = ThreadPoolExecutor(
                 max_workers=MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.get() or 10,
-                thread_name_prefix="MLflowAsyncLoggingStatusCheck",
+                thread_name_prefix=ASYNC_LOGGING_STATUS_CHECK_THREAD_PREFIX,
             )
 
             self._batch_logging_thread.start()
@@ -310,10 +333,10 @@ class AsyncLoggingQueue:
         If the queue is already activated, this method does nothing.
         """
         with self._lock:
-            if self._is_activated:
+            if self.is_active():
                 return
 
             self._set_up_logging_thread()
             atexit.register(self._at_exit_callback)
 
-            self._is_activated = True
+            self._status = QueueStatus.ACTIVE

--- a/tests/utils/test_async_logging_queue.py
+++ b/tests/utils/test_async_logging_queue.py
@@ -70,7 +70,7 @@ def test_single_thread_publish_consume_queue(monkeypatch):
         async_logging_queue.flush()
         # 2 batches are sent to the worker thread pool due to grouping, otherwise it would be 5.
         assert mock_worker_threadpool.submit.call_count == 2
-        assert async_logging_queue.is_terminated()
+        assert async_logging_queue.is_idle()
         assert mock_check_threadpool.shutdown.call_count == 1
         assert mock_worker_threadpool.shutdown.call_count == 1
 
@@ -108,7 +108,7 @@ def test_queue_activation():
     run_id = "test_run_id"
     run_data = RunData()
     async_logging_queue = AsyncLoggingQueue(run_data.consume_queue_data)
-    assert async_logging_queue.is_terminated()
+    assert async_logging_queue.is_idle()
 
     metrics = [
         Metric(
@@ -149,7 +149,7 @@ def test_end_async_logging():
     assert not async_logging_queue._batch_status_check_threadpool._shutdown
 
     async_logging_queue.flush()
-    assert async_logging_queue.is_terminated()
+    assert async_logging_queue.is_idle()
 
 
 def test_partial_logging_failed():

--- a/tests/utils/test_async_logging_queue.py
+++ b/tests/utils/test_async_logging_queue.py
@@ -268,7 +268,7 @@ def test_async_logging_queue_pickle():
     deserialized_queue = pickle.loads(buffer.getvalue())  # Type: AsyncLoggingQueue
     assert deserialized_queue._queue.empty()
     assert deserialized_queue._lock is not None
-    assert deserialized_queue._status is QueueStatus.TERMINATED
+    assert deserialized_queue._status is QueueStatus.IDLE
 
     for run_operation in run_operations:
         run_operation.wait()

--- a/tests/utils/test_async_logging_queue.py
+++ b/tests/utils/test_async_logging_queue.py
@@ -12,7 +12,7 @@ from mlflow import MlflowException
 from mlflow.entities.metric import Metric
 from mlflow.entities.param import Param
 from mlflow.entities.run_tag import RunTag
-from mlflow.utils.async_logging.async_logging_queue import AsyncLoggingQueue
+from mlflow.utils.async_logging.async_logging_queue import AsyncLoggingQueue, QueueStatus
 
 METRIC_PER_BATCH = 250
 TAGS_PER_BATCH = 1
@@ -70,6 +70,9 @@ def test_single_thread_publish_consume_queue(monkeypatch):
         async_logging_queue.flush()
         # 2 batches are sent to the worker thread pool due to grouping, otherwise it would be 5.
         assert mock_worker_threadpool.submit.call_count == 2
+        assert async_logging_queue.is_terminated()
+        assert mock_check_threadpool.shutdown.call_count == 1
+        assert mock_worker_threadpool.shutdown.call_count == 1
 
 
 def test_grouping_batch_in_time_window():
@@ -105,8 +108,7 @@ def test_queue_activation():
     run_id = "test_run_id"
     run_data = RunData()
     async_logging_queue = AsyncLoggingQueue(run_data.consume_queue_data)
-
-    assert not async_logging_queue._is_activated
+    assert async_logging_queue.is_terminated()
 
     metrics = [
         Metric(
@@ -121,7 +123,33 @@ def test_queue_activation():
         async_logging_queue.log_batch_async(run_id=run_id, metrics=metrics, tags=[], params=[])
 
     async_logging_queue.activate()
-    assert async_logging_queue._is_activated
+    assert async_logging_queue.is_active()
+
+
+def test_end_async_logging():
+    run_id = "test_run_id"
+    run_data = RunData()
+    async_logging_queue = AsyncLoggingQueue(run_data.consume_queue_data)
+    async_logging_queue.activate()
+
+    metrics = [
+        Metric(
+            key=f"batch metrics async-{val}",
+            value=val,
+            timestamp=val,
+            step=0,
+        )
+        for val in range(METRIC_PER_BATCH)
+    ]
+    async_logging_queue.log_batch_async(run_id=run_id, metrics=metrics, tags=[], params=[])
+    async_logging_queue.end_async_logging()
+    assert async_logging_queue._status == QueueStatus.TEAR_DOWN
+    # end_async_logging should not shutdown the threadpool
+    assert not async_logging_queue._batch_logging_worker_threadpool._shutdown
+    assert not async_logging_queue._batch_status_check_threadpool._shutdown
+
+    async_logging_queue.flush()
+    assert async_logging_queue.is_terminated()
 
 
 def test_partial_logging_failed():
@@ -240,7 +268,7 @@ def test_async_logging_queue_pickle():
     deserialized_queue = pickle.loads(buffer.getvalue())  # Type: AsyncLoggingQueue
     assert deserialized_queue._queue.empty()
     assert deserialized_queue._lock is not None
-    assert deserialized_queue._is_activated is False
+    assert deserialized_queue._status is QueueStatus.TERMINATED
 
     for run_operation in run_operations:
         run_operation.wait()
@@ -249,7 +277,7 @@ def test_async_logging_queue_pickle():
 
     # try to log using deserialized queue after activating it.
     deserialized_queue.activate()
-    assert deserialized_queue._is_activated
+    assert deserialized_queue.is_active()
 
     run_operations = []
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12346?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12346/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12346
```

</p>
</details>

### What changes are proposed in this pull request?

This PR fixes a small bug about async logging introduced in https://github.com/mlflow/mlflow/pull/12324.

#### Problem

After that PR is merged, we observed some flakiness in CI tests because of the zombie threads from async logging, which were not being cleaned up properly. We found that `mlflow.flush_async_logging()` function doesn't shut them down as expected.

```
import mlflow
import threading

with mlflow.start_run() as run:
    for i in range(10):
       mlflow.log_param(f"p_{i}", i, synchronous=False)

mlflow.flush_async_logging()
print(threading.enumerate()). <= This still shows MLflowBatchLoggingWorkerPool-x threads
```

After some investigation, it turned out that the new side-effect of run termination made the flush 

1. `flush_async_logging` checks if the async queue is "active" or not first ([code](https://github.com/mlflow/mlflow/blob/c5ae48e4f9f656a21aab078601f15ff8af682912/mlflow/store/tracking/abstract_store.py#L634)). If the queue is inactive, it does nothing.
2. Before the code change, the queue was always active unless explicitly flushed.
3. However, [this line](https://github.com/mlflow/mlflow/blob/c5ae48e4f9f656a21aab078601f15ff8af682912/mlflow/tracking/_tracking_service/client.py#L890) added in the PR changed the behavior. It inserted `end_async_logging()` call within `set_terminated` hook, which is executed when a run exists its scope.
4. This `end_async_logging` is a new method to tell the async queue not to receive any data. It also has side effect of setting async queue "inactive" ([code](https://github.com/mlflow/mlflow/blob/c5ae48e4f9f656a21aab078601f15ff8af682912/mlflow/utils/async_logging/async_logging_queue.py#L69)).
5. Therefore, when `flush_async_logging` is called (which is typically after run scope), the queue is already set to "inactive" by the `end_async_logging`, and threads clean up doesn't run.

#### Solution

This PR introduces a new state `TEAR_DOWN` to the queue status, which represents the state where the queue doesn't accept any new data, but work threads are still running. The `end_async_logging()` call sets the queue to `TEAR_DOWN`. Then, `flush_async_logging()` is updated to flush queue when the status is `ACTIVE` **or** `TEAR_DOWN`, so it can take effect even after `end_async_logging()` is called.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

![Screenshot 2024-06-13 at 22 19 31](https://github.com/mlflow/mlflow/assets/31463517/4e9b7c7b-7e2f-4d94-9b0d-53c2877f46b4)

(`MLflowAsyncLoggingLoop` is still alive after flushing, which is on purpose)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
