### PR TITLE
Small refactoring for the Transformers flavor.

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1878,9 +1878,9 @@ class _TransformersWrapper:
 
         if isinstance(self.pipeline, transformers.TableQuestionAnsweringPipeline):
             data = self._coerce_exploded_dict_to_single_dict(data)
-            data = self._parse_input_for_table_question_answering(data)
-        if _is_conversational_pipeline(self.pipeline):
-            data = self._parse_conversation_input(data)
+            return self._parse_input_for_table_question_answering(data)
+        elif _is_conversational_pipeline(self.pipeline):
+            return self._parse_conversation_input(data)
         elif (  # noqa: SIM114
             isinstance(
                 self.pipeline,

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1498,6 +1498,15 @@ def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
     )
 
 
+def _is_conversational_pipeline(pipeline):
+    """
+    Checks if the pipeline is a ConversationalPipeline.
+    """
+    if cp := _try_import_conversational_pipeline():
+        return isinstance(pipeline, cp)
+    return False
+
+
 def _try_import_conversational_pipeline():
     """
     Try importing ConversationalPipeline because for version > 4.41.2
@@ -1750,9 +1759,7 @@ class _TransformersWrapper:
             output_key = None
             data = self._parse_feature_extraction_input(data)
             data = self._format_prompt_template(data)
-        elif (conversational_pipeline := _try_import_conversational_pipeline()) and isinstance(
-            self.pipeline, conversational_pipeline
-        ):
+        elif _is_conversational_pipeline(self.pipeline):
             output_key = None
             if not self._conversation:
                 # this import is valid if conversational_pipeline is not None
@@ -1788,7 +1795,7 @@ class _TransformersWrapper:
         data = self._convert_cast_lists_from_np_back_to_list(data)
 
         # Generate inference data with the pipeline object
-        if (cp := _try_import_conversational_pipeline()) and isinstance(self.pipeline, cp):
+        if _is_conversational_pipeline(self.pipeline):
             conversation_output = self.pipeline(self._conversation)
             return conversation_output.generated_responses[-1]
         else:
@@ -1869,10 +1876,12 @@ class _TransformersWrapper:
         """
         import transformers
 
-        data = self._coerce_exploded_dict_to_single_dict(data)
-        data = self._parse_input_for_table_question_answering(data)
-        data = self._parse_conversation_input(data)
-        if (  # noqa: SIM114
+        if isinstance(self.pipeline, transformers.TableQuestionAnsweringPipeline):
+            data = self._coerce_exploded_dict_to_single_dict(data)
+            data = self._parse_input_for_table_question_answering(data)
+        if _is_conversational_pipeline(self.pipeline):
+            data = self._parse_conversation_input(data)
+        elif (  # noqa: SIM114
             isinstance(
                 self.pipeline,
                 (
@@ -2007,14 +2016,8 @@ class _TransformersWrapper:
                 "Only str, list of str, dict, and list of dict are supported."
             )
 
-    def _parse_conversation_input(self, data):
-        conversational_pipeline = _try_import_conversational_pipeline()
-
-        if (
-            not conversational_pipeline
-            or not isinstance(self.pipeline, conversational_pipeline)
-            or isinstance(data, str)
-        ):
+    def _parse_conversation_input(self, data) -> str:
+        if isinstance(data, str):
             return data
         elif isinstance(data, list) and all(isinstance(elem, dict) for elem in data):
             return next(iter(data[0].values()))
@@ -2023,24 +2026,20 @@ class _TransformersWrapper:
             return next(iter(data.values()))
 
     def _parse_input_for_table_question_answering(self, data):
-        import transformers
-
-        if not isinstance(self.pipeline, transformers.TableQuestionAnsweringPipeline):
-            return data
-
         if "table" not in data:
             raise MlflowException(
                 "The input dictionary must have the 'table' key.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-
         elif isinstance(data["table"], dict):
             data["table"] = json.dumps(data["table"])
             return data
         else:
             return data
 
-    def _coerce_exploded_dict_to_single_dict(self, data):
+    def _coerce_exploded_dict_to_single_dict(
+        self, data: List[Dict[str, Any]]
+    ) -> Dict[str, List[Any]]:
         """
         Parses the result of Pandas DataFrame.to_dict(orient="records") from pyfunc
         signature validation to coerce the output to the required format for a
@@ -2055,20 +2054,14 @@ class _TransformersWrapper:
 
         Output:
 
-        [
-          "We should order more pizzas to meet the demand.",
-          "The venue size should be updated to handle the number of guests.",
-        ]
-
+        {
+          "answer": [
+              "We should order more pizzas to meet the demand.",
+              "The venue size should be updated to handle the number of guests.",
+          ]
+        }
         """
-        import transformers
-
-        if not isinstance(
-            self.pipeline,
-            transformers.TableQuestionAnsweringPipeline,
-        ):
-            return data
-        elif isinstance(data, list) and all(isinstance(item, dict) for item in data):
+        if isinstance(data, list) and all(isinstance(item, dict) for item in data):
             collection = data.copy()
             parsed = collection[0]
             for coll in collection:
@@ -2361,22 +2354,6 @@ class _TransformersWrapper:
             ]
         else:
             return [output_data[0][target_dict_key]]
-
-    def _parse_list_output_for_multiple_candidate_pipelines(self, output_data):
-        # NB: This will not continue to parse nested lists. Pipelines do not output complex
-        # types that are greater than 2 levels deep so there is no need for more complex
-        # traversal for outputs.
-        if isinstance(output_data, list) and len(output_data) < 1:
-            raise MlflowException(
-                "The output of the pipeline contains no data.", error_code=BAD_REQUEST
-            )
-
-        if isinstance(output_data[0], list):
-            return [
-                self._parse_list_output_for_multiple_candidate_pipelines(x) for x in output_data
-            ]
-        else:
-            return output_data[0]
 
     def _parse_question_answer_input(self, data):
         """

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1632,6 +1632,8 @@ def test_ner_pipeline(pipeline_name, model_path, data, result, request):
     reason="Conversation model is deprecated and removed.",
 )
 def test_conversational_pipeline(conversational_pipeline, model_path):
+    assert mlflow.transformers._is_conversational_pipeline(conversational_pipeline)
+
     signature = infer_signature(
         "Hi there!",
         mlflow.transformers.generate_signature_output(conversational_pipeline, "Hi there!"),
@@ -2223,42 +2225,6 @@ def test_parse_list_of_multiple_dicts(mock_pyfunc_wrapper):
 
     assert (
         mock_pyfunc_wrapper._parse_list_of_multiple_dicts(output_data, target_dict_key)
-        == expected_output
-    )
-
-
-def test_parse_list_output_for_multiple_candidate_pipelines(mock_pyfunc_wrapper):
-    # Test with a single candidate pipeline output
-    output_data = [["foo", "bar", "baz"]]
-    expected_output = ["foo"]
-    assert (
-        mock_pyfunc_wrapper._parse_list_output_for_multiple_candidate_pipelines(output_data)
-        == expected_output
-    )
-
-    # Test with multiple candidate pipeline outputs
-    output_data = [
-        ["foo", "bar", "baz"],
-        ["qux", "quux"],
-        ["corge", "grault", "garply", "waldo"],
-    ]
-    expected_output = ["foo", "qux", "corge"]
-
-    assert (
-        mock_pyfunc_wrapper._parse_list_output_for_multiple_candidate_pipelines(output_data)
-        == expected_output
-    )
-
-    # Test with an empty list
-    output_data = []
-    with pytest.raises(MlflowException, match="The output of the pipeline contains no"):
-        mock_pyfunc_wrapper._parse_list_output_for_multiple_candidate_pipelines(output_data)
-
-    # Test with a nested list
-    output_data = [["foo"]]
-    expected_output = ["foo"]
-    assert (
-        mock_pyfunc_wrapper._parse_list_output_for_multiple_candidate_pipelines(output_data)
         == expected_output
     )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12579?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12579/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12579
```

</p>
</details>

### What changes are proposed in this pull request?

Small refactoring for the `_parse_raw_pipeline_input` method, so it will be more clear that which method runs for which pipeline(s). + a few minor correction on docstring/typing

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
