### PR TITLE
Add llama-index to ml-package-versions.yml

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -701,6 +701,24 @@ langchain:
         pytest tests/langchain/test_langchain_autolog.py
       fi
 
+llama_index:
+  package_info:
+    pip_release: "llama-index"
+    install_dev: |
+      pip install git@github.com:run-llama/llama_index.git
+  models:
+    # TODO: Min version is picked randomly, to be replaced with the actual lowerbound.
+    minimum: "0.6.0"
+    maximum: "0.10.53"
+    requirements:
+      ">= 0.0.0": [
+        "llama-index",
+        "openai",
+      ]
+    run:
+      # TODO: Add --ignore flag for autologging test once it's implemented
+      pytest tests/llama_index
+
 sentence_transformers:
   package_info:
     pip_release: "sentence-transformers"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -707,14 +707,13 @@ llama_index:
     install_dev: |
       pip install git@github.com:run-llama/llama_index.git
   models:
-    # TODO: Min version is picked randomly, to be replaced with the actual lowerbound.
-    minimum: "0.6.0"
+    # TODO: Setting min version to 0.10.0 because it is the first version
+    #   with new split package structure e.g llama-index-core. We may be
+    #   able to lower this by adjusting some import statements.
+    minimum: "0.10.0"
     maximum: "0.10.53"
     requirements:
-      ">= 0.0.0": [
-        "llama-index",
-        "openai",
-      ]
+      ">= 0.0.0": ["llama-index", "openai"]
     run:
       # TODO: Add --ignore flag for autologging test once it's implemented
       pytest tests/llama_index

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -270,6 +270,15 @@ _ML_PACKAGE_VERSIONS = {
             "maximum": "0.2.5"
         }
     },
+    "llama_index": {
+        "package_info": {
+            "pip_release": "llama-index"
+        },
+        "models": {
+            "minimum": "0.6.0",
+            "maximum": "0.10.53"
+        }
+    },
     "sentence_transformers": {
         "package_info": {
             "pip_release": "sentence-transformers"

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -275,7 +275,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "llama-index"
         },
         "models": {
-            "minimum": "0.6.0",
+            "minimum": "0.10.0",
             "maximum": "0.10.53"
         }
     },


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12623?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12623/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12623
```

</p>
</details>

### What changes are proposed in this pull request?

Add an entry for `llama-index` within `ml-package-versions.yml`. This is required to trigger flavor tests on PRs.

The minimum supported version is set to `0.10.0` (released in Feb 2024) but it is tentative. That version is where the split package structure was introduced e.g. `llama-index-core` so maybe a good borderline, however, we may be able to lower it further by adjusting some import statements. We will validate it once all features and tests are implemented.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
