### PR TITLE
Fix thread-safety of LangChain tracer

### DIFF
--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -31,6 +31,9 @@ from langchain.embeddings.base import Embeddings
 from langchain.embeddings.fake import FakeEmbeddings
 from langchain.evaluation.qa import QAEvalChain
 
+from mlflow.tracing.export.inference_table import pop_trace
+from mlflow.tracing.provider import reset_tracer_setup
+
 from tests.tracing.helper import get_traces
 
 try:
@@ -2430,7 +2433,7 @@ def _get_message_content(predictions):
         ),
     ],
 )
-def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config):
+def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config, monkeypatch):
     input_example = {
         "messages": [
             {
@@ -2501,6 +2504,12 @@ def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config
             }
         ]
     }
+
+    # Emulate the model serving environment
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("ENABLE_MLFLOW_TRACING", "true")
+    reset_tracer_setup()
+
     request_id = "mock_request_id"
     tracer = MlflowLangchainTracer(prediction_context=Context(request_id))
     input_example = {"messages": [{"role": "user", "content": "What is MLflow?"}]}
@@ -2508,8 +2517,8 @@ def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config
         data=input_example, callback_handlers=[tracer]
     )
     assert response["choices"][0]["message"]["content"] == "Databricks"
-    trace = mlflow.get_trace(tracer._request_id)
-    assert trace.info.tags[DependenciesSchemasType.RETRIEVERS.value] == json.dumps(
+    trace = pop_trace(request_id)
+    assert trace["info"]["tags"][DependenciesSchemasType.RETRIEVERS.value] == json.dumps(
         [
             {
                 "doc_uri": "doc-uri",

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -1,3 +1,5 @@
+import random
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List, Optional
@@ -508,6 +510,8 @@ def test_tracer_thread_safe():
         tracer.on_chain_start(
             {}, {"input": "test input"}, run_id=chain_run_id, name=f"chain_{worker_id}"
         )
+        # wait for a random time (0.5 ~ 1s) to simulate real-world scenario
+        time.sleep(random.random() / 2 + 0.5)
         tracer.on_chain_end({"output": "test output"}, run_id=chain_run_id)
 
     with ThreadPoolExecutor(max_workers=10) as executor:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12701?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12701/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12701
```

</p>
</details>

### Related Issues/PRs

Resolve https://github.com/mlflow/mlflow/issues/12669

### What changes are proposed in this pull request?

https://github.com/mlflow/mlflow/pull/12049 added an instance variable `_root_run_id` to keep track of active root run ID for a trace. However, this breaks thread safety as the tracer can handle multiple traces in parallel i.e. there are multiple active root IDs at the same time.

This PR updates the logic to hold a set of active request IDs (root run ID and request ID is guaranteed to be 1-to-1 mapping).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Validated that the reported issue doesn't occur with the new implementation (with 10 concurrency).

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix thread-safety issue of LangChain tracer, updating the tracer to work with `.batch` call properly.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
