### PR TITLE
Initial commit (and 3 lines of cleanup)

### DIFF
--- a/mlflow/llama_index/serialize_objects.py
+++ b/mlflow/llama_index/serialize_objects.py
@@ -155,10 +155,11 @@ def _serialize_dict_of_objects(dict_of_objects: Dict[str, object], path: str) ->
         else:
             to_serialize.update({k: object_json})
 
-    _logger.info(
-        "Serialization of the following objects are not supported and will not be logged with "
-        f"your model: {', '.join(unsupported_objects)}"
-    )
+    if unsupported_objects:
+        _logger.info(
+            "Serialization of the following objects are not supported and will not be logged with "
+            f"your model: {', '.join(unsupported_objects)}"
+        )
 
     with open(path, "w") as f:
         json.dump(to_serialize, f, indent=2)

--- a/mlflow/llama_index/serialize_objects.py
+++ b/mlflow/llama_index/serialize_objects.py
@@ -11,8 +11,6 @@ from mlflow.exceptions import INTERNAL_ERROR, MlflowException
 
 _logger = logging.getLogger(__name__)
 
-# TODO: add versioning to the map
-# TODO: think about hierarchy of objects
 OBJECT_DICT_METHOD_MAP = {
     llama_index.core.base.llms.base.BaseLLM: ("to_dict", "from_dict"),
     llama_index.core.base.embeddings.base.BaseEmbedding: ("to_dict", "from_dict"),
@@ -72,7 +70,6 @@ def object_to_dict(o: object) -> None:
         o_state_as_dict = _sanitize_api_key(o_state_as_dict)
         o_state_as_dict.pop("class_name")
     else:
-        _logger.warning(f"Skipping serialization of {o} because...")
         return o_state_as_dict
 
     return {
@@ -148,16 +145,20 @@ def _deserialize_dict_of_objects(path: str) -> Dict[str, any]:
 
 def _serialize_dict_of_objects(dict_of_objects: Dict[str, object], path: str) -> None:
     to_serialize = {}
+    unsupported_objects = []
 
     for k, v in dict_of_objects.items():
         object_json = [object_to_dict(vv) for vv in v] if isinstance(v, list) else object_to_dict(v)
 
         if object_json == {}:
-            _logger.info(
-                f"{k} serialization is not supported. It will not be logged with your model"
-            )
+            unsupported_objects.append(k)
         else:
             to_serialize.update({k: object_json})
+
+    _logger.info(
+        "Serialization of the following objects are not supported and will not be logged with "
+        f"your model: {', '.join(unsupported_objects)}"
+    )
 
     with open(path, "w") as f:
         json.dump(to_serialize, f, indent=2)
@@ -176,5 +177,3 @@ def deserialize_settings(path: str):
 
     for k, v in settings_dict.items():
         setattr(Settings, k, v)
-
-    return Settings


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/michael-berk/mlflow/pull/12684?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12684/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12684
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
* Fix logging
* Remove `Settings` return from deserialize - it shuold only be accessed via import
* Remove comments

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
