### PR TITLE
Fix pytest error when running tests against mlflow/data/

### DIFF
--- a/mlflow/data/dataset_source_registry.py
+++ b/mlflow/data/dataset_source_registry.py
@@ -32,8 +32,8 @@ class DatasetSourceRegistry:
                 self.register(entrypoint.load())
             except (AttributeError, ImportError) as exc:
                 warnings.warn(
-                    f"Failure attempting to register dataset source with source type"
-                    f' "{entrypoint}": {exc}',
+                    "Failure attempting to register dataset constructor"
+                    + f' "{entrypoint}": {exc}',
                     stacklevel=2,
                 )
 

--- a/mlflow/data/dataset_source_registry.py
+++ b/mlflow/data/dataset_source_registry.py
@@ -33,7 +33,7 @@ class DatasetSourceRegistry:
             except (AttributeError, ImportError) as exc:
                 warnings.warn(
                     f"Failure attempting to register dataset source with source type"
-                    f' "{entrypoint.source_type}": {exc}',
+                    f' "{entrypoint}": {exc}',
                     stacklevel=2,
                 )
 

--- a/tests/data/test_dataset_registry.py
+++ b/tests/data/test_dataset_registry.py
@@ -146,3 +146,9 @@ def test_register_constructor_and_call(dataset_registry, dataset_source_registry
     assert dataset2.data_list == [4, 5, 6]
     assert dataset2.name == "name2"
     assert dataset2.digest == "digest2"
+
+
+def test_dataset_source_registration_failure(dataset_source_registry):
+    with mock.patch.object(dataset_source_registry, "register", side_effect=ImportError("Error")):
+        with pytest.warns(UserWarning, match="Failure attempting to register dataset constructor"):
+            dataset_source_registry.register_entrypoints()


### PR DESCRIPTION
### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
(mlflow-dev) (base) xiaoqian.yin@M99QR4F6VP mlflow % pytest                                                 
```
ImportError while loading conftest '/Users/xiaoqian.yin/mlflow/conftest.py'.
conftest.py:13: in <module>
    from mlflow.environment_variables import _MLFLOW_TESTING, MLFLOW_TRACKING_URI
mlflow/__init__.py:34: in <module>
    from mlflow import (
mlflow/data/__init__.py:9: in <module>
    from mlflow.data.dataset_source_registry import get_dataset_source_from_json, get_registered_sources
mlflow/data/dataset_source_registry.py:189: in <module>
    _dataset_source_registry.register_entrypoints()
mlflow/data/dataset_source_registry.py:35: in register_entrypoints
    f"Failure attempting to register dataset source with source type"
E   AttributeError: 'EntryPoint' object has no attribute 'source_type'
```
hitting the error above when trying to pytest tests/evaluate/test_evaluation.py for another PR
seems that source_type never existed and this is a bug as @harupy pointed out
adding a quick fix

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

pytest is working again
![image](https://github.com/mlflow/mlflow/assets/171547006/a52a4169-abae-4062-8c15-778c61eb55d0)


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
