### PR TITLE
Implemented GPU metrics for AMD/HIP GPUs

### DIFF
--- a/mlflow/system_metrics/metrics/rocm_monitor.py
+++ b/mlflow/system_metrics/metrics/rocm_monitor.py
@@ -1,0 +1,86 @@
+"""Class for monitoring GPU stats on HIP devices.
+Inspired by GPUMonitor, but with the pynvml method
+named replaced by pyrsmi method names
+"""
+
+import logging
+import sys
+
+from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from pyrsmi import rocml
+except ImportError:
+    # If `pyrsmi` is not installed, a warning will be logged at monitor instantiation.
+    # We don't log a warning here to avoid spamming warning at every import.
+    pass
+
+class ROCMMonitor(BaseMetricsMonitor):
+    """
+        Class for monitoring AMD GPU stats. This is
+        class has been modified and has been inspired by
+        the original GPUMonitor class written by MLflow.
+        This class uses the package pyrsmi which is an
+        offical ROCM python package which tracks and monitor
+        AMD GPU's, has been tested on AMD MI250x 128GB GPUs
+
+        For more information see:
+        https://github.com/ROCm/pyrsmi
+
+        PyPi package:
+        https://pypi.org/project/pyrsmi/
+
+
+    """
+
+    def __init__(self):
+        if "pyrsmi" not in sys.modules:
+            # Only instantiate if `pyrsmi` is installed.
+            raise ImportError(
+                "`pyrsmi` is not installed, to log GPU metrics please run `pip install pyrsmi` "
+                "to install it."
+            )
+
+        try:
+            rocml.smi_initialize()
+        except:
+            raise RunTimeError("Failed to initialize RSMI, skip logging GPU metrics")
+
+        super().__init__()
+
+    def collect_metrics(self):
+        # Get GPU metrics.
+        self.num_gpus = rocml.smi_get_device_count()
+
+        for i in range(self.num_gpus):
+            memory_used  = rocml.smi_get_device_memory_used(i)
+            memory_total = rocml.smi_get_device_memory_total(i)
+            self._metrics[f"gpu_{i}_memory_usage_percentage"].append(
+                round(memory_used / memory_total * 100, 1)
+            )
+            self._metrics[f"gpu_{i}_memory_usage_gigabytes"].append(memory_used / 1e9)
+
+            device_utilization = rocml.smi_get_device_utilization(i)
+            self._metrics[f"gpu_{i}_utilization_percentage"].append(device_utilization)
+
+            power_watts = rocml.smi_get_device_average_power(i)
+            power_capacity_watts = 500  # hard coded for now, should get this from rocm-smi
+            self._metrics[f"gpu_{i}_power_usage_watts"].append(power_watts)
+            self._metrics[f"gpu_{i}_power_usage_percentage"].append(
+                (power_watts / power_capacity_watts) * 100
+            )
+
+            # TODO:
+            # memory_busy (and other useful metrics) are available in pyrsmi>1.1.0.
+            # We are currently on pyrsmi==1.0.1, so these are not available
+            #memory_busy  = rocml.smi_get_device_memory_busy(i)
+            #self._metrics[f"gpu_{i}_memory_busy_time_percent"].append(memory_busy)
+
+    def aggregate_metrics(self):
+        return {k: round(sum(v) / len(v), 1) for k, v in self._metrics.items()}
+
+    def __del__(self):
+        rocml.smi_shutdown()
+


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/evenmn/mlflow/pull/12693?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12693/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12693
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Implemented a new monitor for AMD GPU metrics (ROCMMonitor), based on the existing GPUMonitor class
- Added an if-test in system_metrics_monitor.py which ensures that we fall back on the ROCMMonitor if AMD GPUs exist, but not NVIDIA GPUs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

![Screenshot from 2024-07-16 10-13-05](https://github.com/user-attachments/assets/746c7deb-c84b-4808-b431-6b7946aacd4d)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

The maximum power per GPU is hard-coded as it was not possible to get this from `pyrsmi` (even though it is found in `rocm-smi`). We used 500W, which is the maximum watt for AMD Mi250X GPUs. For other GPUs with other maximum power values, the power usage in percentage will be wrong.

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
