### PR TITLE
Do not remove UC volume that stores model artifacts when creating a model version

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -96,6 +96,7 @@ from mlflow.utils.rest_utils import (
     http_request,
     verify_rest_response,
 )
+from mlflow.utils.uri import _is_uc_volumes_path
 
 _TRACKING_METHOD_TO_INFO = extract_api_info_for_service(MlflowService, _REST_API_PATH_PREFIX)
 _METHOD_TO_INFO = extract_api_info_for_service(UcModelRegistryService, _REST_API_PATH_PREFIX)
@@ -661,16 +662,13 @@ class UcModelRegistryStore(BaseRestStore):
 
     @contextmanager
     def _local_model_dir(self, source, local_model_path):
-        print("local_model_model", local_model_path)  # noqa: T201
         if local_model_path is not None:
             yield local_model_path
         else:
             try:
-                print("source", source)  # noqa: T201
                 local_model_dir = mlflow.artifacts.download_artifacts(
                     artifact_uri=source, tracking_uri=self.tracking_uri
                 )
-                print("successfully downloaded", local_model_dir)  # noqa: T201
             except Exception as e:
                 raise MlflowException(
                     f"Unable to download model artifacts from source artifact location "
@@ -678,13 +676,15 @@ class UcModelRegistryStore(BaseRestStore):
                     f"the source artifact location exists and that you can download from "
                     f"it via mlflow.artifacts.download_artifacts()"
                 ) from e
-            # Clean up temporary model directory at end of block. We assume a temporary
-            # model directory was created if the `source` is not a local path (must be downloaded
-            # from remote to a temporary directory)
-            yield local_model_dir
-            if not os.path.exists(source):
-                print("cleaning up tmp_path", local_model_dir)  # noqa: T201
-                shutil.rmtree(local_model_dir)
+            try:
+                yield local_model_dir
+            finally:
+                # Clean up temporary model directory at end of block. We assume a temporary
+                # model directory was created if the `source` is not a local path
+                # (must be downloaded from remote to a temporary directory) and
+                # `local_model_dir` is not a UC volumes path
+                if not os.path.exists(source) and not _is_uc_volumes_path(local_model_dir):
+                    shutil.rmtree(local_model_dir)
 
     def create_model_version(
         self,

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -661,10 +661,12 @@ class UcModelRegistryStore(BaseRestStore):
 
     @contextmanager
     def _local_model_dir(self, source, local_model_path):
+        print("local_model_model", local_model_path)  # noqa: T201
         if local_model_path is not None:
             yield local_model_path
         else:
             try:
+                print("source", source)  # noqa: T201
                 local_model_dir = mlflow.artifacts.download_artifacts(
                     artifact_uri=source, tracking_uri=self.tracking_uri
                 )

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -670,6 +670,7 @@ class UcModelRegistryStore(BaseRestStore):
                 local_model_dir = mlflow.artifacts.download_artifacts(
                     artifact_uri=source, tracking_uri=self.tracking_uri
                 )
+                print("successfully downloaded", local_model_dir)  # noqa: T201
             except Exception as e:
                 raise MlflowException(
                     f"Unable to download model artifacts from source artifact location "

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -683,6 +683,7 @@ class UcModelRegistryStore(BaseRestStore):
             # from remote to a temporary directory)
             yield local_model_dir
             if not os.path.exists(source):
+                print("cleaning up tmp_path", local_model_dir)  # noqa: T201
                 shutil.rmtree(local_model_dir)
 
     def create_model_version(

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -105,12 +105,16 @@ def is_fuse_or_uc_volumes_uri(uri):
     )
 
 
-def is_uc_volumes_uri(uri):
+def _is_uc_volumes_path(path: str) -> bool:
+    return re.match(r"^/[vV]olumes?/", path) is not None
+
+
+def is_uc_volumes_uri(uri: str) -> bool:
     parsed_uri = urllib.parse.urlparse(uri)
-    return parsed_uri.scheme == "dbfs" and bool(re.match(r"^/[vV]olumes?/", parsed_uri.path))
+    return parsed_uri.scheme == "dbfs" and _is_uc_volumes_path(parsed_uri.path)
 
 
-def is_valid_uc_volumes_uri(uri):
+def is_valid_uc_volumes_uri(uri: str) -> bool:
     parsed_uri = urllib.parse.urlparse(uri)
     return parsed_uri.scheme == "dbfs" and bool(
         re.match(r"^/[vV]olumes?/[^/]+/[^/]+/[^/]+/[^/]+", parsed_uri.path)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12678?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12678/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12678
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #12545 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for the following use case where `register_model` follows `log_model`:

```python
EXP_NAME = "/Users/foo.bar@databricks.com/experiment"
CATALOG = "my-catalog"
SCHEMA = "my-schema"
VOLUME = "my-volue"
ARTIFACT_PATH = f"dbfs:/Volumes/{CATALOG}/{SCHEMA}/{VOLUME}"

mlflow.set_tracking_uri("databricks")
mlflow.set_registry_uri("databricks-uc")

if mlflow.get_experiment_by_name(EXP_NAME) is None:
    mlflow.create_experiment(name=EXP_NAME, artifact_location=ARTIFACT_PATH)
mlflow.set_experiment(EXP_NAME)

model_info = mlflow.sklearn.log_model(
    model,
    "model",
    signature=signature,
)

# On master branch, this line removes the model artifacts stored in the volume
# after completing model registration. The model artifacts must be preserved.
mlflow.register_model(model_info.model_uri, f"{CATALOG}.{SCHEMA}.my-model")
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
