### PR TITLE
Fix type hints in `mlflow/utils/async_logging/async_logging_queue.py`

### DIFF
--- a/mlflow/utils/async_logging/async_artifacts_logging_queue.py
+++ b/mlflow/utils/async_logging/async_artifacts_logging_queue.py
@@ -8,13 +8,13 @@ import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Callable, Union
 
 from mlflow.utils.async_logging.run_artifact import RunArtifact
 from mlflow.utils.async_logging.run_operations import RunOperations
 
 if TYPE_CHECKING:
-    import PIL
+    import PIL.Image
 
 _logger = logging.getLogger(__name__)
 
@@ -25,12 +25,14 @@ class AsyncArtifactsLoggingQueue:
     worker thread. This class is used to process artifacts saving in async fashion.
 
     Args:
-        logging_func: A callable function that takes in two arguments: a string
-            representing the run_id and a list of artifact paths to log.
+        logging_func: A callable function that takes in three arguments:
+            - filename: The name of the artifact file.
+            - artifact_path: The path to the artifact.
+            - artifact: The artifact to be logged.
     """
 
     def __init__(
-        self, artifact_logging_func: callable([str, str, Union["PIL.Image.Image"]])
+        self, artifact_logging_func: Callable[[str, str, Union["PIL.Image.Image"]], None]
     ) -> None:
         self._queue = Queue()
         self._lock = threading.RLock()

--- a/mlflow/utils/async_logging/async_artifacts_logging_queue.py
+++ b/mlflow/utils/async_logging/async_artifacts_logging_queue.py
@@ -34,7 +34,7 @@ class AsyncArtifactsLoggingQueue:
     def __init__(
         self, artifact_logging_func: Callable[[str, str, Union["PIL.Image.Image"]], None]
     ) -> None:
-        self._queue = Queue()
+        self._queue: Queue[RunArtifact] = Queue()
         self._lock = threading.RLock()
         self._artifact_logging_func = artifact_logging_func
 
@@ -99,43 +99,42 @@ class AsyncArtifactsLoggingQueue:
         If an exception occurs during processing, the exception is logged and the artifact event
         is set with the exception. If the queue is empty, it is ignored.
         """
-        run_artifacts = None  # type: RunArtifact
         try:
-            run_artifacts = self._queue.get(timeout=1)
+            run_artifact = self._queue.get(timeout=1)
         except Empty:
             # Ignore empty queue exception
             return
 
-        def logging_func(run_artifacts):
+        def logging_func(run_artifact):
             try:
                 self._artifact_logging_func(
-                    filename=run_artifacts.filename,
-                    artifact_path=run_artifacts.artifact_path,
-                    artifact=run_artifacts.artifact,
+                    filename=run_artifact.filename,
+                    artifact_path=run_artifact.artifact_path,
+                    artifact=run_artifact.artifact,
                 )
 
                 # Signal the artifact processing is done.
-                run_artifacts.completion_event.set()
+                run_artifact.completion_event.set()
 
             except Exception as e:
-                _logger.error(f"Failed to log artifact {run_artifacts.filename}. Exception: {e}")
-                run_artifacts.exception = e
-                run_artifacts.completion_event.set()
+                _logger.error(f"Failed to log artifact {run_artifact.filename}. Exception: {e}")
+                run_artifact.exception = e
+                run_artifact.completion_event.set()
 
-        self._artifact_logging_worker_threadpool.submit(logging_func, run_artifacts)
+        self._artifact_logging_worker_threadpool.submit(logging_func, run_artifact)
 
-    def _wait_for_artifact(self, artifacts: RunArtifact) -> None:
+    def _wait_for_artifact(self, artifact: RunArtifact) -> None:
         """Wait for given artifacts to be processed by the logging thread.
 
         Args:
-            artifacts: The artifacts to wait for.
+            artifact: The artifact to wait for.
 
         Raises:
             Exception: If an exception occurred while processing the artifact.
         """
-        artifacts.completion_event.wait()
-        if artifacts.exception:
-            raise artifacts.exception
+        artifact.completion_event.wait()
+        if artifact.exception:
+            raise artifact.exception
 
     def __getstate__(self):
         """Return the state of the object for pickling.
@@ -202,15 +201,15 @@ class AsyncArtifactsLoggingQueue:
 
         if not self._is_activated:
             raise MlflowException("AsyncArtifactsLoggingQueue is not activated.")
-        artifacts = RunArtifact(
+        artifact = RunArtifact(
             filename=filename,
             artifact_path=artifact_path,
             artifact=artifact,
             completion_event=threading.Event(),
         )
-        self._queue.put(artifacts)
+        self._queue.put(artifact)
         operation_future = self._artifact_status_check_threadpool.submit(
-            self._wait_for_artifact, artifacts
+            self._wait_for_artifact, artifact
         )
         return RunOperations(operation_futures=[operation_future])
 

--- a/mlflow/utils/async_logging/async_logging_queue.py
+++ b/mlflow/utils/async_logging/async_logging_queue.py
@@ -9,7 +9,7 @@ import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from queue import Empty, Queue
-from typing import List
+from typing import Callable, List
 
 from mlflow.entities.metric import Metric
 from mlflow.entities.param import Param
@@ -45,7 +45,9 @@ class AsyncLoggingQueue:
     single worker thread.
     """
 
-    def __init__(self, logging_func: callable([str, [Metric], [Param], [RunTag]])) -> None:
+    def __init__(
+        self, logging_func: Callable[[str, List[Metric], List[Param], List[RunTag]], None]
+    ) -> None:
         """Initializes an AsyncLoggingQueue object.
 
         Args:
@@ -260,7 +262,7 @@ class AsyncLoggingQueue:
         self._stop_data_logging_thread_event = threading.Event()
 
     def log_batch_async(
-        self, run_id: str, params: [Param], tags: [RunTag], metrics: [Metric]
+        self, run_id: str, params: List[Param], tags: List[RunTag], metrics: List[Metric]
     ) -> RunOperations:
         """Asynchronously logs a batch of run data (parameters, tags, and metrics).
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

While I was working on #12597, I found pylance complain the following warning on vscode:


<img width="594" alt="image" src="https://github.com/mlflow/mlflow/assets/17039389/6bc30ffa-d0fb-4c94-bebb-ef8f7acc66e2">


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
