### PR TITLE
Fix `MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS` 

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -32,6 +32,7 @@ from mlflow.environment_variables import (
     MLFLOW_HUGGINGFACE_DEVICE_MAP_STRATEGY,
     MLFLOW_HUGGINGFACE_USE_DEVICE_MAP,
     MLFLOW_HUGGINGFACE_USE_LOW_CPU_MEM_USAGE,
+    MLFLOW_INPUT_EXAMPLE_INFERENCE_TIMEOUT,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.models import (
@@ -112,7 +113,7 @@ from mlflow.utils.environment import (
     _process_pip_requirements,
     _PythonEnv,
     _validate_env_arguments,
-    infer_pip_requirements_with_timeout,
+    infer_pip_requirements,
 )
 from mlflow.utils.file_utils import TempDir, get_total_file_size, write_to
 from mlflow.utils.logging_utils import suppress_logs
@@ -679,8 +680,11 @@ def save_model(
             # the process due to OOM.
             if not is_peft_model(built_pipeline.model):
                 # Infer the pip requirements with a timeout to avoid hanging at prediction
-                inferred_reqs = infer_pip_requirements_with_timeout(
-                    str(path), FLAVOR_NAME, fallback=default_reqs
+                inferred_reqs = infer_pip_requirements(
+                    model_uri=str(path),
+                    flavor=FLAVOR_NAME,
+                    fallback=default_reqs,
+                    timeout=MLFLOW_INPUT_EXAMPLE_INFERENCE_TIMEOUT.get(),
                 )
                 default_reqs = set(inferred_reqs).union(default_reqs)
             default_reqs = sorted(default_reqs)

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -433,19 +433,19 @@ def _load_pypi_package_index():
 _PYPI_PACKAGE_INDEX = None
 
 
-def _infer_requirements(model_uri, flavor):
+def _infer_requirements(model_uri, flavor, raise_on_error=False):
     """Infers the pip requirements of the specified model by creating a subprocess and loading
     the model in it to determine which packages are imported.
 
     Args:
         model_uri: The URI of the model.
         flavor: The flavor name of the model.
+        raise_on_error: If True, raise an exception if an unrecognized package is encountered.
 
     Returns:
         A list of inferred pip requirements.
 
     """
-    raise_on_error = MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS.get()
     _init_modules_to_packages_map()
     global _PYPI_PACKAGE_INDEX
     if _PYPI_PACKAGE_INDEX is None:

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 import pytest
 import yaml
@@ -17,6 +18,7 @@ from mlflow.utils.environment import (
     _process_conda_env,
     _process_pip_requirements,
     _validate_env_arguments,
+    infer_pip_requirements,
 )
 
 from tests.helper_functions import _mlflow_major_version_string
@@ -340,6 +342,38 @@ def test_process_conda_env(tmp_path):
 
     with pytest.raises(TypeError, match=r"Expected .+, but got `int`"):
         _process_conda_env(0)
+
+
+@pytest.mark.parametrize(
+    ("env_var", "fallbacks", "should_raise"),
+    [
+        # 1&2. If env var is True, always throw an exception from inference error
+        (True, ["sklearn"], True),
+        (True, None, True),
+        # 3. If env var is False but fallback is provided, should not throw an exception
+        (False, ["sklearn"], False),
+        # 4. If fallback is not provided, should throw an exception
+        (False, None, True),
+    ],
+)
+def test_infer_requirements_error_handling(env_var, fallbacks, should_raise, monkeypatch):
+    monkeypatch.setenv("MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS", str(env_var))
+
+    call_args = ("path/to/model", "sklearn", fallbacks)
+    with mock.patch(
+        "mlflow.utils.requirements_utils._capture_imported_modules",
+        side_effect=MlflowException("Failed to capture imported modules"),
+    ):
+        if should_raise:
+            with pytest.raises(MlflowException, match="Failed to capture imported module"):
+                infer_pip_requirements(*call_args)
+        else:
+            # Should just pass with warning
+            with mock.patch("mlflow.utils.environment._logger.warning") as warning_mock:
+                infer_pip_requirements(*call_args)
+            warning_mock.assert_called_once()
+            warning_text = warning_mock.call_args[0][0]
+            assert "Encountered an unexpected error while inferring" in warning_text
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -317,19 +317,6 @@ def test_infer_requirements_does_not_print_warning_for_recognized_packages():
         mock_warning.assert_not_called()
 
 
-def test_infer_requirements_raises_when_env_var_set(monkeypatch):
-    monkeypatch.setenv("MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS", "True")
-
-    with mock.patch(
-        "mlflow.utils.requirements_utils._capture_imported_modules",
-        return_value=["sklearn"],
-    ), mock.patch(
-        "mlflow.utils.requirements_utils._PYPI_PACKAGE_INDEX",
-        _PyPIPackageIndex(date="2022-01-01", package_names=set()),
-    ), pytest.raises(MlflowException, match="Failed to infer requirements for the model"):
-        _infer_requirements("path/to/model", "sklearn")
-
-
 def test_capture_imported_modules_scopes_databricks_imports(monkeypatch, tmp_path):
     from mlflow.utils._capture_modules import _CaptureImportedModules
 
@@ -647,16 +634,15 @@ def test_capture_imported_modules_raises_when_env_var_set(monkeypatch):
         def predict(self, context, model_input, params=None):
             raise Exception("Intentional")
 
-    with mlflow.start_run():
-        model_info = mlflow.pyfunc.log_model(
-            "model",
-            python_model=BadModel(),
-            input_example="test",
-        )
     with pytest.raises(
         MlflowException, match="Encountered an error while capturing imported modules"
     ):
-        _capture_imported_modules(model_info.model_uri, mlflow.pyfunc.FLAVOR_NAME)
+        with mlflow.start_run():
+            mlflow.pyfunc.log_model(
+                "model",
+                python_model=BadModel(),
+                input_example="test",
+            )
 
 
 def test_capture_imported_modules_correct():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12547?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12547/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12547
```

</p>
</details>

### What changes are proposed in this pull request?

The environment variable `MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS` was introduced to make dependency inference strict for exceptions.

> Introduce an environment variable configuration that permits an opt-in strict inference capability for dependency validation and inference. By switching the flag to "True", an Exception will be raised instead of the standard warning. The default behavior for this remains as a warning-only.

However, setting this env var to `True` doesn't work as expected, because there are a few more try-catch wrapping in higher call stacks. Exceptions are caught by them anyway and only surfaced as warnings.

This PR fixes that, as well as adding test coverage. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (WIP)

**MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS = False**
<img width="500" alt="Screenshot 2024-07-02 at 17 21 37" src="https://github.com/mlflow/mlflow/assets/31463517/ab28fc93-a263-48f5-8e3b-1f039c311433">

**MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS = True**
<img width="500" alt="Screenshot 2024-07-02 at 17 22 35" src="https://github.com/mlflow/mlflow/assets/31463517/fd7301e0-249c-4a9d-85d8-d1be3b72d668">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
