### PR TITLE
Add example_no_conversion for sentence_transformers

### DIFF
--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -130,6 +130,7 @@ def save_model(
     extra_pip_requirements: Optional[Union[List[str], str]] = None,
     conda_env=None,
     metadata: Optional[Dict[str, Any]] = None,
+    example_no_conversion: bool = False,
 ) -> None:
     """
     .. note::
@@ -169,6 +170,7 @@ def save_model(
         extra_pip_requirements: {{ extra_pip_requirements }}
         conda_env: {{ conda_env }}
         metadata: {{ metadata }}
+        example_no_conversion: {{ example_no_conversion }}
     """
     import sentence_transformers
 
@@ -187,7 +189,9 @@ def save_model(
         )
     elif signature is None and input_example is not None:
         wrapped_model = _SentenceTransformerModelWrapper(model)
-        signature = _infer_signature_from_input_example(input_example, wrapped_model)
+        signature = _infer_signature_from_input_example(
+            input_example, wrapped_model, no_conversion=example_no_conversion
+        )
     elif signature is None:
         signature = _get_default_signature()
     elif signature is False:
@@ -198,7 +202,7 @@ def save_model(
     if signature is not None:
         mlflow_model.signature = signature
     if input_example is not None:
-        _save_example(mlflow_model, input_example, str(path))
+        _save_example(mlflow_model, input_example, str(path), no_conversion=example_no_conversion)
     if metadata is not None:
         mlflow_model.metadata = metadata
     model_config = None
@@ -312,6 +316,7 @@ def log_model(
     extra_pip_requirements: Optional[Union[List[str], str]] = None,
     conda_env=None,
     metadata: Optional[Dict[str, Any]] = None,
+    example_no_conversion: bool = False,
 ):
     """
     .. note::
@@ -376,6 +381,7 @@ def log_model(
         extra_pip_requirements: {{ extra_pip_requirements }}
         conda_env: {{ conda_env }}
         metadata: {{ metadata }}
+        example_no_conversion: {{ example_no_conversion }}
     """
     if task is not None:
         metadata = _verify_task_and_update_metadata(task, metadata)
@@ -394,6 +400,7 @@ def log_model(
         input_example=input_example,
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
+        example_no_conversion=example_no_conversion,
     )
 
 

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -18,7 +18,7 @@ import mlflow.sentence_transformers
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _get_mlflow_model_input_example_dict, _read_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.utils.environment import _mlflow_conda_env
 
@@ -488,19 +488,24 @@ SIGNATURE_FROM_EXAMPLE = infer_signature(
 
 
 @pytest.mark.parametrize(
-    ("example", "signature", "expected_signature"),
+    ("example", "signature", "expected_signature", "example_no_conversion"),
     [
-        (None, None, mlflow.sentence_transformers._get_default_signature()),
-        (SENTENCES_DF, None, SIGNATURE_FROM_EXAMPLE),
-        (None, SIGNATURE, SIGNATURE),
-        (SENTENCES, SIGNATURE, SIGNATURE),
+        (None, None, mlflow.sentence_transformers._get_default_signature(), False),
+        (SENTENCES_DF, None, SIGNATURE_FROM_EXAMPLE, False),
+        (None, SIGNATURE, SIGNATURE, False),
+        (SENTENCES, SIGNATURE, SIGNATURE, False),
+        (SENTENCES, SIGNATURE, SIGNATURE, True),
     ],
 )
 def test_signature_and_examples_are_saved_correctly(
-    example, signature, expected_signature, basic_model, model_path
+    example, signature, expected_signature, basic_model, model_path, example_no_conversion
 ):
     mlflow.sentence_transformers.save_model(
-        basic_model, path=model_path, signature=signature, input_example=example
+        basic_model,
+        path=model_path,
+        signature=signature,
+        input_example=example,
+        example_no_conversion=example_no_conversion,
     )
     mlflow_model = Model.load(model_path)
 
@@ -509,6 +514,10 @@ def test_signature_and_examples_are_saved_correctly(
     if example is None:
         assert mlflow_model.saved_input_example_info is None
     else:
+        if example_no_conversion:
+            assert mlflow_model.saved_input_example_info["type"] == "json_object"
+            saved_example = _get_mlflow_model_input_example_dict(mlflow_model, model_path)
+            assert saved_example == example
         if isinstance(example, pd.DataFrame):
             pd.testing.assert_frame_equal(_read_example(mlflow_model, model_path), example)
         else:

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -518,7 +518,7 @@ def test_signature_and_examples_are_saved_correctly(
             assert mlflow_model.saved_input_example_info["type"] == "json_object"
             saved_example = _get_mlflow_model_input_example_dict(mlflow_model, model_path)
             assert saved_example == example
-        if isinstance(example, pd.DataFrame):
+        elif isinstance(example, pd.DataFrame):
             pd.testing.assert_frame_equal(_read_example(mlflow_model, model_path), example)
         else:
             np.testing.assert_equal(_read_example(mlflow_model, model_path), example)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12355?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12355/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12355
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support example_no_conversion for sentence_transformers flavor

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
