### PR TITLE
Add trace name tag in start_trace

### DIFF
--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -117,6 +117,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             tags.update({TraceTagKey.EVAL_REQUEST_ID: request_id})
         if depedencies_schema := maybe_get_dependencies_schemas():
             tags.update(depedencies_schema)
+        tags.update({TraceTagKey.TRACE_NAME: span.name})
 
         return self._client._start_tracked_trace(
             experiment_id=experiment_id,
@@ -165,12 +166,6 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
                 TraceMetadataKey.OUTPUTS: self._truncate_metadata(
                     root_span.attributes.get(SpanAttributeKey.OUTPUTS)
                 ),
-            }
-        )
-        # Mutable info like trace name should be recorded in tags
-        trace.info.tags.update(
-            {
-                TraceTagKey.TRACE_NAME: root_span.name,
             }
         )
 

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -14,7 +14,6 @@ from mlflow.tracing.constant import (
     TRACE_SCHEMA_VERSION_KEY,
     SpanAttributeKey,
     TraceMetadataKey,
-    TraceTagKey,
 )
 from mlflow.tracing.processor.mlflow import MlflowSpanProcessor
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -48,6 +47,7 @@ def test_on_start(monkeypatch):
         timestamp_ms=5,
         request_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
         tags={
+            "mlflow.traceName": "test_span",
             "mlflow.user": "bob",
             "mlflow.source.name": "test",
             "mlflow.source.type": "LOCAL",
@@ -114,6 +114,7 @@ def test_on_start_with_experiment_id(monkeypatch):
         timestamp_ms=5,
         request_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
         tags={
+            "mlflow.traceName": "test_span",
             "mlflow.user": "bob",
             "mlflow.source.name": "test",
             "mlflow.source.type": "LOCAL",
@@ -229,7 +230,7 @@ def test_on_end():
     trace_output = trace_info.request_metadata.get(TraceMetadataKey.OUTPUTS)
     assert len(trace_output) == 250
     assert trace_output.startswith('{"output": "very long output')
-    assert trace_info.tags == {TraceTagKey.TRACE_NAME: "foo"}
+    assert trace_info.tags == {}
 
     # Non-root span should not be exported
     mock_exporter.reset_mock()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/12353?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12353/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12353
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The trace name is available at the time when we start the trace, so we can directly update the tags there. This resolves an issue where trace name is not available for in-progress traces.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Updated tests and manually tested UI
<img width="1728" alt="Screenshot 2024-06-14 at 1 52 39 PM" src="https://github.com/mlflow/mlflow/assets/148037680/b847859a-304d-49b4-92be-b040bfc4cc4c">



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
