### PR TITLE
Fix stream trace logging with the OpenAI autologging implementation to record the correct chunk structure

### DIFF
--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -731,4 +731,3 @@ def start_mock_openai_server():
             yield base_url
         finally:
             proc.kill()
-            proc.wait()

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -715,17 +715,20 @@ def start_mock_openai_server():
     ) as proc:
         try:
             base_url = f"http://localhost:{port}"
-            for _ in range(3):
+            for _ in range(10):
                 try:
                     resp = requests.get(f"{base_url}/health")
                 except requests.ConnectionError:
-                    time.sleep(1)
+                    time.sleep(2)
                     continue
                 if resp.ok:
                     break
             else:
+                proc.kill()
+                proc.wait()
                 raise RuntimeError("Failed to start mock OpenAI server")
 
             yield base_url
         finally:
             proc.kill()
+            proc.wait()

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -61,6 +61,16 @@ def test_chat_completions_autolog_streaming(client, monkeypatch):
         assert output[1]["id"] == "chatcmpl-123"
         assert output[1]["choices"][0]["delta"]["content"] == " world"
 
+    trace = mlflow.get_last_active_trace()
+    assert trace is not None
+    assert isinstance(trace.data.response, str)
+
+    response_data = json.loads(trace.data.response)
+    assert response_data["chunks"][0]["id"] == "chatcmpl-123"
+    assert response_data["chunks"][0]["choices"][0]["delta"]["content"] == "Hello"
+    assert response_data["chunks"][1]["id"] == "chatcmpl-123"
+    assert response_data["chunks"][1]["choices"][0]["delta"]["content"] == " world"
+
 
 @pytest.mark.skipif(not is_v1, reason="Requires OpenAI SDK v1")
 def test_loaded_chat_completions_autolog(client, monkeypatch):

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -66,10 +66,10 @@ def test_chat_completions_autolog_streaming(client, monkeypatch):
     assert isinstance(trace.data.response, str)
 
     response_data = json.loads(trace.data.response)
-    assert response_data["chunks"][0]["id"] == "chatcmpl-123"
-    assert response_data["chunks"][0]["choices"][0]["delta"]["content"] == "Hello"
-    assert response_data["chunks"][1]["id"] == "chatcmpl-123"
-    assert response_data["chunks"][1]["choices"][0]["delta"]["content"] == " world"
+    assert response_data["result"][0]["id"] == "chatcmpl-123"
+    assert response_data["result"][0]["choices"][0]["delta"]["content"] == "Hello"
+    assert response_data["result"][1]["id"] == "chatcmpl-123"
+    assert response_data["result"][1]["choices"][0]["delta"]["content"] == " world"
 
 
 @pytest.mark.skipif(not is_v1, reason="Requires OpenAI SDK v1")

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -66,10 +66,15 @@ def test_chat_completions_autolog_streaming(client, monkeypatch):
     assert isinstance(trace.data.response, str)
 
     response_data = json.loads(trace.data.response)
-    assert response_data["result"][0]["id"] == "chatcmpl-123"
-    assert response_data["result"][0]["choices"][0]["delta"]["content"] == "Hello"
-    assert response_data["result"][1]["id"] == "chatcmpl-123"
-    assert response_data["result"][1]["choices"][0]["delta"]["content"] == " world"
+
+    assert response_data["result"] == "Hello world"
+
+    stream_event_data = trace.data.spans[0].attributes["events"]
+
+    assert stream_event_data[0]["id"] == "chatcmpl-123"
+    assert stream_event_data[0]["choices"][0]["delta"]["content"] == "Hello"
+    assert stream_event_data[1]["id"] == "chatcmpl-123"
+    assert stream_event_data[1]["choices"][0]["delta"]["content"] == " world"
 
 
 @pytest.mark.skipif(not is_v1, reason="Requires OpenAI SDK v1")
@@ -144,6 +149,21 @@ def test_completions_autolog_streaming(client, monkeypatch):
         assert output[0]["choices"][0]["text"] == "Hello"
         assert output[1]["id"] == "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7"
         assert output[1]["choices"][0]["text"] == " world"
+
+    trace = mlflow.get_last_active_trace()
+    assert trace is not None
+    assert isinstance(trace.data.response, str)
+
+    response_data = json.loads(trace.data.response)
+
+    assert response_data["result"] == "Hello world"
+
+    stream_event_data = trace.data.spans[0].attributes["events"]
+
+    assert stream_event_data[0]["id"] == "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7"
+    assert stream_event_data[0]["choices"][0]["text"] == "Hello"
+    assert stream_event_data[1]["id"] == "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7"
+    assert stream_event_data[1]["choices"][0]["text"] == " world"
 
 
 @pytest.mark.skipif(not is_v1, reason="Requires OpenAI SDK v1")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/12629?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12629/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12629
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adjust the trace logging for streaming implementations with openai autologging to record the chunk structure rather than the stream object reference (current master branch logs the name of the openai.Stream object). 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

![Screenshot 2024-07-10 at 1 37 57 PM](https://github.com/mlflow/mlflow/assets/39283302/1392acca-526e-407e-a15c-6c7b70c829e0)


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
