### PR TITLE
[Evaluation][1] Add to_dictionary() and from_dictionary() methods to the Metric entity

### DIFF
--- a/mlflow/entities/metric.py
+++ b/mlflow/entities/metric.py
@@ -1,4 +1,6 @@
 from mlflow.entities._mlflow_object import _MlflowObject
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.protos.service_pb2 import Metric as ProtoMetric
 from mlflow.protos.service_pb2 import MetricWithRunId as ProtoMetricWithRunId
 
@@ -80,11 +82,16 @@ class Metric(_MlflowObject):
         Returns:
             Metric: The Metric object created from the dictionary.
         """
-        key = metric_dict.get("key")
-        value = metric_dict.get("value")
-        timestamp = metric_dict.get("timestamp")
-        step = metric_dict.get("step", 0)
-        return cls(key=key, value=value, timestamp=timestamp, step=step)
+        required_keys = ["key", "value", "timestamp", "step"]
+        missing_keys = [key for key in required_keys if key not in metric_dict]
+
+        if missing_keys:
+            raise MlflowException(
+                f"Missing required keys {missing_keys} in metric dictionary",
+                INVALID_PARAMETER_VALUE,
+            )
+
+        return cls(**{key: metric_dict[key] for key in required_keys})
 
 
 class MetricWithRunId(Metric):

--- a/mlflow/entities/metric.py
+++ b/mlflow/entities/metric.py
@@ -84,14 +84,13 @@ class Metric(_MlflowObject):
         """
         required_keys = ["key", "value", "timestamp", "step"]
         missing_keys = [key for key in required_keys if key not in metric_dict]
-
         if missing_keys:
             raise MlflowException(
                 f"Missing required keys {missing_keys} in metric dictionary",
                 INVALID_PARAMETER_VALUE,
             )
 
-        return cls(**{key: metric_dict[key] for key in required_keys})
+        return cls(**metric_dict)
 
 
 class MetricWithRunId(Metric):

--- a/mlflow/entities/metric.py
+++ b/mlflow/entities/metric.py
@@ -55,6 +55,37 @@ class Metric(_MlflowObject):
     def __hash__(self):
         return hash((self._key, self._value, self._timestamp, self._step))
 
+    def to_dictionary(self):
+        """
+        Convert the Metric object to a dictionary.
+
+        Returns:
+            dict: The Metric object represented as a dictionary.
+        """
+        return {
+            "key": self.key,
+            "value": self.value,
+            "timestamp": self.timestamp,
+            "step": self.step,
+        }
+
+    @classmethod
+    def from_dictionary(cls, metric_dict):
+        """
+        Create a Metric object from a dictionary.
+
+        Args:
+            metric_dict (dict): Dictionary containing metric information.
+
+        Returns:
+            Metric: The Metric object created from the dictionary.
+        """
+        key = metric_dict.get("key")
+        value = metric_dict.get("value")
+        timestamp = metric_dict.get("timestamp")
+        step = metric_dict.get("step", 0)
+        return cls(key=key, value=value, timestamp=timestamp, step=step)
+
 
 class MetricWithRunId(Metric):
     def __init__(self, metric: Metric, run_id):

--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from mlflow.entities import Metric
@@ -71,7 +73,7 @@ def test_metric_from_dictionary_missing_keys():
     }
 
     with pytest.raises(
-        MlflowException, match="Missing required keys ['step'] in metric dictionary"
+        MlflowException, match=re.escape("Missing required keys ['step'] in metric dictionary")
     ):
         Metric.from_dictionary(incomplete_dict)
 
@@ -82,6 +84,7 @@ def test_metric_from_dictionary_missing_keys():
     }
 
     with pytest.raises(
-        MlflowException, match="Missing required keys ['value'] in metric dictionary"
+        MlflowException,
+        match=re.escape("Missing required keys ['value', 'timestamp'] in metric dictionary"),
     ):
         Metric.from_dictionary(another_incomplete_dict)

--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -1,4 +1,7 @@
+import pytest
+
 from mlflow.entities import Metric
+from mlflow.exceptions import MlflowException
 from mlflow.utils.time import get_current_time_millis
 
 from tests.helper_functions import random_int, random_str
@@ -57,3 +60,28 @@ def test_metric_to_from_dictionary():
     assert recreated_metric.value == original_metric.value
     assert recreated_metric.timestamp == original_metric.timestamp
     assert recreated_metric.step == original_metric.step
+
+
+def test_metric_from_dictionary_missing_keys():
+    # Dictionary with missing keys
+    incomplete_dict = {
+        "key": "accuracy",
+        "value": 0.95,
+        "timestamp": 1623079352000,
+    }
+
+    with pytest.raises(
+        MlflowException, match="Missing required keys ['step'] in metric dictionary"
+    ):
+        Metric.from_dictionary(incomplete_dict)
+
+    # Another dictionary with different missing keys
+    another_incomplete_dict = {
+        "key": "accuracy",
+        "step": 1,
+    }
+
+    with pytest.raises(
+        MlflowException, match="Missing required keys ['value'] in metric dictionary"
+    ):
+        Metric.from_dictionary(another_incomplete_dict)

--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -30,3 +30,30 @@ def test_creation_and_hydration():
 
     metric3 = Metric.from_dictionary(as_dict)
     _check(metric3, key, value, ts, step)
+
+
+def test_metric_to_from_dictionary():
+    # Create a Metric object
+    original_metric = Metric(key="accuracy", value=0.95, timestamp=1623079352000, step=1)
+
+    # Convert the Metric object to a dictionary
+    metric_dict = original_metric.to_dictionary()
+
+    # Verify the dictionary representation
+    expected_dict = {
+        "key": "accuracy",
+        "value": 0.95,
+        "timestamp": 1623079352000,
+        "step": 1,
+    }
+    assert metric_dict == expected_dict
+
+    # Create a new Metric object from the dictionary
+    recreated_metric = Metric.from_dictionary(metric_dict)
+
+    # Verify the recreated Metric object matches the original
+    assert recreated_metric == original_metric
+    assert recreated_metric.key == original_metric.key
+    assert recreated_metric.value == original_metric.value
+    assert recreated_metric.timestamp == original_metric.timestamp
+    assert recreated_metric.step == original_metric.step


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/12522?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12522/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12522
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add to_dictionary() and from_dictionary() methods to the Metric entity. In subsequent PRs, these will be used to serialize Metrics to and from pandas dataframes for evaluation storage.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
