### PR TITLE
#12404 fixing typos pomote/Pomote to promote/Promote

### DIFF
--- a/mlflow/server/js/src/i18n/default/en.json
+++ b/mlflow/server/js/src/i18n/default/en.json
@@ -2309,7 +2309,7 @@
   },
   "oBjwod": {
     "defaultMessage": "Promote {sourceModelName} version {sourceModelVersion}",
-    "description": "Modal title to pomote the model to a different registered model"
+    "description": "Modal title to promote the model to a different registered model"
   },
   "oHW+ks": {
     "defaultMessage": "Description",

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.tsx
@@ -473,7 +473,7 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
     }
   }
 
-  renderPomoteModelButton() {
+  renderPromoteModelButton() {
     const { modelVersion, usingNextModelsUI, navigate } = this.props;
     return usingNextModelsUI ? <PromoteModelButton modelVersion={modelVersion} /> : null;
   }
@@ -495,7 +495,7 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
     return (
       <PageHeader title={title} breadcrumbs={breadcrumbs}>
         {!this.shouldHideDeleteOption() && <OverflowMenu menu={menu} />}
-        {this.renderPomoteModelButton()}
+        {this.renderPromoteModelButton()}
       </PageHeader>
     );
   }

--- a/mlflow/server/js/src/model-registry/components/PromoteModelButton.tsx
+++ b/mlflow/server/js/src/model-registry/components/PromoteModelButton.tsx
@@ -170,14 +170,14 @@ export const PromoteModelButton = (props: PromoteModelButtonImplProps) => {
       >
         <FormattedMessage
           defaultMessage="Promote model"
-          description="Button text to pomote the model to a different registered model"
+          description="Button text to promote the model to a different registered model"
         />
       </Button>
       <Modal
         title={
           <FormattedMessage
             defaultMessage="Promote {sourceModelName} version {sourceModelVersion}"
-            description="Modal title to pomote the model to a different registered model"
+            description="Modal title to promote the model to a different registered model"
             values={{ sourceModelName: modelVersion.name, sourceModelVersion: modelVersion.version }}
           />
         }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BraunRudolf/mlflow/pull/12436?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12436/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12436
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #12404 

### What changes are proposed in this pull request?
Changing pomote/Pomote --> promote/Promote

in:
mlflow/server/js/src/i18n/default/en.json (Ln 16, 2312)
mlflow/server/js/src/model-registry/components/ModelVersionView.tsx (Ln 476, 498)
mlflow/server/js/src/model-registry/components/PromoteModelButton.tsx (Ln 173, 180)
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
