### PR TITLE
Pin xgboost for FLAML

### DIFF
--- a/.github/workflows/recipe.yml
+++ b/.github/workflows/recipe.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
-          pip install pyspark
+          # FLAML is incompatible with xgboost 2.1.0: https://github.com/microsoft/FLAML/issues/1314
+          pip install pyspark 'xgboost<2.1.0'
       - name: Run tests
         run: |
           pytest tests/recipes
@@ -74,7 +75,8 @@ jobs:
           pip install -r requirements/test-requirements.txt
           pip install --no-dependencies tests/resources/mlflow-test-plugin
           pip install .
-          pip install pyspark
+          # FLAML is incompatible with xgboost 2.1.0: https://github.com/microsoft/FLAML/issues/1314
+          pip install pyspark 'xgboost<2.1.0'
           # TODO: Importing datasets in a pandas UDF (created by mlflow.pyfunc.spark_udf) crashes
           # the Python worker. To avoid this, uninstall `datasets`. This is a temporary workaround.
           pip uninstall -y datasets


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12432?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12432/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12432
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Pin xgboost for https://github.com/microsoft/FLAML/issues/1314. `FLAML` is incompatible with xgboost 2.1.0.

https://github.com/mlflow/mlflow/actions/runs/9594083623/job/26455893415

```
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/mlflow/recipes/steps/automl/flaml.py", line 166, in _create_model_automl
    automl.fit(X, y, **automl_settings)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/automl.py", line 1929, in fit
    self._search()
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/automl.py", line 2483, in _search
    self._search_sequential()
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/automl.py", line 2319, in _search_sequential
    analysis = tune.run(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/tune/tune.py", line 814, in run
    result = evaluation_function(trial_to_run.config)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/state.py", line 304, in _compute_with_config_base
    ) = compute_estimator(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/ml.py", line 369, in compute_estimator
    val_loss, metric_for_logging, train_time, pred_time = task.evaluate_model_CV(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/task/generic_task.py", line 740, in evaluate_model_CV
    val_loss_i, metric_i, train_time_i, pred_time_i = get_val_loss(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/ml.py", line 494, in get_val_loss
    estimator.fit(X_train, y_train, budget=budget, free_mem_ratio=free_mem_ratio, **fit_kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/model.py", line 1661, in fit
    return super().fit(X_train, y_train, budget, free_mem_ratio, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/model.py", line 1413, in fit
    self._fit(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/flaml/automl/model.py", line 224, in _fit
    model.fit(X_train, y_train, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/xgboost/core.py", line 726, in inner_f
    return func(**kwargs)
TypeError: fit() got an unexpected keyword argument 'callbacks'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
