### PR TITLE
Fix a hang in `tests/store/tracking/test_sqlalchemy_store.py`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Build
         run: |
           ./tests/db/compose.sh pull -q postgresql mysql mssql
-          docker images --filter reference=postgresql --filter reference=mysql --filter reference=mssql
+          docker images
           ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(cat requirements/skinny-requirements.txt requirements/core-requirements.txt | grep -Ev '^(#|$)')"
       - name: Run tests
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Build
         run: |
           ./tests/db/compose.sh pull -q postgresql mysql mssql
+          docker images --filter reference=postgresql --filter reference=mysql --filter reference=mssql
           ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(cat requirements/skinny-requirements.txt requirements/core-requirements.txt | grep -Ev '^(#|$)')"
       - name: Run tests
         run: |
@@ -114,7 +115,7 @@ jobs:
           err=0
           trap 'err=1' ERR
 
-          for service in $(./tests/db/compose.sh config --services | grep '^mlflow-')
+          for service in $(./tests/db/compose.sh config --services | grep '^mlflow-' | sort)
           do
             # Set `--no-TTY` to show container logs on GitHub Actions:
             # https://github.com/actions/virtual-environments/issues/5022

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -55,7 +55,7 @@ from mlflow.store.tracking.dbmodels.models import (
 
 _logger = logging.getLogger(__name__)
 
-MAX_RETRY_COUNT = 15
+MAX_RETRY_COUNT = 10
 
 
 def _get_package_dir():

--- a/tests/db/compose.yml
+++ b/tests/db/compose.yml
@@ -36,7 +36,9 @@ services:
     command: tests/db/check_migration.sh
 
   mysql:
-    image: mysql
+    # TODO: MySQL 9.0 causes a hang. Investigate and re-enable.
+    # https://github.com/mlflow/mlflow/pull/12560#issuecomment-2205779414
+    image: mysql:8
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root-password

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -153,13 +153,20 @@ def test_fail_on_multiple_drivers():
 
 
 @pytest.fixture
-def store(tmp_path: Path):
+def store(tmp_path: Path, capsys: pytest.CaptureFixture):
     db_uri = MLFLOW_TRACKING_URI.get() or f"{DB_URI}{tmp_path / 'temp.db'}"
     artifact_uri = tmp_path / "artifacts"
     artifact_uri.mkdir(exist_ok=True)
-    store = SqlAlchemyStore(db_uri, artifact_uri.as_uri())
-    yield store
-    _cleanup_database(store)
+    with capsys.disabled():
+        print("Initializing store...")  # noqa: T201
+        store = SqlAlchemyStore(db_uri, artifact_uri.as_uri())
+        print("Initialized store...")  # noqa: T201
+
+        yield store
+
+        print("Cleaning up tables...")  # noqa: T201
+        _cleanup_database(store)
+        print("Cleaned up tables...")  # noqa: T201
 
 
 def _get_store(tmp_path: Path):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -153,20 +153,13 @@ def test_fail_on_multiple_drivers():
 
 
 @pytest.fixture
-def store(tmp_path: Path, capsys: pytest.CaptureFixture):
+def store(tmp_path: Path):
     db_uri = MLFLOW_TRACKING_URI.get() or f"{DB_URI}{tmp_path / 'temp.db'}"
     artifact_uri = tmp_path / "artifacts"
     artifact_uri.mkdir(exist_ok=True)
-    with capsys.disabled():
-        print("Initializing store...")  # noqa: T201
-        store = SqlAlchemyStore(db_uri, artifact_uri.as_uri())
-        print("Initialized store...")  # noqa: T201
-
-        yield store
-
-        print("Cleaning up tables...")  # noqa: T201
-        _cleanup_database(store)
-        print("Cleaned up tables...")  # noqa: T201
+    store = SqlAlchemyStore(db_uri, artifact_uri.as_uri())
+    yield store
+    _cleanup_database(store)
 
 
 def _get_store(tmp_path: Path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12560?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12560/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12560
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

A temporary solution for the following error:

https://github.com/mlflow/mlflow/actions/runs/9775455006/job/26985875566

```
+ [[ ***mysql:3306/mlflowdb?charset=utf8mb4 == mssql* ]]
+ exec pytest tests/store/tracking/test_sqlalchemy_store.py tests/store/model_registry/test_sqlalchemy_store.py tests/db
Environment variable MLFLOW_TRACKING_URI is set to '***mysql:3306/mlflowdb?charset=utf8mb4', which may interfere with tests.
============================= test session starts ==============================
platform linux -- Python 3.8.19, pytest-8.2.2, pluggy-1.5.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /mlflow/home
configfile: pytest.ini
plugins: cov-5.0.0
collecting ... collected 273 items
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[sqlite-pysqlite] PASSED [  0%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[sqlite-pysqlcipher] PASSED [  0%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[postgresql-psycopg2] PASSED [  1%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[postgresql-pg8000] PASSED [  1%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[postgresql-psycopg2cffi] PASSED [  1%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[postgresql-pypostgresql] PASSED [  2%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[postgresql-pygresql] PASSED [  2%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[postgresql-zxjdbc] PASSED [  2%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mysql-mysqldb] PASSED [  3%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mysql-pymysql] PASSED [  3%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mysql-mysqlconnector] PASSED [  4%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mysql-cymysql] PASSED [  4%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mysql-oursql] PASSED [  4%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mysql-gaerdbms] PASSED [  5%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mysql-pyodbc] PASSED [  5%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mysql-zxjdbc] PASSED [  5%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mssql-pyodbc] PASSED [  6%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mssql-mxodbc] PASSED [  6%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mssql-pymssql] PASSED [  6%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mssql-zxjdbc] PASSED [  7%]
tests/store/tracking/test_sqlalchemy_store.py::test_correct_db_type_from_uri[mssql-adodbapi] PASSED [  7%]
tests/store/tracking/test_sqlalchemy_store.py::test_fail_on_unsupported_db_type[oracle://...] PASSED [  8%]
tests/store/tracking/test_sqlalchemy_store.py::test_fail_on_unsupported_db_type[oracle+cx_oracle://...] PASSED [  8%]
tests/store/tracking/test_sqlalchemy_store.py::test_fail_on_unsupported_db_type[snowflake://...] PASSED [  8%]
tests/store/tracking/test_sqlalchemy_store.py::test_fail_on_unsupported_db_type[://...] PASSED [  9%]
tests/store/tracking/test_sqlalchemy_store.py::test_fail_on_unsupported_db_type[abcdefg] PASSED [  9%]
tests/store/tracking/test_sqlalchemy_store.py::test_fail_on_multiple_drivers PASSED [  9%]
tests/store/tracking/test_sqlalchemy_store.py::test_default_experiment ERROR [ 10%]
```

MySQL 9.0 is likely the culprit:

https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
