### PR TITLE
Use editable install in autoformat workflow

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -110,7 +110,7 @@ jobs:
           sudo chmod -R 777 /tmp/protoc
           echo "/tmp/protoc/bin" >> $GITHUB_PATH
           pip install --upgrade pip
-          pip install .
+          pip install -e .
       - if: steps.diff.outputs.protos == 'true'
         run: |
           python ./dev/generate_protos.py


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12497?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12497/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12497
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #12495

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use the editable mode when install mlflow to reflect proto changes and avoid import errors.


The following error occurs on #12495. `code_generator.py` imports mlflow installed before updating compiling protos, and fails to import `SseEncryptionAlgorithm`.

```
Traceback (most recent call last):
  File "./dev/proto_to_graphql/code_generator.py", line 4, in <module>
    from parsing_utils import process_method
  File "/home/runner/work/mlflow/mlflow/dev/proto_to_graphql/parsing_utils.py", line 4, in <module>
    from mlflow.protos import databricks_pb2
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/__init__.py", line 34, in <module>
    from mlflow import (
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/artifacts/__init__.py", line 11, in <module>
    from mlflow.tracking import _get_store
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/tracking/__init__.py", line 8, in <module>
    from mlflow.tracking._model_registry.utils import (
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/tracking/_model_registry/utils.py", line 4, in <module>
    from mlflow.store.db.db_types import DATABASE_ENGINES
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/store/__init__.py", line 1, in <module>
    from mlflow.store import _unity_catalog  # noqa: F401
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/store/_unity_catalog/__init__.py", line 1, in <module>
    from mlflow.store._unity_catalog import registry  # noqa: F401
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/store/_unity_catalog/registry/__init__.py", line 1, in <module>
    from mlflow.store._unity_catalog.registry import rest_store  # noqa: F401
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/store/_unity_catalog/registry/rest_store.py", line 74, in <module>
    from mlflow.utils._unity_catalog_utils import (
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/utils/_unity_catalog_utils.py", line 26, in <module>
    from mlflow.protos.databricks_uc_registry_messages_pb2 import (
ImportError: cannot import name 'SseEncryptionAlgorithm' from 'mlflow.protos.databricks_uc_registry_messages_pb2' (/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/mlflow/protos/databricks_uc_registry_messages_pb2.py)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
