### PR TITLE
Use `uuid.uuid4().hex` to generate a random id for sagemaker model names

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -10,6 +10,7 @@ import sys
 import tarfile
 import time
 import urllib.parse
+import uuid
 from subprocess import Popen
 from typing import Any, Dict, List, Optional
 
@@ -32,7 +33,6 @@ from mlflow.models.container import (
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import get_unique_resource_id
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.proto_json_utils import dump_input_data
 
@@ -1376,7 +1376,8 @@ def _truncate_name(name, max_length):
 
 
 def _get_unique_name(base_name, unique_suffix, unique_id_length=20):
-    unique_resource_string = f"{unique_suffix}{get_unique_resource_id(unique_id_length)}"
+    unique_id = uuid.uuid4().hex[:unique_id_length]
+    unique_resource_string = f"{unique_suffix}{unique_id}"
     max_length = 63 - len(unique_resource_string)
     return _truncate_name(base_name, max_length) + unique_resource_string
 

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -1,9 +1,7 @@
-import base64
 import inspect
 import logging
 import socket
 import subprocess
-import uuid
 from contextlib import closing
 from itertools import islice
 from sys import version_info
@@ -19,37 +17,6 @@ _logger = logging.getLogger(__name__)
 
 def get_major_minor_py_version(py_version):
     return ".".join(py_version.split(".")[:2])
-
-
-def get_unique_resource_id(max_length=None):
-    """
-    Obtains a unique id that can be included in a resource name. This unique id is a valid
-    DNS subname.
-
-    Args:
-        max_length: The maximum length of the identifier.
-
-    Returns:
-        A unique identifier that can be appended to a user-readable resource name to avoid
-        naming collisions.
-    """
-    if max_length is not None and max_length <= 0:
-        raise ValueError(
-            "The specified maximum length for the unique resource id must be positive!"
-        )
-
-    uuid_bytes = uuid.uuid4().bytes
-    # Use base64 encoding to shorten the UUID length. Note that the replacement of the
-    # unsupported '+' symbol maintains uniqueness because the UUID byte string is of a fixed,
-    # 16-byte length
-    uuid_b64 = base64.b64encode(uuid_bytes)
-    # In Python3, `uuid_b64` is a `bytes` object. It needs to be
-    # converted to a string
-    uuid_b64 = uuid_b64.decode("ascii")
-    unique_id = uuid_b64.rstrip("=\n").replace("/", "-").replace("+", "AB").lower()
-    if max_length is not None:
-        unique_id = unique_id[: int(max_length)]
-    return unique_id
 
 
 def reraise(tp, value, tb=None):

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import time
 from collections import namedtuple
 from functools import wraps
@@ -1702,6 +1703,5 @@ def test_get_sagemaker_config_name():
 # Test the behavior when the base name is too long and needs truncation
 def test_name_truncation_for_long_base_name():
     long_base_name = "a" * 100  # 100 characters long
-    with mock.patch("mlflow.sagemaker.get_unique_resource_id", return_value="1234567890abcdef1234"):
-        model_name = mfs._get_sagemaker_model_name(long_base_name)
-    assert model_name == "aaaaaaaaaaaaaaaa---aaaaaaaaaaaaaaaaa-model-1234567890abcdef1234"
+    model_name = mfs._get_sagemaker_model_name(long_base_name)
+    assert re.match(r"^aaaaaaaaaaaaaaaa---aaaaaaaaaaaaaaaaa-model-[0-9a-f]{20}$", model_name)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -7,24 +7,8 @@ from mlflow.utils import (
     _chunk_dict,
     _get_fully_qualified_class_name,
     _truncate_dict,
-    get_unique_resource_id,
     merge_dicts,
 )
-
-
-def test_get_unique_resource_id_respects_max_length():
-    for max_length in range(5, 30, 5):
-        for _ in range(10000):
-            assert len(get_unique_resource_id(max_length=max_length)) <= max_length
-
-
-def test_get_unique_resource_id_with_invalid_max_length_throws_exception():
-    match = "unique resource id must be positive"
-    with pytest.raises(ValueError, match=match):
-        get_unique_resource_id(max_length=-50)
-
-    with pytest.raises(ValueError, match=match):
-        get_unique_resource_id(max_length=0)
 
 
 def test_truncate_dict():


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Fix #12418

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`get_unique_resource_id` occasionally generates a string ending with `-`, which AWS doesn't accept. To ensure the unique ID ends with an alphanumeric character, use `uuid.uuid4().hex` instead.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
