### PR TITLE
Adapt hdfs_artifact_repo to new pyarrow HdfsFileSystem interface

### DIFF
--- a/docs/source/tracking/artifacts-stores.rst
+++ b/docs/source/tracking/artifacts-stores.rst
@@ -199,10 +199,8 @@ There are also two ways to authenticate to HDFS:
   export MLFLOW_KERBEROS_TICKET_CACHE=/tmp/krb5cc_22222222
   export MLFLOW_KERBEROS_USER=user_name_to_use
 
-Most of the cluster contest settings are read from ``hdfs-site.xml`` accessed by the HDFS native
-driver using the ``CLASSPATH`` environment variable.
-
-The HDFS driver that is used is ``libhdfs``.
+The HDFS artifact store is accessed using the ``pyarrow.fs`` module, refer to the
+`PyArrow Documentation <https://arrow.apache.org/docs/python/filesystems.html#filesystem-hdfs>`_ for configuration and environment variables needed.
 
 
 Deletion Behavior

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -1,10 +1,9 @@
 import os
 import posixpath
-import tempfile
 import urllib.parse
 from contextlib import contextmanager
 
-import packaging.version
+from pyarrow.fs import FileSelector, FileType, HadoopFileSystem
 
 from mlflow.entities import FileInfo
 from mlflow.environment_variables import (
@@ -12,9 +11,8 @@ from mlflow.environment_variables import (
     MLFLOW_KERBEROS_USER,
     MLFLOW_PYARROW_EXTRA_CONF,
 )
-from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
-from mlflow.utils.file_utils import mkdir, relative_path_to_artifact_path
+from mlflow.utils.file_utils import relative_path_to_artifact_path
 
 
 class HdfsArtifactRepository(ArtifactRepository):
@@ -41,9 +39,10 @@ class HdfsArtifactRepository(ArtifactRepository):
 
         with hdfs_system(scheme=self.scheme, host=self.host, port=self.port) as hdfs:
             _, file_name = os.path.split(local_file)
-            destination = posixpath.join(hdfs_base_path, file_name)
-            with open(local_file, "rb") as f:
-                hdfs.upload(destination, f)
+            destination_path = posixpath.join(hdfs_base_path, file_name)
+            with open(local_file, "rb") as source:
+                with hdfs.open_output_stream(destination_path) as destination:
+                    destination.write(source.read())
 
     def log_artifacts(self, local_dir, artifact_path=None):
         """
@@ -57,8 +56,8 @@ class HdfsArtifactRepository(ArtifactRepository):
         hdfs_base_path = _resolve_base_path(self.path, artifact_path)
 
         with hdfs_system(scheme=self.scheme, host=self.host, port=self.port) as hdfs:
-            if not hdfs.exists(hdfs_base_path):
-                hdfs.mkdir(hdfs_base_path)
+            if not hdfs.get_file_info(hdfs_base_path).type == FileType.Directory:
+                hdfs.create_dir(hdfs_base_path, recursive=True)
 
             for subdir_path, _, files in os.walk(local_dir):
                 relative_path = _relative_path_local(local_dir, subdir_path)
@@ -69,14 +68,15 @@ class HdfsArtifactRepository(ArtifactRepository):
                     else hdfs_base_path
                 )
 
-                if not hdfs.exists(hdfs_subdir_path):
-                    hdfs.mkdir(hdfs_subdir_path)
+                if not hdfs.get_file_info(hdfs_subdir_path).type == FileType.Directory:
+                    hdfs.create_dir(hdfs_subdir_path, recursive=True)
 
                 for each_file in files:
-                    source = os.path.join(subdir_path, each_file)
-                    destination = posixpath.join(hdfs_subdir_path, each_file)
-                    with open(source, "rb") as f:
-                        hdfs.upload(destination, f)
+                    source_path = os.path.join(subdir_path, each_file)
+                    destination_path = posixpath.join(hdfs_subdir_path, each_file)
+                    with open(source_path, "rb") as source:
+                        with hdfs.open_output_stream(destination_path) as destination:
+                            destination.write(source.read())
 
     def list_artifacts(self, path=None):
         """
@@ -94,83 +94,48 @@ class HdfsArtifactRepository(ArtifactRepository):
 
         with hdfs_system(scheme=self.scheme, host=self.host, port=self.port) as hdfs:
             paths = []
-            if hdfs.exists(hdfs_base_path):
-                for file_detail in hdfs.ls(hdfs_base_path, detail=True):
-                    file_name = file_detail.get("name")
+            base_info = hdfs.get_file_info(hdfs_base_path)
+            if base_info.type == FileType.Directory:
+                selector = FileSelector(hdfs_base_path)
+            elif base_info.type == FileType.File:
+                selector = [hdfs_base_path]
+            else:
+                return []
 
-                    # file_name is hdfs_base_path and not a child of that path
-                    if file_name == hdfs_base_path:
-                        continue
+            for file_detail in hdfs.get_file_info(selector):
+                file_name = file_detail.path
 
-                    # Strip off anything that comes before the artifact root e.g. hdfs://name
-                    offset = file_name.index(self.path)
-                    rel_path = _relative_path_remote(self.path, file_name[offset:])
-                    is_dir = file_detail.get("kind") == "directory"
-                    size = file_detail.get("size")
-                    paths.append(FileInfo(rel_path, is_dir=is_dir, file_size=size))
+                # file_name is hdfs_base_path and not a child of that path
+                if file_name == hdfs_base_path:
+                    continue
+
+                # Strip off anything that comes before the artifact root e.g. hdfs://name
+                offset = file_name.index(self.path)
+                rel_path = _relative_path_remote(self.path, file_name[offset:])
+                is_dir = file_detail.type == FileType.Directory
+                size = file_detail.size
+                paths.append(FileInfo(rel_path, is_dir=is_dir, file_size=size))
             return sorted(paths, key=lambda f: paths)
 
-    def _walk_path(self, hdfs, hdfs_path):
-        if hdfs.exists(hdfs_path):
-            if hdfs.isdir(hdfs_path):
-                for subdir, _, files in hdfs.walk(hdfs_path):
-                    if subdir != hdfs_path:
-                        yield subdir, hdfs.isdir(subdir), hdfs.info(subdir).get("size")
-                    for f in files:
-                        file_path = posixpath.join(subdir, f)
-                        yield file_path, hdfs.isdir(file_path), hdfs.info(file_path).get("size")
-            else:
-                yield hdfs_path, False, hdfs.info(hdfs_path).get("size")
-
-    def download_artifacts(self, artifact_path, dst_path=None):
-        """
-        Download an artifact file or directory to a local directory/file if applicable, and
-        return a local path for it.
-        The caller is responsible for managing the lifecycle of the downloaded artifacts.
-
-        (self.path contains the base path - hdfs:/some/path/run_id/artifacts)
-
-        Args:
-            artifact_path: Relative source path to the desired artifacts file or directory.
-            dst_path: Absolute path of the local filesystem destination directory to which
-                to download the specified artifacts. This directory must already exist. If
-                unspecified, the artifacts will be downloaded to a new, uniquely-named
-                directory on the local filesystem.
-
-        Returns:
-            Absolute path of the local filesystem location containing the downloaded
-            artifacts - file/directory.
-        """
-
-        hdfs_base_path = _resolve_base_path(self.path, artifact_path)
-        if dst_path and os.path.exists(dst_path):
-            local_dir = os.path.abspath(dst_path)
-        else:
-            local_dir = _tmp_dir(dst_path)
-
+    def _is_directory(self, artifact_path):
         with hdfs_system(scheme=self.scheme, host=self.host, port=self.port) as hdfs:
-            if not hdfs.isdir(hdfs_base_path):
-                local_path = os.path.join(local_dir, os.path.normpath(artifact_path))
-                _download_hdfs_file(hdfs, hdfs_base_path, local_path)
-                return local_path
-
-            for path, is_dir, _ in self._walk_path(hdfs, hdfs_base_path):
-                relative_path = _relative_path_remote(hdfs_base_path, path)
-                local_path = os.path.join(local_dir, relative_path) if relative_path else local_dir
-
-                if is_dir:
-                    mkdir(local_path)
-                else:
-                    _download_hdfs_file(hdfs, path, local_path)
-            return local_dir
+            return hdfs.get_file_info(artifact_path).type == FileType.Directory
 
     def _download_file(self, remote_file_path, local_path):
-        raise MlflowException("This is not implemented. Should never be called.")
+        hdfs_base_path = _resolve_base_path(self.path, remote_file_path)
+        with hdfs_system(scheme=self.scheme, host=self.host, port=self.port) as hdfs:
+            with hdfs.open_input_stream(hdfs_base_path) as source:
+                with open(local_path, "wb") as destination:
+                    destination.write(source.read())
 
     def delete_artifacts(self, artifact_path=None):
         path = posixpath.join(self.path, artifact_path) if artifact_path else self.path
         with hdfs_system(scheme=self.scheme, host=self.host, port=self.port) as hdfs:
-            hdfs.delete(path, recursive=True)
+            file_info = hdfs.get_file_info(path)
+            if file_info.type == FileType.File:
+                hdfs.delete_file(path)
+            elif file_info.type == FileType.Directory:
+                hdfs.delete_dir_contents(path)
 
 
 @contextmanager
@@ -184,32 +149,20 @@ def hdfs_system(scheme, host, port):
         host: hostname or when relaying on the core-site.xml config use 'default'
         port: port or when relaying on the core-site.xml config use 0
     """
-    import pyarrow
-
     kerb_ticket = MLFLOW_KERBEROS_TICKET_CACHE.get()
     kerberos_user = MLFLOW_KERBEROS_USER.get()
     extra_conf = _parse_extra_conf(MLFLOW_PYARROW_EXTRA_CONF.get())
 
     host = scheme + "://" + host if host else "default"
 
-    if packaging.version.parse(pyarrow.__version__) < packaging.version.parse("2.0.0"):
-        connected = pyarrow.fs.HadoopFileSystem(
-            host=host,
-            port=port or 0,
-            user=kerberos_user,
-            kerb_ticket=kerb_ticket,
-            extra_conf=extra_conf,
-        )
-    else:
-        connected = pyarrow.hdfs.connect(
-            host=host,
-            port=port or 0,
-            user=kerberos_user,
-            kerb_ticket=kerb_ticket,
-            extra_conf=extra_conf,
-        )
+    connected = HadoopFileSystem(
+        host=host,
+        port=port or 0,
+        user=kerberos_user,
+        kerb_ticket=kerb_ticket,
+        extra_conf=extra_conf,
+    )
     yield connected
-    connected.close()
 
 
 def _resolve_connection_params(artifact_uri):
@@ -238,19 +191,6 @@ def _relative_path_local(base_dir, subdir_path):
 
 def _relative_path_remote(base_dir, subdir_path):
     return _relative_path(base_dir, subdir_path, posixpath)
-
-
-def _tmp_dir(local_path):
-    return os.path.abspath(tempfile.mkdtemp(dir=local_path))
-
-
-def _download_hdfs_file(hdfs, remote_file_path, local_file_path):
-    # Ensure all required directories exist. Without doing this nested files can't be downloaded.
-    dirs = os.path.dirname(local_file_path)
-    if not os.path.exists(dirs):
-        os.makedirs(dirs)
-    with open(local_file_path, "wb") as f:
-        f.write(hdfs.open(remote_file_path, "rb").read())
 
 
 def _parse_extra_conf(extra_conf):

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -3,7 +3,10 @@ import posixpath
 import urllib.parse
 from contextlib import contextmanager
 
-from pyarrow.fs import FileSelector, FileType, HadoopFileSystem
+try:
+    from pyarrow.fs import FileSelector, FileType, HadoopFileSystem
+except ImportError:
+    pass
 
 from mlflow.entities import FileInfo
 from mlflow.environment_variables import (
@@ -155,14 +158,13 @@ def hdfs_system(scheme, host, port):
 
     host = scheme + "://" + host if host else "default"
 
-    connected = HadoopFileSystem(
+    yield HadoopFileSystem(
         host=host,
         port=port or 0,
         user=kerberos_user,
         kerb_ticket=kerb_ticket,
         extra_conf=extra_conf,
     )
-    yield connected
 
 
 def _resolve_connection_params(artifact_uri):

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -121,8 +121,9 @@ class HdfsArtifactRepository(ArtifactRepository):
             return sorted(paths, key=lambda f: paths)
 
     def _is_directory(self, artifact_path):
+        hdfs_base_path = _resolve_base_path(self.path, artifact_path)
         with hdfs_system(scheme=self.scheme, host=self.host, port=self.port) as hdfs:
-            return hdfs.get_file_info(artifact_path).type == FileType.Directory
+            return hdfs.get_file_info(hdfs_base_path).type == FileType.Directory
 
     def _download_file(self, remote_file_path, local_path):
         hdfs_base_path = _resolve_base_path(self.path, remote_file_path)

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -1,17 +1,15 @@
 import os
 import sys
-from io import BufferedReader
 from tempfile import NamedTemporaryFile
 from unittest import mock
-from unittest.mock import ANY, call, mock_open
+from unittest.mock import call
 
+import pyarrow
 import pytest
-from pyarrow import HadoopFileSystem
 
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.hdfs_artifact_repo import (
     HdfsArtifactRepository,
-    _download_hdfs_file,
     _parse_extra_conf,
     _relative_path_remote,
     _resolve_base_path,
@@ -19,7 +17,9 @@ from mlflow.store.artifact.hdfs_artifact_repo import (
 from mlflow.utils.file_utils import TempDir
 
 
-@mock.patch("pyarrow.hdfs.HadoopFileSystem")
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
 def test_log_artifact(hdfs_system_mock):
     repo = HdfsArtifactRepository("hdfs://host_name:8020/hdfs/path")
 
@@ -34,13 +34,13 @@ def test_log_artifact(hdfs_system_mock):
             extra_conf=None, host="hdfs://host_name", kerb_ticket=None, port=8020, user=None
         )
 
-        upload_mock = hdfs_system_mock.return_value.upload
-        upload_mock.assert_called_once_with("/hdfs/path/more_path/some/sample_file", ANY)
-        args, _ = upload_mock.call_args
-        assert isinstance(args[1], BufferedReader)
+        upload_mock = hdfs_system_mock.return_value.open_output_stream
+        upload_mock.assert_called_once_with("/hdfs/path/more_path/some/sample_file")
 
 
-@mock.patch("pyarrow.hdfs.HadoopFileSystem")
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
 def test_log_artifact_viewfs(hdfs_system_mock):
     repo = HdfsArtifactRepository("viewfs://host_name/mypath")
 
@@ -54,13 +54,13 @@ def test_log_artifact_viewfs(hdfs_system_mock):
         hdfs_system_mock.assert_called_once_with(
             extra_conf=None, host="viewfs://host_name", kerb_ticket=None, port=0, user=None
         )
-        upload_mock = hdfs_system_mock.return_value.upload
-        upload_mock.assert_called_once_with("/mypath/more_path/some/sample_file", ANY)
-        args, _ = upload_mock.call_args
-        assert isinstance(args[1], BufferedReader)
+        upload_mock = hdfs_system_mock.return_value.open_output_stream
+        upload_mock.assert_called_once_with("/mypath/more_path/some/sample_file")
 
 
-@mock.patch("pyarrow.hdfs.HadoopFileSystem")
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
 def test_log_artifact_with_kerberos_setup(hdfs_system_mock):
     if sys.platform == "win32":
         pytest.skip()
@@ -82,11 +82,13 @@ def test_log_artifact_with_kerberos_setup(hdfs_system_mock):
             port=0,
             user="some_kerberos_user",
         )
-        upload_mock = hdfs_system_mock.return_value.upload
+        upload_mock = hdfs_system_mock.return_value.open_output_stream
         upload_mock.assert_called_once()
 
 
-@mock.patch("pyarrow.hdfs.HadoopFileSystem")
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
 def test_log_artifact_with_invalid_local_dir(_):
     repo = HdfsArtifactRepository("hdfs://host_name:8020/maybe/path")
 
@@ -94,7 +96,9 @@ def test_log_artifact_with_invalid_local_dir(_):
         repo.log_artifact("/not/existing/local/path", "test_hdfs/some/path")
 
 
-@mock.patch("pyarrow.hdfs.HadoopFileSystem")
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
 def test_log_artifacts(hdfs_system_mock):
     os.environ["MLFLOW_KERBEROS_TICKET_CACHE"] = "/tmp/krb5cc_22222222"
     os.environ["MLFLOW_KERBEROS_USER"] = "some_kerberos_user"
@@ -119,31 +123,27 @@ def test_log_artifacts(hdfs_system_mock):
             user="some_kerberos_user",
         )
 
-        upload_mock = hdfs_system_mock.return_value.upload
+        upload_mock = hdfs_system_mock.return_value.open_output_stream
         upload_mock.assert_has_calls(
             calls=[
-                call("/some_path/maybe/path/file_one.txt", ANY),
-                call("/some_path/maybe/path/subdir/file_two.txt", ANY),
+                call("/some_path/maybe/path/file_one.txt"),
+                call("/some_path/maybe/path/subdir/file_two.txt"),
             ],
             any_order=True,
         )
-        call_args_list = upload_mock.call_args_list
-
-        args, _ = call_args_list[0]
-        assert isinstance(args[1], BufferedReader)
-
-        args, _ = call_args_list[1]
-        assert isinstance(args[1], BufferedReader)
 
 
-@mock.patch("pyarrow.hdfs.HadoopFileSystem")
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
 def test_list_artifacts_root(hdfs_system_mock):
     repo = HdfsArtifactRepository("hdfs://host/some/path")
 
     expected = [FileInfo("model", True, 0)]
 
-    hdfs_system_mock.return_value.ls.return_value = [
-        {"kind": "directory", "name": "hdfs://host/some/path/model", "size": 0}
+    hdfs_system_mock.return_value.get_file_info.side_effect = [
+        pyarrow.fs.FileInfo(path="/some/path/", type=pyarrow.fs.FileType.Directory, size=0),
+        [pyarrow.fs.FileInfo(path="/some/path/model", type=pyarrow.fs.FileType.Directory, size=0)],
     ]
 
     actual = repo.list_artifacts()
@@ -151,9 +151,11 @@ def test_list_artifacts_root(hdfs_system_mock):
     assert actual == expected
 
 
-@mock.patch("pyarrow.hdfs.HadoopFileSystem")
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
 def test_list_artifacts_nested(hdfs_system_mock):
-    repo = HdfsArtifactRepository("hdfs:://host/some/path")
+    repo = HdfsArtifactRepository("hdfs://host/some/path")
 
     expected = [
         FileInfo("model/conda.yaml", False, 33),
@@ -161,10 +163,19 @@ def test_list_artifacts_nested(hdfs_system_mock):
         FileInfo("model/MLmodel", False, 33),
     ]
 
-    hdfs_system_mock.return_value.ls.return_value = [
-        {"kind": "file", "name": "hdfs://host/some/path/model/conda.yaml", "size": 33},
-        {"kind": "file", "name": "hdfs://host/some/path/model/model.pkl", "size": 33},
-        {"kind": "file", "name": "hdfs://host/some/path/model/MLmodel", "size": 33},
+    hdfs_system_mock.return_value.get_file_info.side_effect = [
+        pyarrow.fs.FileInfo(path="/some/path/model", type=pyarrow.fs.FileType.Directory, size=0),
+        [
+            pyarrow.fs.FileInfo(
+                path="/some/path/model/conda.yaml", type=pyarrow.fs.FileType.File, size=33
+            ),
+            pyarrow.fs.FileInfo(
+                path="/some/path/model/model.pkl", type=pyarrow.fs.FileType.File, size=33
+            ),
+            pyarrow.fs.FileInfo(
+                path="/some/path/model/MLmodel", type=pyarrow.fs.FileType.File, size=33
+            ),
+        ],
     ]
 
     actual = repo.list_artifacts("model")
@@ -172,9 +183,13 @@ def test_list_artifacts_nested(hdfs_system_mock):
     assert actual == expected
 
 
-@mock.patch("pyarrow.hdfs.HadoopFileSystem", spec=HadoopFileSystem)
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
 def test_list_artifacts_empty_hdfs_dir(hdfs_system_mock):
-    hdfs_system_mock.return_value.exists.return_value = False
+    hdfs_system_mock.return_value.get_file_info.return_value = pyarrow.fs.FileInfo(
+        path="/some_path/maybe/path", type=pyarrow.fs.FileType.NotFound, size=0
+    )
 
     repo = HdfsArtifactRepository("hdfs:/some_path/maybe/path")
     actual = repo.list_artifacts()
@@ -202,22 +217,20 @@ def test_parse_extra_conf():
         _parse_extra_conf("missing_equals_sign")
 
 
-def test_download_artifacts():
-    expected_data = b"hello"
-    artifact_path = "test.txt"
-    # mock hdfs
-    hdfs = mock.Mock()
-    hdfs.open = mock_open(read_data=expected_data)
-
-    with TempDir() as tmp_dir:
-        _download_hdfs_file(hdfs, artifact_path, os.path.join(tmp_dir.path(), artifact_path))
-        with open(os.path.join(tmp_dir.path(), artifact_path), "rb") as fd:
-            assert expected_data == fd.read()
-
-
-@mock.patch("pyarrow.hdfs.HadoopFileSystem")
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
 def test_delete_artifacts(hdfs_system_mock):
-    delete_mock = hdfs_system_mock.return_value.delete
-    repo = HdfsArtifactRepository("hdfs:/some_path/maybe/path")
+    repo = HdfsArtifactRepository("hdfs:/some_path/maybe/path/")
+    hdfs_system_mock.return_value.get_file_info.return_value = pyarrow.fs.FileInfo(
+        path="/some_path/maybe/path/file.txt", type=pyarrow.fs.FileType.File, size=0
+    )
+    delete_mock = hdfs_system_mock.return_value.delete_file
+    repo.delete_artifacts("file.ext")
+    delete_mock.assert_called_once_with("/some_path/maybe/path/file.ext")
+    hdfs_system_mock.return_value.get_file_info.return_value = pyarrow.fs.FileInfo(
+        path="/some_path/maybe/path/artifacts", type=pyarrow.fs.FileType.Directory, size=0
+    )
+    delete_mock = hdfs_system_mock.return_value.delete_dir_contents
     repo.delete_artifacts("artifacts")
-    delete_mock.assert_called_once_with("/some_path/maybe/path/artifacts", recursive=True)
+    delete_mock.assert_called_once_with("/some_path/maybe/path/artifacts")

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -234,3 +234,18 @@ def test_delete_artifacts(hdfs_system_mock):
     delete_mock = hdfs_system_mock.return_value.delete_dir_contents
     repo.delete_artifacts("artifacts")
     delete_mock.assert_called_once_with("/some_path/maybe/path/artifacts")
+
+
+@mock.patch(
+    "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
+)
+def test_is_directory_called_with_relative_path(hdfs_system_mock):
+    repo = HdfsArtifactRepository("hdfs://host/some/path")
+
+    get_file_info_mock = hdfs_system_mock.return_value.get_file_info
+    get_file_info_mock.side_effect = [
+        pyarrow.fs.FileInfo(path="/some/path/dir", type=pyarrow.fs.FileType.Directory, size=0),
+    ]
+
+    assert repo._is_directory("dir")
+    get_file_info_mock.assert_called_once_with("/some/path/dir")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/antbbn/mlflow/pull/12592?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12592/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12592
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx
Issue  #8213 
PR #9878

### What changes are proposed in this pull request?

According to issue #8213 addressed with PR #9878 we should use `pyarrow.fs.HadoopFileSystem` with pyarrow GREATER THAN 2.0.0 but condition was inverted. It turns out that `pyarrow.fs.HadoopFileSystem` has a completely different interface.
Since we have a higher pyarrow version in the requirements it's safe to completely switch to this new interface and get rid of the check altogether. 

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
