### PR TITLE
Infer requirements

### DIFF
--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -57,7 +57,7 @@ def get_default_pip_requirements():
         Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
         that, at a minimum, contains these requirements.
     """
-    return [_get_pinned_requirement("llama_index")]
+    return [_get_pinned_requirement("llama-index")]
 
 
 def get_default_conda_env():
@@ -190,6 +190,12 @@ def save_model(
         default_reqs = None
         if pip_requirements is None:
             default_reqs = get_default_pip_requirements()
+            inferred_reqs = mlflow.models.infer_pip_requirements(
+                str(path), FLAVOR_NAME, fallback=default_reqs
+            )
+            default_reqs = sorted(set(inferred_reqs).union(default_reqs))
+        else:
+            default_reqs = None
         conda_env, pip_requirements, pip_constraints = _process_pip_requirements(
             default_reqs,
             pip_requirements,

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -710,7 +710,11 @@ llama_index:
     minimum: "0.10.0"
     maximum: "0.10.53"
     requirements:
-      ">= 0.0.0": ["llama-index", "openai"]
+      ">= 0.0.0": [
+          "openai",
+          # Required to test Databricks LLMs
+          "llama-index-llms-databricks",
+        ]
     run:
       # TODO: Add --ignore flag for autologging test once it's implemented
       pytest tests/llama_index

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -197,6 +197,15 @@ def _prune_packages(packages):
     """
     packages = set(packages)
     requires = set(_flatten(map(_get_requires_recursive, packages)))
+
+    # LlamaIndex have one root "llama-index" package that bundles many sub-packages such as
+    # llama-index-llms-openai. Many of those sub-packages are optional, but some are defined
+    # as dependencies of the root package. However, the root package does not pin the versions
+    # for those sub-packages, resulting in non-deterministic behavior when loading the model
+    # later. To address this issue, we keep all sub-packages within the requirements.
+    # Ref: https://github.com/run-llama/llama_index/issues/14788#issuecomment-2232107585
+    requires = {req for req in requires if not req.startswith("llama-index-")}
+
     # Do not exclude mlflow's dependencies
     return packages - (requires - set(_get_requires("mlflow")))
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12695?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12695/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12695
```

</p>
</details>

### What changes are proposed in this pull request?

Update LlamaIndex model saving logic to do requirement inference. Current implementation always use default requirement. Indeed, requirement inference for LlamaIndex is tricky because they have >100 sub packages and all of them. And the particular issue for us is about **dependency pruning**.

When inferring the dependencies, we prune the list of captured packages by recursively removing transitive dependencies. For example, if package A, B, C is captured and C is dependency of A, we only declare A and B as model dependency, as C will be installed along with A anyway. 

However, this is problematic for llama index, where the root package declares some core packages as dependencies but does not pin versions for all of them. As a result, it can install whatever latest version of sub packages and cause unexpected compatibility errors.

As a tangible solution, this PR prevent LlamaIndex sub packages from being pruned. Those sub packages will be listed as dependencies with fixed versions. This aligns with the recommendation from the LlamaIndex team. https://github.com/run-llama/llama_index/issues/14788#issuecomment-2232107585

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (WIP)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
