### PR TITLE
Refactor callback injection

### DIFF
--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -72,7 +72,7 @@ class AutoLoggingConfig:
 
 class CallbackInjectionCM(contextlib.AbstractContextManager):
     """
-    A context manager that injects callbacks into the model for a specific inference function.
+    A context manager that injects callbacks into original callbacks used for model inference.
 
     For RunnableConfig, the callbacks is defined as List[BaseCallbackHandler] or BaseCallbackManager
     https://github.com/langchain-ai/langchain/blob/ed980601e1c630f996aabf85df5cb26178e53099/libs/core/langchain_core/callbacks/base.py#L636
@@ -152,8 +152,7 @@ class CallbackInjectionCM(contextlib.AbstractContextManager):
 
 class RunnableConfigCallbackInjectionCM(contextlib.AbstractContextManager):
     """
-    Context manager to inject callbacks into the runnable config, update RunnableConfig with new
-    callbacks.
+    Context manager to inject callbacks into runnable configs passed during runnable inference.
     For runnable `invoke`, `ainvoke`, `stream` and `astream`, config type is RunnableConfig,
     for `batch` and `abatch`, config type is Union[RunnableConfig, List[RunnableConfig]]
     """
@@ -191,7 +190,7 @@ class RunnableConfigCallbackInjectionCM(contextlib.AbstractContextManager):
 
 class RunnableCallbackInjectionCM(contextlib.AbstractContextManager):
     """
-    Inject callbacks to models that are runnables, update args and kwargs with the new callbacks.
+    Context manager to inject callbacks into args or kwargs used for runnable inference.
 
     `config` is the second positional argument of runnable invoke, batch, stream,
     ainvoke, abatch, astream functions
@@ -244,7 +243,8 @@ class RunnableCallbackInjectionCM(contextlib.AbstractContextManager):
 
 class MlflowCallbackInjectionCM(contextlib.AbstractContextManager):
     """
-    A context manager that injects MLflow callbacks into the function call.
+    A context manager that injects MLflow callbacks into the model inference call.
+
     For runnables, we inject callbacks into `"invoke", "batch", "stream", "ainvoke", "abatch",
     "astream"` functions.
     # below two functions are deprecated and will be removed in the future


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12392?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12392/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12392
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> 
Address this comment: https://github.com/mlflow/mlflow/pull/12326#discussion_r1639104720
I haven't found a way to make the logic even simpler than below 4 context managers, but this refactoring makes sure we reuse sub-cms for updating callbacks. LMK if you have any better ideas :)

### What changes are proposed in this pull request?
Refactored callback injection logics to four CMs now:
1. MlflowCallbackInjectionCM: directly used for inject callbacks for all patched method in langchain autologging
2. RunnableCallbackInjectionCM: update args and kwargs passed in inference with callbacks, this only applies to Runnables and also update args & kwargs when entering/exiting. (So when the function is runnable specific, we directly use this CM inside MlflowCallbackInjectionCM)
3. RunnableConfigCallbackInjectionCM: update config field for runnables. The runnable config passed during inference can be RunnableConfig or List[RunnableConfig] (for batch only). This CM handles both cases and reverts the changes made to runnableConfig after exiting.
4. CallbackInjectionCM: low level CM for mutating callbacks field that is called in above CMs. callbacks field can be either BaseCallbackManager or List[BaseCallbackHandler], and this CM updates callbacks in them when entering, reverts the changes after exiting. 

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
