### PR TITLE
Fix sklearn pipeline predict proba function 

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -516,7 +516,16 @@ class _SklearnModelWrapper:
         # via `pyfunc_predict_fn` argument when saving or logging.
         for predict_fn in self._SUPPORTED_CUSTOM_PREDICT_FN:
             if fn := getattr(self.sklearn_model, predict_fn, None):
-                setattr(self, predict_fn, fn)
+
+                def _custom_predict_fn_wrapper(
+                    data,
+                    params: Optional[Dict[str, Any]] = None
+                ):
+                    params = params or {}
+                    breakpoint()
+                    return fn(data, **params)
+
+                setattr(self, predict_fn, _custom_predict_fn_wrapper)
 
     def predict(
         self,
@@ -531,7 +540,8 @@ class _SklearnModelWrapper:
         Returns:
             Model predictions.
         """
-        return self.sklearn_model.predict(data)
+        params = params or {}
+        return self.sklearn_model.predict(data, **params)
 
 
 class _SklearnCustomModelPicklingError(pickle.PicklingError):

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -522,7 +522,6 @@ class _SklearnModelWrapper:
                     params: Optional[Dict[str, Any]] = None
                 ):
                     params = params or {}
-                    breakpoint()
                     return fn(data, **params)
 
                 setattr(self, predict_fn, _custom_predict_fn_wrapper)

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -502,11 +502,7 @@ def _load_pyfunc(path):
 
 
 def _gen_sklearn_model_predict_fn(origin_fn, fn_name):
-
-    def predict_fn(
-        data,
-        params: Optional[Dict[str, Any]] = None
-    ):
+    def predict_fn(data, params: Optional[Dict[str, Any]] = None):
         params = params or {}
         return origin_fn(data, **params)
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -187,7 +187,8 @@ def test_regressor_evaluation(
 
     expected_metrics = _get_regressor_metrics(y, y_pred, sample_weights=sample_weights)
     expected_metrics["score"] = model._model_impl.score(
-        diabetes_dataset.features_data, diabetes_dataset.labels_data, sample_weight=sample_weights
+        diabetes_dataset.features_data,
+        params={"y": diabetes_dataset.labels_data, "sample_weight": sample_weights},
     )
 
     assert json.loads(tags["mlflow.datasets"]) == [
@@ -243,7 +244,7 @@ def test_regressor_evaluation_disable_logging_metrics_and_artifacts(
 
     expected_metrics = _get_regressor_metrics(y, y_pred, sample_weights=None)
     expected_metrics["score"] = model._model_impl.score(
-        diabetes_dataset.features_data, diabetes_dataset.labels_data
+        diabetes_dataset.features_data, params={"y": diabetes_dataset.labels_data}
     )
 
     check_metrics_not_logged_for_baseline_model_evaluation(
@@ -319,7 +320,8 @@ def test_multi_classifier_evaluation(
         y_true=y, y_pred=y_pred, y_proba=y_probs, sample_weights=sample_weights
     )
     expected_metrics["score"] = model._model_impl.score(
-        iris_dataset.features_data, iris_dataset.labels_data, sample_weight=sample_weights
+        iris_dataset.features_data,
+        params={"y": iris_dataset.labels_data, "sample_weight": sample_weights},
     )
 
     for metric_key, expected_metric_val in expected_metrics.items():
@@ -380,7 +382,7 @@ def test_multi_classifier_evaluation_disable_logging_metrics_and_artifacts(
         y_true=y, y_pred=y_pred, y_proba=y_probs, sample_weights=None
     )
     expected_metrics["score"] = model._model_impl.score(
-        iris_dataset.features_data, iris_dataset.labels_data
+        iris_dataset.features_data, params={"y": iris_dataset.labels_data}
     )
 
     check_metrics_not_logged_for_baseline_model_evaluation(
@@ -445,8 +447,7 @@ def test_bin_classifier_evaluation(
     )
     expected_metrics["score"] = model._model_impl.score(
         breast_cancer_dataset.features_data,
-        breast_cancer_dataset.labels_data,
-        sample_weight=sample_weights,
+        params={"y": breast_cancer_dataset.labels_data, "sample_weight": sample_weights},
     )
 
     for metric_key, expected_metric_val in expected_metrics.items():
@@ -510,7 +511,7 @@ def test_bin_classifier_evaluation_disable_logging_metrics_and_artifacts(
         y_true=y, y_pred=y_pred, y_proba=y_probs, sample_weights=None
     )
     expected_metrics["score"] = model._model_impl.score(
-        breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
+        breast_cancer_dataset.features_data, params={"y": breast_cancer_dataset.labels_data}
     )
 
     check_metrics_not_logged_for_baseline_model_evaluation(
@@ -670,7 +671,7 @@ def test_svm_classifier_evaluation(svm_model_uri, breast_cancer_dataset, baselin
 
     expected_metrics = _get_binary_classifier_metrics(y_true=y, y_pred=y_pred, sample_weights=None)
     expected_metrics["score"] = model._model_impl.score(
-        breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
+        breast_cancer_dataset.features_data, params={"y": breast_cancer_dataset.labels_data}
     )
 
     for metric_key, expected_metric_val in expected_metrics.items():
@@ -754,7 +755,7 @@ def test_svm_classifier_evaluation_disable_logging_metrics_and_artifacts(
 
     expected_metrics = _get_binary_classifier_metrics(y_true=y, y_pred=y_pred, sample_weights=None)
     expected_metrics["score"] = model._model_impl.score(
-        breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
+        breast_cancer_dataset.features_data, params={"y": breast_cancer_dataset.labels_data}
     )
 
     check_metrics_not_logged_for_baseline_model_evaluation(

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -878,6 +878,10 @@ def test_model_registration_metadata_handling(sklearn_knn_model, tmp_path):
     assert os.listdir(dst_full) == ["MLmodel"]
 
 
+@pytest.mark.skipif(
+    Version(sklearn.__version__) < Version("1.0.0"),
+    reason="predict_proba method patching for test doesn't work in scikit-learn < 1",
+)
 def test_pipeline_model_wrapper_prediction(sklearn_knn_model, model_path):
     # Test `_SklearnModelWrapper` supports sklearn pipeline model with arbitrary params.
     # Related issue: https://github.com/mlflow/mlflow/issues/12445


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12489?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12489/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12489
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> Closes #12445

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix sklearn pipeline predict proba function:

sklearn pipeline predict / predict_proba functions has `**params*` argument, the argument name accidentally matches mlflow pyfunc model predict method `params` argument, but they are different. 
I added logic in MLflow to handle this.

Note that this approach will cause `_model_impl` APIs breaking change,

the alternative approach https://github.com/mlflow/mlflow/pull/12554 doesn't have this issue.


### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
