### PR TITLE
Support extra_args with s3 multipart upload

### DIFF
--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -22,7 +22,12 @@ from mlflow.store.artifact.cloud_artifact_repo import (
     _compute_num_chunks,
     _validate_chunk_size_aws,
 )
-from mlflow.store.artifact.s3_artifact_repo import _file_is_directory_marker, _get_s3_client
+from mlflow.store.artifact.s3_artifact_repo import (
+    ALLOWED_MPU_ABORT_ARGS,
+    ALLOWED_MPU_EXTRA_ARGS,
+    _file_is_directory_marker,
+    _get_s3_client,
+)
 from mlflow.utils.file_utils import read_chunk
 from mlflow.utils.request_utils import cloud_storage_http_request
 from mlflow.utils.rest_utils import augmented_raise_for_status
@@ -165,7 +170,7 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         else:
             return None
 
-    def _upload_file(self, s3_client, local_file, bucket, key):
+    def _extra_args(self, local_file):
         extra_args = {}
         extra_args.update(self._s3_upload_extra_args)
         guessed_type, guessed_encoding = guess_type(local_file)
@@ -177,6 +182,10 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         environ_extra_args = self.get_s3_file_upload_extra_args()
         if environ_extra_args is not None:
             extra_args.update(environ_extra_args)
+        return extra_args
+
+    def _upload_file(self, s3_client, local_file, bucket, key):
+        extra_args = self._extra_args(local_file)
 
         def try_func(creds):
             creds.upload_file(Filename=local_file, Bucket=bucket, Key=key, ExtraArgs=extra_args)
@@ -218,9 +227,14 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
     def _multipart_upload(self, cloud_credential_info, local_file, bucket, key):
         # Create multipart upload
         s3_client = cloud_credential_info
-        response = s3_client.create_multipart_upload(
-            Bucket=bucket, Key=key, **self._bucket_owner_params
-        )
+        extra_args = self._extra_args(local_file)
+        # filtered for upload_part / abort_multipart_upload
+        upload_part_args = {k: v for k, v in extra_args.items() if k in ALLOWED_MPU_EXTRA_ARGS}
+        abort_args = {k: v for k, v in extra_args.items() if k in ALLOWED_MPU_ABORT_ARGS}
+        # ALLOWED_EXTRA_ARGS https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html
+        # cannot pass SSECustomerKeyMD5 to create_multipart_upload - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/create_multipart_upload.html
+        extra_args.pop("SSECustomerKeyMD5", None)
+        response = s3_client.create_multipart_upload(Bucket=bucket, Key=key, **extra_args)
         upload_id = response["UploadId"]
 
         num_parts = _compute_num_chunks(local_file, MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get())
@@ -240,7 +254,8 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
                         "UploadId": upload_id,
                         "PartNumber": part_number,
                         **self._bucket_owner_params,
-                    },
+                    }
+                    | upload_part_args,
                 )
                 with cloud_storage_http_request("put", presigned_url, data=data) as response:
                     augmented_raise_for_status(response)
@@ -283,7 +298,7 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
                 Key=key,
                 UploadId=upload_id,
                 MultipartUpload={"Parts": parts},
-                **self._bucket_owner_params,
+                **upload_part_args,
             )
         except Exception as e:
             _logger.warning(
@@ -294,7 +309,7 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
                 Bucket=bucket,
                 Key=key,
                 UploadId=upload_id,
-                **self._bucket_owner_params,
+                **abort_args,
             )
             raise e
 
@@ -350,13 +365,16 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
     def _get_presigned_uri(self, remote_file_path):
         s3_client = self._get_s3_client()
         s3_full_path = posixpath.join(self.bucket_path, remote_file_path)
+        extra_args = self.get_s3_file_upload_extra_args() or {}
+        get_args = {k: v for k, v in extra_args.items() if k in ALLOWED_MPU_EXTRA_ARGS}
         return s3_client.generate_presigned_url(
             "get_object",
             Params={
                 "Bucket": self.bucket,
                 "Key": s3_full_path,
                 **self._bucket_owner_params,
-            },
+            }
+            | get_args,
         )
 
     def _get_read_credential_infos(self, remote_file_paths):

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -82,6 +82,21 @@ _S3_PARAM_TO_HEADER = {
     "WebsiteRedirectLocation": "x-amz-website-redirect-location",
 }
 
+# allowed for complete_multipart_upload, upload_part, get_object
+# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/complete_multipart_upload.html
+# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/upload_part.html
+# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/get_object.html
+# Shared with optimized_s3_artifact_repo.py, which imports these from here to avoid duplication.
+ALLOWED_MPU_EXTRA_ARGS = frozenset({
+    "SSECustomerAlgorithm",
+    "SSECustomerKey",
+    "RequestPayer",
+    "ExpectedBucketOwner",
+})
+# allowed for abort_multipart_upload
+# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/abort_multipart_upload.html
+ALLOWED_MPU_ABORT_ARGS = frozenset({"RequestPayer", "ExpectedBucketOwner"})
+
 
 def _get_utcnow_timestamp():
     return datetime.now(timezone.utc).timestamp()
@@ -333,7 +348,7 @@ class S3ArtifactRepository(
         else:
             return None
 
-    def _upload_file(self, s3_client, local_file, bucket, key):
+    def _extra_args(self, local_file):
         extra_args = {}
         guessed_type, guessed_encoding = guess_type(local_file)
         if guessed_type is not None:
@@ -344,6 +359,10 @@ class S3ArtifactRepository(
         environ_extra_args = self.get_s3_file_upload_extra_args()
         if environ_extra_args is not None:
             extra_args.update(environ_extra_args)
+        return extra_args
+
+    def _upload_file(self, s3_client, local_file, bucket, key):
+        extra_args = self._extra_args(local_file)
         s3_client.upload_file(Filename=local_file, Bucket=bucket, Key=key, ExtraArgs=extra_args)
 
     def log_artifact(self, local_file, artifact_path=None):
@@ -591,10 +610,16 @@ class S3ArtifactRepository(
             dest_path = posixpath.join(dest_path, artifact_path)
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
         s3_client = self._get_s3_client()
+        extra_args = self._extra_args(local_file)
+        # filtered for upload_part
+        upload_part_args = {k: v for k, v in extra_args.items() if k in ALLOWED_MPU_EXTRA_ARGS}
+        # ALLOWED_EXTRA_ARGS https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html
+        # cannot pass SSECustomerKeyMD5 to create_multipart_upload - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/create_multipart_upload.html
+        extra_args.pop("SSECustomerKeyMD5", None)
         create_response = s3_client.create_multipart_upload(
             Bucket=bucket,
             Key=dest_path,
-            **self._bucket_owner_params,
+            **extra_args,
         )
         upload_id = create_response["UploadId"]
         credentials = []
@@ -607,7 +632,8 @@ class S3ArtifactRepository(
                     "PartNumber": i,
                     "UploadId": upload_id,
                     **self._bucket_owner_params,
-                },
+                }
+                | upload_part_args,
             )
             credentials.append(
                 MultipartUploadCredential(
@@ -644,13 +670,16 @@ class S3ArtifactRepository(
             dest_path = posixpath.join(dest_path, artifact_path)
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
         parts = [{"PartNumber": part.part_number, "ETag": part.etag} for part in parts]
+        complete_args = {
+            k: v for k, v in self._extra_args(local_file).items() if k in ALLOWED_MPU_EXTRA_ARGS
+        }
         s3_client = self._get_s3_client()
         s3_client.complete_multipart_upload(
             Bucket=bucket,
             Key=dest_path,
             UploadId=upload_id,
             MultipartUpload={"Parts": parts},
-            **self._bucket_owner_params,
+            **complete_args,
         )
 
     def abort_multipart_upload(self, local_file, upload_id, artifact_path=None):
@@ -672,12 +701,14 @@ class S3ArtifactRepository(
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
+        extra_args = self._extra_args(local_file)
+        abort_args = {k: v for k, v in extra_args.items() if k in ALLOWED_MPU_ABORT_ARGS}
         s3_client = self._get_s3_client()
         s3_client.abort_multipart_upload(
             Bucket=bucket,
             Key=dest_path,
             UploadId=upload_id,
-            **self._bucket_owner_params,
+            **abort_args,
         )
 
     def create_presigned_upload_url(self, artifact_path, expiration=900):

--- a/tests/store/artifact/test_optimized_s3_artifact_repo.py
+++ b/tests/store/artifact/test_optimized_s3_artifact_repo.py
@@ -273,6 +273,87 @@ def test_download_file_in_parallel_when_necessary(
             download_mock.assert_called()
 
 
+def test_multipart_upload_with_bucket_owner(s3_artifact_root, tmp_path, monkeypatch):
+    # ExpectedBucketOwner is folded into _extra_args() as well as self._bucket_owner_params, so
+    # passing both **self._bucket_owner_params and the extra args to the same boto3 call would
+    # raise "got multiple values for keyword argument 'ExpectedBucketOwner'".
+    # Use the default chunk size (10 MB) so the 20-byte file uploads as a single part.
+    monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
+
+    repo = OptimizedS3ArtifactRepository(posixpath.join(s3_artifact_root, "some/path"))
+    local_file = tmp_path / "local_file"
+    local_file.write_bytes(b"0" * 20)
+
+    mock_s3 = mock.Mock()
+    mock_s3.create_multipart_upload.return_value = {"UploadId": "test-upload-id"}
+    mock_s3.generate_presigned_url.return_value = "https://example.com/presigned"
+
+    mock_response = mock.Mock()
+    mock_response.headers = {"ETag": "etag"}
+    with (
+        mock.patch(f"{S3_REPOSITORY_MODULE}.cloud_storage_http_request") as mock_http_request,
+        mock.patch(f"{S3_REPOSITORY_MODULE}.augmented_raise_for_status"),
+    ):
+        mock_http_request.return_value.__enter__.return_value = mock_response
+        repo._multipart_upload(mock_s3, str(local_file), "bucket", "key")
+
+    mock_s3.create_multipart_upload.assert_called_once()
+    create_kwargs = mock_s3.create_multipart_upload.call_args[1]
+    assert create_kwargs["ExpectedBucketOwner"] == "123456789012"
+
+    for call in mock_s3.generate_presigned_url.call_args_list:
+        assert call[1]["Params"]["ExpectedBucketOwner"] == "123456789012"
+
+    mock_s3.complete_multipart_upload.assert_called_once()
+    complete_kwargs = mock_s3.complete_multipart_upload.call_args[1]
+    assert complete_kwargs["ExpectedBucketOwner"] == "123456789012"
+
+    mock_s3.abort_multipart_upload.assert_not_called()
+
+
+def test_multipart_upload_aborts_with_bucket_owner_on_failure(
+    s3_artifact_root, tmp_path, monkeypatch
+):
+    # Regression test: if abort_multipart_upload's own kwargs collided (the same bug as
+    # create/complete above), the abort call in the except handler would raise a *second*
+    # TypeError, masking the original error instead of re-raising it.
+    # Use the default chunk size (10 MB) so the 20-byte file uploads as a single part.
+    monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
+
+    repo = OptimizedS3ArtifactRepository(posixpath.join(s3_artifact_root, "some/path"))
+    local_file = tmp_path / "local_file"
+    local_file.write_bytes(b"0" * 20)
+
+    mock_s3 = mock.Mock()
+    mock_s3.create_multipart_upload.return_value = {"UploadId": "test-upload-id"}
+    mock_s3.generate_presigned_url.return_value = "https://example.com/presigned"
+    mock_s3.complete_multipart_upload.side_effect = Exception("complete failed")
+
+    mock_response = mock.Mock()
+    mock_response.headers = {"ETag": "etag"}
+    with (
+        mock.patch(f"{S3_REPOSITORY_MODULE}.cloud_storage_http_request") as mock_http_request,
+        mock.patch(f"{S3_REPOSITORY_MODULE}.augmented_raise_for_status"),
+    ):
+        mock_http_request.return_value.__enter__.return_value = mock_response
+        with pytest.raises(Exception, match="complete failed"):
+            repo._multipart_upload(mock_s3, str(local_file), "bucket", "key")
+
+    mock_s3.abort_multipart_upload.assert_called_once()
+    abort_kwargs = mock_s3.abort_multipart_upload.call_args[1]
+    assert abort_kwargs["ExpectedBucketOwner"] == "123456789012"
+
+
+def test_get_presigned_uri_merges_extra_args_into_params(s3_artifact_root, monkeypatch):
+    # generate_presigned_url only accepts ClientMethod/Params/ExpiresIn/HttpMethod, so extra
+    # args must be merged into Params rather than passed as top-level kwargs. This exercises the
+    # real (moto-backed) boto3 client so an incorrect call shape raises a TypeError.
+    monkeypatch.setenv("MLFLOW_S3_UPLOAD_EXTRA_ARGS", '{"RequestPayer": "requester"}')
+    repo = OptimizedS3ArtifactRepository(posixpath.join(s3_artifact_root, "some/path"))
+    uri = repo._get_presigned_uri("some/file.txt")
+    assert "some/file.txt" in uri
+
+
 def test_refresh_credentials():
     with (
         mock.patch(

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -741,6 +741,32 @@ def test_multipart_upload_with_bucket_owner(s3_artifact_root, monkeypatch):
         assert params["ExpectedBucketOwner"] == "123456789012"
 
 
+def test_complete_and_abort_multipart_upload_with_bucket_owner(s3_artifact_root, monkeypatch):
+    # ExpectedBucketOwner is folded into _extra_args() as well as self._bucket_owner_params, so
+    # passing both **self._bucket_owner_params and the extra args to the same boto3 call would
+    # raise "got multiple values for keyword argument 'ExpectedBucketOwner'".
+    monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
+    repo_with_owner = S3ArtifactRepository(s3_artifact_root)
+
+    mock_s3 = mock.Mock()
+
+    with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
+        repo_with_owner.complete_multipart_upload(
+            "local_file",
+            "test-upload-id",
+            [MultipartUploadPart(part_number=1, etag="etag1")],
+        )
+        repo_with_owner.abort_multipart_upload("local_file", "test-upload-id")
+
+    mock_s3.complete_multipart_upload.assert_called_once()
+    complete_call_kwargs = mock_s3.complete_multipart_upload.call_args[1]
+    assert complete_call_kwargs["ExpectedBucketOwner"] == "123456789012"
+
+    mock_s3.abort_multipart_upload.assert_called_once()
+    abort_call_kwargs = mock_s3.abort_multipart_upload.call_args[1]
+    assert abort_call_kwargs["ExpectedBucketOwner"] == "123456789012"
+
+
 def test_delete_artifacts_with_bucket_owner(s3_artifact_root, tmp_path, monkeypatch):
     subdir = tmp_path / "subdir"
     subdir.mkdir()


### PR DESCRIPTION
### Related Issues/PRs

Resolve #12754 

### What changes are proposed in this pull request?

Adds 
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
