### PR TITLE
[WIP] Deprecate `mlflow.transformers.generate_signature_output` API.

### DIFF
--- a/examples/transformers/conversational.py
+++ b/examples/transformers/conversational.py
@@ -4,17 +4,11 @@ import mlflow
 
 conversational_pipeline = transformers.pipeline(model="microsoft/DialoGPT-medium")
 
-signature = mlflow.models.infer_signature(
-    "Hi there, chatbot!",
-    mlflow.transformers.generate_signature_output(conversational_pipeline, "Hi there, chatbot!"),
-)
-
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=conversational_pipeline,
         artifact_path="chatbot",
         task="conversational",
-        signature=signature,
         input_example="A clever and witty question",
     )
 

--- a/examples/transformers/load_components.py
+++ b/examples/transformers/load_components.py
@@ -8,16 +8,11 @@ translation_pipeline = transformers.pipeline(
     tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
 )
 
-signature = mlflow.models.infer_signature(
-    "Hi there, chatbot!",
-    mlflow.transformers.generate_signature_output(translation_pipeline, "Hi there, chatbot!"),
-)
-
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=translation_pipeline,
         artifact_path="french_translator",
-        signature=signature,
+        input_example="Hi there, chatbot!",
     )
 
 translation_components = mlflow.transformers.load_model(

--- a/examples/transformers/simple.py
+++ b/examples/transformers/simple.py
@@ -13,18 +13,13 @@ input_example = ["prompt 1", "prompt 2", "prompt 3"]
 
 parameters = {"max_length": 512, "do_sample": True}
 
-signature = mlflow.models.infer_signature(
-    input_example,
-    mlflow.transformers.generate_signature_output(generation_pipeline, input_example),
-    parameters,
-)
-
 with mlflow.start_run() as run:
     model_info = mlflow.transformers.log_model(
         transformers_model=generation_pipeline,
         artifact_path="text_generator",
-        input_example=["prompt 1", "prompt 2", "prompt 3"],
-        signature=signature,
+        # Pass a tuple of (input_data, params) to let MLflow infer the model
+        # signature including the inference parameters
+        input_example=(["prompt 1", "prompt 2", "prompt 3"], parameters),
     )
 
 sentence_generator = mlflow.pyfunc.load_model(model_info.model_uri)

--- a/examples/transformers/whisper.py
+++ b/examples/transformers/whisper.py
@@ -21,15 +21,6 @@ audio_transcription_pipeline = transformers.pipeline(
     task=task, model=model, tokenizer=tokenizer, feature_extractor=feature_extractor
 )
 
-# Note that if the input type is of raw binary audio, the generated signature will match the
-# one created here. For other supported types (i.e., numpy array of float32 with the
-# correct bitrate extraction), a signature is required to override the default of "binary" input
-# type.
-signature = mlflow.models.infer_signature(
-    audio,
-    mlflow.transformers.generate_signature_output(audio_transcription_pipeline, audio),
-)
-
 inference_config = {
     "return_timestamps": "word",
     "chunk_length_s": 20,
@@ -41,7 +32,8 @@ with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=audio_transcription_pipeline,
         artifact_path="whisper_transcriber",
-        signature=signature,
+        # Pass a tuple of (input_data, params) to let MLflow infer the model
+        # signature including the inference parameters
         input_example=audio,
         inference_config=inference_config,
     )

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -192,7 +192,6 @@ def infer_signature(
               .. code-block:: python
 
                     from mlflow.models import infer_signature
-                    from mlflow.transformers import generate_signature_output
 
                     # Define parameters for inference
                     params = {
@@ -204,8 +203,8 @@ def infer_signature(
 
                     # Infer the signature including parameters
                     signature = infer_signature(
-                        data,
-                        generate_signature_output(model, data),
+                        model_input=data,
+                        model_output=model(data),
                         params=params,
                     )
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -92,7 +92,7 @@ from mlflow.transformers.signature import (
 from mlflow.transformers.torch_utils import _TORCH_DTYPE_KEY, _deserialize_torch_dtype
 from mlflow.types.utils import _validate_input_dictionary_contains_only_strings_and_lists_of_strings
 from mlflow.utils import _truncate_and_ellipsize
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import deprecated, experimental
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     disable_discrete_autologging,
@@ -427,20 +427,15 @@ def save_model(
 
             .. code-block:: python
 
-                from mlflow.models import infer_signature
-                from mlflow.transformers import generate_signature_output
                 from transformers import pipeline
 
                 en_to_de = pipeline("translation_en_to_de")
 
                 data = "MLflow is great!"
-                output = generate_signature_output(en_to_de, data)
-                signature = infer_signature(data, output)
 
                 mlflow.transformers.save_model(
                     transformers_model=en_to_de,
                     path="/path/to/save/model",
-                    signature=signature,
                     input_example=data,
                 )
 
@@ -883,15 +878,11 @@ def log_model(
 
             .. code-block:: python
 
-                from mlflow.models import infer_signature
-                from mlflow.transformers import generate_signature_output
                 from transformers import pipeline
 
                 en_to_de = pipeline("translation_en_to_de")
 
                 data = "MLflow is great!"
-                output = generate_signature_output(en_to_de, data)
-                signature = infer_signature(data, output)
 
                 with mlflow.start_run() as run:
                     mlflow.transformers.log_model(
@@ -1527,7 +1518,7 @@ def _try_import_conversational_pipeline():
         return
 
 
-@experimental
+@deprecated(since="2.15.0", alternative="input_example")
 def generate_signature_output(pipeline, data, model_config=None, params=None, flavor_config=None):
     """
     Utility for generating the response output for the purposes of extracting an output signature

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2605,18 +2605,17 @@ def test_qa_pipeline_pyfunc_predict_with_kwargs(small_qa_pipeline):
             ]
         ),
     )
-    assert signature_with_params == expected_signature
 
     with mlflow.start_run():
-        mlflow.transformers.log_model(
+        model_info = mlflow.transformers.log_model(
             transformers_model=small_qa_pipeline,
             artifact_path=artifact_path,
             input_example=(data, parameters),
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+    assert model_info.signature == expected_signature
 
     response = pyfunc_serve_and_score_model(
-        model_uri,
+        model_info.model_uri,
         data=inference_payload,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],
@@ -2691,13 +2690,6 @@ def test_uri_directory_renaming_handling_components(model_path, small_seq2seq_pi
 
 
 def test_pyfunc_model_log_load_with_artifacts_snapshot():
-    architecture = "prajjwal1/bert-tiny"
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-    model = transformers.BertForQuestionAnswering.from_pretrained(architecture)
-    bert_tiny_pipeline = transformers.pipeline(
-        task="question-answering", model=model, tokenizer=tokenizer
-    )
-
     class QAModel(mlflow.pyfunc.PythonModel):
         def load_context(self, context):
             """


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12610?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12610/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12610
```

</p>
</details>

### What changes are proposed in this pull request?

The [mlflow.transformers.generate_signature_output](https://github.com/mlflow/mlflow/blob/master/mlflow/transformers/__init__.py#L1531) was introduced a while ago to make it easier for users to define model signature. However, now we support automatic signature inference from an input example, which is simpler to use and does the same thing under the hood.

This PR adds deprecation note to the API in favor of the input example feature, and remove usage from examples and tests.

**Note**: There are many usage in tutorial notebooks, which will be removed in the follow-up PR to avoid a giant PR.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Deprecate `mlflow.transformers.generate_signature_output` API in favor of the signature inference from the input example. Instead of using this legacy API to manually construct signature, users can pass `input_example` parameter when logging a model, and MLflow automatically infers the input and output signature.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
