### PR TITLE
Isolate tracer provider from OpenTelemetry global state

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -1,3 +1,12 @@
+"""
+This module provides a set of functions to manage the global tracer provider for MLflow tracing.
+
+Every tracing operation in MLflow *MUST* be managed through this module, instead of directly
+using the OpenTelemetry APIs. This is because MLflow needs to control the initialization of the
+tracer provider and ensure that it won't interfere with the other external libraries that might
+use OpenTelemetry e.g. PromptFlow, Snowpark.
+"""
+
 import functools
 import json
 import logging
@@ -5,19 +14,23 @@ from typing import Optional, Tuple
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.util._once import Once
 
 from mlflow.exceptions import MlflowTracingException
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.utils.exception import raise_as_trace_exception
+from mlflow.tracing.utils.once import Once
 from mlflow.utils.databricks_utils import (
     is_in_databricks_model_serving_environment,
     is_mlflow_tracing_enabled_in_model_serving,
 )
 
+# Global tracer provider instance. We manage the tracer provider by ourselves instead of using
+# the global tracer provider provided by OpenTelemetry.
+_MLFLOW_TRACER_PROVIDER = None
+
 # Once() object ensures a function is executed only once in a process.
 # Note that it doesn't work as expected in a distributed environment.
-_TRACER_PROVIDER_INITIALIZED = Once()
+_MLFLOW_TRACER_PROVIDER_INITIALIZED = Once()
 
 _logger = logging.getLogger(__name__)
 
@@ -66,25 +79,32 @@ def start_detached_span(
 def _get_tracer(module_name: str):
     """
     Get a tracer instance for the given module name.
+
+    If the tracer provider is not initialized, this function will initialize the tracer provider.
+    Other simultaneous calls to this function will block until the initialization is done.
     """
     # Initiate tracer provider only once in the application lifecycle
-    _TRACER_PROVIDER_INITIALIZED.do_once(_setup_tracer_provider)
-
-    tracer_provider = trace.get_tracer_provider()
-    return tracer_provider.get_tracer(module_name)
+    _MLFLOW_TRACER_PROVIDER_INITIALIZED.do_once(_setup_tracer_provider)
+    return _MLFLOW_TRACER_PROVIDER.get_tracer(module_name)
 
 
 def _setup_tracer_provider(disabled=False):
     """
     Instantiate a tracer provider and set it as the global tracer provider.
+
+    Note that this function ALWAYS updates the global tracer provider, regardless of the current state.
+    It is the caller's responsibility to ensure that the tracer provider is initialized only once, and
+    update the _MLFLOW_TRACER_PROVIDER_INITIALIZED flag accordingly.
     """
+    global _MLFLOW_TRACER_PROVIDER
+
     if disabled:
-        _force_set_otel_tracer_provider(trace.NoOpTracerProvider())
+        _MLFLOW_TRACER_PROVIDER = trace.NoOpTracerProvider()
         return
 
     if is_in_databricks_model_serving_environment():
         if not is_mlflow_tracing_enabled_in_model_serving():
-            _force_set_otel_tracer_provider(trace.NoOpTracerProvider())
+            _MLFLOW_TRACER_PROVIDER = trace.NoOpTracerProvider()
             return
 
         from mlflow.tracing.export.inference_table import InferenceTableSpanExporter
@@ -101,19 +121,8 @@ def _setup_tracer_provider(disabled=False):
 
     tracer_provider = TracerProvider()
     tracer_provider.add_span_processor(processor)
-    _force_set_otel_tracer_provider(tracer_provider)
+    _MLFLOW_TRACER_PROVIDER = tracer_provider
 
-
-def _force_set_otel_tracer_provider(tracer_provider):
-    """
-    Resetting internal flag used in OpenTelemetry. If we don't reset the flag,
-    set_tracer_provider() will be a no-op after the first call
-    in the application lifecycle.
-    https://github.com/open-telemetry/opentelemetry-python/blob/v1.24.0/opentelemetry-api/src/opentelemetry/trace/__init__.py#L485
-    """
-    with trace._TRACER_PROVIDER_SET_ONCE._lock:
-        trace._TRACER_PROVIDER_SET_ONCE._done = False
-    trace.set_tracer_provider(tracer_provider)
 
 
 @raise_as_trace_exception
@@ -153,9 +162,8 @@ def disable():
     if not _is_enabled():
         return
 
-    reset_tracer_setup()  # Force re-initialization of the tracer provider
-    _TRACER_PROVIDER_INITIALIZED.do_once(lambda: _setup_tracer_provider(disabled=True))
-
+    _setup_tracer_provider(disabled=True)
+    _MLFLOW_TRACER_PROVIDER_INITIALIZED.done = True
 
 @raise_as_trace_exception
 def enable():
@@ -190,11 +198,12 @@ def enable():
         assert len(mlflow.search_traces()) == 2
 
     """
-    if _is_enabled():
+    if _is_enabled() and _MLFLOW_TRACER_PROVIDER_INITIALIZED.done:
         _logger.info("Tracing is already enabled")
         return
 
     _setup_tracer_provider()
+    _MLFLOW_TRACER_PROVIDER_INITIALIZED.done = True
 
 
 def trace_disabled(f):
@@ -252,16 +261,15 @@ def trace_disabled(f):
 
 def reset_tracer_setup():
     """
-    Reset the flags that indicates whether the tracer provider has been initialized.
+    Reset the flags that indicates whether the MLflow tracer provider has been initialized.
     This ensures that the tracer provider is re-initialized when next tracing
     operation is performed.
     """
-    with _TRACER_PROVIDER_INITIALIZED._lock:
-        _TRACER_PROVIDER_INITIALIZED._done = False
     # Set NoOp tracer provider to reset the global tracer to the initial state.
-    # Do not flip _TRACE_PROVIDER_INITIALIZED flag to True so that
-    # the next tracing operation will re-initialize the provider.
     _setup_tracer_provider(disabled=True)
+    # Flip _MLFLOW_TRACE_PROVIDER_INITIALIZED flag to False so that
+    # the next tracing operation will re-initialize the provider.
+    _MLFLOW_TRACER_PROVIDER_INITIALIZED.done = False
 
 
 @raise_as_trace_exception
@@ -274,11 +282,11 @@ def _is_enabled() -> bool:
     1. The default state (before any tracing operation)
     2. The tracer is not either ProxyTracer or NoOpTracer
     """
-    with _TRACER_PROVIDER_INITIALIZED._lock:
-        tracer = trace.get_tracer(__name__)
+    if not _MLFLOW_TRACER_PROVIDER_INITIALIZED.done:
+        return True
 
-        # Occasionally ProxyTracer instance wraps the actual tracer
-        if isinstance(tracer, trace.ProxyTracer):
-            tracer = tracer._tracer
-
-        return not (_TRACER_PROVIDER_INITIALIZED._done and isinstance(tracer, trace.NoOpTracer))
+    tracer = _get_tracer(__name__)
+    # Occasionally ProxyTracer instance wraps the actual tracer
+    if isinstance(tracer, trace.ProxyTracer):
+        tracer = tracer._tracer
+    return not isinstance(tracer, trace.NoOpTracer)

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -92,9 +92,9 @@ def _setup_tracer_provider(disabled=False):
     """
     Instantiate a tracer provider and set it as the global tracer provider.
 
-    Note that this function ALWAYS updates the global tracer provider, regardless of the current state.
-    It is the caller's responsibility to ensure that the tracer provider is initialized only once, and
-    update the _MLFLOW_TRACER_PROVIDER_INITIALIZED flag accordingly.
+    Note that this function ALWAYS updates the global tracer provider, regardless of the current
+    state. It is the caller's responsibility to ensure that the tracer provider is initialized
+    only once, and update the _MLFLOW_TRACER_PROVIDER_INITIALIZED flag accordingly.
     """
     global _MLFLOW_TRACER_PROVIDER
 
@@ -122,7 +122,6 @@ def _setup_tracer_provider(disabled=False):
     tracer_provider = TracerProvider()
     tracer_provider.add_span_processor(processor)
     _MLFLOW_TRACER_PROVIDER = tracer_provider
-
 
 
 @raise_as_trace_exception
@@ -164,6 +163,7 @@ def disable():
 
     _setup_tracer_provider(disabled=True)
     _MLFLOW_TRACER_PROVIDER_INITIALIZED.done = True
+
 
 @raise_as_trace_exception
 def enable():

--- a/mlflow/tracing/utils/once.py
+++ b/mlflow/tracing/utils/once.py
@@ -1,0 +1,35 @@
+# Customized from https://github.com/open-telemetry/opentelemetry-python/blob/754fc36a408dd45e86d4a0f820f84e692f14b4c1/opentelemetry-api/src/opentelemetry/util/_once.py
+from threading import Lock
+from typing import Callable
+
+
+class Once:
+    """Execute a function exactly once and block all callers until the function returns"""
+
+    def __init__(self) -> None:
+        self.__lock = Lock()
+        self.__done = False
+
+    @property
+    def done(self):
+        with self.__lock:
+            return self.__done
+
+    @done.setter
+    def done(self, value):
+        with self.__lock:
+            self.__done = value
+
+    def do_once(self, func: Callable[[], None]):
+        """
+        Execute ``func`` if it hasn't been executed or return.
+        Will block until ``func`` has been called by one thread.
+        """
+        if self.__done:
+            return
+
+        with self.__lock:
+            if not self.__done:
+                func()
+                self.__done = True
+                return

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -542,6 +542,42 @@ def test_start_span_context_manager_with_imperative_apis():
     }
 
 
+def test_mlflow_trace_isolated_from_other_otel_processors():
+    # Set up non-MLFlow tracer
+    import opentelemetry.sdk.trace as trace_sdk
+    from opentelemetry import trace
+
+    class MockOtelExporter(trace_sdk.export.SpanExporter):
+        def __init__(self):
+            self.exported_spans = []
+
+        def export(self, spans):
+            self.exported_spans.extend(spans)
+
+    other_exporter = MockOtelExporter()
+    provider = trace_sdk.TracerProvider()
+    processor = trace_sdk.export.SimpleSpanProcessor(other_exporter)
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+
+    # Create MLflow trace
+    with mlflow.start_span(name="mlflow_span"):
+        pass
+
+    # Create non-MLflow trace
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("non_mlflow_span"):
+        pass
+
+    # MLflow only processes spans created with MLflow APIs
+    assert len(TRACE_BUFFER) == 1
+    assert mlflow.get_last_active_trace().data.spans[0].name == "mlflow_span"
+
+    # Other spans are processed by the other processor
+    assert len(other_exporter.exported_spans) == 1
+    assert other_exporter.exported_spans[0].name == "non_mlflow_span"
+
+
 @mock.patch("mlflow.tracing.export.mlflow.get_display_handler")
 def test_get_trace(mock_get_display_handler):
     model = DefaultTestModel()

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -57,7 +57,7 @@ def test_reset_tracer_setup(mock_setup_tracer_provider):
 
     start_span_in_context("test2")
     assert mock_setup_tracer_provider.call_count == 3
-    mock_setup_tracer_provider.assert_has_calls(
+    assert mock_setup_tracer_provider.mock_calls == (
         [
             mock.call(),
             mock.call(disabled=True),

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1,6 +1,6 @@
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
-from concurrent.futures import ThreadPoolExecutor
 import pytest
 from opentelemetry import trace
 
@@ -25,8 +25,9 @@ from mlflow.tracing.provider import (
 @pytest.fixture
 def mock_setup_tracer_provider():
     # To count the number of times _setup_tracer_provider is called
-    with mock.patch("mlflow.tracing.provider._setup_tracer_provider",
-                    side_effect=_setup_tracer_provider) as setup_mock:
+    with mock.patch(
+        "mlflow.tracing.provider._setup_tracer_provider", side_effect=_setup_tracer_provider
+    ) as setup_mock:
         yield setup_mock
 
 
@@ -56,12 +57,13 @@ def test_reset_tracer_setup(mock_setup_tracer_provider):
 
     start_span_in_context("test2")
     assert mock_setup_tracer_provider.call_count == 3
-    mock_setup_tracer_provider.assert_has_calls([
-        mock.call(),
-        mock.call(disabled=True),
-        mock.call(),
-    ])
-
+    mock_setup_tracer_provider.assert_has_calls(
+        [
+            mock.call(),
+            mock.call(disabled=True),
+            mock.call(),
+        ]
+    )
 
 
 def test_span_processor_and_exporter_model_serving(mock_databricks_serving_with_tracing_env):

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from concurrent.futures import ThreadPoolExecutor
 import pytest
 from opentelemetry import trace
 
@@ -9,42 +10,61 @@ from mlflow.tracing.export.inference_table import (
     _TRACE_BUFFER,
     InferenceTableSpanExporter,
 )
-from mlflow.tracing.export.mlflow import MlflowSpanExporter
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
-from mlflow.tracing.processor.mlflow import MlflowSpanProcessor
 from mlflow.tracing.provider import (
-    _TRACER_PROVIDER_INITIALIZED,
     _get_tracer,
     _is_enabled,
+    _setup_tracer_provider,
+    reset_tracer_setup,
+    start_span_in_context,
     trace_disabled,
 )
 
 
-# Mock client getter just to count the number of calls
-def test_tracer_provider_singleton():
-    # Reset the Once object as there might be other tests that have already initialized it
-    _TRACER_PROVIDER_INITIALIZED._done = False
-    _get_tracer("module_1")
-    assert _TRACER_PROVIDER_INITIALIZED._done is True
-
-    # Trace provider should be identical for different moments in time
-    tracer_provider_1 = trace.get_tracer_provider()
-    tracer_provider_2 = trace.get_tracer_provider()
-    assert tracer_provider_1 is tracer_provider_2
+@pytest.fixture
+def mock_setup_tracer_provider():
+    # To count the number of times _setup_tracer_provider is called
+    with mock.patch("mlflow.tracing.provider._setup_tracer_provider",
+                    side_effect=_setup_tracer_provider) as setup_mock:
+        yield setup_mock
 
 
-def test_span_processor_and_exporter_default():
-    _TRACER_PROVIDER_INITIALIZED._done = False
-    tracer = _get_tracer("test")
-    processors = tracer.span_processor._span_processors
-    assert len(processors) == 1
-    assert isinstance(processors[0], MlflowSpanProcessor)
-    assert isinstance(processors[0].span_exporter, MlflowSpanExporter)
+def test_tracer_provider_initialized_once(mock_setup_tracer_provider):
+    assert mock_setup_tracer_provider.call_count == 0
+    start_span_in_context("test1")
+    assert mock_setup_tracer_provider.call_count == 1
+
+    start_span_in_context("test_2")
+    start_span_in_context("test_3")
+    assert mock_setup_tracer_provider.call_count == 1
+
+    # Thread safety
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        executor.map(start_span_in_context, ["test_4", "test_5"])
+    assert mock_setup_tracer_provider.call_count == 1
+
+
+def test_reset_tracer_setup(mock_setup_tracer_provider):
+    assert mock_setup_tracer_provider.call_count == 0
+
+    start_span_in_context("test1")
+    assert mock_setup_tracer_provider.call_count == 1
+
+    reset_tracer_setup()
+    assert mock_setup_tracer_provider.call_count == 2
+
+    start_span_in_context("test2")
+    assert mock_setup_tracer_provider.call_count == 3
+    mock_setup_tracer_provider.assert_has_calls([
+        mock.call(),
+        mock.call(disabled=True),
+        mock.call(),
+    ])
+
 
 
 def test_span_processor_and_exporter_model_serving(mock_databricks_serving_with_tracing_env):
-    _TRACER_PROVIDER_INITIALIZED._done = False
     tracer = _get_tracer("test")
     processors = tracer.span_processor._span_processors
     assert len(processors) == 1
@@ -91,7 +111,6 @@ def test_trace_disabled_decorator(enabled_initially):
     if not enabled_initially:
         mlflow.tracing.disable()
     assert _is_enabled() == enabled_initially
-
     call_count = 0
 
     @trace_disabled
@@ -140,6 +159,25 @@ def test_trace_disabled_decorator(enabled_initially):
         assert enable_mock.call_count == (1 if enabled_initially else 0)
 
 
+def test_disable_enable_tracing_not_mutate_otel_provider():
+    # This test validates that disable/enable MLflow tracing does not mutate the OpenTelemetry's
+    # global tracer provider instance.
+    otel_tracer_provider = trace.get_tracer_provider()
+
+    mlflow.tracing.disable()
+    assert trace.get_tracer_provider() is otel_tracer_provider
+
+    mlflow.tracing.enable()
+    assert trace.get_tracer_provider() is otel_tracer_provider
+
+    @trace_disabled
+    def test_fn():
+        assert trace.get_tracer_provider() is otel_tracer_provider
+
+    test_fn()
+    assert trace.get_tracer_provider() is otel_tracer_provider
+
+
 def test_is_enabled():
     # Before doing anything -> tracing is considered as "on"
     assert _is_enabled()
@@ -166,7 +204,7 @@ def test_is_enabled():
 
     # _is_enabled() should only raise MlflowTracingException
     with mock.patch(
-        "mlflow.tracing.provider.trace.get_tracer", side_effect=ValueError("error")
+        "mlflow.tracing.provider._get_tracer", side_effect=ValueError("error")
     ) as get_tracer_mock:
         with pytest.raises(MlflowTracingException, match="error"):
             assert _is_enabled() is False


### PR DESCRIPTION
### Related Issues/PRs
https://github.com/mlflow/mlflow/issues/12380, https://github.com/mlflow/mlflow/issues/12341


### What changes are proposed in this pull request?

#### Problem
MLflow tracing may be used within an environment where other services already use OpenTelemetry (e.g. Snowpark, Promptflow). There are a few isolation issues within such environment:

1. MLflow set the global tracer provider ([code](https://github.com/mlflow/mlflow/blob/master/mlflow/tracing/provider.py#L116)) to configure tracing. This overwrites existing tracer provider configured by the other services.
2. Spans created by other services are exported to MLflow tracking server, which causes errors because they don't meet criteria e.g. request_id.

#### Solution
To address this problem, we decided to manage our own tracer provider instance, isolated from the managed by OpenTelemetry SDK. This solves above two issues:
1. Since the tracer provider instance is different, we have no risk of overwriting existing configuration.
2. Span exporter is configured per tracer provider instance. Therefore, MLflow exporter only receives spans that is created via our tracer provider i.e. MLflow tracing APIs. 

Please refer to the design doc for more detailed discussion about this choice.


#### Limitation
This PR only isolate tracer provider i.e. config isolation. This does not isolate all entanglement in OTel. For example, the active span context is tracked by a global variable in OTel SDK, which both MLflow and other services rely on. Therefore, mixing span creation like this still cause errors after this PR.
```
from opentelemetry import trace
non_mlflow_tracer = trace.get_tracer(__name__)

with mlflow.start_span():
    with non_mlflow_tracer.start_as_current_span():  # <- this confuses MLflow span as parent
        with mlflow.start_span():  # <- this also confuses non-MLflow span as parent
            pass
```
We haven't received requests for this use case.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
```
from opentelemetry import trace
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import (
    SimpleSpanProcessor,
    ConsoleSpanExporter,
)

provider = TracerProvider()
processor = SimpleSpanProcessor(ConsoleSpanExporter())
provider.add_span_processor(processor)

trace.set_tracer_provider(provider)
tracer = trace.get_tracer("my.tracer.name")

# Create non-MLflow spans
with tracer.start_as_current_span("non_otel_span") as span:
    with tracer.start_as_current_span("non_otel_span_child"):
        pass

# Create MLflow spans
import mlflow

with mlflow.start_span(name="mlflow_span") as span:
    with mlflow.start_span(name="mlflow_span_child") as child_span:
        child_span.set_attribute("fruit", "apply")
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixing an integration issue with external services that internally uses OpenTelemetry.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
