### PR TITLE
Fix linux env setup CI

### DIFF
--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -50,9 +50,6 @@ jobs:
         run: |
           git config --global user.name "test"
           git config --global user.email "test@mlflow.org"
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 120
       - name: Run Environment tests
         run: |
           curl https://pyenv.run | bash

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -42,7 +42,7 @@ jobs:
     if: github.event_name != 'schedule' || github.repository == 'mlflow-automation/mlflow'
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           # this might remove tools that are actually needed,
           # when set to "true" but frees about 6 GB
@@ -62,5 +62,3 @@ jobs:
           export PYENV_ROOT="$HOME/.pyenv"
           [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
           TERM=xterm bash ./dev/test-dev-env-setup.sh
-
-

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -58,7 +58,4 @@ jobs:
           git config --global user.email "test@mlflow.org"
       - name: Run Environment tests
         run: |
-          curl https://pyenv.run | bash
-          export PYENV_ROOT="$HOME/.pyenv"
-          [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
           TERM=xterm bash ./dev/test-dev-env-setup.sh

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -50,10 +50,11 @@ jobs:
         run: |
           git config --global user.name "test"
           git config --global user.email "test@mlflow.org"
-      - name: Run Environment tests
-        run: |
-          TERM=xterm bash ./dev/test-dev-env-setup.sh
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 120
+      - name: Run Environment tests
+        run: |
+          TERM=xterm bash ./dev/test-dev-env-setup.sh
+
 

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -53,3 +53,7 @@ jobs:
       - name: Run Environment tests
         run: |
           TERM=xterm bash ./dev/test-dev-env-setup.sh
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 120
+

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -55,6 +55,9 @@ jobs:
         timeout-minutes: 120
       - name: Run Environment tests
         run: |
+          curl https://pyenv.run | bash
+          export PYENV_ROOT="$HOME/.pyenv"
+          [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
           TERM=xterm bash ./dev/test-dev-env-setup.sh
 
 

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -41,6 +41,12 @@ jobs:
     timeout-minutes: 30
     if: github.event_name != 'schedule' || github.repository == 'mlflow-automation/mlflow'
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # when set to "true" but frees about 6 GB
+          tool-cache: true
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -135,7 +135,9 @@ minor_to_micro() {
 # Note: if xcode isn't installed, this will fail.
 # $1: name of package that requires brew
 check_and_install_brew() {
-  if [ -z "$(command -v brew)" ]; then
+  # command -v returns exit code 1 if pyenv does not exist, which directly terminates our test script.
+  # Appending `|| true` to ignore the exit code.
+  if [ -z "$(command -v brew || true)" ]; then
     echo "Homebrew is required to install $1 on MacOS. Installing in your home directory."
     bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
@@ -171,7 +173,8 @@ version_gt() {
 
 # Check if pyenv is installed and offer to install it if not present
 check_and_install_pyenv() {
-  # `|| true` is for preventing scrip termination when `set -o errexit` bash flag is set.
+  # command -v returns exit code 1 if pyenv does not exist, which directly terminates our test script.
+  # Appending `|| true` to ignore the exit code.
   pyenv_exist=$(command -v pyenv || true)
   if [ -z "$pyenv_exist" ]; then
     if [ -z "$GITHUB_ACTIONS" ]; then

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -171,11 +171,8 @@ version_gt() {
 
 # Check if pyenv is installed and offer to install it if not present
 check_and_install_pyenv() {
-  if [ -z "$GITHUB_ACTIONS" ]; then
-    pyenv_exist=$(command -v pyenv)
-  else
-    pyenv_exist=""
-  fi
+  # `|| true` is for preventing scrip termination when `set -o errexit` bash flag is set.
+  pyenv_exist=$(command -v pyenv || true)
   if [ -z "$pyenv_exist" ]; then
     if [ -z "$GITHUB_ACTIONS" ]; then
       read -p "pyenv is required to be installed to manage python versions. Would you like to install it? $(tput bold)(y/n)$(tput sgr0): " -n 1 -r

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -135,7 +135,7 @@ minor_to_micro() {
 # Note: if xcode isn't installed, this will fail.
 # $1: name of package that requires brew
 check_and_install_brew() {
-  # command -v returns exit code 1 if pyenv does not exist, which directly terminates our test script.
+  # command -v returns exit code 1 if brew does not exist, which directly terminates our test script.
   # Appending `|| true` to ignore the exit code.
   if [ -z "$(command -v brew || true)" ]; then
     echo "Homebrew is required to install $1 on MacOS. Installing in your home directory."

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -171,8 +171,11 @@ version_gt() {
 
 # Check if pyenv is installed and offer to install it if not present
 check_and_install_pyenv() {
-  pyenv_exist=$(command -v pyenv)
-
+  if [ -z "$GITHUB_ACTIONS" ]; then
+    pyenv_exist=$(command -v pyenv)
+  else
+    pyenv_exist=""
+  fi
   if [ -z "$pyenv_exist" ]; then
     if [ -z "$GITHUB_ACTIONS" ]; then
       read -p "pyenv is required to be installed to manage python versions. Would you like to install it? $(tput bold)(y/n)$(tput sgr0): " -n 1 -r


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12485?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12485/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12485
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix linux env setup CI.

The dev-env-setup CI is broken (this line `pyenv_exist=$(command -v pyenv)` causes the script exit abnormally:

In MLflow master, the script execution terminates after executing `pyenv_exist=$(command -v pyenv)` command, because `command -v pyenv` return value is non-zero and in `dev/test-dev-env-setup.sh` we have a line `set -o errexit` so when `command -v pyenv` return non-zero value the script is terminated.

I updated it to 
```
    pyenv_exist=$(command -v pyenv || true)
```
then the CI works.

testing run: https://github.com/WeichenXu123/mlflow/actions/workflows/dev-setup.yml

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
