### PR TITLE
Pin huggingface-hub in cross version test

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -591,7 +591,7 @@ transformers:
       ">= 0.0.0": [
           "datasets",
           # 0.22.0 is broken: https://github.com/huggingface/huggingface_hub/issues/2157
-          # 0.24.0 contains a breaking change that is incompatible with setfit
+          # 0.24.0 contains a breaking change for setfit: https://github.com/huggingface/setfit/issues/544
           "huggingface_hub<0.24.0,!=0.22.0",
           "hf_transfer",
           "torch",

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -591,7 +591,8 @@ transformers:
       ">= 0.0.0": [
           "datasets",
           # 0.22.0 is broken: https://github.com/huggingface/huggingface_hub/issues/2157
-          "huggingface_hub!=0.22.0",
+          # 0.24.0 contains a breaking change that is incompatible with setfit
+          "huggingface_hub<0.24.0,!=0.22.0",
           "hf_transfer",
           "torch",
           "torchvision",

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -21,8 +21,9 @@ ipython
 flaml[automl]
 # Required by transformers tests
 # Note: other requirements for transformers are defined in cross-version-tests.yml
-# they are not installed here due to their size and stability implications for other test suites
-huggingface_hub
+# they are not installed here due to their size and stability implications for other test suites.
+# this is pinned because huggingface_hub >= 0.24.0 causes setfit to be unimportable
+huggingface_hub<0.24.0
 # Pinned due to protobuf requirement pinning in 1.3.0 of ml-server that is incompatible
 # 1.4.0 does not support pydantic v2 https://github.com/SeldonIO/MLServer/pull/1595
 mlserver>=1.2.0,!=1.3.1,<1.4.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -22,7 +22,8 @@ flaml[automl]
 # Required by transformers tests
 # Note: other requirements for transformers are defined in cross-version-tests.yml
 # they are not installed here due to their size and stability implications for other test suites.
-# this is pinned because huggingface_hub >= 0.24.0 causes setfit to be unimportable
+# this is pinned because huggingface_hub >= 0.24.0 causes setfit to be unimportable, see
+# https://github.com/huggingface/setfit/issues/544
 huggingface_hub<0.24.0
 # Pinned due to protobuf requirement pinning in 1.3.0 of ml-server that is incompatible
 # 1.4.0 does not support pydantic v2 https://github.com/SeldonIO/MLServer/pull/1595

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -11,7 +11,9 @@ import pyspark
 import pyspark.ml
 import pytest
 import pytorch_lightning
-import setfit
+
+# commenting out setfit as it's broken with huggingface-hub >= 0.24.0
+# import setfit
 import sklearn
 import statsmodels
 import tensorflow
@@ -43,7 +45,7 @@ library_to_mlflow_module_without_spark_datasource = {
     pytorch_lightning: mlflow.pytorch,
     lightning: mlflow.pytorch,
     transformers: mlflow.transformers,
-    setfit: mlflow.transformers,
+    # setfit: mlflow.transformers,
 }
 
 library_to_mlflow_module = {

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -11,9 +11,7 @@ import pyspark
 import pyspark.ml
 import pytest
 import pytorch_lightning
-
-# commenting out setfit as it's broken with huggingface-hub >= 0.24.0
-# import setfit
+import setfit
 import sklearn
 import statsmodels
 import tensorflow
@@ -45,7 +43,7 @@ library_to_mlflow_module_without_spark_datasource = {
     pytorch_lightning: mlflow.pytorch,
     lightning: mlflow.pytorch,
     transformers: mlflow.transformers,
-    # setfit: mlflow.transformers,
+    setfit: mlflow.transformers,
 }
 
 library_to_mlflow_module = {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/12709?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12709/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12709
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

HF hub recently released 0.24.0 with a breaking change that causes setfit to not load anymore. Since we can't control setfit, we have to pin HF hub.

We can also migrate away from using setfit, since it seems to release very infrequently, but this is a quicker fix.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
