### PR TITLE
Fix flaky langchain test

### DIFF
--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2477,14 +2477,9 @@ def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config
         extra_args=["--env-manager", "local"],
     )
     predictions = PredictionsResponse.from_json(response.content.decode("utf-8"))["predictions"]
-    expected = [try_transform_response_to_chat_format(answer)]
-
-    # Excldue the `created` timestamp from the comparison as it is not deterministic
-    def _pop_created_timestamp(predictions):
-        for prediction in predictions:
-            prediction.pop("created")
-
-    assert _pop_created_timestamp(predictions) == _pop_created_timestamp(expected)
+    # Mock out the `created` timestamp as it is not deterministic
+    expected = [{**try_transform_response_to_chat_format(answer), "created": mock.ANY}]
+    assert expected == predictions
 
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{artifact_path}"
     pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2407,24 +2407,27 @@ def chain_model_signature():
     )
 
 
+def _get_message_content(predictions):
+    return predictions[0]["choices"][0]["message"]["content"]
+
+
 @pytest.mark.skipif(
     Version(langchain.__version__) < _LC_MIN_VERSION_SUPPORT_RUNNABLE, reason="feature not existing"
 )
 @pytest.mark.parametrize(
-    "chain_path",
+    ("chain_path", "model_config"),
     [
-        os.path.abspath("tests/langchain/sample_code/chain.py"),
-        "tests/langchain/../langchain/sample_code/chain.py",
+        (
+            os.path.abspath("tests/langchain/sample_code/chain.py"),
+            os.path.abspath("tests/langchain/sample_code/config.yml"),
+        ),
+        (
+            "tests/langchain/../langchain/sample_code/chain.py",
+            "tests/langchain/../langchain/sample_code/config.yml",
+        ),
     ],
 )
-@pytest.mark.parametrize(
-    "model_config",
-    [
-        os.path.abspath("tests/langchain/sample_code/config.yml"),
-        "tests/langchain/../langchain/sample_code/config.yml",
-    ],
-)
-def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config, monkeypatch):
+def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config):
     input_example = {
         "messages": [
             {
@@ -2465,13 +2468,7 @@ def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config
     answer = "Databricks"
     assert loaded_model.invoke(input_example) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert (
-        pyfunc_loaded_model.predict(input_example)[0]
-        .get("choices")[0]
-        .get("message")
-        .get("content")
-        == answer
-    )
+    assert answer == _get_message_content(pyfunc_loaded_model.predict(input_example))
 
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
@@ -2479,9 +2476,15 @@ def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],
     )
-    assert PredictionsResponse.from_json(response.content.decode("utf-8")) == {
-        "predictions": [try_transform_response_to_chat_format(answer)]
-    }
+    predictions = PredictionsResponse.from_json(response.content.decode("utf-8"))["predictions"]
+    expected = [try_transform_response_to_chat_format(answer)]
+
+    # Excldue the `created` timestamp from the comparison as it is not deterministic
+    def _pop_created_timestamp(predictions):
+        for prediction in predictions:
+            prediction.pop("created")
+
+    assert _pop_created_timestamp(predictions) == _pop_created_timestamp(expected)
 
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{artifact_path}"
     pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
@@ -2557,13 +2560,7 @@ def test_save_load_chain_as_code_model_config_dict(chain_model_signature, chain_
     answer = "modified response"
     assert loaded_model.invoke(input_example) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert (
-        pyfunc_loaded_model.predict(input_example)[0]
-        .get("choices")[0]
-        .get("message")
-        .get("content")
-        == answer
-    )
+    assert answer == _get_message_content(pyfunc_loaded_model.predict(input_example))
 
 
 @pytest.mark.skipif(
@@ -2608,13 +2605,7 @@ def test_save_load_chain_as_code_with_different_names(
     answer = "Databricks"
     assert loaded_model.invoke(input_example) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert (
-        pyfunc_loaded_model.predict(input_example)[0]
-        .get("choices")[0]
-        .get("message")
-        .get("content")
-        == answer
-    )
+    assert answer == _get_message_content(pyfunc_loaded_model.predict(input_example))
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12556?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12556/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12556
```

</p>
</details>

### What changes are proposed in this pull request?
The test `test_save_load_chain_as_code` in LangChain flavor has been flaky, due to strict assertion of timestamps. This PR excludes the field from comparison.

Sample failed test: https://github.com/mlflow-automation/mlflow/actions/runs/9761725389/job/26943645817#step:12:1475
```
  Full diff:
    {
        'predictions': [
            {
                'choices': [
                    {
                        'finish_reason': None,
                        'index': 0,
                        'message': {
                            'content': 'Databricks',
                            'role': 'assistant',
                        },
                    },
                ],
  -             'created': 1719937083,
  ?                                 ^
  +             'created': 1719937082,
  ?                                 ^
                'id': None,
                'model': None,
                'object': 'chat.completion',
                'usage': {
                    'completion_tokens': None,
                    'prompt_tokens': None,
                    'total_tokens': None,
                },
            },
        ],
    }
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
