### PR TITLE
[1] Implement LlamaIndex Tracing

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -218,7 +218,8 @@ class MlflowEventHandler(BaseEventHandler, extra="allow"):
 
     @singledispatchmethod
     def _handle_event(self, event: BaseEvent, span: LiveSpan):
-        ...
+        # Pass through the events we are not interested in
+        pass
 
     @_handle_event.register
     def _(self, event: AgentToolCallEvent, span: LiveSpan):

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -1,0 +1,295 @@
+import inspect
+import json
+import logging
+from functools import singledispatchmethod
+from typing import Any, Dict, Optional
+
+from llama_index.core.base.agent.types import BaseAgent, BaseAgentWorker
+from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.core.base.embeddings.base import BaseEmbedding
+from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.instrumentation.event_handlers import BaseEventHandler
+from llama_index.core.instrumentation.events import BaseEvent
+from llama_index.core.instrumentation.events.agent import AgentToolCallEvent
+from llama_index.core.instrumentation.events.embedding import EmbeddingStartEvent
+from llama_index.core.instrumentation.events.llm import (
+    LLMChatEndEvent,
+    LLMChatInProgressEvent,
+    LLMChatStartEvent,
+    LLMCompletionEndEvent,
+    LLMCompletionInProgressEvent,
+    LLMCompletionStartEvent,
+    LLMPredictStartEvent,
+)
+from llama_index.core.instrumentation.events.rerank import ReRankStartEvent
+from llama_index.core.instrumentation.span.base import BaseSpan
+from llama_index.core.instrumentation.span_handlers import BaseSpanHandler
+from llama_index.core.multi_modal_llms import MultiModalLLM
+from llama_index.core.tools import BaseTool
+from pydantic import PrivateAttr
+
+import mlflow
+from mlflow.entities import LiveSpan, SpanEvent, SpanType
+from mlflow.tracing.constant import SpanAttributeKey
+
+_logger = logging.getLogger(__name__)
+
+
+class _LlamaSpan(BaseSpan, extra="allow"):
+    _mlflow_span: LiveSpan = PrivateAttr()
+
+    def __init__(self, id_: str, parent_id: Optional[str], mlflow_span: LiveSpan):
+        super().__init__(id_=id_, parent_id=parent_id)
+        self._mlflow_span = mlflow_span
+
+
+class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
+    _mlflow_client: mlflow.MlflowClient = PrivateAttr()
+
+    def __init__(self, client: mlflow.MlflowClient):
+        super().__init__()
+        self._mlflow_client = client
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "MlflowSpanHandler"
+
+    def new_span(
+        self,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        parent_span_id: Optional[str] = None,
+    ) -> _LlamaSpan:
+        try:
+            input_args = bound_args.arguments
+            attributes = self._get_instance_attributes(instance)
+            span_type = self._get_span_type(instance) or SpanType.UNKNOWN
+            if parent_span_id and (parent := self.open_spans.get(parent_span_id)):
+                parent_span = parent._mlflow_span
+                span = self._mlflow_client.start_span(
+                    request_id=parent_span.request_id,
+                    parent_id=parent_span.span_id,
+                    name=id_.partition("-")[0],
+                    span_type=span_type,
+                    inputs=input_args,
+                    attributes=attributes,
+                )
+            else:
+                span = self._mlflow_client.start_trace(
+                    name=id_.partition("-")[0],
+                    span_type=span_type,
+                    inputs=input_args,
+                    attributes=attributes,
+                )
+            return _LlamaSpan(id_=id_, parent_id=parent_span_id, mlflow_span=span)
+        except BaseException as e:
+            _logger.debug(f"Failed to create a new span: {e}", exc_info=True)
+
+    def prepare_to_exit_span(
+        self,
+        id_: str,
+        result: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> _LlamaSpan:
+        try:
+            llama_span = self.open_spans.get(id_)
+            span = llama_span._mlflow_span
+            if span.parent_id is None:
+                self._mlflow_client.end_trace(span.request_id, outputs=result)
+            else:
+                self._mlflow_client.end_span(span.request_id, span.span_id, outputs=result)
+            return llama_span
+        except BaseException as e:
+            _logger.debug(f"Failed to end a span: {e}", exc_info=True)
+
+    def prepare_to_drop_span(self, id_: str, err: Optional[Exception], **kwargs) -> _LlamaSpan:
+        """Logic for handling errors during the model execution."""
+        llama_span = self.open_spans.get(id_)
+        span = llama_span._mlflow_span
+        span.add_event(SpanEvent.from_exception(err))
+
+        if span.parent_id is None:
+            self._mlflow_client.end_trace(span.request_id, status="ERROR")
+        else:
+            self._mlflow_client.end_span(span.request_id, span.span_id, status="ERROR")
+        return llama_span
+
+    def _get_span_type(self, instance: Any) -> SpanType:
+        """
+        Map LlamaIndex instance type to MLflow span type. Some span type cannot be determined
+        by instance type alone, rather need event info e.g. ChatModel, ReRanker
+        """
+        if isinstance(instance, (BaseLLM, MultiModalLLM)):
+            return SpanType.LLM
+        elif isinstance(instance, BaseRetriever):
+            return SpanType.RETRIEVER
+        elif isinstance(instance, (BaseAgent, BaseAgentWorker)):
+            return SpanType.AGENT
+        elif isinstance(instance, BaseEmbedding):
+            return SpanType.EMBEDDING
+        elif isinstance(instance, BaseTool):
+            return SpanType.TOOL
+        else:
+            return SpanType.CHAIN
+
+    @singledispatchmethod
+    def _get_instance_attributes(self, instance: Any) -> Dict[str, Any]:
+        """
+        Extract span attributes from LlamaIndex objects.
+
+        NB: There are some overlap between attributes extracted from instance metadata and the
+        events. For example, model name for an LLM is available in both. However, events might
+        not always be triggered (e.g. 3P llm integration doesn't implement the event logic),
+        so the instance metadata serves as a fallback source of information.
+        """
+
+    # TODO: Union type hint doesn't work with singledispatchmethod, so we have to define
+    #  two separate methods for BaseLLM and MultiModalLLM. Once we upgrade to Python 3.10,
+    #  we can use `BaseLLM | MultiModelLLM` type hint and it works with singledispatchmethod.
+    @_get_instance_attributes.register
+    def _(self, instance: BaseLLM):
+        return self._get_llm_attributes(instance)
+
+    @_get_instance_attributes.register
+    def _(self, instance: MultiModalLLM):
+        return self._get_llm_attributes(instance)
+
+    def _get_llm_attributes(self, instance) -> Dict[str, Any]:
+        attr = {}
+        if metadata := instance.metadata:
+            attr["model_name"] = metadata.model_name
+            if params_str := metadata.json(exclude_unset=True):
+                attr["invocation_params"] = json.loads(params_str)
+        return attr
+
+    @_get_instance_attributes.register
+    def _(self, instance: BaseEmbedding):
+        return {
+            "model_name": instance.model_name,
+            "embed_batch_size": instance.embed_batch_size,
+        }
+
+    @_get_instance_attributes.register
+    def _(self, instance: BaseTool):
+        metadata = instance.metadata
+        attributes = {"description": metadata.description}
+        try:
+            attributes["name"] = metadata.name
+        except ValueError:
+            # ToolMetadata.get_name() raises ValueError if name is None
+            pass
+        try:
+            attributes["parameters"] = json.loads(metadata.fn_schema_str)
+        except ValueError:
+            # ToolMetadata.get_fn_schema_str() raises ValueError if fn_schema is None
+            pass
+        return attributes
+
+
+class MlflowEventHandler(BaseEventHandler, extra="allow"):
+    """
+    Event handler processes various events that are triggered during execution.
+
+    Events are used as supplemental source for recording additional metadata to the span,
+    such as model name, parameters to the span, because they are not available in the inputs
+    and outputs in SpanHandler.
+    """
+
+    _span_handler: MlflowSpanHandler
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "MlflowEventHandler"
+
+    def __init__(self, _span_handler):
+        super().__init__()
+        self._span_handler = _span_handler
+
+    def handle(self, event: BaseEvent) -> Any:
+        # TODO: These two InProgress events are triggered per streaming chunk. We
+        # ignore them for now but they should be accumulated as SpanEvents of the parent span.
+        if isinstance(event, (LLMChatInProgressEvent, LLMCompletionInProgressEvent)):
+            return
+
+        if span := self._span_handler.open_spans.get(event.span_id):
+            self._handle_event(event, span._mlflow_span)
+
+    @singledispatchmethod
+    def _handle_event(self, event: BaseEvent, span: LiveSpan):
+        ...
+
+    @_handle_event.register
+    def _(self, event: AgentToolCallEvent, span: LiveSpan):
+        span.set_attribute("name", event.tool.name)
+        span.set_attribute("description", event.tool.description)
+        span.set_attribute("parameters", event.tool.get_parameters_dict())
+
+    @_handle_event.register
+    def _(self, event: EmbeddingStartEvent, span: LiveSpan):
+        span.set_attribute("model_dict", event.model_dict)
+
+    @_handle_event.register
+    def _(self, event: LLMPredictStartEvent, span: LiveSpan):
+        """
+        An event triggered when LLM's predict() is called.
+
+        In LlamaIndex, predict() is a gateway method that dispatch the request to
+        either chat() or completion() method depending on the model type, as well
+        as crafting prompt from the template.
+        """
+        template = event.template
+        template_args = {
+            **template.kwargs,
+            **(event.template_args if event.template_args else {}),
+        }
+        span.set_attributes(
+            {
+                "prmopt_template": template.get_template(),
+                "template_arguments": {var: template_args.get(var) for var in template_args},
+            }
+        )
+
+    @_handle_event.register
+    def _(self, event: LLMCompletionStartEvent, span: LiveSpan):
+        span.set_attribute("prompt", event.prompt)
+        span.set_attribute("model_dict", event.model_dict)
+
+    @_handle_event.register
+    def _(self, event: LLMCompletionEndEvent, span: LiveSpan):
+        span.set_attribute("usage", self._extract_token_counts(event.response))
+
+    @_handle_event.register
+    def _(self, event: LLMChatStartEvent, span: LiveSpan):
+        span.set_attribute(SpanAttributeKey.SPAN_TYPE, SpanType.CHAT_MODEL)
+        span.set_attribute("model_dict", event.model_dict)
+
+    @_handle_event.register
+    def _(self, event: LLMChatEndEvent, span: LiveSpan):
+        span.set_attribute("usage", self._extract_token_counts(event.response))
+
+    @_handle_event.register
+    def _(self, event: ReRankStartEvent, span: LiveSpan):
+        span.set_attribute(SpanAttributeKey.SPAN_TYPE, SpanType.RERANKER)
+        span.set_attributes(
+            {
+                "model_name": event.model_name,
+                "top_n": event.top_n,
+            }
+        )
+
+    def _extract_token_counts(self, response) -> Dict[str, int]:
+        if (
+            (raw := getattr(response, "raw", None))
+            and hasattr(raw, "get")
+            and (usage := raw.get("usage"))
+        ):
+            return usage
+        else:
+            usage = {}
+            # Look for token counts in additional_kwargs of the completion payload
+            if additional_kwargs := getattr(response, "additional_kwargs", None):
+                for k in ["prompt_tokens", "completion_tokens", "total_tokens"]:
+                    if (v := additional_kwargs.get(k)) is not None:
+                        usage[k] = v
+            return usage

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -6,6 +6,7 @@ import json
 import logging
 import uuid
 from collections import Counter
+from dataclasses import asdict, is_dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -67,6 +68,12 @@ class TraceJSONEncoder(json.JSONEncoder):
                     return obj.dict()
         except ImportError:
             pass
+
+        # Some dataclass object defines __str__ method that doesn't return the full object
+        # representation, so we use dict representation instead.
+        # E.g. https://github.com/run-llama/llama_index/blob/29ece9b058f6b9a1cf29bc723ed4aa3a39879ad5/llama-index-core/llama_index/core/chat_engine/types.py#L63-L64
+        if is_dataclass(obj):
+            return asdict(obj)
 
         try:
             return super().default(obj)

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -18,28 +18,7 @@ from mlflow.entities.trace import Trace
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.llama_index.tracer import MlflowEventHandler, MlflowSpanHandler
 from mlflow.tracing.constant import SpanAttributeKey
-
-_TEST_EXPERIMENT = "__test-llama-index-tracing"
-
-
-@pytest.fixture(autouse=True)
-def experiment_id(tmp_path):
-    """Create a new experiment for each test and clean up after."""
-    # Delete the experiment if it already exists
-    exp = mlflow.get_experiment_by_name(_TEST_EXPERIMENT)
-    if exp is not None:
-        mlflow.delete_experiment(exp.experiment_id)
-
-    exp_id = mlflow.create_experiment(
-        name=_TEST_EXPERIMENT,
-        artifact_location=str(tmp_path),
-    )
-    mlflow.set_experiment(experiment_id=exp_id)
-    yield exp_id
-
-    # Clean up
-    mlflow.delete_experiment(exp_id)
-    mlflow.set_experiment(experiment_id=0)  # default experiment
+from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 
 
 @pytest.fixture(autouse=True)
@@ -74,8 +53,7 @@ def set_handlers():
 
 def _get_all_traces() -> List[Trace]:
     """Utility function to get all traces in the test experiment."""
-    exp_id = mlflow.get_experiment_by_name(_TEST_EXPERIMENT).experiment_id
-    return mlflow.MlflowClient().search_traces(experiment_ids=[exp_id])
+    return mlflow.MlflowClient().search_traces(experiment_ids=[DEFAULT_EXPERIMENT_ID])
 
 
 @pytest.mark.parametrize("is_async", [True, False])

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -1,0 +1,198 @@
+import asyncio
+from typing import List
+from unittest.mock import ANY
+
+import openai
+import pytest
+from llama_index.core import (
+    Settings,
+)
+from llama_index.core.instrumentation import get_dispatcher
+from llama_index.core.llms import ChatMessage
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.llms.openai import OpenAI
+
+import mlflow
+from mlflow.entities.span import SpanType
+from mlflow.entities.trace import Trace
+from mlflow.entities.trace_status import TraceStatus
+from mlflow.llama_index.tracer import MlflowEventHandler, MlflowSpanHandler
+from mlflow.tracing.constant import SpanAttributeKey
+
+_TEST_EXPERIMENT = "__test-llama-index-tracing"
+
+
+@pytest.fixture(autouse=True)
+def experiment_id(tmp_path):
+    """Create a new experiment for each test and clean up after."""
+    # Delete the experiment if it already exists
+    exp = mlflow.get_experiment_by_name(_TEST_EXPERIMENT)
+    if exp is not None:
+        mlflow.delete_experiment(exp.experiment_id)
+
+    exp_id = mlflow.create_experiment(
+        name=_TEST_EXPERIMENT,
+        artifact_location=str(tmp_path),
+    )
+    mlflow.set_experiment(experiment_id=exp_id)
+    yield exp_id
+
+    # Clean up
+    mlflow.delete_experiment(exp_id)
+    mlflow.set_experiment(experiment_id=0)  # default experiment
+
+
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch, mock_openai):
+    """Set the LLM and Embedding model to the mock OpenAI server."""
+    monkeypatch.setenvs(
+        {
+            "OPENAI_API_KEY": "test",
+            "OPENAI_API_BASE": mock_openai,
+        }
+    )
+    # Need to reset the settings to reflect the new env variables
+    monkeypatch.setattr(Settings, "llm", OpenAI())
+    monkeypatch.setattr(Settings, "embed_model", OpenAIEmbedding())
+
+
+@pytest.fixture(autouse=True)
+def set_handlers():
+    span_handler = MlflowSpanHandler(mlflow.MlflowClient())
+    event_handler = MlflowEventHandler(span_handler)
+
+    dsp = get_dispatcher()
+    dsp.add_span_handler(span_handler)
+    dsp.add_event_handler(event_handler)
+
+    yield
+
+    # Clean up
+    dsp.span_handlers = []
+    dsp.event_handlers = []
+
+
+def _get_all_traces() -> List[Trace]:
+    """Utility function to get all traces in the test experiment."""
+    exp_id = mlflow.get_experiment_by_name(_TEST_EXPERIMENT).experiment_id
+    return mlflow.MlflowClient().search_traces(experiment_ids=[exp_id])
+
+
+@pytest.mark.parametrize("is_async", [True, False])
+def test_trace_llm_complete(is_async):
+    # By default llama-index uses "gpt-3.5-turbo" model that only has chat interface,
+    # and llama-index redirects completion call to chat endpoint. We use non-chat
+    # model here to test trace for completion.
+    model_name = "gpt-3.5-turbo-instruct"
+    llm = OpenAI(model=model_name)
+
+    response = asyncio.run(llm.acomplete("Hello")) if is_async else llm.complete("Hello")
+    assert response.text == "Hello"
+
+    traces = _get_all_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == TraceStatus.OK
+
+    spans = traces[0].data.spans
+    assert len(spans) == 1
+    assert spans[0].name == "OpenAI.acomplete" if is_async else "OpenAI.complete"
+
+    attr = spans[0].attributes
+    assert attr[SpanAttributeKey.SPAN_TYPE] == SpanType.LLM
+    assert attr[SpanAttributeKey.INPUTS] == {"args": ["Hello"]}
+    assert attr[SpanAttributeKey.OUTPUTS]["text"] == "Hello"
+    assert attr["usage"] == {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
+    assert attr["prompt"] == "Hello"
+    assert attr["invocation_params"]["model_name"] == model_name
+    assert attr["model_dict"]["model"] == model_name
+
+
+@pytest.mark.parametrize("is_async", [True, False])
+def test_trace_llm_chat(is_async):
+    llm = OpenAI()
+    message = ChatMessage(role="system", content="Hello")
+
+    response = asyncio.run(llm.achat([message])) if is_async else llm.chat([message])
+    assert isinstance(response.message, ChatMessage)
+    assert response.message.content == '[{"role": "system", "content": "Hello"}]'
+
+    traces = _get_all_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == TraceStatus.OK
+
+    spans = traces[0].data.spans
+    assert len(spans) == 1
+    assert spans[0].name == "OpenAI.achat" if is_async else "OpenAI.chat"
+
+    attr = spans[0].attributes
+    assert attr[SpanAttributeKey.SPAN_TYPE] == SpanType.CHAT_MODEL
+    assert attr[SpanAttributeKey.INPUTS] == {
+        "messages": [{"role": "system", "content": "Hello", "additional_kwargs": {}}]
+    }
+    assert attr[SpanAttributeKey.OUTPUTS] == {
+        "message": {
+            "role": "assistant",
+            "content": '[{"role": "system", "content": "Hello"}]',
+            "additional_kwargs": {},
+        },
+        "raw": ANY,
+        "delta": None,
+        "logprobs": None,
+        "additional_kwargs": {},
+    }
+    assert attr["usage"] == {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21}
+    assert attr["invocation_params"]["model_name"] == llm.metadata.model_name
+    assert attr["model_dict"]["model"] == llm.metadata.model_name
+
+
+def test_trace_llm_error(monkeypatch):
+    # Disable callback as it doesn't handle error response well
+    monkeypatch.setattr(Settings, "callback_manager", None)
+
+    llm = OpenAI(
+        api_base="http://localhost:1234/invalid/base",
+        timeout=1,
+        max_retries=0,
+    )
+
+    with pytest.raises(openai.APIConnectionError, match="Connection error."):
+        llm.chat([ChatMessage(role="system", content="Hello")])
+
+    traces = _get_all_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == TraceStatus.ERROR
+    spans = traces[0].data.spans
+    assert len(spans) == 1
+    assert spans[0].name == "OpenAI.chat"
+    assert spans[0].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.CHAT_MODEL
+    assert spans[0].attributes[SpanAttributeKey.INPUTS] == {
+        "messages": [{"role": "system", "content": "Hello", "additional_kwargs": {}}]
+    }
+    assert SpanAttributeKey.OUTPUTS not in spans[0].attributes
+    events = traces[0].data.spans[0].events
+    assert len(events) == 1
+    assert events[0].attributes["exception.message"] == "Connection error."
+
+
+def test_trace_retriever():
+    pass
+
+
+def test_trace_agent():
+    pass
+
+
+def test_trace_query_engine():
+    pass
+
+
+def test_trace_query_engine_async():
+    pass
+
+
+def test_trace_chat_engine():
+    pass
+
+
+def test_trace_reranker():
+    pass

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import pickle
+from dataclasses import asdict
 from typing import List
 
 import pytest
@@ -114,7 +115,7 @@ def test_chat_model_with_trace(tmp_path):
     assert len(traces) == 1
     assert traces[0].info.tags[TraceTagKey.TRACE_NAME] == "predict"
     request = json.loads(traces[0].data.request)
-    assert request["messages"] == [str(ChatMessage(**msg)) for msg in messages]
+    assert request["messages"] == [asdict(ChatMessage(**msg)) for msg in messages]
 
 
 def test_chat_model_save_throws_with_signature(tmp_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12618?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12618/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12618
```

</p>
</details>

### What changes are proposed in this pull request?

Add tracing implementation for LlamaIndex. LLamaIndex recently updated their method of allowing integrators to generate tracing. Previously it was a single callback based, but now it needs two separate **handlers**:

- **SpanHandler** - This handler defines entrypoints for starting and ending spans. Similar to how LangChain tracing works, LlamaIndex already creates their own spans structure and give us those spans and Ids, from which we can build our own MLflow spans.
- **EventHandler** - This handler is primary used for adding supplemental metadata e.g. model name to spans, using `Event` objects that are triggered within the index e.g. LLM start, Agent start, etc.

<img src="https://github.com/user-attachments/assets/37d20aa0-7e35-4449-9374-20f4d6043c35" width="500">


The above diagram illustrates how these components work together to create a span. Please refer to https://docs.llamaindex.ai/en/stable/module_guides/observability/instrumentation/ for more detailed and accurate explanation🙂

This PR is the first effort to implement the two key **handlers** to generate traces. It actually is 90% of the work to make tracing work, with a few follow-ups to be addressed in the incoming PRs.

**TODOs**
1. Add unit tests for complex models (https://github.com/mlflow/mlflow/pull/12626)
2. (Fully) support streaming and update tests. The handler already mostly works for streaming, but need some minor update like recording chunk events.
3. Add documentation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
