### PR TITLE
Fix transformers cross-version test

### DIFF
--- a/mlflow/data/huggingface_dataset.py
+++ b/mlflow/data/huggingface_dataset.py
@@ -181,6 +181,7 @@ def from_huggingface(
     revision=None,
     name: Optional[str] = None,
     digest: Optional[str] = None,
+    trust_remote_code: Optional[bool] = None,
 ) -> HuggingFaceDataset:
     """
     Create a `mlflow.data.huggingface_dataset.HuggingFaceDataset` from a Hugging Face dataset.
@@ -235,6 +236,7 @@ def from_huggingface(
             data_files=data_files,
             split=ds.split,
             revision=revision,
+            trust_remote_code=trust_remote_code,
         )
     else:
         context_tags = registry.resolve_tags()

--- a/mlflow/data/huggingface_dataset.py
+++ b/mlflow/data/huggingface_dataset.py
@@ -213,6 +213,7 @@ def from_huggingface(
             generated.
         digest: The digest (hash, fingerprint) of the dataset. If unspecified, a digest is
             automatically computed.
+        trust_remote_code: Whether to trust remote code from the dataset repo.
     """
     import datasets
 

--- a/mlflow/data/huggingface_dataset_source.py
+++ b/mlflow/data/huggingface_dataset_source.py
@@ -71,7 +71,7 @@ class HuggingFaceDatasetSource(DatasetSource):
             "revision": self.revision,
         }
 
-        # this argument was only added in 2.16.0
+        # this argument only exists in >= 2.16.0
         if Version(datasets.__version__) >= Version("2.16.0"):
             load_kwargs["trust_remote_code"] = self.trust_remote_code
 

--- a/mlflow/data/huggingface_dataset_source.py
+++ b/mlflow/data/huggingface_dataset_source.py
@@ -36,6 +36,7 @@ class HuggingFaceDatasetSource(DatasetSource):
             data_files: Paths to source data file(s) for the Hugging Face dataset configuration.
             split: Which split of the data to load.
             revision: Version of the dataset script to load.
+            trust_remote_code: Whether to trust remote code from the dataset repo.
         """
         self.path = path
         self.config_name = config_name

--- a/mlflow/data/huggingface_dataset_source.py
+++ b/mlflow/data/huggingface_dataset_source.py
@@ -19,6 +19,7 @@ class HuggingFaceDatasetSource(DatasetSource):
         ] = None,
         split: Optional[Union[str, "datasets.Split"]] = None,
         revision: Optional[Union[str, "datasets.Version"]] = None,
+        trust_remote_code: Optional[bool] = None,
     ):
         """Create a `HuggingFaceDatasetSource` instance.
 
@@ -42,6 +43,7 @@ class HuggingFaceDatasetSource(DatasetSource):
         self.data_files = data_files
         self.split = split
         self.revision = revision
+        self.trust_remote_code = trust_remote_code
 
     @staticmethod
     def _get_source_type() -> str:
@@ -58,6 +60,7 @@ class HuggingFaceDatasetSource(DatasetSource):
             An instance of `datasets.Dataset`.
         """
         import datasets
+        from packaging.version import Version
 
         load_kwargs = {
             "path": self.path,
@@ -67,6 +70,11 @@ class HuggingFaceDatasetSource(DatasetSource):
             "split": self.split,
             "revision": self.revision,
         }
+
+        # this argument was only added in 2.16.0
+        if Version(datasets.__version__) >= Version("2.16.0"):
+            load_kwargs["trust_remote_code"] = self.trust_remote_code
+
         intersecting_keys = set(load_kwargs.keys()) & set(kwargs.keys())
         if intersecting_keys:
             raise KeyError(

--- a/tests/data/test_huggingface_dataset_and_source.py
+++ b/tests/data/test_huggingface_dataset_and_source.py
@@ -50,8 +50,12 @@ def test_from_huggingface_dataset_constructs_expected_dataset():
 def test_from_huggingface_dataset_constructs_expected_dataset_with_revision():
     new_revision = "c33cbf965006dba64f134f7bef69c53d5d0d285d"
     old_revision = "8ca2693371541a5ba2b23981de4222be3bef149f"
-    ds_new = datasets.load_dataset("rotten_tomatoes", split="train", revision=new_revision)
-    ds_old = datasets.load_dataset("rotten_tomatoes", split="train", revision=old_revision)
+    ds_new = datasets.load_dataset(
+        "cornell-movie-review-data/rotten_tomatoes", split="train", revision=new_revision
+    )
+    ds_old = datasets.load_dataset(
+        "cornell-movie-review-data/rotten_tomatoes", split="train", revision=old_revision
+    )
 
     mlflow_ds_new = mlflow.data.from_huggingface(
         ds_new, path="rotten_tomatoes", revision=new_revision

--- a/tests/data/test_huggingface_dataset_and_source.py
+++ b/tests/data/test_huggingface_dataset_and_source.py
@@ -51,10 +51,16 @@ def test_from_huggingface_dataset_constructs_expected_dataset_with_revision():
     new_revision = "c33cbf965006dba64f134f7bef69c53d5d0d285d"
     old_revision = "8ca2693371541a5ba2b23981de4222be3bef149f"
     ds_new = datasets.load_dataset(
-        "cornell-movie-review-data/rotten_tomatoes", split="train", revision=new_revision
+        "cornell-movie-review-data/rotten_tomatoes",
+        split="train",
+        revision=new_revision,
+        trust_remote_code=True,
     )
     ds_old = datasets.load_dataset(
-        "cornell-movie-review-data/rotten_tomatoes", split="train", revision=old_revision
+        "cornell-movie-review-data/rotten_tomatoes",
+        split="train",
+        revision=old_revision,
+        trust_remote_code=True,
     )
 
     mlflow_ds_new = mlflow.data.from_huggingface(

--- a/tests/data/test_huggingface_dataset_and_source.py
+++ b/tests/data/test_huggingface_dataset_and_source.py
@@ -64,10 +64,10 @@ def test_from_huggingface_dataset_constructs_expected_dataset_with_revision():
     )
 
     mlflow_ds_new = mlflow.data.from_huggingface(
-        ds_new, path="rotten_tomatoes", revision=new_revision
+        ds_new, path="rotten_tomatoes", revision=new_revision, trust_remote_code=True
     )
     mlflow_ds_old = mlflow.data.from_huggingface(
-        ds_old, path="rotten_tomatoes", revision=old_revision
+        ds_old, path="rotten_tomatoes", revision=old_revision, trust_remote_code=True
     )
 
     reloaded_ds_new = mlflow_ds_new.source.load()

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -499,7 +499,7 @@ def test_multi_modal_component_save_and_load(component_multi_modal, model_path, 
         # Make sure that the component usage works correctly when extracted from inference loading
         model = loaded_components["model"]
         processor = loaded_components["processor"]
-        question = "What are the cats doing?"
+        question = "What is the wall clock doing?"
         inputs = processor(image_for_test, question, return_tensors="pt")
         outputs = model(**inputs)
         logits = outputs.logits

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -114,8 +114,8 @@ def mock_pyfunc_wrapper():
 @pytest.fixture
 @flaky()
 def image_for_test():
-    dataset = load_dataset("huggingface/cats-image")
-    return dataset["test"]["image"][0]
+    dataset = load_dataset("hf-internal-testing/dummy_image_text_data")
+    return dataset["train"]["image"][0]
 
 
 @pytest.fixture

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -115,7 +115,7 @@ def mock_pyfunc_wrapper():
 @flaky()
 def image_for_test():
     dataset = load_dataset("hf-internal-testing/dummy_image_text_data")
-    return dataset["train"]["image"][0]
+    return dataset["train"]["image"][3]
 
 
 @pytest.fixture
@@ -438,14 +438,14 @@ def test_basic_save_model_and_load_vision_pipeline(small_vision_model, model_pat
     )
     loaded = mlflow.transformers.load_model(model_path)
     prediction = loaded(image_for_test)
-    assert prediction[0]["label"] == "tabby, tabby cat"
+    assert prediction[0]["label"] == "wall clock"
     assert prediction[0]["score"] > 0.5
 
 
 @flaky()
 def test_multi_modal_pipeline_save_and_load(small_multi_modal_pipeline, model_path, image_for_test):
     mlflow.transformers.save_model(transformers_model=small_multi_modal_pipeline, path=model_path)
-    question = "How many cats are in the picture?"
+    question = "How many wall clocks are in the picture?"
     # Load components
     components = mlflow.transformers.load_model(model_path, return_type="components")
     if IS_NEW_FEATURE_EXTRACTION_API:
@@ -455,11 +455,11 @@ def test_multi_modal_pipeline_save_and_load(small_multi_modal_pipeline, model_pa
     assert set(components.keys()).intersection(expected_components) == expected_components
     constructed_pipeline = transformers.pipeline(**components)
     answer = constructed_pipeline(image=image_for_test, question=question)
-    assert answer[0]["answer"] == "2"
+    assert answer[0]["answer"] == "1"
     # Load pipeline
     pipeline = mlflow.transformers.load_model(model_path)
     pipeline_answer = pipeline(image=image_for_test, question=question)
-    assert pipeline_answer[0]["answer"] == "2"
+    assert pipeline_answer[0]["answer"] == "1"
     # Test invalid loading mode
     with pytest.raises(MlflowException, match="The specified return_type mode 'magic' is"):
         mlflow.transformers.load_model(model_path, return_type="magic")

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -499,7 +499,7 @@ def test_multi_modal_component_save_and_load(component_multi_modal, model_path, 
         # Make sure that the component usage works correctly when extracted from inference loading
         model = loaded_components["model"]
         processor = loaded_components["processor"]
-        question = "What is the wall clock doing?"
+        question = "What are the cats doing?"
         inputs = processor(image_for_test, question, return_tensors="pt")
         outputs = model(**inputs)
         logits = outputs.logits


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/12351?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12351/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12351
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Switch the image dataset to one that doesn't require custom code: https://huggingface.co/datasets/hf-internal-testing/dummy_image_text_data

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
