### PR TITLE
Implement autologging (tracing-only) for llama-index

### DIFF
--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -340,6 +340,7 @@ def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
 
 @experimental
 def autolog(
+    log_traces: bool = True,
     disable: bool = False,
     silent: bool = False,
 ):
@@ -348,6 +349,9 @@ def autolog(
     only supports autologging for tracing.
 
     Args:
+        log_traces: If ``True``, traces are logged for Langchain models by using
+            MlflowLangchainTracer as a callback during inference. If ``False``, no traces are
+            collected during inference. Default to ``True``.
         disable: If ``True``, disables the llama_index autologging integration. If ``False``,
             enables the llama_index autologging integration.
         silent: If ``True``, suppress all event logs and warnings from MLflow during LlamaIndex
@@ -357,10 +361,10 @@ def autolog(
     # caveat is that the wrapped function is NOT executed when disable=True is passed. This prevents
     # us from running cleaning up logging when autologging is turned off. To workaround this, we
     # annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
-    if disable:
-        remove_llama_index_tracer()
-    else:
+    if log_traces and not disable:
         set_llama_index_tracer()
+    else:
+        remove_llama_index_tracer()
 
     _autolog(disable=disable, silent=silent)
 

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -47,7 +47,7 @@ def set_llama_index_tracer():
 
     span_handler = None
     for handler in dsp.span_handlers:
-        if handler.class_name() == "MlflowSpanHandler":
+        if isinstance(handler, MlflowSpanHandler):
             _logger.debug("MlflowSpanHandler is already set to the dispatcher. Skip setting.")
             span_handler = handler
             break
@@ -56,7 +56,7 @@ def set_llama_index_tracer():
         dsp.add_span_handler(span_handler)
 
     for handler in dsp.event_handlers:
-        if handler.class_name() == "MlflowEventHandler":
+        if isinstance(handler, MlflowEventHandler):
             _logger.debug("MlflowEventHandler is already set to the dispatcher. Skip setting.")
             break
     else:

--- a/tests/llama_index/test_llama_index_autolog.py
+++ b/tests/llama_index/test_llama_index_autolog.py
@@ -1,0 +1,77 @@
+from unittest import mock
+
+from llama_index.core.instrumentation import get_dispatcher
+from llama_index.core.instrumentation.event_handlers.base import BaseEventHandler
+from llama_index.core.instrumentation.span_handlers.base import BaseSpanHandler
+from llama_index.llms.openai import OpenAI
+
+import mlflow
+
+from tests.llama_index.test_llama_index_tracer import _get_all_traces
+
+
+def test_autolog_enable_tracing(multi_index):
+    mlflow.llama_index.autolog()
+
+    query_engine = multi_index.as_query_engine()
+
+    query_engine.query("Hello")
+    query_engine.query("Hola")
+
+    traces = _get_all_traces()
+    assert len(traces) == 2
+
+    # Enabling autolog multiple times should not create duplicate spans
+    mlflow.llama_index.autolog()
+    mlflow.llama_index.autolog()
+
+    chat_engine = multi_index.as_chat_engine()
+    chat_engine.chat("Hello again!")
+
+    assert len(_get_all_traces()) == 3
+
+    mlflow.llama_index.autolog(disable=True)
+    query_engine.query("Hello again!")
+
+    traces = _get_all_traces()
+    assert len(_get_all_traces()) == 3
+
+
+def test_autolog_preserve_user_provided_handlers():
+    user_span_handler = mock.MagicMock(spec=BaseSpanHandler)
+    user_event_handler = mock.MagicMock(spec=BaseEventHandler)
+
+    dsp = get_dispatcher()
+    dsp.add_span_handler(user_span_handler)
+    dsp.add_event_handler(user_event_handler)
+
+    mlflow.llama_index.autolog()
+
+    llm = OpenAI()
+    llm.complete("Hello")
+
+    assert user_span_handler in dsp.span_handlers
+    assert user_event_handler in dsp.event_handlers
+    user_span_handler.span_enter.assert_called_once()
+    user_span_handler.span_exit.assert_called_once()
+    assert user_event_handler.handle.call_count == 2  # LLM start + end
+
+    traces = _get_all_traces()
+    assert len(traces) == 1
+
+    user_span_handler.reset_mock()
+    user_event_handler.reset_mock()
+
+    mlflow.llama_index.autolog(disable=True)
+
+    assert user_span_handler in dsp.span_handlers
+    assert user_event_handler in dsp.event_handlers
+
+    llm.complete("Hello, again!")
+
+    user_span_handler.span_enter.assert_called_once()
+    user_span_handler.span_exit.assert_called_once()
+    assert user_event_handler.handle.call_count == 2
+
+    traces = _get_all_traces()
+    assert len(traces) == 1

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -9,7 +9,6 @@ from llama_index.agent.openai import OpenAIAgent
 from llama_index.core import (
     Settings,
 )
-from llama_index.core.instrumentation import get_dispatcher
 from llama_index.core.llms import ChatMessage, ChatResponse
 from llama_index.core.retrievers import VectorIndexRetriever
 from llama_index.core.tools import FunctionTool
@@ -20,25 +19,17 @@ import mlflow
 from mlflow.entities.span import SpanType
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_status import TraceStatus
-from mlflow.llama_index.tracer import MlflowEventHandler, MlflowSpanHandler
+from mlflow.llama_index.tracer import remove_llama_index_tracer, set_llama_index_tracer
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 
 
 @pytest.fixture(autouse=True)
 def set_handlers():
-    span_handler = MlflowSpanHandler(mlflow.MlflowClient())
-    event_handler = MlflowEventHandler(span_handler)
-
-    dsp = get_dispatcher()
-    dsp.add_span_handler(span_handler)
-    dsp.add_event_handler(event_handler)
-
+    set_llama_index_tracer()
     yield
-
     # Clean up
-    dsp.span_handlers = []
-    dsp.event_handlers = []
+    remove_llama_index_tracer()
 
 
 def _get_all_traces() -> List[Trace]:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12677?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12677/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12677
```

</p>
</details>

### What changes are proposed in this pull request?

Implement barebone autologging support (only tracing) for llama-index. Since tracer (i.e. span/event handlers) is managed via global variable in llama index, we don't need to patch or inject function calls.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Testing the tracing functionality in staging.
![Screenshot 2024-07-16 at 15 21 40](https://github.com/user-attachments/assets/4aec45f7-256e-43d3-947b-d095a071d9f8)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Will file a PR for the main documentation page today.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
