### PR TITLE
Edit mlflow-typo script to ignore typos in i18n files

### DIFF
--- a/dev/mlflow-typo.sh
+++ b/dev/mlflow-typo.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 
 ALLOWED_PATTERNS='Mlflow\(|"Mlflow"|import Mlflow$'
-if grep -InE ' \bM(lf|LF|lF)low\b' "$@" | grep -vE "$ALLOWED_PATTERNS"; then
+# add globs to this list to ignore them in grep
+EXCLUDED_FILES=(
+    # ignore typos in i18n files, since they're not controlled by us
+    "mlflow/server/js/src/lang/*.json"
+)
+
+EXCLUDE_ARGS=""
+for pattern in "${EXCLUDED_FILES[@]}"; do
+    EXCLUDE_ARGS="$EXCLUDE_ARGS --exclude=$pattern"
+done
+
+if grep -InE ' \bM(lf|LF|lF)low\b' $EXCLUDE_ARGS "$@" | grep -vE "$ALLOWED_PATTERNS"; then
     echo -e "\nFound typo for MLflow spelling in above file(s). Please use 'MLflow' instead of 'Mlflow'."
     exit 1
 else


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/12635?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12635/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12635
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The newest UI sync has some typos in i18n files. This means that some of the translations have MLFlow instead of MLflow. I'm not sure if we can really do anything about this (perhaps we can request a change of translation, or maybe edit the files directly, but I'm not sure if this will affect the string hashes).

In order to unblock CI for the UI sync, this PR adds the ability to ignore typos in certain filepaths.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested by adding a typo to some random file with and without adding the path to the list

Before (added to `README.rst`):
```
$ pre-commit
mlflow-typo..............................................................Failed
- hook id: mlflow-typo
- exit code: 1

README.rst:4: MLFlow

Found typo for MLflow spelling in above file(s). Please use 'MLflow' instead of 'Mlflow'.
```

After adding `README.rst` to the ignore list:
```
pre-commit
mlflow-typo..............................................................Passed
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
