### PR TITLE
Show scoring server model loading failure for `evaluate(env_manager="virtualenv")`

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1142,7 +1142,7 @@ def _load_model_or_server(
             # the scoring server is still running but client can't connect to it.
             # kill the server.
             scoring_server_proc.kill()
-            server_output = scoring_server_proc.stdout.read()
+        server_output = scoring_server_proc.stdout.read()
         raise MlflowException(
             "MLflow model server failed to launch, server process stdout / stderr outputs are:\n" +
             server_output

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1146,7 +1146,7 @@ def _load_model_or_server(
         if isinstance(server_output, bytes):
             server_output = server_output.decode("UTF-8")
         raise MlflowException(
-            "MLflow model server failed to launch, server process stdout / stderr outputs are:\n" +
+            "MLflow model server failed to launch, server process stdout and stderr are:\n" +
             server_output
         ) from e
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1142,6 +1142,7 @@ def _load_model_or_server(
             # the scoring server is still running but client can't connect to it.
             # kill the server.
             scoring_server_proc.kill()
+            scoring_server_proc.wait()
         server_output = scoring_server_proc.stdout.read()
         raise MlflowException(
             "MLflow model server failed to launch, server process stdout / stderr outputs are:\n" +

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1142,7 +1142,9 @@ def _load_model_or_server(
             # the scoring server is still running but client can't connect to it.
             # kill the server.
             scoring_server_proc.kill()
-        server_output, _ = scoring_server_proc.communicate()
+        server_output, _ = scoring_server_proc.communicate(timeout=15)
+        if isinstance(server_output, bytes):
+            server_output = server_output.decode("UTF-8")
         raise MlflowException(
             "MLflow model server failed to launch, server process stdout / stderr outputs are:\n" +
             server_output

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1138,7 +1138,15 @@ def _load_model_or_server(
     try:
         client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
     except Exception as e:
-        raise MlflowException("MLflow model server failed to launch.") from e
+        if scoring_server_proc.poll() is None:
+            # the scoring server is still running but client can't connect to it.
+            # kill the server.
+            scoring_server_proc.kill()
+            server_output = scoring_server_proc.stdout.read()
+        raise MlflowException(
+            "MLflow model server failed to launch, server process stdout / stderr outputs are:\n" +
+            server_output
+        ) from e
 
     return _ServedPyFuncModel(
         model_meta=model_meta, client=client, server_pid=scoring_server_proc.pid

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1146,8 +1146,8 @@ def _load_model_or_server(
         if isinstance(server_output, bytes):
             server_output = server_output.decode("UTF-8")
         raise MlflowException(
-            "MLflow model server failed to launch, server process stdout and stderr are:\n" +
-            server_output
+            "MLflow model server failed to launch, server process stdout and stderr are:\n"
+            + server_output
         ) from e
 
     return _ServedPyFuncModel(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1142,8 +1142,7 @@ def _load_model_or_server(
             # the scoring server is still running but client can't connect to it.
             # kill the server.
             scoring_server_proc.kill()
-            scoring_server_proc.wait()
-        server_output = scoring_server_proc.stdout.read()
+        server_output, _ = scoring_server_proc.communicate()
         raise MlflowException(
             "MLflow model server failed to launch, server process stdout / stderr outputs are:\n" +
             server_output

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -2142,9 +2142,13 @@ def test_import_evaluation_dataset():
     from mlflow.models.evaluation.base import EvaluationDataset  # noqa: F401
 
 
-def test_evaluate_shows_server_stdout_and_stderr_on_error(linear_regressor_model_uri, diabetes_dataset):
+def test_evaluate_shows_server_stdout_and_stderr_on_error(
+    linear_regressor_model_uri, diabetes_dataset
+):
     with mlflow.start_run():
-        server_proc = subprocess.Popen("foo", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        server_proc = subprocess.Popen(
+            ["echo", "test1324"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
         with mock.patch(
             "mlflow.pyfunc.scoring_server.client.ScoringServerClient.wait_server_ready",
             side_effect=RuntimeError("Wait scoring server ready timeout."),
@@ -2152,7 +2156,7 @@ def test_evaluate_shows_server_stdout_and_stderr_on_error(linear_regressor_model
             "mlflow.pyfunc.backend.PyFuncBackend.serve",
             return_value=server_proc,
         ) as mock_serve:
-            with pytest.raises(MlflowException, match=r"foo:.*not found"):
+            with pytest.raises(MlflowException, match="test1324"):
                 evaluate(
                     linear_regressor_model_uri,
                     diabetes_dataset._constructor_args["data"],

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -2150,9 +2150,6 @@ def test_evaluate_shows_server_stdout_and_stderr_on_error(
             ["echo", "test1324"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )
         with mock.patch(
-            "mlflow.pyfunc.scoring_server.client.ScoringServerClient.wait_server_ready",
-            side_effect=RuntimeError("Wait scoring server ready timeout."),
-        ) as mock_wait_server_ready, mock.patch(
             "mlflow.pyfunc.backend.PyFuncBackend.serve",
             return_value=server_proc,
         ) as mock_serve:
@@ -2165,5 +2162,4 @@ def test_evaluate_shows_server_stdout_and_stderr_on_error(
                     evaluators="dummy_evaluator",
                     env_manager="virtualenv",
                 )
-            mock_wait_server_ready.assert_called_once()
             mock_serve.assert_called_once()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12473?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12473/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12473
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Show scoring server model loading failure for `evaluate(env_manager="virtualenv")`:

When a model can’t be loaded in a subprocess within a virtualenv during mlflow.evaluate(env_manager="virtualenv"), the user can’t see the stacktrace.
We should detect model load failures and print the failure stacktrace to stdout when a model can’t be loaded in a subprocess with env_manager="virtualenv".

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

Manually testing:

First, we need to create a modified mlflow version that tweaks model scoring server code  to make it raise an exception:
( https://github.com/WeichenXu123/mlflow.git@eval-err-trace-test , Diff: https://github.com/WeichenXu123/mlflow/compare/_load_model_or_server-err-trace...WeichenXu123:mlflow:eval-err-trace-test?expand=1 )

then, run the following code:
```
from sklearn.datasets import fetch_california_housing
from sklearn.linear_model import LinearRegression
from sklearn.model_selection import train_test_split

import mlflow

california_housing_data = fetch_california_housing()

X_train, X_test, y_train, y_test = train_test_split(
    california_housing_data.data, california_housing_data.target, test_size=0.33, random_state=42
)

with mlflow.start_run() as run:
    model = LinearRegression().fit(X_train, y_train)
    mlflow.sklearn.log_model(model, "model", pip_requirements=[
        "scikit-learn",
        "git+https://github.com/WeichenXu123/mlflow.git@eval-err-trace-test"
    ])
    model_uri = mlflow.get_artifact_uri("model")

    result = mlflow.evaluate(
        model_uri,
        X_test,
        targets=y_test,
        model_type="regressor",
        evaluators="default",
        feature_names=california_housing_data.feature_names,
        evaluator_config={"explainability_nsamples": 1000},
        env_manager="virtualenv",
    )

print(f"metrics:\n{result.metrics}")
print(f"artifacts:\n{result.artifacts}")
```

then, the error stack is captured, we got error message like:

```
2024/06/27 03:27:02 INFO mlflow.utils.environment: === Running command '['bash', '-c', 'source /home/weichen.xu/.mlflow/envs/mlflow-c55c731cbae4196f03886b6fe70879e46cd4a8de/bin/activate && exec gunicorn --timeout=60 -b 127.0.0.1:34659 -w 1 ${GUNICORN_CMD_ARGS} -- mlflow.pyfunc.scoring_server.wsgi:app']'
2024/06/27 03:27:02 INFO mlflow.pyfunc: Scoring server process started at PID: 30067
Traceback (most recent call last):
  File "/home/weichen.xu/mlflow/mlflow/pyfunc/__init__.py", line 1139, in _load_model_or_server
    client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
  File "/home/weichen.xu/mlflow/mlflow/pyfunc/scoring_server/client.py", line 72, in wait_server_ready
    raise RuntimeError(f"Server process already exit with returncode {return_code}")
RuntimeError: Server process already exit with returncode 3

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/weichen.xu/mlflow/examples/evaluation/evaluate_on_regressor.py", line 21, in <module>
    result = mlflow.evaluate(
  File "/home/weichen.xu/mlflow/mlflow/models/evaluation/base.py", line 1501, in evaluate
    model = _load_model_or_server(model, env_manager, model_config)
  File "/home/weichen.xu/mlflow/mlflow/pyfunc/__init__.py", line 1147, in _load_model_or_server
    raise MlflowException(
mlflow.exceptions.MlflowException: MLflow model server failed to launch, server process stdout / stderr outputs are:
[2024-06-27 03:27:02 +0000] [30067] [INFO] Starting gunicorn 22.0.0
[2024-06-27 03:27:02 +0000] [30067] [INFO] Listening at: http://127.0.0.1:34659 (30067)
[2024-06-27 03:27:02 +0000] [30067] [INFO] Using worker: sync
[2024-06-27 03:27:02 +0000] [30070] [INFO] Booting worker with pid: 30070
[2024-06-27 03:27:03 +0000] [30070] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/home/weichen.xu/.mlflow/envs/mlflow-c55c731cbae4196f03886b6fe70879e46cd4a8de/lib/python3.9/site-packages/gunicorn/arbiter.py", line 609, in spawn_worker
    worker.init_process()
  File "/home/weichen.xu/.mlflow/envs/mlflow-c55c731cbae4196f03886b6fe70879e46cd4a8de/lib/python3.9/site-packages/gunicorn/workers/base.py", line 134, in init_process
    self.load_wsgi()
  File "/home/weichen.xu/.mlflow/envs/mlflow-c55c731cbae4196f03886b6fe70879e46cd4a8de/lib/python3.9/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/home/weichen.xu/.mlflow/envs/mlflow-c55c731cbae4196f03886b6fe70879e46cd4a8de/lib/python3.9/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/home/weichen.xu/.mlflow/envs/mlflow-c55c731cbae4196f03886b6fe70879e46cd4a8de/lib/python3.9/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
    return self.load_wsgiapp()
  File "/home/weichen.xu/.mlflow/envs/mlflow-c55c731cbae4196f03886b6fe70879e46cd4a8de/lib/python3.9/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/home/weichen.xu/.mlflow/envs/mlflow-c55c731cbae4196f03886b6fe70879e46cd4a8de/lib/python3.9/site-packages/gunicorn/util.py", line 371, in import_app
    mod = importlib.import_module(module)
  File "/home/weichen.xu/.pyenv/versions/3.9.19/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/weichen.xu/.mlflow/envs/mlflow-c55c731cbae4196f03886b6fe70879e46cd4a8de/lib/python3.9/site-packages/mlflow/pyfunc/scoring_server/wsgi.py", line 5, in <module>
    raise RuntimeError("Test failure 123423")
RuntimeError: Test failure 123423
[2024-06-27 03:27:03 +0000] [30070] [INFO] Worker exiting (pid: 30070)
[2024-06-27 03:27:03 +0000] [30067] [ERROR] Worker (pid:30070) exited with code 3
[2024-06-27 03:27:03 +0000] [30067] [ERROR] Shutting down: Master
[2024-06-27 03:27:03 +0000] [30067] [ERROR] Reason: Worker failed to boot.
```

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
