### PR TITLE
Fix slow test

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
         with:
-          python-version: 3.8.19
+          python-version: 3.9
       - uses: ./.github/actions/setup-pyenv
       - uses: ./.github/actions/setup-java
       - name: Install dependencies
@@ -69,7 +69,7 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
-          python -m pip install langchain_experimental
+          python -m pip install langchain_experimental tf-keras
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -72,7 +72,7 @@ jobs:
           # We need to install `tf-keras` because the transformer flavor
           # tests depends on Keras < 3 but the `./dev/install-common-deps.sh`
           # installs Keras 3 in python 3.9 environment.
-          python -m pip install langchain_experimental "tf-keras<3"
+          python -m pip install langchain_experimental tf-keras
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -69,6 +69,9 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
+          # We need to install `tf-keras` because the transformer flavor
+          # tests depends on Keras < 3 but the `./dev/install-common-deps.sh`
+          # installs Keras 3 in python 3.9 environment.
           python -m pip install langchain_experimental tf-keras
       - uses: ./.github/actions/pipdeptree
       - name: Run tests

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -69,9 +69,8 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
-          # We need to install `tf-keras` because the transformer flavor
-          # tests depends on Keras < 3 but the `./dev/install-common-deps.sh`
-          # installs Keras 3 in python 3.9 environment.
+          # transformers requires `tf-keras` when keras 3.0 is installed.
+          # See https://github.com/huggingface/transformers/issues/27377 for more details.
           python -m pip install langchain_experimental tf-keras
       - uses: ./.github/actions/pipdeptree
       - name: Run tests

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
         with:
-          python-version: 3.9
+          python-version: 3.8.19
       - uses: ./.github/actions/setup-pyenv
       - uses: ./.github/actions/setup-java
       - name: Install dependencies

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -72,7 +72,7 @@ jobs:
           # We need to install `tf-keras` because the transformer flavor
           # tests depends on Keras < 3 but the `./dev/install-common-deps.sh`
           # installs Keras 3 in python 3.9 environment.
-          python -m pip install langchain_experimental keras<3
+          python -m pip install langchain_experimental tf-keras<3
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -72,7 +72,7 @@ jobs:
           # We need to install `tf-keras` because the transformer flavor
           # tests depends on Keras < 3 but the `./dev/install-common-deps.sh`
           # installs Keras 3 in python 3.9 environment.
-          python -m pip install langchain_experimental tf-keras==2.*
+          python -m pip install langchain_experimental keras<3
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -60,6 +60,8 @@ jobs:
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
+        with:
+          python-version: 3.9
       - uses: ./.github/actions/setup-pyenv
       - uses: ./.github/actions/setup-java
       - name: Install dependencies

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -72,7 +72,7 @@ jobs:
           # We need to install `tf-keras` because the transformer flavor
           # tests depends on Keras < 3 but the `./dev/install-common-deps.sh`
           # installs Keras 3 in python 3.9 environment.
-          python -m pip install langchain_experimental tf-keras
+          python -m pip install langchain_experimental tf-keras==2.*
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -72,7 +72,7 @@ jobs:
           # We need to install `tf-keras` because the transformer flavor
           # tests depends on Keras < 3 but the `./dev/install-common-deps.sh`
           # installs Keras 3 in python 3.9 environment.
-          python -m pip install langchain_experimental tf-keras<3
+          python -m pip install langchain_experimental "tf-keras<3"
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12468?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12468/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12468
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Slow test has [issue](https://github.com/mlflow-automation/mlflow/actions/runs/9646024912/job/26601503990) in python 3.8, but python 3.8 will approach EOL soon, I upgrade the CI to use python 3.9

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
