### PR TITLE
Improve Java's fluent API ergonomics for creating nested runs 

### DIFF
--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/ActiveRunTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/ActiveRunTest.java
@@ -188,6 +188,34 @@ public class ActiveRunTest {
   }
 
   @Test
+  public void testWithActiveChildRun() {
+    ActiveRun activeRun = getActiveRun();
+
+    when(mockClient.createRun(any(CreateRun.class)))
+      .thenReturn(RunInfo.newBuilder().setRunId("test-id").build());
+
+    activeRun.withActiveChildRun("apple", activeChildRun -> {
+      assertEquals(activeChildRun.getId(), "test-id");
+    });
+    verify(mockClient).createRun(any(CreateRun.class));
+    verify(mockClient).setTerminated(any(), any());
+  }
+
+  @Test
+  public void testWithChildActiveRunNoRunName() {
+    ActiveRun activeRun = getActiveRun();
+
+    when(mockClient.createRun(any(CreateRun.class)))
+      .thenReturn(RunInfo.newBuilder().setRunId("test-id").build());
+
+    activeRun.withActiveChildRun("apple", activeChildRun -> {
+      assertEquals(activeChildRun.getId(), "test-id");
+    });
+    verify(mockClient).createRun(any(CreateRun.class));
+    verify(mockClient).setTerminated(any(), any());
+  }
+
+  @Test
   public void testEndRun() {
     ActiveRun activeRun = getActiveRun();
     activeRun.endRun();


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/JD557/mlflow/pull/12683?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12683/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12683
```

</p>
</details>

### Related Issues/PRs

(None that I could find)

### What changes are proposed in this pull request?

Currently, in the Java fluent API, creating nested runs is a bit cumbersome:
- There's no way to create a nested run with `MlflowContext#withActiveRun`
- `MlflowContext#startRun(runName, parentRunId)` takes a `parentRunId`, which can be a bit error prone (being a `String`), especially when we probably created the parent run and have it around anyway.

To address this, this PR adds `ActiveRun#startChildRun` and `ActiveRun#withChildActiveRun` (I'm a bit unsure about the name... maybe the `Child` part was not needed), to make the nesting a bit cleaner and closer to the Python API.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds `ActiveRun#startChildRun` and `ActiveRun#withChildActiveRun` to the Java fluent API to create nested runs.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [x] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
