### PR TITLE
Shutdown thread pool executors in artifact repositories

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -80,7 +80,6 @@ class ArtifactRepository:
         """
         A context manager that sets the thread pools for the artifact repository. Parallelized
         file upload/download operations must be performed within the context manager.
-
         """
         if self.thread_pool is None or self.chunk_thread_pool is None:
             with self._create_thread_pool() as tp, self._create_thread_pool() as ctp:
@@ -89,6 +88,8 @@ class ArtifactRepository:
                 try:
                     yield
                 finally:
+                    # Detach dead thread pools and ensure new ones will be created in the next
+                    # context manager invocation
                     self.thread_pool = None
                     self.chunk_thread_pool = None
         else:

--- a/mlflow/store/artifact/azure_data_lake_artifact_repo.py
+++ b/mlflow/store/artifact/azure_data_lake_artifact_repo.py
@@ -108,7 +108,7 @@ class AzureDataLakeArtifactRepository(CloudArtifactRepository):
         self._parse_credentials(new_creds["credential"])
         return self.fs_client
 
-    def log_artifact(self, local_file, artifact_path=None):
+    def _log_artifact(self, local_file, artifact_path=None):
         dest_path = self.base_data_lake_directory
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
@@ -127,6 +127,10 @@ class AzureDataLakeArtifactRepository(CloudArtifactRepository):
         _retry_with_new_creds(
             try_func=try_func, creds_func=self._refresh_credentials, og_creds=self.fs_client
         )
+
+    def log_artifact(self, local_file, artifact_path=None):
+        with self._set_thread_pools():
+            return self._log_artifact(local_file, artifact_path)
 
     def list_artifacts(self, path=None):
         directory_to_list = self.base_data_lake_directory

--- a/mlflow/store/artifact/cloud_artifact_repo.py
+++ b/mlflow/store/artifact/cloud_artifact_repo.py
@@ -158,7 +158,7 @@ class CloudArtifactRepository(ArtifactRepository):
                 for staged_upload, write_credential_info in zip(
                     staged_upload_chunk, write_credential_infos
                 ):
-                    upload_future = self.thread_pool.submit(
+                    upload_future = self.file_thread_pool.submit(
                         self._upload_to_cloud,
                         cloud_credential_info=write_credential_info,
                         src_file_path=staged_upload.src_file_path,

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -709,7 +709,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             self._abort_multipart_upload(create_mpu_resp.abort_credential_info)
             raise e
 
-    def log_artifact(self, local_file, artifact_path=None):
+    def _log_artifact(self, local_file, artifact_path=None):
         src_file_name = os.path.basename(local_file)
         artifact_file_path = posixpath.join(artifact_path or "", src_file_name)
         write_credential_info = self._get_write_credential_infos([artifact_file_path])[0]
@@ -718,6 +718,10 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             src_file_path=local_file,
             artifact_file_path=artifact_file_path,
         )
+
+    def log_artifact(self, local_file, artifact_path=None):
+        with self._set_thread_pools():
+            self._log_artifact(local_file, artifact_path)
 
     def list_artifacts(self, path=None):
         if path:

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -256,7 +256,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         )
         return res.credential_info
 
-    def upload_trace_data(self, trace_data: str) -> None:
+    def _upload_trace_data(self, trace_data: str) -> None:
         cred = self._get_upload_trace_data_cred_info()
         with write_local_temp_trace_data_file(trace_data) as temp_file:
             if cred.type == ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI:
@@ -282,6 +282,10 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                 or cred.type == ArtifactCredentialType.GCP_SIGNED_URL
             ):
                 self._signed_url_upload_file(cred, temp_file)
+
+    def upload_trace_data(self, trace_data: str) -> None:
+        with self._set_thread_pools():
+            self._upload_trace_data(trace_data)
 
     def _get_read_credential_infos(self, remote_file_paths):
         """

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -68,11 +68,6 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
         warn_on_deprecated_cross_workspace_registry_uri(self.databricks_profile_uri)
         client = MlflowClient(registry_uri=self.databricks_profile_uri)
         self.model_name, self.model_version = get_model_name_and_version(client, artifact_uri)
-        # Use an isolated thread pool executor for chunk uploads/downloads to avoid a deadlock
-        # caused by waiting for a chunk-upload/download task within a file-upload/download task.
-        # See https://superfastpython.com/threadpoolexecutor-deadlock/#Deadlock_1_Submit_and_Wait_for_a_Task_Within_a_Task
-        # for more details
-        self.chunk_thread_pool = self._create_thread_pool()
 
     def _call_endpoint(self, json, endpoint):
         db_creds = get_databricks_host_creds(self.databricks_profile_uri)

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -172,7 +172,7 @@ def test_log_artifacts(http_artifact_repo, tmp_path, artifact_path):
     tmp_path_a.write_text("0")
     tmp_path_b.write_text("1")
 
-    with mock.patch.object(http_artifact_repo, "log_artifact") as mock_log_artifact:
+    with mock.patch.object(http_artifact_repo, "_log_artifact") as mock_log_artifact:
         http_artifact_repo.log_artifacts(tmp_path, artifact_path)
         mock_log_artifact.assert_has_calls(
             [

--- a/tests/store/artifact/test_mlflow_artifact_repo.py
+++ b/tests/store/artifact/test_mlflow_artifact_repo.py
@@ -171,7 +171,7 @@ def test_log_artifacts(mlflow_artifact_repo, tmp_path, artifact_path):
     tmp_path_a.write_text("0")
     tmp_path_b.write_text("1")
 
-    with mock.patch.object(mlflow_artifact_repo, "log_artifact") as mock_log_artifact:
+    with mock.patch.object(mlflow_artifact_repo, "_log_artifact") as mock_log_artifact:
         mlflow_artifact_repo.log_artifacts(tmp_path, artifact_path)
         mock_log_artifact.assert_has_calls(
             [


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

As discovered in #12430, the thread pool executors used in artifact repositories are not properly shutdown. This PR fixes it using a context manager.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
