### PR TITLE
Fix nested trace issue in LangChain tracer.

### DIFF
--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -175,9 +175,9 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
                 (active_span := mlflow.get_current_active_span())
                 and (active_span.request_id == request_id)
             )
-            # Case 3: The root span is created by client API outside this callback.
-            # In this case, we have no way to check if it is active so just assume
-            # it is active.
+            # Case 3: The root span is created by client API outside this callback,
+            # and passed via the `parent_span` argument of the callback. In this case,
+            # we have no way to check if it is active or not, so just assume it is.
             or self._parent_span
         )
 

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -138,11 +138,12 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
     ):
         """Close MLflow Span (or Trace if it is root component)"""
         self._run_span_mapping.pop(str(run_id), None)
-        if span.request_id not in self._active_request_ids:
-            # If the request ID is not found in the active list, it means that the trace is already
-            # ended i.e. a parent span ends earlier then its child. For example, this occurs during
-            # streaming inference if the generator returned by stream() is not consumed completely
-            # while the child span still wait until the stream is exhausted.
+
+        if not self._is_trace_active(span.request_id):
+            # A trace (root span) may be already ended i.e. a parent span ends earlier then its
+            # child. For example, this occurs during streaming inference if the generator
+            # returned by stream() is not consumed completely while the child span still
+            # wait until the stream is exhausted.
             _logger.debug(
                 f"Request ID {span.request_id} is not started or already ended. "
                 f"Skipping end span for {span}."
@@ -150,7 +151,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
             return
 
         # Remove the request ID from the active list if the span being ended is the root span
-        if span.parent_id is None:
+        if (span.parent_id is None) and (span.request_id in self._active_request_ids):
             self._active_request_ids.remove(span.request_id)
 
         with maybe_set_prediction_context(self._prediction_context):
@@ -161,6 +162,24 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
                 attributes=attributes,
                 status=status,
             )
+
+    def _is_trace_active(self, request_id: str) -> bool:
+        """Check if a trace with the given request ID is active (i.e. not ended yet)"""
+        return (
+            # Case 1: The root span is started by this callback, the ID
+            # should be in the active list, otherwise it's already ended.
+            request_id in self._active_request_ids
+            # Case 2: The root span is created by fluent API outside this callback.
+            # In this case, we check the context to see if the trace is active or not.
+            or (
+                (active_span := mlflow.get_current_active_span())
+                and (active_span.request_id == request_id)
+            )
+            # Case 3: The root span is created by client API outside this callback.
+            # In this case, we have no way to check if it is active so just assume
+            # it is active.
+            or self._parent_span
+        )
 
     def _reset(self):
         self._run_span_mapping = {}

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -594,3 +594,38 @@ def test_tracer_noop_when_tracing_disabled(monkeypatch):
     assert get_traces() == []
     # No warning should be issued
     mock_logger.warning.assert_not_called()
+
+
+def test_tracer_nested_trace():
+    # Validate if the callback works properly if it is used in a context
+    # of an active span created by MLflow fluent API.
+    llm = OpenAI(temperature=0.9)
+    prompt = PromptTemplate(
+        input_variables=["product"],
+        template="What is a good name for a company that makes {product}?",
+    )
+    chain = prompt | llm | StrOutputParser()
+
+    @mlflow.trace(name="parent", span_type="SPECIAL")
+    def run(message):
+        with _mock_request(return_value=_mock_chat_completion_response()):
+            return chain.invoke(message, config={"callbacks": [MlflowLangchainTracer()]})
+
+    response = run("MLflow")
+    expected_response = TEST_CONTENT
+    assert response == expected_response
+
+    trace = mlflow.get_last_active_trace()
+    assert trace is not None
+    spans = trace.data.spans
+    assert spans[0].name == "parent"
+    assert spans[0].attributes[SpanAttributeKey.SPAN_TYPE] == "SPECIAL"
+    assert spans[0].attributes[SpanAttributeKey.INPUTS] == {"message": "MLflow"}
+    assert spans[0].attributes[SpanAttributeKey.OUTPUTS] == TEST_CONTENT
+    assert spans[0].status == SpanStatus(SpanStatusCode.OK)
+    assert spans[1].name == "RunnableSequence"
+    assert spans[1].attributes[SpanAttributeKey.SPAN_TYPE] == "CHAIN"
+    assert spans[1].attributes[SpanAttributeKey.INPUTS] == "MLflow"
+    assert spans[1].attributes[SpanAttributeKey.OUTPUTS] == TEST_CONTENT
+    assert spans[1].status == SpanStatus(SpanStatusCode.OK)
+    assert spans[1].parent_id == spans[0].span_id

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -596,6 +596,10 @@ def test_tracer_noop_when_tracing_disabled(monkeypatch):
     mock_logger.warning.assert_not_called()
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.1.0"),
+    reason="ChatPromptTemplate expecting dict input",
+)
 def test_tracer_nested_trace():
     # Validate if the callback works properly if it is used in a context
     # of an active span created by MLflow fluent API.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12705?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12705/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12705
```

</p>
</details>

### What changes are proposed in this pull request?

The LangChain tracer should support nested trace creation like this
```
mlflow.langchain.autolog()

chain = prompt | llm | parser

@mlflow.trace(name="parent")
def run(message):
    chain.invoke(message)

# -> This should a trace with "parent" as root span and the langchain spans as children.
```

However, this doesn't work after https://github.com/mlflow/mlflow/pull/12049. The trace is still generated, but the children LangChain spans are not ended and lacks output fields. This is because `self._root_run_id` (replaced with `self. _active_request_ids` by the recent PR) is only set if the callback starts a trace via `client.start_trace`. In the nested case, the callback only starts child spans and `self._root_run_id` is not set, then [this condition](https://github.com/mlflow/mlflow/blob/master/mlflow/langchain/langchain_tracer.py#L142) is always `False` and those spans are not ended.

This PR updates the logic to consider nested case. 


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix broken spans issue of LangChain tracer when a parent span is created outside LangChain.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
