### PR TITLE
Condense mimebundle serialization for traces

### DIFF
--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -14,7 +14,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 # for databricks notebooks. For traces above this size, we will only
 # serialize the trace info, and the notebook cell renderer will fetch
 # the data asynchronously using the request ID.
-MAX_TRACE_JSON_SIZE_BYTES = 100000  # 100 KB
+MAX_TRACE_JSON_SIZE_BYTES = 100_000  # 100 KB
 
 
 @dataclass

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -68,7 +68,14 @@ class Trace(_MlflowObject):
         in Databricks notebooks to display the Trace object in a nicer UI.
         """
         return {
-            "application/databricks.mlflow.trace": self.info.request_id,
+            # databricks notebooks will use the request ID to
+            # fetch the trace from the backend. including the
+            # full JSON can cause notebooks to exceed size limits
+            "application/databricks.mlflow.traceId": json.dumps(
+                {
+                    "request_id": self.info.request_id,
+                }
+            ),
             "text/plain": self.__repr__(),
         }
 

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -64,7 +64,7 @@ class Trace(_MlflowObject):
         # databricks notebooks will use the request ID to
         # fetch the trace from the backend. including the
         # full JSON can cause notebooks to exceed size limits
-        return json.dumps({"request_id": self.info.request_id})
+        return json.dumps(self.info.request_id)
 
     def _repr_mimebundle_(self, include=None, exclude=None):
         """

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -71,11 +71,7 @@ class Trace(_MlflowObject):
             # databricks notebooks will use the request ID to
             # fetch the trace from the backend. including the
             # full JSON can cause notebooks to exceed size limits
-            "application/databricks.mlflow.traceId": json.dumps(
-                {
-                    "request_id": self.info.request_id,
-                }
-            ),
+            "application/databricks.mlflow.traceId": json.dumps(self.info.to_dict()),
             "text/plain": self.__repr__(),
         }
 

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -23,6 +23,9 @@ class Trace(_MlflowObject):
     info: TraceInfo
     data: TraceData
 
+    def __repr__(self) -> str:
+        return f"Trace(request_id={self.info.request_id})"
+
     def to_dict(self) -> Dict[str, Any]:
         return {"info": self.info.to_dict(), "data": self.data.to_dict()}
 

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -64,9 +64,12 @@ class Trace(_MlflowObject):
         return cls.from_dict(trace_dict)
 
     def _serialize_for_mimebundle(self) -> str:
+        from mlflow.tracing.utils import TraceJSONEncoder
+
         json_str = self.to_json()
         if len(json_str.encode("utf-8")) >= MAX_TRACE_JSON_SIZE_BYTES:
-            return json.dumps(self.info.to_dict())
+            return json.dumps(self.info.to_dict(), cls=TraceJSONEncoder)
+
         return json_str
 
     def _repr_mimebundle_(self, include=None, exclude=None):

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -71,7 +71,7 @@ class Trace(_MlflowObject):
             # databricks notebooks will use the request ID to
             # fetch the trace from the backend. including the
             # full JSON can cause notebooks to exceed size limits
-            "application/databricks.mlflow.traceId": json.dumps(self.info.to_dict()),
+            "application/databricks.mlflow.trace": json.dumps(self.info.to_dict()),
             "text/plain": self.__repr__(),
         }
 

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -68,7 +68,7 @@ class Trace(_MlflowObject):
         in Databricks notebooks to display the Trace object in a nicer UI.
         """
         return {
-            "application/databricks.mlflow.trace": self.to_json(),
+            "application/databricks.mlflow.trace": self.info.request_id,
             "text/plain": self.__repr__(),
         }
 

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -14,7 +14,7 @@ def _serialize_trace_list(traces: List[Trace]):
         # we can't just call trace.to_json() because this
         # will cause the trace to be serialized twice (once
         # by to_json and once by json.dumps)
-        [json.loads(trace.to_json()) for trace in traces]
+        [json.loads(trace._serialize_for_mimebundle()) for trace in traces]
     )
 
 

--- a/tests/tracing/display/test_ipython.py
+++ b/tests/tracing/display/test_ipython.py
@@ -143,9 +143,9 @@ def test_display_deduplicates_traces(monkeypatch):
     assert mock_display.call_count == 1
     assert mock_display.call_args[0][0] == {
         "application/databricks.mlflow.trace": json.dumps(
-            [json.loads(t.to_json()) for t in expected]
+            [json.loads(t._serialize_for_mimebundle()) for t in expected]
         ),
-        "text/plain": expected.__repr__(),
+        "text/plain": repr(expected),
     }
 
 
@@ -168,8 +168,8 @@ def test_display_respects_max_limit(monkeypatch):
 
     assert mock_display.call_count == 1
     assert mock_display.call_args[0][0] == {
-        "application/databricks.mlflow.trace": trace_a.to_json(),
-        "text/plain": trace_a.__repr__(),
+        "application/databricks.mlflow.trace": trace_a._serialize_for_mimebundle(),
+        "text/plain": repr(trace_a),
     }
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/12685?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12685/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12685
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR detects if a JSON-ified trace will be larger than 100kb, and if so, only serialize the trace info.

In databricks notebooks, if the frontend detects that only the trace info is present, it will asynchronously fetch the trace data from the backend.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
