### PR TITLE
Fix `preview-docs` workflow

### DIFF
--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -48,13 +48,13 @@ def main():
     parser.add_argument("--workflow-run-id", required=True)
     args = parser.parse_args()
 
-    gh_session = Session()
+    github_session = Session()
     if github_token := os.environ.get("GITHUB_TOKEN"):
-        gh_session.headers.update({"Authorization": f"token {github_token}"})
+        github_session.headers.update({"Authorization": f"token {github_token}"})
 
-    cci_session = Session()
+    circle_session = Session()
     if circle_token := os.environ.get("CIRCLE_TOKEN"):
-        cci_session.headers.update({"Circle-Token": circle_token})
+        circle_session.headers.update({"Circle-Token": circle_token})
 
     # Get the ID of the build_doc job
     repo = "mlflow/mlflow"
@@ -62,7 +62,7 @@ def main():
     job_id = None
     workflow_run_link = f"https://github.com/{repo}/actions/runs/{args.workflow_run_id}"
     for _ in range(5):
-        status = gh_session.get(
+        status = github_session.get(
             f"https://api.github.com/repos/{repo}/commits/{args.commit_sha}/status"
         )
         build_doc_status = next(
@@ -91,14 +91,14 @@ Failed to find a documentation preview for {args.commit_sha}.
 
 </details>
 """
-        upsert_comment(gh_session, repo, args.pull_number, comment_body)
+        upsert_comment(github_session, repo, args.pull_number, comment_body)
         return
 
     # Get the artifact URL of the top level index.html
-    job = cci_session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
+    job = circle_session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
     job_url = job["web_url"]
     workflow_id = job["latest_workflow"]["id"]
-    workflow = cci_session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
+    workflow = circle_session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
     build_doc_job = next(filter(lambda s: s["name"] == build_doc_job_name, workflow["items"]))
     build_doc_job_id = build_doc_job["id"]
     top_page = f"https://output.circle-artifacts.com/output/job/{build_doc_job_id}/artifacts/0/docs/build/html/index.html"
@@ -122,7 +122,7 @@ completes successfully.
 
 </details>
 """
-    upsert_comment(gh_session, repo, args.pull_number, comment_body)
+    upsert_comment(github_session, repo, args.pull_number, comment_body)
 
 
 if __name__ == "__main__":

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -48,14 +48,13 @@ def main():
     parser.add_argument("--workflow-run-id", required=True)
     args = parser.parse_args()
 
-    headers = {}
+    gh_session = Session()
     if github_token := os.environ.get("GITHUB_TOKEN"):
-        headers["Authorization"] = f"token {github_token}"
-    if circle_token := os.environ.get("CIRCLE_TOKEN"):
-        headers["Circle-Token"] = circle_token
+        gh_session.headers.update({"Authorization": f"token {github_token}"})
 
-    session = Session()
-    session.headers.update(headers)
+    cci_session = Session()
+    if circle_token := os.environ.get("CIRCLE_TOKEN"):
+        cci_session.headers.update({"Circle-Token": circle_token})
 
     # Get the ID of the build_doc job
     repo = "mlflow/mlflow"
@@ -63,7 +62,7 @@ def main():
     job_id = None
     workflow_run_link = f"https://github.com/{repo}/actions/runs/{args.workflow_run_id}"
     for _ in range(5):
-        status = session.get(
+        status = gh_session.get(
             f"https://api.github.com/repos/{repo}/commits/{args.commit_sha}/status"
         )
         build_doc_status = next(
@@ -92,14 +91,14 @@ Failed to find a documentation preview for {args.commit_sha}.
 
 </details>
 """
-        upsert_comment(session, repo, args.pull_number, comment_body)
+        upsert_comment(gh_session, repo, args.pull_number, comment_body)
         return
 
     # Get the artifact URL of the top level index.html
-    job = session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
+    job = cci_session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
     job_url = job["web_url"]
     workflow_id = job["latest_workflow"]["id"]
-    workflow = session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
+    workflow = cci_session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
     build_doc_job = next(filter(lambda s: s["name"] == build_doc_job_name, workflow["items"]))
     build_doc_job_id = build_doc_job["id"]
     top_page = f"https://output.circle-artifacts.com/output/job/{build_doc_job_id}/artifacts/0/docs/build/html/index.html"
@@ -123,7 +122,7 @@ completes successfully.
 
 </details>
 """
-    upsert_comment(session, repo, args.pull_number, comment_body)
+    upsert_comment(gh_session, repo, args.pull_number, comment_body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12499?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12499/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12499
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Separate request sessions for GitHub and CircleCI in the `preview-docs` job to fix the error:

https://github.com/mlflow/mlflow/actions/runs/9688671667/job/26737567934

```
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/dev/preview_docs.py", line 130, in <module>
    main()
  File "/home/runner/work/mlflow/mlflow/dev/preview_docs.py", line 99, in main
    job = session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
  File "/home/runner/work/mlflow/mlflow/dev/preview_docs.py", line 12, in get
    resp.raise_for_status()
  File "/usr/lib/python3/dist-packages/requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://circleci.com/api/v2/project/gh/mlflow/mlflow/job/[11](https://github.com/mlflow/mlflow/actions/runs/9688671667/job/26737567934#step:4:12)2758
```

Manual confirmation:

```bash
export CIRCLE_TOKEN=<my valid token>
curl https://circleci.com/api/v2/project/gh/mlflow/mlflow/job/112758 \
  --header "Circle-Token: $CIRCLE_TOKEN" # works
curl https://circleci.com/api/v2/project/gh/mlflow/mlflow/job/112758 \
  --header "Circle-Token: $CIRCLE_TOKEN" --header "Authorization: token foo"  # used to work but doesn't now
```


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Test: https://github.com/mlflow/mlflow/pull/12501, See https://github.com/mlflow/mlflow/pull/12501#issuecomment-2192990548

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
