### PR TITLE
[2.14.2 blocker] Fix log_model issue in MLflow >= 2.13 that causes databricks DLT py4j service crashing

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -640,5 +640,5 @@ MLFLOW_ENABLE_DB_SDK = _BooleanEnvironmentVariable("MLFLOW_ENABLE_DB_SDK", True)
 
 #: A flag representing whether MLFlow runs in the child process for capturing modules.
 MLFLOW_IN_CAPTURE_MODULE_PROCESS = _BooleanEnvironmentVariable(
-    "MLFLOW_IN_CAPTURE_MODULE_PROCESS", True
+    "MLFLOW_IN_CAPTURE_MODULE_PROCESS", False
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -639,6 +639,6 @@ MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS = _EnvironmentVariable(
 MLFLOW_ENABLE_DB_SDK = _BooleanEnvironmentVariable("MLFLOW_ENABLE_DB_SDK", True)
 
 #: A flag that's set to 'true' in the child process for capturing modules.
-MLFLOW_IN_CAPTURE_MODULE_PROCESS = _BooleanEnvironmentVariable(
+_MLFLOW_IN_CAPTURE_MODULE_PROCESS = _BooleanEnvironmentVariable(
     "MLFLOW_IN_CAPTURE_MODULE_PROCESS", False
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -637,3 +637,8 @@ MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS = _EnvironmentVariable(
 #: set this environment variable to true.
 #: (default: ``True``)
 MLFLOW_ENABLE_DB_SDK = _BooleanEnvironmentVariable("MLFLOW_ENABLE_DB_SDK", True)
+
+#: A flag representing whether MLFlow runs in the child process for capturing modules.
+MLFLOW_IN_CAPTURE_MODULE_PROCESS = _BooleanEnvironmentVariable(
+    "MLFLOW_IN_CAPTURE_MODULE_PROCESS", True
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -638,7 +638,7 @@ MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS = _EnvironmentVariable(
 #: (default: ``True``)
 MLFLOW_ENABLE_DB_SDK = _BooleanEnvironmentVariable("MLFLOW_ENABLE_DB_SDK", True)
 
-#: A flag representing whether MLFlow runs in the child process for capturing modules.
+#: A flag that's set to 'true' in the child process for capturing modules.
 MLFLOW_IN_CAPTURE_MODULE_PROCESS = _BooleanEnvironmentVariable(
     "MLFLOW_IN_CAPTURE_MODULE_PROCESS", False
 )

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -408,8 +408,8 @@ import mlflow
 import mlflow.pyfunc.loaders
 import mlflow.pyfunc.model
 from mlflow.environment_variables import (
+    _MLFLOW_IN_CAPTURE_MODULE_PROCESS,
     _MLFLOW_TESTING,
-    MLFLOW_IN_CAPTURE_MODULE_PROCESS,
     MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT,
 )
 from mlflow.exceptions import MlflowException
@@ -963,7 +963,7 @@ def load_model(
 
     lineage_header_info = None
     if (
-        (not MLFLOW_IN_CAPTURE_MODULE_PROCESS.get())
+        (not _MLFLOW_IN_CAPTURE_MODULE_PROCESS.get())
         and databricks_utils.is_in_databricks_runtime()
         and (
             databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job()

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -410,6 +410,7 @@ import mlflow.pyfunc.model
 from mlflow.environment_variables import (
     _MLFLOW_TESTING,
     MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT,
+    MLFLOW_IN_CAPTURE_MODULE_PROCESS,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature
@@ -961,7 +962,7 @@ def load_model(
     """
 
     lineage_header_info = None
-    if databricks_utils.is_in_databricks_runtime() and (
+    if (not MLFLOW_IN_CAPTURE_MODULE_PROCESS.get()) and databricks_utils.is_in_databricks_runtime() and (
         databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job()
     ):
         entity_list = []

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -409,8 +409,8 @@ import mlflow.pyfunc.loaders
 import mlflow.pyfunc.model
 from mlflow.environment_variables import (
     _MLFLOW_TESTING,
-    MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT,
     MLFLOW_IN_CAPTURE_MODULE_PROCESS,
+    MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature
@@ -962,8 +962,12 @@ def load_model(
     """
 
     lineage_header_info = None
-    if (not MLFLOW_IN_CAPTURE_MODULE_PROCESS.get()) and databricks_utils.is_in_databricks_runtime() and (
-        databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job()
+    if (
+        (not MLFLOW_IN_CAPTURE_MODULE_PROCESS.get())
+        and databricks_utils.is_in_databricks_runtime()
+        and (
+            databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job()
+        )
     ):
         entity_list = []
         # Get notebook id and job id, pack them into lineage_header_info

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -23,7 +23,7 @@ from packaging.version import InvalidVersion, Version
 
 import mlflow
 from mlflow.environment_variables import (
-    MLFLOW_IN_CAPTURE_MODULE_PROCESS,
+    _MLFLOW_IN_CAPTURE_MODULE_PROCESS,
     MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS,
     MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT,
 )
@@ -323,7 +323,7 @@ def _capture_imported_modules(model_uri, flavor, record_full_module=False):
                         env={
                             **main_env,
                             **transformer_env,
-                            MLFLOW_IN_CAPTURE_MODULE_PROCESS.name: "true",
+                            _MLFLOW_IN_CAPTURE_MODULE_PROCESS.name: "true",
                         },
                     )
                     with open(output_file) as f:
@@ -355,7 +355,7 @@ def _capture_imported_modules(model_uri, flavor, record_full_module=False):
             timeout_seconds=process_timeout,
             env={
                 **main_env,
-                MLFLOW_IN_CAPTURE_MODULE_PROCESS.name: "true",
+                _MLFLOW_IN_CAPTURE_MODULE_PROCESS.name: "true",
             },
         )
 

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -25,6 +25,7 @@ import mlflow
 from mlflow.environment_variables import (
     MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS,
     MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT,
+    MLFLOW_IN_CAPTURE_MODULE_PROCESS,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -204,6 +205,8 @@ def _run_command(cmd, timeout_seconds, env=None):
     """
     Runs the specified command. If it exits with non-zero status, `MlflowException` is raised.
     """
+    env = env or os.environ.copy()
+    env[MLFLOW_IN_CAPTURE_MODULE_PROCESS.name] = "true"
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     timer = Timer(timeout_seconds, proc.kill)
     try:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12514?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12514/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12514
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
DLT pipeline for Bug reproducing:
https://e2-dogfood.staging.cloud.databricks.com/pipelines/5c84c85c-de16-4439-b329-81e60071a698/updates/cbceae0d-4293-44a8-a9f6-a3b59d141176?o=6051921418418893

Since MLflow 2.13, notebook lineage feature for loading uc model was introduced: https://github.com/mlflow/mlflow/pull/11305

but this feature causes severe bug in DLT product:
if invoking mlflow log_model, it casuse DLT spark py4j services crashing, results in:
<img width="764" alt="image" src="https://github.com/mlflow/mlflow/assets/19235986/cf69b6e5-ebc7-4d27-966f-970c3a2de2a4">

This is because when logging model model, we spawn a child process to capture model dependencies, and in the child process, it calls `load_model` API, and internally it calls `databricks_utils.get_notebook_id()` / `databricks_utils.get_job_id()`, the 2 API invocations **in child process of DLT REPL** triggers severe bug in databricks DLT that results in spark py4j services crashing.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
