### PR TITLE
Add ApiError into GraphQL schema

### DIFF
--- a/dev/proto_to_graphql/code_generator.py
+++ b/dev/proto_to_graphql/code_generator.py
@@ -16,6 +16,7 @@ class GenerateSchemaState:
         self.queries = set()  # method_descriptor
         self.mutations = set()  # method_descriptor
         self.inputs = []  # field_descriptor
+        self.outputs = set()  # field_descriptor
         self.types = []  # field_descriptor
         self.enums = set()  # enum_descriptor
         self.method_names = set()  # package_name_method_name

--- a/dev/proto_to_graphql/parsing_utils.py
+++ b/dev/proto_to_graphql/parsing_utils.py
@@ -26,6 +26,7 @@ def process_method(method_descriptor, state):
             state.queries.add(method_descriptor)
         else:
             state.mutations.add(method_descriptor)
+        state.outputs.add(method_descriptor.output_type)
         populate_message_types(method_descriptor.input_type, state, True, set())
         populate_message_types(method_descriptor.output_type, state, False, set())
 

--- a/dev/proto_to_graphql/schema_autogeneration.py
+++ b/dev/proto_to_graphql/schema_autogeneration.py
@@ -84,6 +84,7 @@ def generate_schema(state):
     schema_builder += "import graphene\n"
     schema_builder += "import mlflow\n"
     schema_builder += "from mlflow.server.graphql.graphql_custom_scalars import LongString\n"
+    schema_builder += "from mlflow.server.graphql.graphql_errors import ApiError\n"
     schema_builder += "from mlflow.utils.proto_json_utils import parse_dict\n"
     schema_builder += "\n"
 
@@ -102,6 +103,9 @@ def generate_schema(state):
         for field in type.fields:
             graphene_type = get_graphene_type_for_field(field, False)
             schema_builder += f"\n{INDENT}{camel_to_snake(field.name)} = {graphene_type}"
+
+        if type in state.outputs:
+            schema_builder += f"\n{INDENT}apiError = graphene.Field(ApiError)"
 
         if len(type.fields) == 0:
             schema_builder += f"\n{INDENT}{DUMMY_FIELD}"

--- a/mlflow/server/graphql/autogenerated_graphql_schema.py
+++ b/mlflow/server/graphql/autogenerated_graphql_schema.py
@@ -3,6 +3,7 @@
 import graphene
 import mlflow
 from mlflow.server.graphql.graphql_custom_scalars import LongString
+from mlflow.server.graphql.graphql_errors import ApiError
 from mlflow.utils.proto_json_utils import parse_dict
 
 
@@ -51,6 +52,7 @@ class MlflowModelVersion(graphene.ObjectType):
 class MlflowSearchModelVersionsResponse(graphene.ObjectType):
     model_versions = graphene.List(graphene.NonNull(MlflowModelVersion))
     next_page_token = graphene.String()
+    apiError = graphene.Field(ApiError)
 
 
 class MlflowDatasetSummary(graphene.ObjectType):
@@ -62,6 +64,7 @@ class MlflowDatasetSummary(graphene.ObjectType):
 
 class MlflowSearchDatasetsResponse(graphene.ObjectType):
     dataset_summaries = graphene.List(graphene.NonNull(MlflowDatasetSummary))
+    apiError = graphene.Field(ApiError)
 
 
 class MlflowMetricWithRunId(graphene.ObjectType):
@@ -74,6 +77,7 @@ class MlflowMetricWithRunId(graphene.ObjectType):
 
 class MlflowGetMetricHistoryBulkIntervalResponse(graphene.ObjectType):
     metrics = graphene.List(graphene.NonNull(MlflowMetricWithRunId))
+    apiError = graphene.Field(ApiError)
 
 
 class MlflowFileInfo(graphene.ObjectType):
@@ -86,6 +90,7 @@ class MlflowListArtifactsResponse(graphene.ObjectType):
     root_uri = graphene.String()
     files = graphene.List(graphene.NonNull(MlflowFileInfo))
     next_page_token = graphene.String()
+    apiError = graphene.Field(ApiError)
 
 
 class MlflowDataset(graphene.ObjectType):
@@ -156,10 +161,12 @@ class MlflowRun(graphene.ObjectType):
 class MlflowSearchRunsResponse(graphene.ObjectType):
     runs = graphene.List(graphene.NonNull('mlflow.server.graphql.graphql_schema_extensions.MlflowRunExtension'))
     next_page_token = graphene.String()
+    apiError = graphene.Field(ApiError)
 
 
 class MlflowGetRunResponse(graphene.ObjectType):
     run = graphene.Field('mlflow.server.graphql.graphql_schema_extensions.MlflowRunExtension')
+    apiError = graphene.Field(ApiError)
 
 
 class MlflowExperimentTag(graphene.ObjectType):
@@ -179,6 +186,7 @@ class MlflowExperiment(graphene.ObjectType):
 
 class MlflowGetExperimentResponse(graphene.ObjectType):
     experiment = graphene.Field(MlflowExperiment)
+    apiError = graphene.Field(ApiError)
 
 
 class MlflowSearchModelVersionsInput(graphene.InputObjectType):

--- a/mlflow/server/graphql/graphql_errors.py
+++ b/mlflow/server/graphql/graphql_errors.py
@@ -1,0 +1,15 @@
+import graphene
+
+
+class ErrorDetail(graphene.ObjectType):
+    # NOTE: This is not an exhaustive list, might need to add more things in the future if needed.
+    field = graphene.String()
+    message = graphene.String()
+
+
+class ApiError(graphene.ObjectType):
+    code = graphene.String()
+    message = graphene.String()
+    help_url = graphene.String()
+    trace_id = graphene.String()
+    error_details = graphene.List(ErrorDetail)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/edwardfeng-db/mlflow/pull/12702?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12702/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12702
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
- Adding `ApiError` into the repsonses of autogenerated graphql schema so that the schema matches that of the universe

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
