### PR TITLE
Fix mlflow evaluate using xgboost model

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -60,7 +60,6 @@ from mlflow.models.evaluation.base import (
 from mlflow.models.utils import plot_lines
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.pyfunc import _ServedPyFuncModel
-from mlflow.sklearn import _SklearnModelWrapper
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.proto_json_utils import NumpyEncoder
 from mlflow.utils.time import get_current_time_millis
@@ -131,22 +130,15 @@ def _infer_model_type_by_labels(labels):
 
 def _extract_raw_model(model):
     model_loader_module = model.metadata.flavors["python_function"]["loader_module"]
+    # If we load a sklearn/xgboost model with mlflow.pyfunc.load_model, the model will be wrapped
+    # with a wrapper, we need to extract the raw model from it.
+    # Extract the raw model of xgboost flavor so that shap explainer uses the raw model
+    # instead of the wrapper and skip data schema validation.
     if model_loader_module in ["mlflow.sklearn", "mlflow.xgboost"] and not isinstance(
         model, _ServedPyFuncModel
     ):
-        # If we load a sklearn model with mlflow.pyfunc.load_model, the model will be wrapped
-        # with _SklearnModelWrapper, we need to extract the raw model from it.
-        if isinstance(model._model_impl, _SklearnModelWrapper):
-            return model_loader_module, model._model_impl.sklearn_model
-        # extract the raw model of xgboost flavor so that shap explainer uses the raw model
-        # instead of the wrapper and skip data schema validation
-        try:
-            from mlflow.xgboost import _XGBModelWrapper
-
-            if isinstance(model._model_impl, _XGBModelWrapper):
-                return model_loader_module, model._model_impl.xgb_model
-        except ImportError:
-            pass
+        if hasattr(model._model_impl, "get_raw_model"):
+            return model_loader_module, model._model_impl.get_raw_model()
         return model_loader_module, model._model_impl
     else:
         return model_loader_module, None

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -518,6 +518,12 @@ class _SklearnModelWrapper:
             if fn := getattr(self.sklearn_model, predict_fn, None):
                 setattr(self, predict_fn, fn)
 
+    def get_raw_model(self):
+        """
+        Returns the underlying scikit-learn model.
+        """
+        return self.sklearn_model
+
     def predict(
         self,
         data,

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -341,6 +341,12 @@ class _XGBModelWrapper:
     def __init__(self, xgb_model):
         self.xgb_model = xgb_model
 
+    def get_raw_model(self):
+        """
+        Returns the underlying XGBoost model.
+        """
+        return self.xgb_model
+
     def predict(
         self,
         dataframe,

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -385,6 +385,15 @@ def _wrapped_xgboost_model_predict_fn(model, validate_features=True):
         return model.predict
 
 
+def _wrapped_xgboost_model_predict_proba_fn(model, validate_features=True):
+    import xgboost as xgb
+
+    predict_proba_fn = getattr(model, "predict_proba", None)
+    if isinstance(model, xgb.XGBModel) and predict_proba_fn is not None:
+        return partial(predict_proba_fn, validate_features=validate_features)
+    return predict_proba_fn
+
+
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     importance_types=None,

--- a/temp.zip
+++ b/temp.zip
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>9476C5Q4E14DK4PM</RequestId><HostId>snmPOrPGEyaOMTXkjaG4awQkzGt191GOYIfXgbzYffRIsY8JwQOUHk5A43P9YRlDKDvIWx+t9aQ=</HostId></Error>

--- a/temp.zip
+++ b/temp.zip
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>9476C5Q4E14DK4PM</RequestId><HostId>snmPOrPGEyaOMTXkjaG4awQkzGt191GOYIfXgbzYffRIsY8JwQOUHk5A43P9YRlDKDvIWx+t9aQ=</HostId></Error>

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -4301,7 +4301,7 @@ def test_xgboost_model_evaluate_work_with_shap_explainer():
     import xgboost
     from sklearn.model_selection import train_test_split
 
-    mlflow.autolog(log_input_examples=True)
+    mlflow.xgboost.autolog(log_input_examples=True)
     X, y = shap.datasets.adult()
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12599?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12599/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12599
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #12516

[robmcd](https://github.com/robmcd) opened this issue last week · 2 comments

### What changes are proposed in this pull request?
The root cause of the problem is that mlflow autologging uses `mlflow.xgboost` to log the model, and we fail to extract the real xgboost raw model in such case. Shap explainer needs to use the original raw model's predict function as the sampled data is converted to float64 type and shouldn't be verified against the model signature. This PR fixes the problem.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
