### PR TITLE
Resolve Embedding and Setting deserialization bug

### DIFF
--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -334,14 +334,14 @@ def load_model(model_uri, dst_path=None):
     settings_path = os.path.join(local_model_path, _SETTINGS_FILE)
     # NB: Settings is a singleton and can be loaded via llama_index.core.Settings
     deserialize_settings(settings_path)
-
     return _load_index(local_model_path, flavor_conf)
 
 
 def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
+    index = load_model(path)
     flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
     engine_type = flavor_conf.pop("engine_type")
-    return create_engine_wrapper(_load_index(path, flavor_conf), engine_type, model_config)
+    return create_engine_wrapper(index, engine_type, model_config)
 
 
 @experimental

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -710,8 +710,9 @@ llama_index:
     requirements:
       ">= 0.0.0": [
           "openai",
-          # Required to test Databricks LLMs
+          # Required to test Databricks integration
           "llama-index-llms-databricks",
+          "llama-index-embeddings-databricks",
         ]
     run:
       # TODO: Add --ignore flag for autologging test once it's implemented

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -1,8 +1,14 @@
+from typing import Any
+
 import numpy as np
 import pandas as pd
 import pytest
-from llama_index.core import QueryBundle, Settings
+from llama_index.core import QueryBundle, Settings, VectorStoreIndex
 from llama_index.core.llms import ChatMessage
+from llama_index.embeddings.databricks import DatabricksEmbedding
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.llms.databricks import Databricks
+from llama_index.llms.openai import OpenAI
 
 import mlflow
 import mlflow.llama_index
@@ -58,33 +64,6 @@ def test_llama_index_native_log_and_load_model(request, index_fixture):
     engine = loaded_model.as_query_engine()
     assert engine is not None
     assert engine.query("Spell llamaindex").response != ""
-
-
-def test_llama_index_requirement_inference(monkeypatch, single_index, model_path):
-    from llama_index.llms.databricks import Databricks
-
-    # NB: Setting Databricks LLM so that the subpackage llama-index-llms-databricks
-    #     will be inferred as a requirement. We don't have to set API keys here as
-    #     Databricks LLM class simply delegates the failed API calls to OpenAI,
-    #     which we have mocked with the fake local server.
-    monkeypatch.setattr(Settings, "llm", Databricks(model="dbrx-instruct"))
-
-    mlflow.llama_index.save_model(
-        single_index, path=model_path, input_example="hi", engine_type="query"
-    )
-
-    with model_path.joinpath("requirements.txt").open() as file:
-        requirements = file.read()
-    reqs = {req.split("==")[0] for req in requirements.split("\n") if requirements}
-    assert "llama-index" in reqs
-    # The subpackage should be listed as requirements while they are dependencies
-    # of the root "llama-index" package. This is to ensure that the version of
-    # the subpackage is fixed.
-    assert "llama-index-core" in reqs
-    assert "llama-index-llms-openai" in reqs
-
-    # Subpackage that is not declared as a dependency of the root package
-    assert "llama-index-llms-databricks" in reqs
 
 
 @pytest.mark.parametrize(
@@ -312,3 +291,50 @@ def test_retriever_engine_predict(single_index, with_input_example):
 
     predictions = model.predict(payload)
     assert all(p["class_name"] == "NodeWithScore" for p in predictions)
+
+
+def test_llama_index_databricks_integration(monkeypatch, document, model_path, mock_openai):
+    monkeypatch.setenvs({"DATABRICKS_TOKEN": "test", "DATABRICKS_SERVING_ENDPOINT": mock_openai})
+    monkeypatch.setattr(Settings, "llm", Databricks(model="dbrx-instruct"))
+    monkeypatch.setattr(
+        Settings, "embed_model", DatabricksEmbedding(model="databricks-bge-large-en")
+    )
+
+    index = VectorStoreIndex(nodes=[document])
+    mlflow.llama_index.save_model(index, path=model_path, input_example="hi", engine_type="query")
+
+    with model_path.joinpath("requirements.txt").open() as file:
+        requirements = file.read()
+    reqs = {req.split("==")[0] for req in requirements.split("\n") if requirements}
+    assert "llama-index" in reqs
+    # The subpackage should be listed as requirements while they are dependencies
+    # of the root "llama-index" package. This is to ensure that the version of
+    # the subpackage is fixed.
+    assert "llama-index-core" in reqs
+
+    # Subpackage that is not declared as a dependency of the root package
+    assert "llama-index-llms-databricks" in reqs
+    assert "llama-index-embeddings-databricks" in reqs
+
+    # Reset setting before loading back to validate the setting deserialization
+    class _FakeLLM(OpenAI):
+        def chat(self, *args, **kwargs: Any):
+            raise Exception("Should not be called")
+
+    class _FakeEmbedding(OpenAIEmbedding):
+        def _get_query_embedding(self, *args, **kwargs: Any):
+            raise Exception("Should not be called")
+
+    # Set dummy settings to validate the deserialization
+    monkeypatch.setattr(Settings, "llm", _FakeLLM())
+    monkeypatch.setattr(Settings, "embed_model", _FakeEmbedding())
+
+    # validate if the mocking works
+    with pytest.raises(Exception, match="Should not be called"):
+        index.as_query_engine().query("Spell llamaindex")
+
+    loaded_model = mlflow.pyfunc.load_model(model_path)
+
+    response = loaded_model.predict("Spell llamaindex")
+    assert isinstance(response, str)
+    assert response != ""


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12704?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12704/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12704
```

</p>
</details>

### What changes are proposed in this pull request?

While testing the flavor with Databricks LLMs/embeddings, found a few issues.
1. Embedding model cannot be instantiated due to an error `TypeError: pydantic.main.BaseModel.__init__() got multiple values for keyword argument 'model_name`. This is an inconsistency in LlamaIndex side where `BaseEmbedding` class has `model_name` as constructor argument while many implementation like `DatabricksEmbeddings` has `model`. It's not feasible to solve this for all community classes in llama index so we have to handle this in our logic.
2. Setting is not deserialized when loading pyfunc. It is deserialized when loading via `mlflow.llama_index.load_model`, but not via `mlflow.pyfunc.load_model`. This is because the `deserialize_settings()` is not called within `_load_pyfunc()`.

This PR fixes the both issues.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested index loading with `Databricks` LLM and `DatabricksEmbedding`.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
