### PR TITLE
Fix predict_stream for AgentExecutor and other non-Runnable chains

### DIFF
--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -108,12 +108,6 @@ class APIRequest:
     def _prepare_to_serialize(self, response: dict):
         """
         Converts LangChain objects to JSON-serializable formats.
-
-        TODO: This conversion should not happen within Pyfunc model, because users do not need
-            to serialize the output of the model until serving the model as a REST API. For
-            those users, this implicit change of the output format is not desirable. We keep
-            this logic here for backward compatibility, but this should be instead handled
-            by the serving code in the future.
         """
         from langchain.load.dump import dumps
 

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -218,7 +218,9 @@ class APIRequest:
                 # to maintain existing code, single output chains will still return
                 # only the result
                 response = response.popitem()[1]
-            else:
+            elif not self.stream:
+                # DO NOT call _prepare_to_serialize for stream output. It will consume the generator
+                # until the end and the iterator will be empty when the user tries to consume it.
                 self._prepare_to_serialize(response)
 
         return response

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -508,10 +508,7 @@ def test_langchain_agent_model_predict_stream():
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
     loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
-    langchain_input = {
-        "input": "What was the high temperature in SF yesterday in Fahrenheit?"
-        "What is that number raised to the .023 power?"
-    }
+    langchain_input = {"input": "foo"}
     with _mock_request(return_value=_MockResponse(200, langchain_agent_output)):
         response = loaded_model.predict_stream([langchain_input])
         assert inspect.isgenerator(response)

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -339,6 +339,7 @@ def test_langchain_model_predict():
         result = loaded_model.predict([{"product": "MLflow"}])
         assert result == [TEST_CONTENT]
 
+
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.354"),
     reason="LLMChain does not support streaming before LangChain 0.0.354",

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -339,7 +339,10 @@ def test_langchain_model_predict():
         result = loaded_model.predict([{"product": "MLflow"}])
         assert result == [TEST_CONTENT]
 
-
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.354"),
+    reason="LLMChain does not support streaming before LangChain 0.0.354",
+)
 def test_langchain_model_predict_stream():
     with _mock_request(return_value=_mock_chat_completion_response()):
         model = create_openai_llmchain()
@@ -486,7 +489,7 @@ def test_langchain_agent_model_predict(return_intermediate_steps):
 
 
 @pytest.mark.skipif(
-    Version(langchain.__version__) >= Version("0.0.354"),
+    Version(langchain.__version__) < Version("0.0.354"),
     reason="AgentExecutor does not support streaming before LangChain 0.0.354",
 )
 def test_langchain_agent_model_predict_stream():

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -485,6 +485,10 @@ def test_langchain_agent_model_predict(return_intermediate_steps):
         )
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) >= Version("0.0.354"),
+    reason="AgentExecutor does not support streaming before LangChain 0.0.354",
+)
 def test_langchain_agent_model_predict_stream():
     langchain_agent_output = {
         "id": "chatcmpl-123",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12518?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12518/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12518
```

</p>
</details>

### What changes are proposed in this pull request?

The `predict_stream` method returns empty generator for AgentExecutor. This is because the [_prepare_to_serialize](https://github.com/mlflow/mlflow/blob/master/mlflow/langchain/api_request_parallel_processor.py#L222) method here consumes the generator until the end by `in` operator. Any non-Runnable models (except BaseRetriever) suffer from this issue.

This fix just band-aiding it by skip the post process for streaming response and add a few test cases, but also thinking of adding more test coverage and refactoring soon.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Agent Streaming (returns iterator of intermediate steps

![Screenshot 2024-06-28 at 16 24 24](https://github.com/mlflow/mlflow/assets/31463517/095a12f0-7ec5-437c-92ff-4497b483af7f)

LLMChain Streaming (doesn't have actual streaming handler so fallback to normal prediction)

![Screenshot 2024-06-28 at 16 25 22](https://github.com/mlflow/mlflow/assets/31463517/49946d5b-b9f1-4b94-8aa0-4c902d01487f)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `predict_stream` Pyfunc API for LangChain AgentExecutor.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
