### PR TITLE
[2] Add more test coverage to Llama index tracing

### DIFF
--- a/tests/llama_index/conftest.py
+++ b/tests/llama_index/conftest.py
@@ -18,6 +18,8 @@ from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.openai import OpenAI
 from pyspark.sql import SparkSession
 
+from mlflow.tracing.provider import trace_disabled
+
 from tests.helper_functions import start_mock_openai_server
 
 
@@ -88,11 +90,13 @@ def document():
 
 
 @pytest.fixture
+@trace_disabled
 def single_index(document):
     return VectorStoreIndex(nodes=[document])
 
 
 @pytest.fixture
+@trace_disabled
 def multi_index(document):
     return VectorStoreIndex(nodes=[document] * 5)
 

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -1,16 +1,22 @@
 import asyncio
+from dataclasses import asdict
 from typing import List
 from unittest.mock import ANY
 
 import openai
 import pytest
+from llama_index.agent.openai import OpenAIAgent
 from llama_index.core import (
+    Document,
     Settings,
+    VectorStoreIndex,
 )
 from llama_index.core.instrumentation import get_dispatcher
-from llama_index.core.llms import ChatMessage
-from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.core.llms import ChatMessage, ChatResponse
+from llama_index.core.retrievers import VectorIndexRetriever
+from llama_index.core.tools import FunctionTool
 from llama_index.llms.openai import OpenAI
+from openai.types.chat import ChatCompletionMessageToolCall
 
 import mlflow
 from mlflow.entities.span import SpanType
@@ -18,21 +24,8 @@ from mlflow.entities.trace import Trace
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.llama_index.tracer import MlflowEventHandler, MlflowSpanHandler
 from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
-
-
-@pytest.fixture(autouse=True)
-def patch_settings(monkeypatch, mock_openai):
-    """Set the LLM and Embedding model to the mock OpenAI server."""
-    monkeypatch.setenvs(
-        {
-            "OPENAI_API_KEY": "test",
-            "OPENAI_API_BASE": mock_openai,
-        }
-    )
-    # Need to reset the settings to reflect the new env variables
-    monkeypatch.setattr(Settings, "llm", OpenAI())
-    monkeypatch.setattr(Settings, "embed_model", OpenAIEmbedding())
 
 
 @pytest.fixture(autouse=True)
@@ -54,6 +47,17 @@ def set_handlers():
 def _get_all_traces() -> List[Trace]:
     """Utility function to get all traces in the test experiment."""
     return mlflow.MlflowClient().search_traces(experiment_ids=[DEFAULT_EXPERIMENT_ID])
+
+
+@pytest.fixture
+@trace_disabled
+def index():
+    documents = [
+        Document(text="apple", meta={"category": "fruit"}),
+        Document(text="carrot", meta={"category": "vegetable"}),
+        Document(text="tuna", meta={"category": "fish"}),
+    ]
+    return VectorStoreIndex(documents)
 
 
 @pytest.mark.parametrize("is_async", [True, False])
@@ -152,25 +156,195 @@ def test_trace_llm_error(monkeypatch):
     assert events[0].attributes["exception.message"] == "Connection error."
 
 
-def test_trace_retriever():
-    pass
+@pytest.mark.parametrize("is_async", [True, False])
+def test_trace_retriever(index, is_async):
+    retriever = VectorIndexRetriever(index, similarity_top_k=3)
+
+    if is_async:
+        retrieved = asyncio.run(retriever.aretrieve("apple"))
+    else:
+        retrieved = retriever.retrieve("apple")
+    assert len(retrieved) == 3
+
+    traces = _get_all_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == TraceStatus.OK
+
+    spans = traces[0].data.spans
+    assert len(spans) == 4
+    for i in range(1, 4):
+        assert spans[i].parent_id == spans[i - 1].span_id
+
+    assert spans[0].name == "BaseRetriever.aretrieve" if is_async else "BaseRetriever.retrieve"
+    assert spans[0].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.RETRIEVER
+    assert spans[0].attributes[SpanAttributeKey.INPUTS] == {"str_or_query_bundle": "apple"}
+    output = spans[0].attributes[SpanAttributeKey.OUTPUTS]
+    assert len(output) == 3
+    for node, expected in zip(output, retrieved):
+        assert node["node"]["text"] == expected.text
+
+    assert spans[1].name.startswith("VectorIndexRetriever")
+    assert spans[1].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.RETRIEVER
+    assert spans[1].attributes[SpanAttributeKey.INPUTS]["query_bundle"]["query_str"] == "apple"
+    assert (
+        spans[1].attributes[SpanAttributeKey.OUTPUTS]
+        == spans[0].attributes[SpanAttributeKey.OUTPUTS]
+    )
+
+    assert spans[2].name.startswith("BaseEmbedding")
+    assert spans[2].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.EMBEDDING
+    assert spans[2].attributes[SpanAttributeKey.INPUTS] == {"query": "apple"}
+    assert len(spans[2].attributes[SpanAttributeKey.OUTPUTS]) == 1536  # embedding size
+    assert spans[2].attributes["model_name"] == Settings.embed_model.model_name
+
+    assert spans[3].name.startswith("OpenAIEmbedding")
+    assert spans[3].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.EMBEDDING
+    assert spans[3].attributes[SpanAttributeKey.INPUTS] == {"query": "apple"}
+    assert len(spans[3].attributes[SpanAttributeKey.OUTPUTS]) == 1536  # embedding size
+    assert spans[3].attributes["model_name"] == Settings.embed_model.model_name
+
+
+@pytest.mark.parametrize("is_async", [True, False])
+def test_trace_query_engine(index, is_async):
+    engine = index.as_query_engine()
+
+    response = asyncio.run(engine.aquery("Hello")) if is_async else engine.query("Hello")
+    assert response.response.startswith('[{"role": "system", "content": "You are an')
+    response = asdict(response)
+
+    traces = _get_all_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == TraceStatus.OK
+
+    spans = traces[0].data.spans
+    assert len(spans) == 13 if is_async else 14
+
+    # Validate the tree structure
+    # 0 -- 1 -- 2 -- 3 -- 4 -- 5
+    #   \- 6 -- 7 -- 8
+    #             \- 9 -- 10
+    #                  \- 11 -- 12 (-- 13)
+    for i in range(1, 6):
+        assert spans[i].parent_id == spans[i - 1].span_id
+    assert spans[6].parent_id == spans[1].span_id
+    assert spans[7].parent_id == spans[6].span_id
+    assert spans[8].parent_id == spans[7].span_id
+    assert spans[9].parent_id == spans[7].span_id
+    assert spans[10].parent_id == spans[9].span_id
+    assert spans[11].parent_id == spans[9].span_id
+    assert spans[12].parent_id == spans[11].span_id
+    if not is_async:
+        assert spans[13].parent_id == spans[12].span_id
+
+    # Async methods have "a" prefix
+    prefix = "a" if is_async else ""
+
+    # Validate span attributes for some key spans
+    assert spans[0].name == f"BaseQueryEngine.{prefix}query"
+    assert spans[0].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.CHAIN
+    assert spans[0].attributes[SpanAttributeKey.INPUTS] == {"str_or_query_bundle": "Hello"}
+    assert spans[0].attributes[SpanAttributeKey.OUTPUTS] == response
+
+    assert spans[2].name == f"BaseRetriever.{prefix}retrieve"
+    assert spans[2].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.RETRIEVER
+
+    assert spans[6].name == f"BaseSynthesizer.{prefix}synthesize"
+    assert spans[6].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.CHAIN
+    assert spans[6].attributes[SpanAttributeKey.INPUTS] == {"query": ANY, "nodes": ANY}
+
+    assert spans[9].name == f"Refine.{prefix}get_response"
+    assert spans[9].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.CHAIN
+    assert spans[9].attributes[SpanAttributeKey.INPUTS] == {
+        "query_str": "Hello",
+        "text_chunks": ANY,
+        "prev_response": None,
+    }
+
+    llm_method_name = f"OpenAI.{prefix}chat"
+    assert spans[-1].name == llm_method_name
+    assert spans[-1].attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.CHAT_MODEL
+    assert spans[-1].attributes[SpanAttributeKey.INPUTS] == {
+        "messages": [
+            {"role": "system", "content": ANY, "additional_kwargs": {}},
+            {"role": "user", "content": ANY, "additional_kwargs": {}},
+        ]
+    }
 
 
 def test_trace_agent():
-    pass
+    # Mock LLM to return deterministic responses and let the agent use a tool
+    class MockLLMForAgent(OpenAI, extra="allow"):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._mock_response = iter(
+                [
+                    ChatResponse(
+                        message=ChatMessage(
+                            role="assistant",
+                            content=None,
+                            additional_kwargs={
+                                "tool_calls": [
+                                    ChatCompletionMessageToolCall(
+                                        id="test",
+                                        function={
+                                            "name": "add",
+                                            "arguments": '{"a": 1, "b": 2}',
+                                        },
+                                        type="function",
+                                    )
+                                ]
+                            },
+                        )
+                    ),
+                    ChatResponse(
+                        message=ChatMessage(
+                            role="assistant",
+                            content="The result is 3",
+                        )
+                    ),
+                ]
+            )
+
+        def chat(self, *args, **kwargs):
+            return next(self._mock_response)
+
+    def add(a: int, b: int) -> int:
+        """Add two integers and returns the result integer"""
+        return a + b
+
+    add_tool = FunctionTool.from_defaults(fn=add)
+
+    llm = MockLLMForAgent()
+    agent = OpenAIAgent.from_tools([add_tool], llm=llm)
+    response = agent.chat("What is 1 + 2?").response
+
+    assert response == "The result is 3"
+
+    traces = _get_all_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == TraceStatus.OK
+
+    spans = traces[0].data.spans
+    name_to_span = {span.name: span for span in spans}
+    tool_span = name_to_span["FunctionTool.call"]
+    assert tool_span.attributes[SpanAttributeKey.SPAN_TYPE] == SpanType.TOOL
+    assert tool_span.attributes[SpanAttributeKey.INPUTS] == {"kwargs": {"a": 1, "b": 2}}
+    assert tool_span.attributes[SpanAttributeKey.OUTPUTS]["content"] == "3"
+    assert tool_span.attributes["name"] == "add"
+    assert tool_span.attributes["description"] is not None
+    assert tool_span.attributes["parameters"] is not None
 
 
-def test_trace_query_engine():
-    pass
+@pytest.mark.parametrize("is_async", [True, False])
+def test_trace_chat_engine(index, is_async):
+    chat_engine = index.as_chat_engine()
 
+    response = asyncio.run(chat_engine.achat("Hello")) if is_async else chat_engine.chat("Hello")
+    assert response.response == '[{"role": "user", "content": "Hello"}]'
 
-def test_trace_query_engine_async():
-    pass
-
-
-def test_trace_chat_engine():
-    pass
-
-
-def test_trace_reranker():
-    pass
+    # Since chat engine is a complex agent-based system, it is challenging to strictly
+    # validate the trace structure and attributes. The detailed validation is done in
+    # other tests for individual components.
+    traces = _get_all_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == TraceStatus.OK


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12626?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12626/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12626
```

</p>
</details>

### Related Issues/PRs

Follow up of https://github.com/mlflow/mlflow/pull/12618. The all change in this PR is in `tests/llama_index/test_llama_index_tracer.py`.

### What changes are proposed in this pull request?

Add tests for complex objects like query engine, agent, retriever, etc.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
