### PR TITLE
Refactor `mlflow/langchain/databricks_dependencies.py` to avoid mutating list

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Set
+from typing import Generator, List, Set
 
 from mlflow.models.resources import DatabricksServingEndpoint, DatabricksVectorSearchIndex, Resource
 
@@ -18,7 +18,7 @@ def _get_embedding_model_endpoint_names(index):
     return embedding_model_endpoint_names
 
 
-def _extract_databricks_dependencies_from_retriever(retriever, dependency_list: List[Resource]):
+def _extract_databricks_dependencies_from_retriever(retriever) -> Generator[Resource, None, None]:
     try:
         from langchain.embeddings import DatabricksEmbeddings as LegacyDatabricksEmbeddings
         from langchain.vectorstores import (
@@ -39,16 +39,16 @@ def _extract_databricks_dependencies_from_retriever(retriever, dependency_list: 
     if vectorstore:
         if isinstance(vectorstore, (DatabricksVectorSearch, LegacyDatabricksVectorSearch)):
             index = vectorstore.index
-            dependency_list.append(DatabricksVectorSearchIndex(index_name=index.name))
+            yield DatabricksVectorSearchIndex(index_name=index.name)
             for embedding_endpoint in _get_embedding_model_endpoint_names(index):
-                dependency_list.append(DatabricksServingEndpoint(endpoint_name=embedding_endpoint))
+                yield DatabricksServingEndpoint(endpoint_name=embedding_endpoint)
 
         embeddings = getattr(vectorstore, "embeddings", None)
         if isinstance(embeddings, (DatabricksEmbeddings, LegacyDatabricksEmbeddings)):
-            dependency_list.append(DatabricksServingEndpoint(endpoint_name=embeddings.endpoint))
+            yield DatabricksServingEndpoint(endpoint_name=embeddings.endpoint)
 
 
-def _extract_databricks_dependencies_from_llm(llm, dependency_list: List[Resource]):
+def _extract_databricks_dependencies_from_llm(llm) -> Generator[Resource, None, None]:
     try:
         from langchain.llms import Databricks as LegacyDatabricks
     except ImportError:
@@ -57,10 +57,10 @@ def _extract_databricks_dependencies_from_llm(llm, dependency_list: List[Resourc
     from langchain_community.llms import Databricks
 
     if isinstance(llm, (LegacyDatabricks, Databricks)):
-        dependency_list.append(DatabricksServingEndpoint(endpoint_name=llm.endpoint_name))
+        yield DatabricksServingEndpoint(endpoint_name=llm.endpoint_name)
 
 
-def _extract_databricks_dependencies_from_chat_model(chat_model, dependency_list: List[Resource]):
+def _extract_databricks_dependencies_from_chat_model(chat_model) -> Generator[Resource, None, None]:
     try:
         from langchain.chat_models import ChatDatabricks as LegacyChatDatabricks
     except ImportError:
@@ -71,7 +71,7 @@ def _extract_databricks_dependencies_from_chat_model(chat_model, dependency_list
     from langchain_community.chat_models import ChatDatabricks
 
     if isinstance(chat_model, (LegacyChatDatabricks, ChatDatabricks)):
-        dependency_list.append(DatabricksServingEndpoint(endpoint_name=chat_model.endpoint))
+        yield DatabricksServingEndpoint(endpoint_name=chat_model.endpoint)
 
 
 _LEGACY_MODEL_ATTR_SET = {
@@ -87,7 +87,7 @@ _LEGACY_MODEL_ATTR_SET = {
 }
 
 
-def _extract_dependency_list_from_lc_model(lc_model, dependency_list: List[Resource]):
+def _extract_dependency_list_from_lc_model(lc_model) -> Generator[Resource, None, None]:
     """
     This function contains the logic to examine a non-Runnable component of a langchain model.
     The logic here does not cover all legacy chains. If you need to support a custom chain,
@@ -97,20 +97,19 @@ def _extract_dependency_list_from_lc_model(lc_model, dependency_list: List[Resou
         return
 
     # leaf node
-    _extract_databricks_dependencies_from_chat_model(lc_model, dependency_list)
-    _extract_databricks_dependencies_from_retriever(lc_model, dependency_list)
-    _extract_databricks_dependencies_from_llm(lc_model, dependency_list)
+    yield from _extract_databricks_dependencies_from_chat_model(lc_model)
+    yield from _extract_databricks_dependencies_from_retriever(lc_model)
+    yield from _extract_databricks_dependencies_from_llm(lc_model)
 
     # recursively inspect legacy chain
     for attr_name in _LEGACY_MODEL_ATTR_SET:
-        _extract_dependency_list_from_lc_model(getattr(lc_model, attr_name, None), dependency_list)
+        yield from _extract_dependency_list_from_lc_model(getattr(lc_model, attr_name, None))
 
 
 def _traverse_runnable(
     lc_model,
-    dependency_list: List[Resource],
     visited: Set[str],
-):
+) -> Generator[Resource, None, None]:
     """
     This function contains the logic to traverse a langchain_core.runnables.RunnableSerializable
     object. It first inspects the current object using _extract_dependency_list_from_lc_model
@@ -126,16 +125,15 @@ def _traverse_runnable(
 
     # Visit the current object
     visited.add(current_object_id)
-    _extract_dependency_list_from_lc_model(lc_model, dependency_list)
+    yield from _extract_dependency_list_from_lc_model(lc_model)
 
     if isinstance(lc_model, Runnable):
         # Visit the returned graph
         for node in lc_model.get_graph().nodes.values():
-            _traverse_runnable(node.data, dependency_list, visited)
+            yield from _traverse_runnable(node.data, visited)
     else:
         # No-op for non-runnable, if any
         pass
-    return
 
 
 def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> List[Resource]:
@@ -160,8 +158,7 @@ def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> Li
     If a chat_model is found, it will be used to extract the databricks chat dependencies.
     """
     try:
-        dependency_list = []
-        _traverse_runnable(lc_model, dependency_list, set())
+        dependency_list = list(_traverse_runnable(lc_model, set()))
         # Filter out duplicate dependencies so same dependencies are not added multiple times
         # We can't use set here as the object is not hashable so we need to filter it out manually.
         unique_dependencies = []

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -120,7 +120,6 @@ def _traverse_runnable(
     from langchain_core.runnables import Runnable
 
     visited = visited or set()
-
     current_object_id = id(lc_model)
     if current_object_id in visited:
         return

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -167,7 +167,6 @@ def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> Li
             if dependency not in unique_dependencies:
                 unique_dependencies.append(dependency)
         return unique_dependencies
-        return list(_traverse_runnable(lc_model))
     except Exception:
         if log_errors_as_warnings:
             _logger.warning(

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -50,8 +50,7 @@ def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch)
         llm_kwargs["allow_dangerous_deserialization"] = True
 
     llm = Databricks(**llm_kwargs)
-    resources = []
-    _extract_databricks_dependencies_from_llm(llm, resources)
+    resources = list(_extract_databricks_dependencies_from_llm(llm))
     assert resources == [
         DatabricksServingEndpoint(endpoint_name="databricks-mixtral-8x7b-instruct")
     ]
@@ -137,8 +136,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 
     vectorstore = DatabricksVectorSearch(vs_index, text_column="content", embedding=embedding_model)
     retriever = vectorstore.as_retriever()
-    resources = []
-    _extract_databricks_dependencies_from_retriever(retriever, resources)
+    resources = list(_extract_databricks_dependencies_from_retriever(retriever))
     assert resources == [
         DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
         DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
@@ -166,8 +164,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 
     vectorstore = DatabricksVectorSearch(vs_index, text_column="content", embedding=embedding_model)
     retriever = vectorstore.as_retriever()
-    resources = []
-    _extract_databricks_dependencies_from_retriever(retriever, resources)
+    resources = list(_extract_databricks_dependencies_from_retriever(retriever))
     assert resources == [
         DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
         DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
@@ -199,8 +196,7 @@ def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in
 
     vectorstore = DatabricksVectorSearch(vs_index, text_column="content")
     retriever = vectorstore.as_retriever()
-    resources = []
-    _extract_databricks_dependencies_from_retriever(retriever, resources)
+    resources = list(_extract_databricks_dependencies_from_retriever(retriever))
     assert resources == [
         DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
         DatabricksServingEndpoint(endpoint_name="embedding-model"),
@@ -232,8 +228,7 @@ def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in
 
     vectorstore = DatabricksVectorSearch(vs_index, text_column="content")
     retriever = vectorstore.as_retriever()
-    resources = []
-    _extract_databricks_dependencies_from_retriever(retriever, resources)
+    resources = list(_extract_databricks_dependencies_from_retriever(retriever))
     assert resources == [
         DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
         DatabricksServingEndpoint(endpoint_name="embedding-model"),
@@ -251,8 +246,7 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
 
     chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
-    resources = []
-    _extract_databricks_dependencies_from_chat_model(chat_model, resources)
+    resources = list(_extract_databricks_dependencies_from_chat_model(chat_model))
     assert resources == [DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat")]
 
 
@@ -267,8 +261,7 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
 
     chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
-    resources = []
-    _extract_databricks_dependencies_from_chat_model(chat_model, resources)
+    resources = _extract_databricks_dependencies_from_chat_model(chat_model)
     assert resources == [DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat")]
 
 
@@ -341,8 +334,7 @@ def test_parsing_dependency_correct_loads_langchain_modules():
             AttributeError, match="module 'langchain_community' has no attribute 'llms'"
         ):
             langchain_community.llms.Databricks
-        resources = []
-        _extract_databricks_dependencies_from_llm("", resources)
+        _extract_databricks_dependencies_from_llm("")
 
         # import works as expected after _extract_databricks_dependencies_from_llm
         langchain_community.llms.Databricks
@@ -360,8 +352,7 @@ def test_parsing_dependency_correct_loads_langchain_modules():
         ):
             langchain_community.vectorstores.DatabricksVectorSearch
 
-        resources = []
-        _extract_databricks_dependencies_from_retriever("", resources)
+        _extract_databricks_dependencies_from_retriever("")
         # import works as expected after _extract_databricks_dependencies_from_retriever
         langchain_community.vectorstores.DatabricksVectorSearch
         langchain_community.embeddings.DatabricksEmbeddings
@@ -374,8 +365,7 @@ def test_parsing_dependency_correct_loads_langchain_modules():
         ):
             langchain_community.chat_models.ChatDatabricks
 
-        resources = []
-        _extract_databricks_dependencies_from_chat_model("", resources)
+        _extract_databricks_dependencies_from_chat_model("")
         # import works as expected after _extract_databricks_dependencies_from_chat_model
         langchain_community.chat_models.ChatDatabricks
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -334,7 +334,7 @@ def test_parsing_dependency_correct_loads_langchain_modules():
             AttributeError, match="module 'langchain_community' has no attribute 'llms'"
         ):
             langchain_community.llms.Databricks
-        _extract_databricks_dependencies_from_llm("")
+        list(_extract_databricks_dependencies_from_llm(""))
 
         # import works as expected after _extract_databricks_dependencies_from_llm
         langchain_community.llms.Databricks

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -261,7 +261,7 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
 
     chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
-    resources = _extract_databricks_dependencies_from_chat_model(chat_model)
+    resources = list(_extract_databricks_dependencies_from_chat_model(chat_model))
     assert resources == [DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat")]
 
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -352,7 +352,7 @@ def test_parsing_dependency_correct_loads_langchain_modules():
         ):
             langchain_community.vectorstores.DatabricksVectorSearch
 
-        _extract_databricks_dependencies_from_retriever("")
+        list(_extract_databricks_dependencies_from_retriever(""))
         # import works as expected after _extract_databricks_dependencies_from_retriever
         langchain_community.vectorstores.DatabricksVectorSearch
         langchain_community.embeddings.DatabricksEmbeddings
@@ -365,7 +365,7 @@ def test_parsing_dependency_correct_loads_langchain_modules():
         ):
             langchain_community.chat_models.ChatDatabricks
 
-        _extract_databricks_dependencies_from_chat_model("")
+        list(_extract_databricks_dependencies_from_chat_model(""))
         # import works as expected after _extract_databricks_dependencies_from_chat_model
         langchain_community.chat_models.ChatDatabricks
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -68,7 +68,7 @@ from mlflow.langchain.utils import (
 from mlflow.langchain.utils.chat import try_transform_response_to_chat_format
 from mlflow.models import Model
 from mlflow.models.dependencies_schemas import DependenciesSchemasType
-from mlflow.models.resources import DatabricksServingEndpoint, DatabricksVectorSearchIndex, Resource
+from mlflow.models.resources import DatabricksServingEndpoint, DatabricksVectorSearchIndex
 from mlflow.models.signature import ModelSignature, Schema, infer_signature
 from mlflow.pyfunc.context import Context
 from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_KEY
@@ -1797,9 +1797,9 @@ def test_chat_with_history(spark, fake_chat_model):
     }
 
 
-def _extract_endpoint_name_from_lc_model(lc_model, dependency_list: List[Resource]):
+def _extract_endpoint_name_from_lc_model(lc_model):
     if type(lc_model).__name__ == type(get_fake_chat_model()).__name__:
-        dependency_list.append(DatabricksServingEndpoint(endpoint_name=lc_model.endpoint_name))
+        yield DatabricksServingEndpoint(endpoint_name=lc_model.endpoint_name)
 
 
 @pytest.mark.skipif(
@@ -1839,17 +1839,17 @@ def test_databricks_dependency_extraction_from_lcel_chain():
     }
 
 
-def _extract_databricks_dependencies_from_retriever(retriever, dependency_list: List[Resource]):
+def _extract_databricks_dependencies_from_retriever(retriever):
     import langchain_community
 
     vectorstore = getattr(retriever, "vectorstore", None)
     if vectorstore:
         if isinstance(vectorstore, langchain_community.vectorstores.faiss.FAISS):
-            dependency_list.append(DatabricksVectorSearchIndex(index_name="faiss-index"))
+            yield DatabricksVectorSearchIndex(index_name="faiss-index")
 
         embeddings = getattr(vectorstore, "embeddings", None)
         if isinstance(embeddings, FakeEmbeddings):
-            dependency_list.append(DatabricksServingEndpoint(endpoint_name="fake-embeddings"))
+            yield DatabricksServingEndpoint(endpoint_name="fake-embeddings")
 
 
 def _extract_databricks_dependencies_from_llm(llm):

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1852,9 +1852,9 @@ def _extract_databricks_dependencies_from_retriever(retriever, dependency_list: 
             dependency_list.append(DatabricksServingEndpoint(endpoint_name="fake-embeddings"))
 
 
-def _extract_databricks_dependencies_from_llm(llm, dependency_list: List[Resource]):
+def _extract_databricks_dependencies_from_llm(llm):
     if isinstance(llm, FakeLLM):
-        dependency_list.append(DatabricksServingEndpoint(endpoint_name=llm.endpoint_name))
+        yield DatabricksServingEndpoint(endpoint_name=llm.endpoint_name)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12507?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12507/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12507
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Title. A function that mutates arguments often causes surprises. This PR removes the `dependency_list` argument from extract functions and chains them using `yield from`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
