### PR TITLE
Handle no headers presigned url

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -3,6 +3,7 @@ import logging
 import os
 import posixpath
 import tempfile
+import traceback
 from abc import ABC, ABCMeta, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
@@ -257,6 +258,7 @@ class ArtifactRepository:
 
         # Wait for downloads to complete and collect failures
         failed_downloads = {}
+        tracebacks = {}
         with ArtifactProgressBar.files(desc="Downloading artifacts", total=len(futures)) as pbar:
             for f in as_completed(futures):
                 try:
@@ -265,11 +267,13 @@ class ArtifactRepository:
                 except Exception as e:
                     path = futures[f]
                     failed_downloads[path] = e
+                    tracebacks[path] = traceback.format_exc()
 
         if failed_downloads:
-            template = "##### File {path} #####\n{error}"
+            template = "##### File {path} #####\n{error}\nTraceback:\n{traceback}\n"
             failures = "\n".join(
-                template.format(path=path, error=error) for path, error in failed_downloads.items()
+                template.format(path=path, error=error, traceback=tracebacks[path])
+                for path, error in failed_downloads.items()
             )
             raise MlflowException(
                 message=(

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -270,7 +270,11 @@ class ArtifactRepository:
                     tracebacks[path] = traceback.format_exc()
 
         if failed_downloads:
-            template = "##### File {path} #####\n{error}\nTraceback:\n{traceback}\n"
+            if _logger.isEnabledFor(logging.DEBUG):
+                template = "##### File {path} #####\n{error}\nTraceback:\n{traceback}\n"
+            else:
+                template = "##### File {path} #####\n{error}"
+
             failures = "\n".join(
                 template.format(path=path, error=error, traceback=tracebacks[path])
                 for path, error in failed_downloads.items()

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -135,6 +135,8 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
         return json_response.get("signed_uri", None), json_response.get("headers", None)
 
     def _extract_headers_from_signed_url(self, headers):
+        if headers is None:
+            return {}
         filtered_headers = filter(lambda h: "name" in h and "value" in h, headers)
         return {header.get("name"): header.get("value") for header in filtered_headers}
 

--- a/tests/store/artifact/test_artifact_repo.py
+++ b/tests/store/artifact/test_artifact_repo.py
@@ -1,3 +1,4 @@
+import logging
 import posixpath
 import time
 from unittest import mock
@@ -6,7 +7,7 @@ import pytest
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
-from mlflow.store.artifact.artifact_repo import ArtifactRepository
+from mlflow.store.artifact.artifact_repo import ArtifactRepository, _logger
 from mlflow.utils.file_utils import TempDir
 
 _MOCK_ERROR = "MOCK ERROR"
@@ -205,3 +206,30 @@ def test_download_artifacts_provides_failure_info(base_uri, download_arg, list_r
         err_msg = str(exc.value)
         assert _MODEL_FILE in err_msg
         assert _MOCK_ERROR in err_msg
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_download_artifacts_provides_traceback_info(debug):
+    if debug:
+        _logger.setLevel(logging.DEBUG)
+    else:
+        _logger.setLevel(logging.INFO)
+
+    def list_artifacts(path):
+        fullpath = posixpath.join(_PARENT_MODEL_DIR, path)
+        if fullpath.endswith(_MODEL_DIR) or fullpath.endswith(_MODEL_DIR + "/"):
+            return [FileInfo(item, False, _DUMMY_FILE_SIZE) for item in [_MODEL_FILE]]
+        else:
+            return []
+
+    with mock.patch.object(FailureArtifactRepositoryImpl, "list_artifacts") as list_artifacts_mock:
+        list_artifacts_mock.side_effect = list_artifacts
+        repo = FailureArtifactRepositoryImpl(_PARENT_MODEL_DIR)
+        try:
+            repo.download_artifacts("")
+        except MlflowException as exc:
+            err_msg = str(exc.message)
+            if debug:
+                assert "Traceback" in err_msg
+            else:
+                assert "Traceback" not in err_msg

--- a/tests/store/artifact/test_artifact_repo.py
+++ b/tests/store/artifact/test_artifact_repo.py
@@ -10,6 +10,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository, _logger
 from mlflow.utils.file_utils import TempDir
 
+from tests.utils.test_logging_utils import reset_logging_level  # noqa F401
+
 _MOCK_ERROR = "MOCK ERROR"
 _MODEL_FILE = "modelfile"
 _MODEL_DIR = "model"
@@ -209,7 +211,7 @@ def test_download_artifacts_provides_failure_info(base_uri, download_arg, list_r
 
 
 @pytest.mark.parametrize("debug", [True, False])
-def test_download_artifacts_provides_traceback_info(debug):
+def test_download_artifacts_provides_traceback_info(debug, reset_logging_level):
     if debug:
         _logger.setLevel(logging.DEBUG)
     else:

--- a/tests/store/artifact/test_artifact_repo.py
+++ b/tests/store/artifact/test_artifact_repo.py
@@ -7,10 +7,10 @@ import pytest
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
-from mlflow.store.artifact.artifact_repo import ArtifactRepository, _logger
+from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import TempDir
 
-from tests.utils.test_logging_utils import reset_logging_level  # noqa F401
+from tests.utils.test_logging_utils import logger, reset_logging_level  # noqa F401
 
 _MOCK_ERROR = "MOCK ERROR"
 _MODEL_FILE = "modelfile"
@@ -213,9 +213,9 @@ def test_download_artifacts_provides_failure_info(base_uri, download_arg, list_r
 @pytest.mark.parametrize("debug", [True, False])
 def test_download_artifacts_provides_traceback_info(debug, reset_logging_level):
     if debug:
-        _logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
     else:
-        _logger.setLevel(logging.INFO)
+        logger.setLevel(logging.INFO)
 
     def list_artifacts(path):
         fullpath = posixpath.join(_PARENT_MODEL_DIR, path)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/12349?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12349/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12349
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Presigned URLs can be used without headers. If that is the case, the current code will coalesce an empty list of headers to a `None` object (as protos do not differentiate between an empty list and an unset list). The code then tries to iterate and filter on the `None` object, which creates an error. 
This PR returns an empty map `{}` when the headers are `None`. It also adds additional logging on errors.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests 

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
