### PR TITLE
Show more helpful message when viewing in-progress traces

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces/ExperimentViewTraceDataDrawer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces/ExperimentViewTraceDataDrawer.tsx
@@ -5,6 +5,7 @@ import {
   Spacer,
   TableSkeleton,
   TitleSkeleton,
+  WarningIcon,
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { getTraceDisplayName } from './ExperimentViewTraces.utils';
@@ -30,7 +31,15 @@ export const ExperimentViewTraceDataDrawer = ({
   loadingTraceInfo?: boolean;
   onClose: () => void;
 }) => {
-  const { traceData, loading, error } = useExperimentTraceData(requestId);
+  const {
+    traceData,
+    loading: loadingTraceData,
+    error,
+  } = useExperimentTraceData(
+    requestId,
+    // skip fetching trace data if trace is in progress
+    traceInfo?.status === 'IN_PROGRESS',
+  );
   const { theme } = useDesignSystemTheme();
 
   // Usually, we rely on the parent component to provide trace info object (when clicked in a table row).
@@ -74,11 +83,33 @@ export const ExperimentViewTraceDataDrawer = ({
   const containsSpans = (traceData?.spans || []).length > 0;
 
   const renderContent = () => {
-    if (loading) {
+    if (loadingTraceData || loadingTraceInfo || loadingInternalTracingInfo) {
       return (
         <>
           <TitleSkeleton />
           <TableSkeleton lines={5} />
+        </>
+      );
+    }
+    if (traceInfo?.status === 'IN_PROGRESS') {
+      return (
+        <>
+          <Spacer size="lg" />
+          <Empty
+            image={<WarningIcon />}
+            description={
+              <FormattedMessage
+                defaultMessage="Trace data is not available for in-progress traces. Please wait for the trace to complete."
+                description="Experiment page > traces data drawer > in-progress description"
+              />
+            }
+            title={
+              <FormattedMessage
+                defaultMessage="Trace data not available"
+                description="Experiment page > traces data drawer > in-progress title"
+              />
+            }
+          />
         </>
       );
     }
@@ -88,12 +119,17 @@ export const ExperimentViewTraceDataDrawer = ({
         <>
           <Spacer size="lg" />
           <Empty
-            image={<DangerIcon />}
-            description={errorMessage}
+            image={<WarningIcon />}
+            description={
+              <FormattedMessage
+                defaultMessage="Trace data is not available for in-progress traces. Please wait for the trace to complete."
+                description="Experiment page > traces data drawer > in-progress description"
+              />
+            }
             title={
               <FormattedMessage
-                defaultMessage="Error"
-                description="Experiment page > traces data drawer > error state title"
+                defaultMessage="Trace data not available"
+                description="Experiment page > traces data drawer > in-progress title"
               />
             }
           />

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces/hooks/useExperimentTraceData.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces/hooks/useExperimentTraceData.tsx
@@ -3,7 +3,7 @@ import { MlflowService } from '../../../../../sdk/MlflowService';
 import { type ModelTraceData } from '@databricks/web-shared/model-trace-explorer';
 import Utils from '../../../../../../common/utils/Utils';
 
-export const useExperimentTraceData = (traceId?: string) => {
+export const useExperimentTraceData = (traceId?: string, skip = false) => {
   const [traceData, setTraceData] = useState<ModelTraceData | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | undefined>(undefined);
@@ -26,10 +26,10 @@ export const useExperimentTraceData = (traceId?: string) => {
   }, []);
 
   useEffect(() => {
-    if (traceId) {
+    if (traceId && !skip) {
       fetchTraceData(traceId);
     }
-  }, [fetchTraceData, traceId]);
+  }, [fetchTraceData, traceId, skip]);
 
   return { traceData, loading, error };
 };

--- a/mlflow/server/js/src/i18n/default/en.json
+++ b/mlflow/server/js/src/i18n/default/en.json
@@ -1007,6 +1007,10 @@
     "defaultMessage": "Hugging Face",
     "description": "Experiment dataset drawer > source type > Hugging Face source type label"
   },
+  "K+5g8S": {
+    "defaultMessage": "Trace data is not available for in-progress traces. Please wait for the trace to complete.",
+    "description": "Experiment page > traces data drawer > in-progress description"
+  },
   "K5rmCE": {
     "defaultMessage": "S3",
     "description": "Experiment dataset drawer > source type > S3 source type label"
@@ -1875,10 +1879,6 @@
     "defaultMessage": "Run page loading",
     "description": "Run page > Loading state"
   },
-  "eavoW/": {
-    "defaultMessage": "Error",
-    "description": "Experiment page > traces data drawer > error state title"
-  },
   "eeLqSn": {
     "defaultMessage": "Submit",
     "description": "Experiment page > artifact compare view > \"add new row\" modal submit button label"
@@ -2346,6 +2346,10 @@
   "owr9l2": {
     "defaultMessage": "No group by columns selected",
     "description": "Experiment page > artifact compare view > empty state for no group by columns selected > title"
+  },
+  "p0O0uP": {
+    "defaultMessage": "Trace data not available",
+    "description": "Experiment page > traces data drawer > in-progress title"
   },
   "p1H1KR": {
     "defaultMessage": "Last 30 days",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/12354?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12354/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12354
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This resolves feedback about a confusing error that shows up when clicking on in-progress traces in the UI. We now show a warning that tells the user that span data is only available when a trace finishes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:


https://github.com/mlflow/mlflow/assets/148037680/8f306a8a-d3a0-46f0-a5bd-80a6d01f147d



After:

https://github.com/mlflow/mlflow/assets/148037680/a877c6cb-cd51-4803-8767-09c86c6556aa




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
