### PR TITLE
Fix batch inference for Whisper model and refactor tests

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -173,6 +173,13 @@ _PROMPT_TEMPLATE_RETURN_FULL_TEXT_INFO = (
 )
 
 
+# Alias for the audio data types that Transformers pipeline (e.g. Whisper) expects.
+# It can be one of:
+#  1. A string representing the path or URL to an audio file.
+#  2. A bytes object representing the raw audio data.
+#  3. A float numpy array representing the audio time series.
+AudioInput = Union[str, bytes, np.ndarray]
+
 _logger = logging.getLogger(__name__)
 
 
@@ -2633,94 +2640,65 @@ class _TransformersWrapper:
 
         return input_data
 
-    def _convert_audio_input(self, data):
+    def _convert_audio_input(
+        self, data: Union[AudioInput, List[Dict[int, List[AudioInput]]]]
+    ) -> Union[AudioInput, List[AudioInput]]:
         """
-        Conversion utility for decoding the base64 encoded bytes data of a raw soundfile when
-        parsed through model serving, if applicable. Direct usage of the pyfunc implementation
-        outside of model serving will treat this utility as a noop.
+        Convert the input data into the format that the Transformers pipeline expects.
 
-        For reference, the expected encoding for input to Model Serving will be:
+        Args:
+            data: The input data to be converted. This can be one of the following:
+                1. A single input audio data (bytes, numpy array, or a path or URI to an audio file)
+                2. List of dictionaries, derived from Pandas DataFrame with `orient="records"`.
+                   This is the outcome of the pyfunc signature validation for the audio input.
+                   E.g. [{[0]: <audio data>}, {[1]: <audio data>}]
 
-        import requests
-        import base64
-
-        response = requests.get("https://www.my.sound/a/sound/file.wav")
-        encoded_audio = base64.b64encode(response.content).decode("ascii")
-
-        inference_data = json.dumps({"inputs": [encoded_audio]})
-
-        or
-
-        inference_df = pd.DataFrame(
-        pd.Series([encoded_audio], name="audio_file")
-        )
-        split_dict = {"dataframe_split": inference_df.to_dict(orient="split")}
-        split_json = json.dumps(split_dict)
-
-        or
-
-        records_dict = {"dataframe_records": inference_df.to_dict(orient="records")}
-        records_json = json.dumps(records_dict)
-
-        This utility will convert this JSON encoded, base64 encoded text back into bytes for
-        input into the AutomaticSpeechRecognitionPipeline for inference.
+        Returns:
+            A single or list of audio data.
         """
+        if isinstance(data, list):
+            data = [list(element.values())[0] for element in data]
+            decoded = [self._decode_audio(audio) for audio in data]
+            # Signature validation converts a single audio data into a list (via Pandas Series).
+            # We have to unwrap it back not to confuse with batch processing.
+            return decoded if len(decoded) > 1 else decoded[0]
+        else:
+            return self._decode_audio(data)
 
-        def is_base64(s):
-            try:
-                return base64.b64encode(base64.b64decode(s)) == s
-            except binascii.Error:
-                return False
-
-        def decode_audio(encoded):
-            if isinstance(encoded, str):
-                # This is to support blob style passing of uri locations to process audio files
-                # on disk or object store. Note that if a uri is passed, a signature *must be*
-                # provided for serving to function as the default signature uses bytes.
-                return encoded
-            elif isinstance(encoded, bytes):
-                # For input types 'dataframe_split' and 'dataframe_records', the encoding
-                # conversion to bytes is handled.
-                if not is_base64(encoded):
-                    return encoded
-                else:
-                    # For input type 'inputs', explicit decoding of the b64encoded audio is needed.
-                    return base64.b64decode(encoded)
+    def _decode_audio(self, audio: AudioInput) -> AudioInput:
+        """
+        Decode the audio data if it is base64 encoded bytes, otherwise no-op.
+        """
+        if isinstance(audio, str):
+            # Input is an URI to the audio file to be processed.
+            self._validate_str_input_uri_or_file(audio)
+            return audio
+        elif isinstance(audio, np.ndarray):
+            # Input is a numpy array that contains floating point time series of the audio.
+            return audio
+        elif isinstance(audio, bytes):
+            # Input is a bytes object. In model serving, the input audio data is b64encoded.
+            # They are typically decoded before reaching here, but iff the inference payload
+            # contains raw bytes in the key 'inputs', the upstream code will not decode the
+            # bytes. Therefore, we need to decode the bytes here. For other cases like
+            # 'dataframe_records' or 'dataframe_split', the bytes should be already decoded.
+            if self.is_base64_audio(audio):
+                return base64.b64decode(audio)
             else:
-                try:
-                    return base64.b64decode(encoded)
-                except binascii.Error as e:
-                    raise MlflowException(
-                        "The encoded soundfile that was passed has not been properly base64 "
-                        "encoded. Please ensure that the raw sound bytes have been processed with "
-                        "`base64.b64encode(<audio data bytes>).decode('ascii')`"
-                    ) from e
+                return audio
+        else:
+            raise MlflowException(
+                "Invalid audio data. Must be either bytes, str, or np.ndarray.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
 
-        # The example input data that is processed by this logic is from the pd.DataFrame
-        # conversion that happens within serving wherein the bytes input data is cast to
-        # a pd.DataFrame(pd.Series([raw_bytes])) and then cast to JSON serializable data in the
-        # format:
-        # {[0]: [{[0]: <audio data>}]}
-        # In the inputs format, due to the modification of how types are not enforced, the
-        # logic that is present in processing `records` and `split` format orientation when casting
-        # back to dictionary does not do the automatic decoding of the data from base64 encoded
-        # back to bytes. This is the reason for the conditional logic within `decode_audio` based
-        # on whether the bytes data is base64 encoded or standard bytes format.
-        # The output of the conversion present in the conditional structural validation below is
-        # to return the only input format that the audio transcription pipeline permits:
-        # a bytes input of a single element.
-        if isinstance(data, list) and all(isinstance(element, dict) for element in data):
-            encoded_audio = list(data[0].values())[0]
-            if isinstance(encoded_audio, str):
-                self._validate_str_input_uri_or_file(encoded_audio)
-            return decode_audio(encoded_audio)
-        elif isinstance(data, str):
-            self._validate_str_input_uri_or_file(data)
-        # For new schema, we extract the data field out when converting
-        # pandas DataFrame to dictionary.
-        elif isinstance(data, bytes):
-            return decode_audio(data)
-        return data
+    @staticmethod
+    def is_base64_audio(audio: bytes) -> bool:
+        """Check whether input audio is a base64 encoded"""
+        try:
+            return base64.b64encode(base64.b64decode(audio)) == audio
+        except binascii.Error:
+            return False
 
     @staticmethod
     def _validate_str_input_uri_or_file(input_str):

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -90,7 +90,7 @@ def infer_or_get_default_signature(
     For signature inference in some Pipelines that support complex input types, an input example
     is needed.
     """
-    if example:
+    if example is not None:
         try:
             timeout = MLFLOW_INPUT_EXAMPLE_INFERENCE_TIMEOUT.get()
             if timeout and is_windows():

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2517,7 +2517,7 @@ def test_whisper_model_predict(model_path, whisper_pipeline, input_format, with_
     transcription = loaded_pipeline(audio)
     assert transcription["text"].startswith(" 30")
     # strip the leading space
-    expected_text = transcription["text"].strip()
+    expected_text = transcription["text"].lstrip()
 
     # 2. Single prediction with Pyfunc
     loaded_pyfunc = mlflow.pyfunc.load_model(model_path)
@@ -2616,6 +2616,7 @@ def test_whisper_model_support_timestamps(whisper_pipeline):
 
     def _assert_prediction(pred):
         assert pred["text"] == gt["text"]
+        assert len(pred["chunks"]) == len(gt["chunks"])
         for pred_chunk, gt_chunk in zip(pred["chunks"], gt["chunks"]):
             assert pred_chunk["text"] == gt_chunk["text"]
             # Timestamps are tuples, but converted to list when serialized to JSON.

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -57,6 +57,7 @@ from tests.helper_functions import (
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
     flaky,
+    pyfunc_scoring_endpoint,
     pyfunc_serve_and_score_model,
 )
 from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API
@@ -117,24 +118,6 @@ def mock_pyfunc_wrapper():
 def image_for_test():
     dataset = load_dataset("hf-internal-testing/dummy_image_text_data")
     return dataset["train"]["image"][3]
-
-
-@pytest.fixture
-def sound_file_for_test():
-    datasets_path = pathlib.Path(__file__).resolve().parent.parent.joinpath("datasets")
-    audio, _ = librosa.load(datasets_path.joinpath("apollo11_launch.wav"), sr=16000)
-    return audio
-
-
-@pytest.fixture
-def raw_audio_file():
-    return read_raw_audio_file()
-
-
-def read_raw_audio_file():
-    datasets_path = pathlib.Path(__file__).resolve().parent.parent.joinpath("datasets")
-
-    return datasets_path.joinpath("apollo11_launch.wav").read_bytes()
 
 
 @pytest.mark.parametrize(
@@ -1724,10 +1707,10 @@ def test_qa_pipeline_pyfunc_predict(small_qa_pipeline):
         ("random string", False),
     ],
 )
-def test_vision_is_base64_image(input_image, result):
+def test_vision_is_base64_encoded(input_image, result):
     if input_image == "base64":
         input_image = base64.b64encode(image_file_path.read_bytes()).decode("utf-8")
-    assert _TransformersWrapper.is_base64_image(input_image) == result
+    assert _TransformersWrapper.is_base64_encoded(input_image) == result
 
 
 @pytest.mark.parametrize(
@@ -2501,163 +2484,119 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
     assert "\n\n" in inference[0]
 
 
-@pytest.mark.skipif(
-    Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
-)
-def test_whisper_model_save_and_load(model_path, whisper_pipeline, sound_file_for_test):
-    # NB: This test validates pre-processing via converting the sounds file into the
-    # appropriate bitrate encoding rate and casting to a numpy array. Other tests validate
-    # the 'raw' file input of bytes.
+def read_audio_data(format: str):
+    datasets_path = pathlib.Path(__file__).resolve().parent.parent.joinpath("datasets")
+    wav_file_path = datasets_path.joinpath("apollo11_launch.wav")
+    if format == "float":
+        audio, _ = librosa.load(wav_file_path, sr=16000)
+        return audio
+    elif format == "bytes":
+        return wav_file_path.read_bytes()
+    elif format == "file":
+        return wav_file_path.as_posix()
+    else:
+        raise ValueError(f"Invalid format: {format}")
 
-    model_config = {
-        "return_timestamps": "word",
-        "chunk_length_s": 20,
-        "stride_length_s": [5, 3],
-    }
 
-    signature = infer_signature(
-        sound_file_for_test,
-        mlflow.transformers.generate_signature_output(whisper_pipeline, sound_file_for_test),
-    )
+@pytest.mark.parametrize("input_format", ["float", "bytes", "file"])
+@pytest.mark.parametrize("with_input_example", [True, False])
+def test_whisper_model_predict(model_path, whisper_pipeline, input_format, with_input_example):
+    if input_format == "float" and not with_input_example:
+        pytest.skip("If the input format is float, the default signature must be overridden.")
 
+    audio = read_audio_data(input_format)
     mlflow.transformers.save_model(
         transformers_model=whisper_pipeline,
         path=model_path,
-        model_config=model_config,
-        signature=signature,
+        input_example=audio if with_input_example else None,
+        save_pretrained=False,
     )
 
+    # 1. Single prediction with native transformer pipeline
     loaded_pipeline = mlflow.transformers.load_model(model_path)
-
-    transcription = loaded_pipeline(sound_file_for_test, **model_config)
+    transcription = loaded_pipeline(audio)
     assert transcription["text"].startswith(" 30")
+    # strip the leading space
+    expected_text = transcription["text"].strip()
 
+    # 2. Single prediction with Pyfunc
     loaded_pyfunc = mlflow.pyfunc.load_model(model_path)
+    pyfunc_transcription = loaded_pyfunc.predict(audio)[0]
+    assert pyfunc_transcription == expected_text
 
-    pyfunc_transcription = json.loads(loaded_pyfunc.predict(sound_file_for_test)[0])
+    # 3. Batch prediction with Pyfunc. Float input format is not supported for batch prediction,
+    # because our signature framework doesn't support a list of numpy array.
+    if input_format != "float":
+        batch_transcription = loaded_pyfunc.predict([audio, audio])
+        assert len(batch_transcription) == 2
+        assert all(ts == expected_text for ts in batch_transcription)
 
-    assert transcription["text"] == pyfunc_transcription["text"]
-    # Due to the choice of using tuples within the return type, equivalency validation for the
-    # "chunks" values is not explicitly equivalent since tuples are cast to lists when json
-    # serialized.
-    assert transcription["chunks"][0]["text"] == pyfunc_transcription["chunks"][0]["text"]
+
+def test_whisper_model_serve_and_score(whisper_pipeline):
+    # Request payload to the model serving endpoint contains base64 encoded audio data
+    audio = read_audio_data("bytes")
+    encoded_audio = base64.b64encode(audio).decode("ascii")
+
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=whisper_pipeline,
+            artifact_path="whisper",
+            save_pretrained=False,
+        )
+
+    def _assert_response(response, length=1):
+        preds = json.loads(response.content.decode("utf-8"))["predictions"]
+        assert len(preds) == length
+        assert all(pred.startswith("30") for pred in preds)
+
+    with pyfunc_scoring_endpoint(
+        model_info.model_uri,
+        extra_args=["--env-manager", "local"],
+    ) as endpoint:
+        content_type = pyfunc_scoring_server.CONTENT_TYPE_JSON
+
+        # Test payload with "inputs" key
+        inputs_dict = {"inputs": [encoded_audio]}
+        payload = json.dumps(inputs_dict)
+        response = endpoint.invoke(payload, content_type=content_type)
+        _assert_response(response)
+
+        # Test payload with "dataframe_split" key
+        inference_df = pd.DataFrame(pd.Series([encoded_audio], name="audio_file"))
+        split_dict = {"dataframe_split": inference_df.to_dict(orient="split")}
+        payload = json.dumps(split_dict)
+        response = endpoint.invoke(payload, content_type=content_type)
+        _assert_response(response)
+
+        # Test payload with "dataframe_records" key
+        records_dict = {"dataframe_records": inference_df.to_dict(orient="records")}
+        payload = json.dumps(records_dict)
+        response = endpoint.invoke(payload, content_type=content_type)
+        _assert_response(response)
+
+        # Test batch prediction
+        inputs_dict = {"inputs": [encoded_audio, encoded_audio]}
+        payload = json.dumps(inputs_dict)
+        response = endpoint.invoke(payload, content_type=content_type)
+        _assert_response(response, length=2)
+
+        # Scoring with audio file URI is not supported yet (pyfunc prediction works tho)
+        inputs_dict = {"inputs": [read_audio_data("file")]}
+        payload = json.dumps(inputs_dict)
+        response = endpoint.invoke(payload, content_type=content_type)
+        response = json.loads(response.content.decode("utf-8"))
+        assert response["error_code"] == "INVALID_PARAMETER_VALUE"
+        assert "Failed to process the input audio data. Either" in response["message"]
 
 
 @pytest.mark.skipif(
     Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
 )
-def test_whisper_model_signature_inference(whisper_pipeline, sound_file_for_test):
-    signature = infer_signature(
-        sound_file_for_test,
-        mlflow.transformers.generate_signature_output(whisper_pipeline, sound_file_for_test),
-    )
+def test_whisper_model_support_timestamps(whisper_pipeline):
+    # Request payload to the model serving endpoint contains base64 encoded audio data
+    audio = read_audio_data("bytes")
+    encoded_audio = base64.b64encode(audio).decode("ascii")
 
-    model_config = {
-        "return_timestamps": "word",
-        "chunk_length_s": 20,
-        "stride_length_s": [5, 3],
-    }
-    complex_signature = infer_signature(
-        sound_file_for_test,
-        mlflow.transformers.generate_signature_output(
-            whisper_pipeline, sound_file_for_test, model_config
-        ),
-    )
-
-    assert signature == complex_signature
-
-
-def test_whisper_model_serve_and_score_with_inferred_signature(whisper_pipeline, raw_audio_file):
-    artifact_path = "whisper"
-
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=whisper_pipeline, artifact_path=artifact_path
-        )
-
-    # Test inputs format
-    inference_payload = json.dumps({"inputs": [base64.b64encode(raw_audio_file).decode("ascii")]})
-
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
-
-    assert values.loc[0, 0].startswith("30")
-
-
-def test_whisper_model_serve_and_score(whisper_pipeline, raw_audio_file):
-    artifact_path = "whisper"
-    signature = infer_signature(
-        raw_audio_file,
-        mlflow.transformers.generate_signature_output(whisper_pipeline, raw_audio_file),
-    )
-
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=whisper_pipeline, artifact_path=artifact_path, signature=signature
-        )
-
-    # Test inputs format
-    inference_payload = json.dumps({"inputs": [base64.b64encode(raw_audio_file).decode("ascii")]})
-
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-
-    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
-
-    assert values.loc[0, 0].startswith("30")
-
-    # Test split format
-    inference_df = pd.DataFrame(
-        pd.Series([base64.b64encode(raw_audio_file).decode("ascii")], name="audio_file")
-    )
-    split_dict = {"dataframe_split": inference_df.to_dict(orient="split")}
-    split_json = json.dumps(split_dict)
-
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=split_json,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-
-    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
-
-    assert values.loc[0, 0].startswith("30")
-
-    # Test records format
-    records_dict = {"dataframe_records": inference_df.to_dict(orient="records")}
-    records_json = json.dumps(records_dict)
-
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=records_json,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-
-    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
-
-    assert values.loc[0, 0].startswith("30")
-
-
-@pytest.mark.skipif(
-    Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
-)
-def test_whisper_model_serve_and_score_with_timestamps(whisper_pipeline, raw_audio_file):
-    artifact_path = "whisper_timestamps"
-    signature = infer_signature(
-        raw_audio_file,
-        mlflow.transformers.generate_signature_output(whisper_pipeline, raw_audio_file),
-    )
     model_config = {
         "return_timestamps": "word",
         "chunk_length_s": 20,
@@ -2667,30 +2606,75 @@ def test_whisper_model_serve_and_score_with_timestamps(whisper_pipeline, raw_aud
     with mlflow.start_run():
         model_info = mlflow.transformers.log_model(
             transformers_model=whisper_pipeline,
-            artifact_path=artifact_path,
-            signature=signature,
+            artifact_path="whisper_timestamps",
             model_config=model_config,
-            input_example=raw_audio_file,
+            input_example=(audio, model_config),
         )
 
-    inference_payload = json.dumps({"inputs": [base64.b64encode(raw_audio_file).decode("ascii")]})
+    # Native transformers prediction as ground truth
+    gt = whisper_pipeline(audio, **model_config)
 
-    response = pyfunc_serve_and_score_model(
+    def _assert_prediction(pred):
+        assert pred["text"] == gt["text"]
+        for pred_chunk, gt_chunk in zip(pred["chunks"], gt["chunks"]):
+            assert pred_chunk["text"] == gt_chunk["text"]
+            # Timestamps are tuples, but converted to list when serialized to JSON.
+            assert tuple(pred_chunk["timestamp"]) == gt_chunk["timestamp"]
+
+    # Prediction with Pyfunc
+    loaded_pyfunc = mlflow.pyfunc.load_model(model_info.model_uri)
+    prediction = json.loads(loaded_pyfunc.predict(audio)[0])
+    _assert_prediction(prediction)
+
+    # Serve and score
+    with pyfunc_scoring_endpoint(
         model_info.model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],
+    ) as endpoint:
+        content_type = pyfunc_scoring_server.CONTENT_TYPE_JSON
+        payload = json.dumps({"inputs": [encoded_audio]})
+        response = endpoint.invoke(payload, content_type=content_type)
+
+        predictions = json.loads(response.content.decode("utf-8"))["predictions"]
+        # When return_timestamps is specified, the predictions list contains json
+        # serialized output from the pipeline.
+        _assert_prediction(json.loads(predictions[0]))
+
+        # Request with inference params
+        payload = json.dumps(
+            {
+                "inputs": [encoded_audio],
+                "model_config": model_config,
+            }
+        )
+        response = endpoint.invoke(payload, content_type=content_type)
+        predictions = json.loads(response.content.decode("utf-8"))["predictions"]
+        _assert_prediction(json.loads(predictions[0]))
+
+
+def test_whisper_model_pyfunc_with_malformed_input(whisper_pipeline, model_path):
+    mlflow.transformers.save_model(
+        transformers_model=whisper_pipeline,
+        path=model_path,
+        save_pretrained=False,
     )
 
-    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
-    payload_output = json.loads(values.loc[0, 0])
+    pyfunc_model = mlflow.pyfunc.load_model(model_path)
 
-    assert (
-        payload_output["text"]
-        == mlflow.transformers.load_model(model_info.model_uri)(raw_audio_file, **model_config)[
-            "text"
-        ]
-    )
+    invalid_audio = b"This isn't a real audio file"
+    with pytest.raises(MlflowException, match="Failed to process the input audio data. Either"):
+        pyfunc_model.predict([invalid_audio])
+
+    bad_uri_msg = "An invalid string input was provided. String"
+
+    with pytest.raises(MlflowException, match=bad_uri_msg):
+        pyfunc_model.predict("An invalid path")
+
+    with pytest.raises(MlflowException, match=bad_uri_msg):
+        pyfunc_model.predict("//www.invalid.net/audio.wav")
+
+    with pytest.raises(MlflowException, match=bad_uri_msg):
+        pyfunc_model.predict("https:///my/audio.mp3")
 
 
 def test_audio_classification_pipeline(audio_classification_pipeline, raw_audio_file):
@@ -2751,133 +2735,6 @@ def test_audio_classification_with_default_schema(audio_classification_pipeline,
     assert isinstance(values, pd.DataFrame)
     assert len(values) > 1
     assert list(values.columns) == ["score", "label"]
-
-
-@pytest.mark.skipif(
-    Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
-)
-def test_whisper_model_with_url(whisper_pipeline):
-    artifact_path = "whisper_url"
-
-    url = (
-        "https://raw.githubusercontent.com/mlflow/mlflow/master/tests/datasets/apollo11_launch.wav"
-    )
-
-    signature = infer_signature(
-        url, mlflow.transformers.generate_signature_output(whisper_pipeline, url)
-    )
-
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=whisper_pipeline,
-            artifact_path=artifact_path,
-            signature=signature,
-        )
-
-    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
-
-    url_inference = pyfunc_model.predict(url)
-
-    inference_payload = json.dumps({"inputs": [url]})
-
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-
-    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
-    payload_output = values.loc[0, 0]
-
-    assert url_inference[0] == payload_output
-
-
-@pytest.mark.skipif(
-    Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
-)
-def test_whisper_model_pyfunc_with_invalid_uri_input(whisper_pipeline):
-    artifact_path = "whisper_url"
-
-    url = (
-        "https://raw.githubusercontent.com/mlflow/mlflow/master/tests/datasets/apollo11_launch.wav"
-    )
-
-    signature = infer_signature(
-        url,
-        mlflow.transformers.generate_signature_output(whisper_pipeline, url),
-    )
-
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=whisper_pipeline,
-            artifact_path=artifact_path,
-            signature=signature,
-        )
-
-    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
-
-    bad_uri_msg = "An invalid string input was provided. String"
-
-    with pytest.raises(MlflowException, match=bad_uri_msg):
-        pyfunc_model.predict("An invalid path")
-
-    with pytest.raises(MlflowException, match=bad_uri_msg):
-        pyfunc_model.predict("//www.invalid.net/audio.wav")
-
-    with pytest.raises(MlflowException, match=bad_uri_msg):
-        pyfunc_model.predict("https:///my/audio.mp3")
-
-
-@pytest.mark.skipif(
-    Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
-)
-def test_whisper_model_using_uri_with_default_signature_raises(whisper_pipeline):
-    artifact_path = "whisper_url"
-
-    url = (
-        "https://raw.githubusercontent.com/mlflow/mlflow/master/tests/datasets/apollo11_launch.wav"
-    )
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=whisper_pipeline,
-            artifact_path=artifact_path,
-        )
-
-    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
-
-    url_inference = pyfunc_model.predict(url)
-
-    assert url_inference[0].startswith("30")
-    # Ensure that direct pyfunc calling even with a conflicting signature still functions
-    inference_payload = json.dumps({"inputs": [url]})
-
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-    response_data = json.loads(response.content.decode("utf-8"))
-
-    assert response_data["error_code"] == "INVALID_PARAMETER_VALUE"
-    assert "Failed to process the input audio data. Either" in response_data["message"]
-
-
-def test_whisper_model_with_malformed_audio(whisper_pipeline):
-    artifact_path = "whisper"
-
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=whisper_pipeline, artifact_path=artifact_path
-        )
-
-    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
-
-    invalid_audio = b"This isn't a real audio file"
-
-    with pytest.raises(MlflowException, match="Failed to process the input audio data. Either"):
-        pyfunc_model.predict([invalid_audio])
 
 
 @pytest.mark.parametrize(
@@ -3020,102 +2877,6 @@ def test_qa_pipeline_pyfunc_predict_with_kwargs(small_qa_pipeline):
     ]
 
 
-@pytest.mark.skipif(
-    Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
-)
-def test_whisper_model_serve_and_score_with_timestamps_with_kwargs(
-    whisper_pipeline, raw_audio_file
-):
-    artifact_path = "whisper_timestamps"
-    model_config = {
-        "return_timestamps": "word",
-        "chunk_length_s": 20,
-        "stride_length_s": [5, 3],
-    }
-    signature = infer_signature(
-        raw_audio_file,
-        mlflow.transformers.generate_signature_output(whisper_pipeline, raw_audio_file),
-        params=model_config,
-    )
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=whisper_pipeline,
-            artifact_path=artifact_path,
-            signature=signature,
-            input_example=raw_audio_file,
-        )
-
-    inference_payload = json.dumps(
-        {
-            "inputs": [base64.b64encode(raw_audio_file).decode("ascii")],
-            "model_config": model_config,
-        }
-    )
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
-    payload_output = json.loads(values.loc[0, 0])
-
-    assert (
-        payload_output["text"]
-        == mlflow.transformers.load_model(model_info.model_uri)(raw_audio_file, **model_config)[
-            "text"
-        ]
-    )
-
-
-@pytest.mark.skipif(
-    Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
-)
-def test_whisper_model_serve_and_score_with_input_example_with_params(
-    whisper_pipeline, raw_audio_file
-):
-    artifact_path = "whisper_timestamps"
-    inference_config = {
-        "return_timestamps": "word",
-        "chunk_length_s": 20,
-        "stride_length_s": [5, 3],
-    }
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=whisper_pipeline,
-            artifact_path=artifact_path,
-            input_example=(raw_audio_file, inference_config),
-        )
-    # model signature inferred from input_example
-    signature = infer_signature(
-        raw_audio_file,
-        mlflow.transformers.generate_signature_output(whisper_pipeline, raw_audio_file),
-        params=inference_config,
-    )
-    assert model_info.signature == signature
-
-    inference_payload = json.dumps(
-        {
-            "inputs": [base64.b64encode(raw_audio_file).decode("ascii")],
-        }
-    )
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
-    payload_output = json.loads(values.loc[0, 0])
-
-    assert (
-        payload_output["text"]
-        == mlflow.transformers.load_model(model_info.model_uri)(raw_audio_file, **inference_config)[
-            "text"
-        ]
-    )
-
-
 def test_uri_directory_renaming_handling_pipeline(model_path, small_seq2seq_pipeline):
     with mlflow.start_run():
         mlflow.transformers.save_model(transformers_model=small_seq2seq_pipeline, path=model_path)
@@ -3171,35 +2932,6 @@ def test_uri_directory_renaming_handling_components(model_path, small_seq2seq_pi
     prediction = loaded_model.predict("test")
     assert isinstance(prediction, pd.DataFrame)
     assert isinstance(prediction["label"][0], str)
-
-
-@pytest.mark.skipif(
-    Version(transformers.__version__) < Version("4.29.2"), reason="Feature does not exist"
-)
-def test_whisper_model_supports_timestamps(raw_audio_file, whisper_pipeline):
-    model_config = {
-        "return_timestamps": "word",
-        "chunk_length_s": 60,
-        "batch_size": 1,
-    }
-
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            transformers_model=whisper_pipeline,
-            artifact_path="model",
-            model_config=model_config,
-        )
-
-    model_uri = model_info.model_uri
-    whisper = mlflow.transformers.load_model(model_uri)
-
-    prediction = whisper(raw_audio_file, **model_config)
-    whisper_pyfunc = mlflow.pyfunc.load_model(model_uri)
-    prediction_inference = json.loads(whisper_pyfunc.predict(raw_audio_file)[0])
-
-    first_timestamp = prediction["chunks"][0]["timestamp"]
-    assert isinstance(first_timestamp, tuple)
-    assert prediction_inference["chunks"][0]["timestamp"][1] == first_timestamp[1]
 
 
 def test_pyfunc_model_log_load_with_artifacts_snapshot():
@@ -3834,7 +3566,7 @@ HF_COMMIT_HASH_PATTERN = re.compile(r"^[a-z0-9]{40}$")
             else {"feature_extractor", "tokenizer"},
         ),
         ("fill_mask_pipeline", "The quick brown <mask> jumps over the lazy dog.", {"tokenizer"}),
-        ("whisper_pipeline", read_raw_audio_file, {"feature_extractor", "tokenizer"}),
+        ("whisper_pipeline", lambda: read_audio_data("bytes"), {"feature_extractor", "tokenizer"}),
         ("feature_extraction_pipeline", "What is MLflow?", {"tokenizer"}),
     ],
 )


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the batch inference issue in the Transformers Whisper pipeline.

The Transformers pipeline supports batch inference - if a list of audio data is passed, it will return multiple transcriptions.
```
whiper_pipeline = transformers.pipeline(
    task=task, model=whipsper_model, tokenizer=tokenizer, feature_extractor=feature_extractor
)
whiper_pipeline([audio, audio])
>> [{'text': ' 30-kan vihän konein.'}, {'text': ' 30-kan vihän konein.'}]
```

However, when it is loaded as MLflow Pyfunc model, the model only returns a single transcription and discards the latter.
```
pyfunc_model.predict([audio, audio])
>> ['30-kan vihän konein.']    # <- Only returns single transcription.
```

This PR fixes the issue so that the model returns multiple transcriptions for batch requests, as well as organizing the test cases to increase test coverage while reducing runtime.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="469" alt="Screenshot 2024-07-04 at 19 43 07" src="https://github.com/mlflow/mlflow/assets/31463517/d67b9891-424c-43ca-95c8-9c7baf0fbfe9">

Pyfunc model returns multiple transcriptions for a batch request.

(**TODO**: Will do more testing with model serving)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix batch inference issue of the Transformers Whipsper pipeline loaded as MLflow model.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
