### PR TITLE
Fix falsy value check for span input/output recording

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -610,10 +610,10 @@ class MlflowClient:
             if isinstance(mlflow_span, NoOpSpan):
                 return mlflow_span
 
-            if inputs:
+            if inputs is not None:
                 mlflow_span.set_inputs(inputs)
-            if attributes:
-                mlflow_span.set_attributes(attributes)
+            mlflow_span.set_attributes(attributes or {})
+
             trace_manager = InMemoryTraceManager.get_instance()
             tags = exclude_immutable_tags(tags or {})
             if is_in_databricks_model_serving_environment():
@@ -857,9 +857,8 @@ class MlflowClient:
         try:
             otel_span = mlflow.tracing.provider.start_detached_span(name, parent=parent_span._span)
             span = create_mlflow_span(otel_span, request_id, span_type)
-            if attributes:
-                span.set_attributes(attributes)
-            if inputs:
+            span.set_attributes(attributes or {})
+            if inputs is not None:
                 span.set_inputs(inputs)
 
             trace_manager.register_span(span)
@@ -878,7 +877,7 @@ class MlflowClient:
         request_id: str,
         span_id: str,
         outputs: Optional[Dict[str, Any]] = None,
-        attributes: Optional[Any] = None,
+        attributes: Optional[Dict[str, Any]] = None,
         status: Union[SpanStatus, str] = "OK",
     ):
         """
@@ -909,9 +908,8 @@ class MlflowClient:
                 error_code=RESOURCE_DOES_NOT_EXIST,
             )
 
-        if attributes:
-            span.set_attributes(attributes or {})
-        if outputs:
+        span.set_attributes(attributes or {})
+        if outputs is not None:
             span.set_outputs(outputs)
         span.set_status(status)
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -480,6 +480,25 @@ def test_start_and_end_trace(tracking_uri, with_active_run):
     assert child_span_2.start_time_ns <= child_span_2.end_time_ns - 0.1 * 1e6
 
 
+def test_start_and_end_trace_capture_falsy_input_and_output(tracking_uri):
+    # This test is to verify that the trace is correctly logged when the input and output are falsy values
+    client = MlflowClient(tracking_uri)
+    experiment_id = client.create_experiment("test_experiment")
+
+    root = client.start_trace(name="root", experiment_id=experiment_id, inputs=[])
+    span = client.start_span(
+        name="child", request_id=root.request_id, parent_id=root.span_id, inputs=0
+    )
+    client.end_span(request_id=root.request_id, span_id=span.span_id, outputs=False)
+    client.end_trace(request_id=root.request_id, outputs="")
+
+    trace = client.get_trace(root.request_id)
+    assert trace.data.spans[0].inputs == []
+    assert trace.data.spans[0].outputs == ""
+    assert trace.data.spans[1].inputs == 0
+    assert trace.data.spans[1].outputs is False
+
+
 @pytest.mark.usefixtures("reset_active_experiment")
 def test_start_and_end_trace_before_all_span_end():
     # This test is to verify that the trace is still exported even if some spans are not ended

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -481,7 +481,7 @@ def test_start_and_end_trace(tracking_uri, with_active_run):
 
 
 def test_start_and_end_trace_capture_falsy_input_and_output(tracking_uri):
-    # This test is to verify that the trace is correctly logged when the input and output are falsy values
+    # This test is to verify that falsy input and output values are correctly logged
     client = MlflowClient(tracking_uri)
     experiment_id = client.create_experiment("test_experiment")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12444?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12444/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12444
```

</p>
</details>

### What changes are proposed in this pull request?

**Problem**

While going though some tutorial, I found some chain doesn't have `output` recorded.

![Screenshot 2024-06-21 at 13 22 47](https://github.com/mlflow/mlflow/assets/31463517/f5717039-481c-4342-89dc-d007175660d7)

This `extract_chat_history` chain returns empty list `[]`, because we don't have any chat history. However, the empty list should be at least recorded as output, because this doesn't mean the chain has no output.

**Fix**
The root cause is [this condition](https://github.com/mlflow/mlflow/blob/master/mlflow/tracking/client.py#L914-L915) skips recording outputs for such falesy values. We should explicitly check `None` instead.

Note: Theoretically it is still possible to have a function explicitly returns `None`, but it's not possible to distinguish from no output.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

![Screenshot 2024-06-21 at 13 36 03](https://github.com/mlflow/mlflow/assets/31463517/8d177506-6908-4ad6-be45-e0b227bf5dd2)

`outputs: []` is recorded to the span.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
