### PR TITLE
Fix params and model_config handling for llm/v1/xxx Transformers model

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -69,7 +69,7 @@ from mlflow.transformers.llm_inference_utils import (
     postprocess_output_for_llm_inference_task,
     postprocess_output_for_llm_v1_embedding_task,
     preprocess_llm_embedding_params,
-    preprocess_llm_inference_params,
+    preprocess_llm_inference_input,
 )
 from mlflow.transformers.model_io import (
     _COMPONENTS_BINARY_DIR_NAME,
@@ -1655,20 +1655,19 @@ class _TransformersWrapper:
         Returns:
             Model predictions.
         """
-        if self.llm_inference_task == _LLM_INFERENCE_TASK_CHAT:
-            convert_data_messages_with_chat_template(data, self.pipeline.tokenizer)
-            data, params = preprocess_llm_inference_params(data, self.flavor_config)
-        elif self.llm_inference_task == _LLM_INFERENCE_TASK_COMPLETIONS:
-            data, params = preprocess_llm_inference_params(data, self.flavor_config)
-        elif self.llm_inference_task == _LLM_INFERENCE_TASK_EMBEDDING:
-            data, params = preprocess_llm_embedding_params(data)
-
         # NB: This `predict` method updates the model_config several times. To make the predict
         # call idempotent, we keep the original self.model_config immutable and creates a deep
         # copy of it at every predict call.
         model_config = copy.deepcopy(dict(self.model_config))
+        params = self._merge_model_config_with_params(model_config, params)
 
-        model_config = self._merge_model_config_with_params(model_config, params)
+        if self.llm_inference_task == _LLM_INFERENCE_TASK_CHAT:
+            data, params = preprocess_llm_inference_input(data, params, self.flavor_config)
+            data = convert_data_messages_with_chat_template(data, self.pipeline.tokenizer)
+        elif self.llm_inference_task == _LLM_INFERENCE_TASK_COMPLETIONS:
+            data, params = preprocess_llm_inference_input(data, params, self.flavor_config)
+        elif self.llm_inference_task == _LLM_INFERENCE_TASK_EMBEDDING:
+            data, params = preprocess_llm_embedding_params(data)
 
         if isinstance(data, pd.DataFrame):
             input_data = self._convert_pandas_to_dict(data)
@@ -1700,7 +1699,7 @@ class _TransformersWrapper:
                 _validate_input_dictionary_contains_only_strings_and_lists_of_strings(x)
                 for x in input_data
             )
-        return self._predict(input_data, model_config)
+        return self._predict(input_data, params)
 
     def _predict(self, data, model_config):
         import transformers

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -64,7 +64,7 @@ from mlflow.transformers.llm_inference_utils import (
     _METADATA_LLM_INFERENCE_TASK_KEY,
     _SUPPORTED_LLM_INFERENCE_TASK_TYPES_BY_PIPELINE_TASK,
     _get_default_task_for_llm_inference_task,
-    convert_data_messages_with_chat_template,
+    convert_messages_to_prompt,
     infer_signature_from_llm_inference_task,
     postprocess_output_for_llm_inference_task,
     postprocess_output_for_llm_v1_embedding_task,
@@ -1663,7 +1663,7 @@ class _TransformersWrapper:
 
         if self.llm_inference_task == _LLM_INFERENCE_TASK_CHAT:
             data, params = preprocess_llm_inference_input(data, params, self.flavor_config)
-            data = convert_data_messages_with_chat_template(data, self.pipeline.tokenizer)
+            data = [convert_messages_to_prompt(msgs, self.pipeline.tokenizer) for msgs in data]
         elif self.llm_inference_task == _LLM_INFERENCE_TASK_COMPLETIONS:
             data, params = preprocess_llm_inference_input(data, params, self.flavor_config)
         elif self.llm_inference_task == _LLM_INFERENCE_TASK_EMBEDDING:

--- a/mlflow/transformers/llm_inference_utils.py
+++ b/mlflow/transformers/llm_inference_utils.py
@@ -4,10 +4,13 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
+import numpy as np
 import pandas as pd
 
 from mlflow.exceptions import MlflowException
 from mlflow.models import ModelSignature
+from mlflow.protos.databricks_pb2 import BAD_REQUEST
+from mlflow.transformers.flavor_config import FlavorKey
 from mlflow.types.llm import (
     CHAT_MODEL_INPUT_SCHEMA,
     CHAT_MODEL_OUTPUT_SCHEMA,
@@ -55,6 +58,11 @@ _SIGNATURE_FOR_LLM_INFERENCE_TASK = {
     ),
 }
 
+_LLM_INFERENCE_TASK_TO_DATA_FIELD = {
+    _LLM_INFERENCE_TASK_CHAT: "messages",
+    _LLM_INFERENCE_TASK_COMPLETIONS: "prompt",
+}
+
 
 def infer_signature_from_llm_inference_task(
     inference_task: str, signature: Optional[ModelSignature] = None
@@ -73,25 +81,17 @@ def infer_signature_from_llm_inference_task(
     return inferred_signature
 
 
-def convert_data_messages_with_chat_template(data, tokenizer):
+def convert_data_messages_with_chat_template(messages: List[Dict], tokenizer):
     """For the Chat inference task, apply chat template to messages to create prompt."""
-    if "messages" in data.columns:
-        messages = data.pop("messages").tolist()[0]
-    else:
-        raise MlflowException("The 'messages' field is required for the Chat inference task.")
-
     try:
-        messages_str = tokenizer.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
-        )
+        return tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
     except Exception as e:
         raise MlflowException(f"Failed to apply chat template: {e}")
 
-    data["prompt"] = messages_str
 
-
-def preprocess_llm_inference_params(
-    data,
+def preprocess_llm_inference_input(
+    data: pd.DataFrame,
+    params: Optional[Dict[str, Any]] = None,
     flavor_config: Optional[Dict[str, Any]] = None,
 ) -> Tuple[List[Any], Dict[str, Any]]:
     """
@@ -106,27 +106,34 @@ def preprocess_llm_inference_params(
             "`data` is expected to be a pandas DataFrame for MLflow inference task after signature "
             f"enforcement, but got type: {type(data)}."
         )
+    flavor_config = flavor_config or {}
+    params = params or {}
+    # Pandas convert None to np.nan internally, which is not preferred
+    data = data.replace(np.nan, None).to_dict(orient="list")
 
-    updated_data = []
-    params = {}
+    # Extract list of input data (prompt, messages) to LLM
+    task = flavor_config[_LLM_INFERENCE_TASK_KEY]
+    input_col = _LLM_INFERENCE_TASK_TO_DATA_FIELD.get(task)
+    if input_col not in data:
+        raise MlflowException(
+            f"Transformer model saved with `{task}` task excepts `{input_col}`"
+            "to be passed as input data.",
+            error_code=BAD_REQUEST,
+        )
+    update_data = data.pop(input_col)
 
-    for column in data.columns:
-        if column in ["prompt", "messages"]:
-            updated_data = data[column].tolist()
-        else:
-            param = data[column].tolist()[0]
-            if column == "max_tokens":
-                params["max_new_tokens"] = param
-            elif column == "stop":
-                source_model_name = (
-                    flavor_config.get("source_model_name") if flavor_config else None
-                )
-                if stop := _get_stopping_criteria(param, source_model_name):
-                    params["stopping_criteria"] = stop
-            else:
-                params[column] = param
+    # The rest of fields in input payload should goes to params and override default ones
+    params_in_data = {k: v[0] for k, v in data.items() if v[0] is not None}
+    params = {**params, **params_in_data}
 
-    return updated_data, params
+    if max_tokens := params.pop("max_tokens", None):
+        params["max_new_tokens"] = max_tokens
+    if stop := params.pop("stop", None):
+        params["stopping_criteria"] = _get_stopping_criteria(
+            stop,
+            flavor_config.get(FlavorKey.MODEL_NAME),
+        )
+    return update_data, params
 
 
 def _get_stopping_criteria(stop: Optional[Union[str, List[str]]], model_name: Optional[str] = None):

--- a/mlflow/transformers/llm_inference_utils.py
+++ b/mlflow/transformers/llm_inference_utils.py
@@ -93,7 +93,7 @@ def convert_messages_to_prompt(messages: List[Dict], tokenizer) -> str:
     """
     if not (isinstance(messages, list) and all(isinstance(msg, dict) for msg in messages)):
         raise MlflowException(
-            f"Input messages for chat task should be list of dictionaries, but got: {type(messages)}.",
+            f"Input messages should be list of dictionaries, but got: {type(messages)}.",
             error_code=INVALID_PARAMETER_VALUE,
         )
 

--- a/tests/transformers/test_transformers_llm_inference_utils.py
+++ b/tests/transformers/test_transformers_llm_inference_utils.py
@@ -67,7 +67,7 @@ def test_apply_chat_template():
     prompt = convert_messages_to_prompt(data1, DummyTokenizer())
     assert prompt == "one two"
 
-    with pytest.raises(MlflowException, match=r"Input messages for chat task should"):
+    with pytest.raises(MlflowException, match=r"Input messages should be list of"):
         convert_messages_to_prompt([["one", "two"]], DummyTokenizer())
 
 

--- a/tests/transformers/test_transformers_llm_inference_utils.py
+++ b/tests/transformers/test_transformers_llm_inference_utils.py
@@ -1,4 +1,5 @@
 import uuid
+from collections import namedtuple
 from typing import Dict, List
 from unittest import mock
 
@@ -16,7 +17,7 @@ from mlflow.transformers.llm_inference_utils import (
     _get_token_usage,
     convert_data_messages_with_chat_template,
     infer_signature_from_llm_inference_task,
-    preprocess_llm_inference_params,
+    preprocess_llm_inference_input,
 )
 from mlflow.types.llm import (
     CHAT_MODEL_INPUT_SCHEMA,
@@ -79,22 +80,125 @@ def test_apply_chat_template():
     pd.testing.assert_frame_equal(data1, expected_data)
 
 
-def test_preprocess_llm_inference_params():
-    data = pd.DataFrame(
-        {
-            "prompt": ["Hello world!"],
-            "temperature": [0.7],
-            "max_tokens": [100],
-            # do not pass this to params as it is None
-            "stop": None,
-        }
-    )
+_TestCase = namedtuple("_TestCase", ["data", "params", "expected_data", "expected_params"])
 
-    data, params = preprocess_llm_inference_params(data, flavor_config=None)
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        # Case 0: Data only includes prompt
+        _TestCase(
+            data={"prompt": ["Hello world!"]},
+            params={},
+            expected_data=["Hello world!"],
+            expected_params={},
+        ),
+        # Case 1: Data includes prompt and params
+        _TestCase(
+            data={
+                "prompt": ["Hello world!"],
+                "temperature": [0.7],
+                "max_tokens": [100],
+                "stop": None,
+            },
+            params={},
+            expected_data=["Hello world!"],
+            expected_params={
+                "temperature": 0.7,
+                # max_tokens is replaced with max_new_tokens
+                "max_new_tokens": 100,
+                # do not pass `stop` to params as it is None
+            },
+        ),
+        # Case 2: Params are passed if not specified in data
+        _TestCase(
+            data={
+                "prompt": ["Hello world!"],
+            },
+            params={
+                "temperature": 0.7,
+                "max_tokens": 100,
+                "stop": ["foo", "bar"],
+            },
+            expected_data=["Hello world!"],
+            expected_params={
+                "temperature": 0.7,
+                "max_new_tokens": 100,
+                # Stopping criteria is _StopSequenceMatchCriteria instance
+                # "stop": ...
+            },
+        ),
+        # Case 3: Data overrides params
+        _TestCase(
+            data={
+                "messages": ["Hello world!"],
+                "temperature": [0.1],
+                "max_tokens": [100],
+                "stop": [["foo", "bar"]],
+            },
+            params={
+                "temperature": [0.2],
+                "max_tokens": [200],
+                "stop": ["foo", "bar", "baz"],
+            },
+            expected_data=["Hello world!"],
+            expected_params={
+                "temperature": 0.1,
+                "max_new_tokens": 100,
+            },
+        ),
+        # Case 4: Batch input
+        _TestCase(
+            data={
+                "prompt": ["Hello!", "Hi", "Hola"],
+                "temperature": [0.1, 0.2, 0.3],
+                "max_tokens": [None, 200, 300],
+            },
+            params={
+                "temperature": 0.4,
+                "max_tokens": 400,
+            },
+            expected_data=["Hello!", "Hi", "Hola"],
+            # The values in the first data is used, otherwise params
+            expected_params={
+                "temperature": 0.1,
+                "max_new_tokens": 400,
+            },
+        ),
+    ],
+)
+def test_preprocess_llm_inference_input(case):
+    data = pd.DataFrame(case.data)
+
+    task = "llm/v1/completions" if "prompt" in case.data else "llm/v1/chat"
+    flavor_config = {"inference_task": task, "source_model_name": "test"}
+
+    with mock.patch(
+        "mlflow.transformers.llm_inference_utils._get_stopping_criteria"
+    ) as mock_get_stopping_criteria:
+        data, params = preprocess_llm_inference_input(data, case.params, flavor_config)
 
     # Test that OpenAI params are separated from data and replaced with Hugging Face params
-    assert data == ["Hello world!"]
-    assert params == {"max_new_tokens": 100, "temperature": 0.7}
+    assert data == case.expected_data
+    if "stopping_criteria" in params:
+        assert params.pop("stopping_criteria") is not None
+        mock_get_stopping_criteria.assert_called_once_with(["foo", "bar"], "test")
+    assert params == case.expected_params
+
+
+def test_preprocess_llm_inference_input_raise_if_key_invalid():
+    # Missing input key
+    with pytest.raises(MlflowException, match=r"Transformer model saved with"):
+        preprocess_llm_inference_input(
+            pd.DataFrame({"invalid_key": [1, 2, 3]}),
+            flavor_config={"inference_task": "llm/v1/completions"},
+        )
+
+    # Unmatched key (should be "messages" for chat task)
+    with pytest.raises(MlflowException, match=r"Transformer model saved with"):
+        preprocess_llm_inference_input(
+            pd.DataFrame({"prompt": ["Hi"]}), flavor_config={"inference_task": "llm/v1/chat"}
+        )
 
 
 @mock.patch("transformers.AutoTokenizer.from_pretrained")

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3465,6 +3465,7 @@ def test_text_generation_task_completions_predict_with_max_tokens(
         transformers_model=text_generation_pipeline,
         path=model_path,
         task="llm/v1/completions",
+        model_config={"max_tokens": 10},
     )
 
     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
@@ -3484,6 +3485,12 @@ def test_text_generation_task_completions_predict_with_max_tokens(
         and inference[0]["usage"]["completion_tokens"] < 10
     )
 
+    # Override model_config with runtime params
+    inference = pyfunc_loaded.predict(
+        {"prompt": "How to learn Python in 3 weeks?", "max_tokens": 5},
+    )
+    assert inference[0]["usage"]["completion_tokens"] == 5
+
 
 def test_text_generation_task_completions_predict_with_stop(text_generation_pipeline, model_path):
     mlflow.transformers.save_model(
@@ -3491,11 +3498,12 @@ def test_text_generation_task_completions_predict_with_stop(text_generation_pipe
         path=model_path,
         task="llm/v1/completions",
         metadata={"foo": "bar"},
+        model_config={"stop": ["Python"]},
     )
 
     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
     inference = pyfunc_loaded.predict(
-        {"prompt": "How to learn Python in 3 weeks?", "stop": ["Python"]},
+        {"prompt": "How to learn Python in 3 weeks?"},
     )
 
     assert inference[0]["choices"][0]["finish_reason"] == "stop"
@@ -3503,6 +3511,12 @@ def test_text_generation_task_completions_predict_with_stop(text_generation_pipe
         inference[0]["choices"][0]["text"].endswith("Python")
         or "Python" not in inference[0]["choices"][0]["text"]
     )
+
+    # Override model_config with runtime params
+    inference = pyfunc_loaded.predict(
+        {"prompt": "How to learn Python in 3 weeks?", "stop": ["Abracadabra"]},
+    )
+    assert not inference[0]["choices"][0]["text"].endswith("Python")
 
 
 def test_text_generation_task_completions_serve(text_generation_pipeline):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3506,11 +3506,14 @@ def test_text_generation_task_completions_predict_with_stop(text_generation_pipe
         {"prompt": "How to learn Python in 3 weeks?"},
     )
 
+    if "Python" not in inference[0]["choices"][0]["text"]:
+        pytest.skip(
+            "Model did not generate text containing 'Python', "
+            "skipping validation of stop parameter in inference"
+        )
+
     assert inference[0]["choices"][0]["finish_reason"] == "stop"
-    assert (
-        inference[0]["choices"][0]["text"].endswith("Python")
-        or "Python" not in inference[0]["choices"][0]["text"]
-    )
+    assert inference[0]["choices"][0]["text"].endswith("Python")
 
     # Override model_config with runtime params
     inference = pyfunc_loaded.predict(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12401?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12401/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12401
```

</p>
</details>

### What changes are proposed in this pull request?

#### Problem

The `model_config` argument in `log_model()` is used to specify default parameters passed for the model at inference time.

```
mlflow.transformers.log_model(pipeline, "model", model_config={"temperature": 0})
...

loaded_model.predict({"prompt": "foo"})   # <- temperature 0 is used
```

However, some parameters in `model_config` is ignored used when `llm/v1/xxx` task is specified, such as `stop`, `max_tokens`. 
```
mlflow.transformers.log_model(pipeline, "model", model_config={"stop": ["bar"]})
...

loaded_model.predict({"prompt": "foo"})   # <- stop sequence is not used for inference
```

#### Root Cause

This issue is due to the way how we preprocess those params to the format Transformers expect. For example, when `stop` is passed as a part of input payload, MLflow translate it to `stopping_criteria` [here](https://github.com/mlflow/mlflow/blob/master/mlflow/transformers/__init__.py#L1660). The `model_config` is injected to the request after this preprocessing, therefore, its params are not translated and thus ignored.

#### Solution 
This PR updates the preprocess logic to consider `model_config`, not only input payload.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested in notebook (pyfunc calling) and model serving.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `model_config` ignorance in the Transformers models saved with `llm/v1/completions` or `llm/v1/chat`. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
