### PR TITLE
Reset `sys.path` and `sys.modules` after loading a model with custom code

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -510,7 +510,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _get_flavor_configuration_from_ml_model_file,
     _get_overridden_pyfunc_model_config,
-    _preserve_sys_path_and_modules,
+    _reset_sys_path_and_modules,
     _validate_and_copy_file_to_directory,
     _validate_and_get_model_config_from_file,
     _validate_and_prepare_target_save_path,
@@ -997,8 +997,8 @@ def load_model(
     if not suppress_warnings:
         _warn_potentially_incompatible_py_version_if_necessary(model_py_version=model_py_version)
 
-    with _preserve_sys_path_and_modules():
-        _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE)
+    code_path = _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE)
+    with _reset_sys_path_and_modules({code_path}):
         data_path = os.path.join(local_path, conf[DATA]) if (DATA in conf) else local_path
 
         if isinstance(model_config, str):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -510,7 +510,6 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _get_flavor_configuration_from_ml_model_file,
     _get_overridden_pyfunc_model_config,
-    _reset_sys_path_and_modules,
     _validate_and_copy_file_to_directory,
     _validate_and_get_model_config_from_file,
     _validate_and_prepare_target_save_path,
@@ -997,8 +996,7 @@ def load_model(
     if not suppress_warnings:
         _warn_potentially_incompatible_py_version_if_necessary(model_py_version=model_py_version)
 
-    code_path = _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE)
-    with _reset_sys_path_and_modules({code_path}):
+    with _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE):
         data_path = os.path.join(local_path, conf[DATA]) if (DATA in conf) else local_path
 
         if isinstance(model_config, str):

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -297,9 +297,9 @@ def _restore_sys_path_and_modules(sys_path: Set[str], start_modules: Set[str]):
                 for mod in _iter_modules(module_name):
                     sys.modules.pop(mod, None)
 
-    for path in sys_path:
-        while path in sys.path:
-            sys.path.remove(path)
+    # for path in sys_path:
+    #     while path in sys.path:
+    #         sys.path.remove(path)
 
 
 @contextlib.contextmanager

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -292,6 +292,11 @@ def _add_code_from_conf_to_system_path(local_path, conf, code_key=FLAVOR_CONFIG_
 
 
 def _iter_modules(module_name: str) -> Iterator[str]:
+    """
+    Example:
+    >>> list(_iter_modules("a.b.c"))
+    ['a.b.c', 'a.b', 'a']
+    """
     yield module_name
     while (ind := module_name.rfind(".")) != -1:
         yield module_name[:ind]

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -293,6 +293,8 @@ def _add_code_from_conf_to_system_path(local_path, conf, code_key=FLAVOR_CONFIG_
 
 def _iter_modules(module_name: str) -> Iterator[str]:
     """
+    Yields the module name and all its parent modules.
+
     Example:
     >>> list(_iter_modules("a.b.c"))
     ['a.b.c', 'a.b', 'a']

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -298,7 +298,7 @@ def _restore_sys_path_and_modules(sys_path: Set[str], start_modules: Set[str]):
                     sys.modules.pop(mod, None)
 
     for path in sys_path:
-        if path in sys.path:
+        while path in sys.path:
             sys.path.remove(path)
 
 

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -292,6 +292,7 @@ def _add_code_from_conf_to_system_path(local_path, conf, code_key=FLAVOR_CONFIG_
 
 
 def _iter_modules(module_name: str) -> Iterator[str]:
+    yield module_name
     while (ind := module_name.rfind(".")) != -1:
         yield module_name[:ind]
 

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -300,6 +300,7 @@ def _iter_modules(module_name: str) -> Iterator[str]:
     yield module_name
     while (ind := module_name.rfind(".")) != -1:
         yield module_name[:ind]
+        module_name = module_name[:ind]
 
 
 def _restore_sys_path_and_modules(start_path: Set[str], start_modules: Set[str]):

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -316,8 +316,8 @@ def _add_code_from_conf_to_system_path(local_path, conf, code_key=FLAVOR_CONFIG_
     """
     assert isinstance(conf, dict), "`conf` argument must be a dict."
 
-    if value := conf.get(code_key):
-        code_path = os.path.join(local_path, value)
+    if code_value := conf.get(code_key):
+        code_path = os.path.join(local_path, code_value)
         _add_code_to_system_path(code_path)
         start_modules = set(sys.modules)
         try:

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -297,9 +297,11 @@ def _iter_modules(module_name: str) -> Iterator[str]:
     >>> list(_iter_modules("a.b.c"))
     ['a.b.c', 'a.b', 'a']
     """
-    yield module_name
-    while (ind := module_name.rfind(".")) != -1:
-        yield module_name[:ind]
+    while True:
+        yield module_name
+        ind = module_name.rfind(".")
+        if ind == -1:
+            break
         module_name = module_name[:ind]
 
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1979,7 +1979,7 @@ def test_model_as_code_pycache_cleaned_up():
     assert list(Path(path).rglob("__pycache__")) == []
 
 
-def test_load_model_custom_code(tmp_path, monkeypatch):
+def test_load_model_custom_code_same_module_name(tmp_path, monkeypatch):
     sys.path.insert(0, str(tmp_path))
     my_model_path = tmp_path / "my_model.py"
     monkeypatch.syspath_prepend(str(tmp_path))

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2014,7 +2014,12 @@ class MyModel(mlflow.pyfunc.PythonModel):
     sys.path.remove(str(tmp_path))
     sys.modules.pop("my_model", None)
 
+    with pytest.raises(ImportError, match="No module named 'my_model'"):
+        from my_model import MyModel
+
     pred = mlflow.pyfunc.load_model(model1.model_uri).predict([0])
     assert pred == [1]
     pred = mlflow.pyfunc.load_model(model2.model_uri).predict([0])
     assert pred == [2]
+
+    from my_model import MyModel

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2021,5 +2021,8 @@ class MyModel(mlflow.pyfunc.PythonModel):
     assert pred == [1]
     pred = mlflow.pyfunc.load_model(model2.model_uri).predict([0])
     assert pred == [2]
+    # loading `m2` should not affect `m1`
+    pred = mlflow.pyfunc.load_model(model1.model_uri).predict([0])
+    assert pred == [1]
 
     from my_model import MyModel

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1983,14 +1983,14 @@ def test_load_model_custom_code_same_module_name(tmp_path, monkeypatch):
     sys.path.insert(0, str(tmp_path))
     my_model_path = tmp_path / "my_model.py"
     monkeypatch.syspath_prepend(str(tmp_path))
-    code = """
+    code_template = """
 import mlflow
 
 class MyModel(mlflow.pyfunc.PythonModel):
     def predict(self, context, model_input):
         return [{n}] * len(model_input)
 """
-    my_model_path.write_text(code.format(n=1))
+    my_model_path.write_text(code_template.format(n=1))
 
     from my_model import MyModel
 
@@ -2001,7 +2001,7 @@ class MyModel(mlflow.pyfunc.PythonModel):
             code_paths=[my_model_path],
         )
 
-    my_model_path.write_text(code.format(n=2))
+    my_model_path.write_text(code_template.format(n=2))
 
     with mlflow.start_run():
         model2 = mlflow.pyfunc.log_model(


### PR DESCRIPTION
### Install MLflow from the PR branch:

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12456/merge
```

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Fix #12395
Fix #12377

### What changes are proposed in this pull request?

In the following code, the second `load_model` call uses the custom modules cached in the first `load_model` call, which is an undesired behavior. This PR fixes this issue.

```python
# See the test in this PR for complete code.

m1_info = mlflow.pyfunc.log_model(..., code_paths=["my_model.py"])
# made changes in my_model.py
m2_info = mlflow.pyfunc.log_model(..., code_paths=["my_model.py"])

m1 = mlflowl.pyfunc.load_model(m1_info.model_uri, ...)
m2 = mlflowl.pyfunc.load_model(m2_info.model_uri, ...)  # uses `my_model.py` associated with m1!
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
