### PR TITLE
Replace `assert_has_calls` with assert `mock_calls` for exact match

### DIFF
--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -713,18 +713,18 @@ def test_list_artifacts_handles_pagination(databricks_artifact_repo):
     ) as message_mock, mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._call_endpoint",
         side_effect=list_artifact_paginated_response_protos,
-    ): 
-
+    ):
         artifacts = databricks_artifact_repo.list_artifacts()
         assert {file.path for file in artifacts} == {"a.txt", "b", "c.txt", "d", "e.txt", "f"}
         calls = [
-        mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="")),
-        mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="2")),
-        mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="4")),
-        mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="6")),
+            mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="")),
+            mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="2")),
+            mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="4")),
+            mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="6")),
         ]
-        
+
         assert message_mock.mock_calls == calls
+
 
 def test_get_read_credential_infos_handles_pagination(databricks_artifact_repo):
     """

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -713,17 +713,18 @@ def test_list_artifacts_handles_pagination(databricks_artifact_repo):
     ) as message_mock, mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._call_endpoint",
         side_effect=list_artifact_paginated_response_protos,
-    ):
+    ): 
+
         artifacts = databricks_artifact_repo.list_artifacts()
         assert {file.path for file in artifacts} == {"a.txt", "b", "c.txt", "d", "e.txt", "f"}
         calls = [
-            mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="")),
-            mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="2")),
-            mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="4")),
-            mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="6")),
+        mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="")),
+        mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="2")),
+        mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="4")),
+        mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="6")),
         ]
-        message_mock.assert_has_calls(calls)
-
+        
+        assert message_mock.mock_calls == calls
 
 def test_get_read_credential_infos_handles_pagination(databricks_artifact_repo):
     """

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -722,7 +722,6 @@ def test_list_artifacts_handles_pagination(databricks_artifact_repo):
             mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="4")),
             mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="6")),
         ]
-
         assert message_mock.mock_calls == calls
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12510?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12510/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12510
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #12512

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

title

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
