### PR TITLE
Make `mlflow` depend on `mlflow-skinny` to prevent version mismtach

### DIFF
--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -64,7 +64,7 @@ jobs:
           if [ "${{ matrix.type }}" == "skinny" ]; then
             python dev/build.py --package-type skinny
           else
-            python dev/build.sh
+            python dev/build.py
           fi
 
           # List distribution files and check their file sizes

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -62,9 +62,9 @@ jobs:
         id: build-dist
         run: |
           if [ "${{ matrix.type }}" == "skinny" ]; then
-            ./dev/build.py --package-type skinny
+            python dev/build.py --package-type skinny
           else
-            ./dev/build.sh
+            python dev/build.sh
           fi
 
           # List distribution files and check their file sizes

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -62,7 +62,7 @@ jobs:
         id: build-dist
         run: |
           if [ "${{ matrix.type }}" == "skinny" ]; then
-            ./dev/build.sh --skinny
+            ./dev/build.py --package-type skinny
           else
             ./dev/build.sh
           fi

--- a/dev/build.py
+++ b/dev/build.py
@@ -1,6 +1,8 @@
 import argparse
+import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 
 def parse_args():
@@ -16,6 +18,15 @@ def parse_args():
 
 def main():
     args = parse_args()
+
+    for path in map(Path, ["build", "dist", "mlflow.egg-info", "mlflow_skinny.egg-info"]):
+        if not path.exists():
+            continue
+        if path.is_file():
+            path.unlink()
+        else:
+            shutil.rmtree(path)
+
     try:
         if args.package_type == "skinny":
             with open("README_SKINNY.rst") as f1, open("README.rst") as f2:
@@ -33,7 +44,7 @@ def main():
 
         subprocess.check_call([sys.executable, "-m", "build"])
     finally:
-        subprocess.check_call(["git", "restore", "."])
+        subprocess.check_call(["git", "restore", ":^dev/build.py"])
 
 
 if __name__ == "__main__":

--- a/dev/build.py
+++ b/dev/build.py
@@ -1,0 +1,40 @@
+import argparse
+import subprocess
+import sys
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--package-type",
+        help="Package type to build. Default is 'dev'.",
+        choices=["skinny", "release", "dev"],
+        default="dev",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        if args.package_type == "skinny":
+            with open("README_SKINNY.rst") as f1, open("README.rst") as f2:
+                readme = f1.read() + "\n" + f2.read()
+
+            with open("README.rst", "w") as f:
+                f.write(readme)
+
+            with open("pyproject.skinny.toml") as f1, open("pyproject.toml", "w") as f2:
+                f2.write(f1.read())
+
+        elif args.package_type == "release":
+            with open("pyproject.release.toml") as f1, open("pyproject.toml", "w") as f2:
+                f2.write(f1.read())
+
+        subprocess.check_call([sys.executable, "-m", "build"])
+    finally:
+        subprocess.check_call(["git", "restore", "."])
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -231,9 +231,9 @@ def main() -> None:
             "https://taplo.tamasfe.dev/cli/introduction.html."
         )
         return
-    build(PackageType.DEV)
-    build(PackageType.RELEASE)
-    build(PackageType.SKINNY)
+
+    for package_type in PackageType:
+        build(package_type)
 
 
 if __name__ == "__main__":

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -220,7 +220,7 @@ def build(package_type: PackageType) -> None:
             f.write(original)
 
     if taplo := shutil.which("taplo"):
-        subprocess.run([taplo, "fmt", out_path], check=True)
+        subprocess.check_call([taplo, "fmt", out_path])
 
 
 def main() -> None:

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -68,9 +68,7 @@ def build(package_type: PackageType) -> None:
     if package_type is PackageType.SKINNY:
         dependencies = sorted(skinny_requirements)
     elif package_type is PackageType.RELEASE:
-        dependencies = [f"mlflow-skinny=={package_version}"] + sorted(
-            set(core_requirements) - set(skinny_requirements)
-        )
+        dependencies = [f"mlflow-skinny=={package_version}"] + sorted(core_requirements)
     else:
         dependencies = sorted(core_requirements + skinny_requirements)
 

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -93,10 +93,7 @@ def build(package_type: PackageType) -> None:
             "name": package_name,
             "version": package_version,
             "maintainers": [
-                {
-                    "name": "Databricks",
-                    "email": "mlflow-oss-maintainers@googlegroups.com ",
-                }
+                {"name": "Databricks", "email": "mlflow-oss-maintainers@googlegroups.com "}
             ],
             "description": (
                 "MLflow is an open source platform for the complete machine learning lifecycle"

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import re
 import shutil
 import subprocess
@@ -224,17 +223,6 @@ def build(package_type: PackageType) -> None:
 
     if taplo := shutil.which("taplo"):
         subprocess.run([taplo, "fmt", out_path], check=True)
-
-
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--release",
-        action="store_true",
-        help="If True, make mlflow depend on mlflow-skinny.",
-        required=False,
-    )
-    return parser.parse_args()
 
 
 def main() -> None:

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -46,9 +46,7 @@ def build(package_type: PackageType) -> None:
     core_requirements = read_requirements(Path("requirements", "core-requirements.txt"))
     gateways_requirements = read_requirements(Path("requirements", "gateway-requirements.txt"))
     package_version = re.search(
-        r'^VERSION = "([a-z0-9\.]+)"$',
-        Path("mlflow", "version.py").read_text(),
-        re.MULTILINE,
+        r'^VERSION = "([a-z0-9\.]+)"$', Path("mlflow", "version.py").read_text(), re.MULTILINE
     ).group(1)
     python_version = Path("requirements", "python-version.txt").read_text().strip()
     versions_yaml = read_package_versions_yml()

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -1,0 +1,136 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mlflow"
+version = "2.14.2.dev0"
+description = "MLflow is an open source platform for the complete machine learning lifecycle"
+readme = "README.rst"
+keywords = ["mlflow", "ai", "databricks"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Intended Audience :: End Users/Desktop",
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: Information Technology",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3.8",
+]
+requires-python = ">=3.8"
+dependencies = [
+  "mlflow-skinny==2.14.2.dev0",
+  "Flask<4",
+  "Jinja2<4,>=2.11; platform_system != 'Windows'",
+  "Jinja2<4,>=3.0; platform_system == 'Windows'",
+  "alembic<2,!=1.10.0",
+  "docker<8,>=4.0.0",
+  "graphene<4",
+  "gunicorn<23; platform_system != 'Windows'",
+  "markdown<4,>=3.3",
+  "matplotlib<4",
+  "numpy<2",
+  "pandas<3",
+  "pyarrow<16,>=4.0.0",
+  "querystring_parser<2",
+  "scikit-learn<2",
+  "scipy<2",
+  "sqlalchemy<3,>=1.4.0",
+  "waitress<4; platform_system == 'Windows'",
+]
+[[project.maintainers]]
+name = "Databricks"
+email = "mlflow-oss-maintainers@googlegroups.com "
+
+[project.license]
+file = "LICENSE.txt"
+
+[project.optional-dependencies]
+extras = [
+  "pyarrow",
+  "requests-auth-aws-sigv4",
+  "boto3",
+  "botocore",
+  "google-cloud-storage>=1.30.0",
+  "azureml-core>=1.2.0",
+  "pysftp",
+  "kubernetes",
+  "mlserver>=1.2.0,!=1.3.1,<1.4.0",
+  "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
+  "virtualenv",
+  "prometheus-flask-exporter",
+]
+databricks = [
+  "azure-storage-file-datalake>12",
+  "google-cloud-storage>=1.30.0",
+  "boto3>1",
+  "botocore",
+]
+gateway = [
+  "pydantic<3,>=1.0",
+  "fastapi<1",
+  "uvicorn[standard]<1",
+  "watchfiles<1",
+  "aiohttp<4",
+  "boto3<2,>=1.28.56",
+  "tiktoken<1",
+  "slowapi<1,>=0.1.9",
+]
+genai = [
+  "pydantic<3,>=1.0",
+  "fastapi<1",
+  "uvicorn[standard]<1",
+  "watchfiles<1",
+  "aiohttp<4",
+  "boto3<2,>=1.28.56",
+  "tiktoken<1",
+  "slowapi<1,>=0.1.9",
+]
+sqlserver = ["mlflow-dbstore"]
+aliyun-oss = ["aliyunstoreplugin"]
+xethub = ["mlflow-xethub"]
+jfrog = ["mlflow-jfrog-plugin"]
+langchain = ["langchain>=0.1.0,<=0.2.5"]
+
+[project.urls]
+homepage = "https://mlflow.org"
+issues = "https://github.com/mlflow/mlflow/issues"
+documentation = "https://mlflow.org/docs/latest/index.html"
+repository = "https://github.com/mlflow/mlflow"
+
+[project.scripts]
+mlflow = "mlflow.cli:cli"
+
+[project.entry-points."mlflow.app"]
+basic-auth = "mlflow.server.auth:create_app"
+
+[project.entry-points."mlflow.app.client"]
+basic-auth = "mlflow.server.auth.client:AuthServiceClient"
+
+[project.entry-points."mlflow.deployments"]
+databricks = "mlflow.deployments.databricks"
+http = "mlflow.deployments.mlflow"
+https = "mlflow.deployments.mlflow"
+openai = "mlflow.deployments.openai"
+
+[tool.setuptools.package-data]
+mlflow = [
+  "store/db_migrations/alembic.ini",
+  "temporary_db_migrations_for_pre_1_users/alembic.ini",
+  "pypi_package_index.json",
+  "pyspark/ml/log_model_allowlist.txt",
+  "server/auth/basic_auth.ini",
+  "server/auth/db/migrations/alembic.ini",
+  "recipes/resources/**/*",
+  "recipes/cards/templates/**/*",
+  "models/container/**/*",
+  "server/js/build/**/*",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["mlflow", "mlflow.*"]
+exclude = ["tests", "tests.*"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12426?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12426/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12426
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The mlflow-and-mlflow-skinny co-installation issue has bitten us too many times before. This PR makes `mlflow x.y.z` depend on `mlflow-skinny x.y.z` to prevent their version mismatch. Once this PR is merged, we'll have three mlflow variants:

| Variant          | Dependencies                               | Notes                                                                                                                             |
| ---------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
| mlflow-skinny    | skinny dependencies                        | skinny is always skinny                                                                                                           |
| mlflow (dev)     | skinny dependencies + core dependencies    | mlflow for development, installable via `pip install git+https://github.com/mlflow/mlflow.git`. Doesn't depend on `mlflow-skinny` |
| mlflow (release) | `mlflow-skinny==x.y.z` + core dependencies | mlflow published on PyPI. Depends on `mlflow-skinny`                                                                              |


<details><summary>How to reproduce the error</summary>
<p>

```
docker run --rm python:3.8 bash -c "pip install mlflow==2.14.0 && pip install mlflow-skinny==2.13.2 && python -c 'import mlflow'"
```

Output

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.8/site-packages/mlflow/__init__.py", line 109, in <module>
    from mlflow.tracing.fluent import (
  File "/usr/local/lib/python3.8/site-packages/mlflow/tracing/fluent.py", line 26, in <module>
    from mlflow.tracing.utils import (
ImportError: cannot import name 'extract_span_inputs_outputs' from 'mlflow.tracing.utils' (/usr/local/lib/python3.8/site-packages/mlflow/tracing/utils/__init__.py)
```

File structure:

```
> tree /usr/local/lib/python3.8/site-packages/mlflow/tracing
...
├── utils     # comes from 2.14.0
│   ├── __init__.py
│   ├── __pycache__
│   │   ├── __init__.cpython-38.pyc
│   │   └── search.cpython-38.pyc
│   └── search.py
└── utils.py  # comes from 2.13.2
```

</p>
</details> 



### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

#### Code for manual testing

<details><summary>Open</summary>
<p>

```python
"""
Simulate the installation of mlflow that depends on mlflow-skinny
"""
import contextlib
import re
import shutil
import socket
import subprocess
import sys
import tempfile
from pathlib import Path


def get_safe_port():
    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
        sock.bind(("localhost", 0))
        return sock.getsockname()[1]


@contextlib.contextmanager
def serve_wheels():
    with tempfile.TemporaryDirectory() as tmpdir:
        subprocess.check_call(
            [
                sys.executable,
                "dev/build.py",
                "--package-type",
                "skinny",
            ],
            stdout=subprocess.DEVNULL,
        )
        mlflow_skinny_dir = Path(tmpdir) / "mlflow-skinny"
        shutil.copytree("dist", mlflow_skinny_dir)

        subprocess.check_call(
            [
                sys.executable,
                "dev/build.py",
                "--package-type",
                "release",
            ],
            stdout=subprocess.DEVNULL,
        )
        subprocess.check_call(["dev/build.sh"], stdout=subprocess.DEVNULL)
        mlflow_dir = Path(tmpdir) / "mlflow"
        shutil.copytree("dist", mlflow_dir)

        port = get_safe_port()
        with subprocess.Popen(
            [
                sys.executable,
                "-m",
                "http.server",
                str(port),
            ],
            cwd=tmpdir,
        ) as prc:
            try:
                yield f"http://localhost:{port}"
            finally:
                prc.terminate()


def main():
    version = re.search(
        r'^VERSION = "([a-z0-9\.]+)"$',
        Path("mlflow", "version.py").read_text(),
        re.MULTILINE,
    ).group(1)
    with serve_wheels() as url:
        subprocess.check_call(
            [
                sys.executable,
                "-m",
                "pip",
                "install",
                "--pre",
                f"mlflow=={version}",
                "--extra-index-url",
                url,
            ]
        )
        subprocess.check_call([sys.executable, "-m", "pip", "list"])


if __name__ == "__main__":
    main()
```

Output:

```
...
matplotlib                         3.7.5
mlflow                             2.14.2.dev0
mlflow-skinny                      2.14.2.dev0
numpy                              1.24.4
...
```

</p>
</details> 

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
