### PR TITLE
Creating compatibility with Kubeflow Dashboard UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.enzyme.test.tsx
@@ -55,3 +55,41 @@ describe('CompareRunPage', () => {
     expect(wrapper.find(CompareRunPage).length).toBe(1);
   });
 });
+
+describe('CompareRunPage URI encoded', () => {
+  let wrapper;
+  let minimalProps: any;
+  let minimalStore: any;
+  const mockStore = configureStore([thunk, promiseMiddleware()]);
+
+  beforeEach(() => {
+    // TODO: remove global fetch mock by explicitly mocking all the service API calls
+    // @ts-expect-error TS(2322): Type 'Mock<Promise<{ ok: true; status: number; tex... Remove this comment to see the full error message
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('') }));
+    minimalProps = {
+      location: {
+        search: "?runs=%5B%252281d708375e574d6cbf4985b8701d67d2%2522,%25225f70fea1ef004d3180a6c34fe2d0d94e%2522%5D&experiments=%5B%25220%2522%5D",
+      },
+      experimentIds: ['12345'],
+      runUuids: ['runn-1234-5678-9012', 'runn-1234-5678-9034'],
+      dispatch: jest.fn(),
+    }; 
+    minimalStore = mockStore({
+      entities: {},
+      apis: jest.fn((key) => {
+        return {};
+      }),
+    });
+  });
+
+  test('should render with minimal props without exploding', () => {
+    wrapper = mountWithIntl(
+      <Provider store={minimalStore}>
+        <MemoryRouter>
+          <CompareRunPage {...minimalProps} />
+        </MemoryRouter>
+      </Provider>,
+    );
+    expect(wrapper.find(CompareRunPage).length).toBe(1);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.enzyme.test.tsx
@@ -68,12 +68,13 @@ describe('CompareRunPage URI encoded', () => {
     global.fetch = jest.fn(() => Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('') }));
     minimalProps = {
       location: {
-        search: "?runs=%5B%252281d708375e574d6cbf4985b8701d67d2%2522,%25225f70fea1ef004d3180a6c34fe2d0d94e%2522%5D&experiments=%5B%25220%2522%5D",
+        search:
+          '?runs=%5B%252281d708375e574d6cbf4985b8701d67d2%2522,%25225f70fea1ef004d3180a6c34fe2d0d94e%2522%5D&experiments=%5B%25220%2522%5D',
       },
       experimentIds: ['12345'],
       runUuids: ['runn-1234-5678-9012', 'runn-1234-5678-9034'],
       dispatch: jest.fn(),
-    }; 
+    };
     minimalStore = mockStore({
       entities: {},
       apis: jest.fn((key) => {

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
@@ -63,9 +63,18 @@ class CompareRunPageImpl extends Component<CompareRunPageProps> {
   }
 }
 
+const decodeURI = (uri: string): string => {
+  const decodedURI = decodeURIComponent(uri);
+  if (uri !== decodedURI) {
+    return decodeURI(decodedURI);
+  }
+  return decodedURI;
+}
+
 const mapStateToProps = (state: any, ownProps: WithRouterNextProps) => {
   const { location } = ownProps;
-  const searchValues = qs.parse(location.search);
+  const locationSearchDecoded = decodeURI(location.search);
+  const searchValues = qs.parse(locationSearchDecoded);
   // @ts-expect-error TS(2345): Argument of type 'string | string[] | ParsedQs | P... Remove this comment to see the full error message
   const runUuids = JSON.parse(searchValues['?runs']);
   // @ts-expect-error TS(2345): Argument of type 'string | string[] | ParsedQs | P... Remove this comment to see the full error message

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
@@ -63,13 +63,17 @@ class CompareRunPageImpl extends Component<CompareRunPageProps> {
   }
 }
 
+/**
+ * When integrated via IFrame in Kubeflow it re-encodes the URI (sometimes multiple times), leading to an unparsable JSON.
+ * This function decodes the URI until it is parsable.
+ */
 const decodeURI = (uri: string): string => {
   const decodedURI = decodeURIComponent(uri);
   if (uri !== decodedURI) {
     return decodeURI(decodedURI);
   }
   return decodedURI;
-}
+};
 
 const mapStateToProps = (state: any, ownProps: WithRouterNextProps) => {
   const { location } = ownProps;


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/cgilviadee/mlflow/pull/12663?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12663/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12663
```

</p>
</details>

A lot of projects nowadays are combining MLflow and Kubeflow to get the best of both worlds. When integrating MLflow into the Kubeflow dashboard there is a bug that breaks the compare runs feature. The log says  "Unexpected token '%', "[%2248f495a"... is not valid JSON". I guess the culprit behind this is the iframe. The paramters get re-encoded (sometimes multiple times over). I am not too sure if this is the right place to put it, but it fixes the bug for me.

### Related Issues/PRs

Resolve  #12657

### What changes are proposed in this pull request?

Fix "Unexpected token '%', "[%2248f495a"... is not a valid JSON" error. Making MLflow more robust.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. 

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
