### PR TITLE
Log image supports auto-scaling float values

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2208,7 +2208,7 @@ class MlflowClient:
                 .. warning::
 
                     - Out-of-range integer values will raise ValueError.
-                    - Out-of-range float values will raise ValueError.
+                    - Out-of-range float values will auto-scale with min/max and warn.
 
             - shape (H: height, W: width):
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1272,7 +1272,7 @@ def log_image(
             .. warning::
 
                 - Out-of-range integer values will raise ValueError.
-                - Out-of-range float values will raise ValueError.
+                - Out-of-range float values will auto-scale with min/max and warn.
 
         - shape (H: height, W: width):
 

--- a/mlflow/tracking/multimedia.py
+++ b/mlflow/tracking/multimedia.py
@@ -3,6 +3,7 @@ Internal module implementing multi-media objects and utilities in MLflow. Multi-
 exposed to users at the top-level :py:mod:`mlflow` module.
 """
 
+import warnings
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 if TYPE_CHECKING:
@@ -57,11 +58,14 @@ def convert_to_pil_image(image: Union["numpy.ndarray", list]) -> "PIL.Image.Imag
                     "Ensure all pixel values are within the specified range."
                 )
             else:
-                raise ValueError(
+                warnings.warn(
                     "Float pixel values out of acceptable range [0.0, 1.0]. "
                     f"Found minimum value {x.min()} and maximum value {x.max()}. "
-                    "Ensure all pixel values are within the specified range."
+                    "Rescaling values to [0.0, 1.0] with min/max scaler.",
+                    stacklevel=2,
                 )
+                # Min-max scaling
+                x = (x - x.min()) / (x.max() - x.min())
 
         # float or bool
         if not is_int:

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -129,8 +129,8 @@ def test_log_image_numpy_emits_warning_for_out_of_range_values(array):
         ):
             mlflow.log_image(image, "image.png")
     else:
-        with mlflow.start_run(), pytest.raises(
-            ValueError, match="Float pixel values out of acceptable range"
+        with mlflow.start_run(), pytest.warns(
+            UserWarning, match="Float pixel values out of acceptable range"
         ):
             mlflow.log_image(image, "image.png")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jessechancy/mlflow/pull/12476?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12476/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12476
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As requested by Mosaic team, we will be auto-scaling float values if they are out of the supported range [0.0, 1.0]. This will help users to easily log intermediate tensors. 

The auto-scale will be a MinMaxScaler. We will throw a UserWarning if its outside the supported range.

<img width="1228" alt="Screenshot 2024-06-25 at 2 09 17 PM" src="https://github.com/mlflow/mlflow/assets/44277300/00fedd7c-936e-4f18-9f4b-60910ff64026">

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
