### PR TITLE
[WIP] Move `model_path` fixture to top level conftest.py

### DIFF
--- a/examples/sktime/test_sktime_model_export.py
+++ b/examples/sktime/test_sktime_model_export.py
@@ -33,12 +33,6 @@ ALPHA = [0.1, 0.5, 0.9]
 COV = False
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    """Create a temporary path to save/log model."""
-    return tmp_path.joinpath("model")
-
-
 @pytest.fixture(scope="module")
 def mock_s3_bucket():
     """Create a mock S3 bucket using moto.

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -92,11 +92,6 @@ def get_reg_model_signature():
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def custom_env(tmp_path):
     conda_env_path = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env_path, additional_pip_deps=["catboost", "pytest"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,3 +192,16 @@ def mock_is_in_databricks(request):
         "mlflow.models.model.is_in_databricks_runtime", return_value=request.param
     ) as mock_databricks:
         yield mock_databricks
+
+
+@pytest.fixture
+def model_path(tmp_path):
+    model_path = tmp_path / "model"
+
+    yield model_path
+
+    # Pytest keeps the temporary directory created by `tmp_path` fixture for 3 recent test sessions
+    # by default. This is useful for debugging during local testing, but in CI it just wastes the
+    # disk space.
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        shutil.rmtree(model_path, ignore_errors=True)

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -39,11 +39,6 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
 )
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return tmp_path.joinpath("model")
-
-
 @pytest.fixture(scope="module")
 def diviner_data():
     return example_data_generator.generate_example_data(

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -50,11 +50,6 @@ def fastai_model():
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def fastai_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["fastai", "pytest"])

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -77,11 +77,6 @@ def h2o_iris_model_signature():
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def h2o_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["h2o", "pytest"])

--- a/tests/johnsnowlabs/test_johnsnowlabs_model_export.py
+++ b/tests/johnsnowlabs/test_johnsnowlabs_model_export.py
@@ -107,11 +107,6 @@ def jsl_model(load_and_init_model):
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return str(tmp_path / "model")
-
-
-@pytest.fixture
 def spark_custom_env(tmp_path):
     conda_env = str(tmp_path / "conda_env.yml")
     additional_pip_deps = ["pyspark", "pytest"]

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -101,11 +101,6 @@ def _mock_async_request(content=TEST_CONTENT):
         yield m
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return tmp_path / "model"
-
-
 @pytest.fixture(scope="module")
 def spark():
     with SparkSession.builder.master("local[*]").getOrCreate() as s:

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -84,11 +84,6 @@ def lgb_sklearn_model():
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def lgb_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["lightgbm", "pytest"])

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -225,11 +225,6 @@ def predicted_multiple_inputs(data_multiple_inputs):
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def onnx_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["onnx", "pytest", "torch"])

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -107,11 +107,6 @@ def pd_model_signature():
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def pd_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["paddle", "pytest"])

--- a/tests/pmdarima/test_pmdarima_model_export.py
+++ b/tests/pmdarima/test_pmdarima_model_export.py
@@ -39,11 +39,6 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return tmp_path.joinpath("model")
-
-
-@pytest.fixture
 def pmdarima_custom_env(tmp_path):
     conda_env = tmp_path.joinpath("conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["pmdarima"])

--- a/tests/prophet/test_prophet_model_export.py
+++ b/tests/prophet/test_prophet_model_export.py
@@ -124,11 +124,6 @@ def prophet_model():
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return tmp_path.joinpath("model")
-
-
-@pytest.fixture
 def prophet_custom_env(tmp_path):
     conda_env = tmp_path.joinpath("conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["prophet"])

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -11,7 +11,6 @@ To run this test, run the following command manually
 import contextlib
 import json
 import os
-import shutil
 import sys
 import threading
 import time
@@ -68,19 +67,6 @@ pytestmark = pytest.mark.skipif(
     not _MLFLOW_RUN_SLOW_TESTS.get(),
     reason="Skip slow tests. Set MLFLOW_RUN_SLOW_TESTS environment variable to run them.",
 )
-
-
-@pytest.fixture
-def model_path(tmp_path):
-    model_path = tmp_path.joinpath("model")
-
-    yield model_path
-
-    # Pytest keeps the temporary directory created by `tmp_path` fixture for 3 recent test sessions
-    # by default. This is useful for debugging during local testing, but in CI it just wastes the
-    # disk space.
-    if os.getenv("GITHUB_ACTIONS") == "true":
-        shutil.rmtree(model_path, ignore_errors=True)
 
 
 @contextlib.contextmanager

--- a/tests/pyfunc/test_inferred_code_path.py
+++ b/tests/pyfunc/test_inferred_code_path.py
@@ -10,11 +10,6 @@ import mlflow
 from mlflow.models import Model
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return tmp_path / "model"
-
-
 @pytest.fixture(scope="module")
 def iris_data():
     iris = sklearn.datasets.load_iris()

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -122,11 +122,6 @@ def sklearn_logreg_model(iris_data):
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def pyfunc_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -73,11 +73,6 @@ def sklearn_knn_model(iris_data):
     return knn_model
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
 def test_model_save_load(sklearn_knn_model, iris_data, tmp_path, model_path):
     sk_model_path = os.path.join(tmp_path, "knn.pkl")
     with open(sk_model_path, "wb") as f:

--- a/tests/pyfunc/test_pyfunc_model_config.py
+++ b/tests/pyfunc/test_pyfunc_model_config.py
@@ -8,11 +8,6 @@ from mlflow.models import Model
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def model_config():
     return {
         "use_gpu": True,

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -194,11 +194,6 @@ def keras_model():
     return ModelWithData(model=model, inference_data=X)
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
 def test_scoring_server_responds_to_malformed_json_input_with_error_code_and_message(
     sklearn_model, model_path
 ):

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -137,11 +137,6 @@ def spark():
         yield session
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -167,11 +167,6 @@ def module_scoped_subclassed_model(data):
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def pytorch_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["pytorch", "torchvision", "pytest"])

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -32,11 +32,6 @@ from tests.helper_functions import (
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return tmp_path.joinpath("model")
-
-
-@pytest.fixture
 def basic_model():
     return SentenceTransformer("all-MiniLM-L6-v2")
 

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -120,11 +120,6 @@ def sklearn_custom_transformer_model(sklearn_knn_model, iris_df):
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def sklearn_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["scikit-learn", "pytest"])

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -88,11 +88,6 @@ def spacy_custom_env(tmp_path):
     return conda_env
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
 def test_model_save_load(spacy_model_with_data, model_path):
     spacy_model = spacy_model_with_data.model
     mlflow.spacy.save_model(spacy_model=spacy_model, path=model_path)

--- a/tests/spark/test_spark_connect_model_export.py
+++ b/tests/spark/test_spark_connect_model_export.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import numpy as np
 import pandas as pd
@@ -30,11 +29,6 @@ def _get_spark_connect_session():
             "spark.jars.packages", f"org.apache.spark:spark-connect_2.12:{pyspark.__version__}"
         )
     return builder.getOrCreate()
-
-
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
 
 
 def score_model_as_udf(model_uri, pandas_df, result_type):
@@ -80,11 +74,6 @@ def spark_model(iris_df):
         pandas_df=iris_pandas_df,
         predictions=preds_pandas_df,
     )
-
-
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
 
 
 def test_model_export(spark_model, model_path):

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -186,11 +186,6 @@ def spark_model_estimator(iris_df):
     )
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
 @pytest.mark.usefixtures("spark")
 def test_hadoop_filesystem(tmp_path):
     # copy local dir to and back from HadoopFS and make sure the results match

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -57,11 +57,6 @@ def _get_dates_from_df(df):
 
 
 @pytest.fixture
-def model_path(tmp_path, subdir="model"):
-    return os.path.join(tmp_path, subdir)
-
-
-@pytest.fixture
 def statsmodels_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["pytest", "statsmodels"])

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -171,11 +171,6 @@ def custom_predicted(custom_model, data):
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def keras_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["keras", "tensorflow", "pytest"])

--- a/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
+++ b/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
@@ -36,11 +36,6 @@ IS_TENSORFLOW_AVAILABLE = _is_available_on_pypi("tensorflow")
 EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if IS_TENSORFLOW_AVAILABLE else ["--env-manager", "local"]
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
 @pytest.fixture(scope="module")
 def data():
     iris = datasets.load_iris()

--- a/tests/tensorflow/test_load_saved_tensorflow_estimator.py
+++ b/tests/tensorflow/test_load_saved_tensorflow_estimator.py
@@ -30,11 +30,6 @@ def tf_custom_env(tmp_path):
     return conda_env
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
 ModelDataInfo = collections.namedtuple(
     "ModelDataInfo",
     [

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -25,11 +25,6 @@ def sklearn_knn_model():
     return knn_model
 
 
-@pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
 def test_get_flavor_configuration_throws_exception_when_model_configuration_does_not_exist(
     model_path,
 ):

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -81,11 +81,6 @@ def xgb_sklearn_model():
 
 
 @pytest.fixture
-def model_path(tmp_path):
-    return os.path.join(tmp_path, "model")
-
-
-@pytest.fixture
 def xgb_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["xgboost", "pytest"])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12609?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12609/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12609
```

</p>
</details>

### What changes are proposed in this pull request?

The `model_path` fixture is used in almost all flavor tests. Moving it to top-level conftest to avoid boilor-plate code + apply the file clean up to all flavors to reduce disk usage.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
