### PR TITLE
[Bug bash] Llama index client state fix

### DIFF
--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -17,6 +17,7 @@ from mlflow.models import Model, ModelInputExample, ModelSignature
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import _infer_signature_from_input_example
 from mlflow.models.utils import _save_example
+from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.annotations import experimental
@@ -73,7 +74,7 @@ def _validate_engine_type(engine_type: str):
     if engine_type not in SUPPORTED_ENGINES:
         raise ValueError(
             f"Currently mlflow only supports the following engine types: "
-            f"{SUPPORTED_ENGINES}. {engine_type} is not supported, so please"
+            f"{SUPPORTED_ENGINES}. {engine_type} is not supported, so please "
             "use one of the above types."
         )
 
@@ -90,7 +91,9 @@ def _get_llama_index_version() -> str:
         )
 
 
+@experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
+@trace_disabled  # Suppress traces while loading model
 def save_model(
     index,
     path: str,
@@ -215,7 +218,9 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
+@experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
+@trace_disabled  # Suppress traces while loading model
 def log_model(
     index,
     artifact_path: str,
@@ -305,6 +310,8 @@ def _load_index(path, flavor_conf):
     return load_index_from_storage(storage_context)
 
 
+@experimental
+@trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):
     """
     Load a ``llama_index`` index from a local file or a run.

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -28,13 +28,12 @@ from llama_index.core.instrumentation.span.base import BaseSpan
 from llama_index.core.instrumentation.span_handlers import BaseSpanHandler
 from llama_index.core.multi_modal_llms import MultiModalLLM
 from llama_index.core.tools import BaseTool
-from mlflow.tracking.client import MlflowClient
 from pydantic import PrivateAttr
 
-import mlflow
 from mlflow.entities import LiveSpan, SpanEvent, SpanType
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracking.client import MlflowClient
 
 _logger = logging.getLogger(__name__)
 
@@ -140,7 +139,6 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                     attributes=attributes,
                 )
             else:
-                print(mlflow.get_tracking_uri())
                 span = MlflowClient().start_trace(
                     name=id_.partition("-")[0],
                     span_type=span_type,

--- a/tests/llama_index/test_llama_index_autolog.py
+++ b/tests/llama_index/test_llama_index_autolog.py
@@ -75,3 +75,18 @@ def test_autolog_preserve_user_provided_handlers():
 
     traces = _get_all_traces()
     assert len(traces) == 1
+
+
+def test_autolog_should_not_generate_traces_during_logging_loading(single_index):
+    mlflow.llama_index.autolog()
+
+    with mlflow.start_run():
+        model_info = mlflow.llama_index.log_model(
+            single_index, "model", input_example="Hello", engine_type="query"
+        )
+    loaded = mlflow.pyfunc.load_model(model_info.model_uri)
+
+    assert len(_get_all_traces()) == 0
+
+    loaded.predict("Hello")
+    assert len(_get_all_traces()) == 1

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -4,8 +4,6 @@ from dataclasses import asdict
 from typing import List
 from unittest.mock import ANY
 
-import mlflow.tracking._tracking_service
-from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 import openai
 import pytest
 from llama_index.agent.openai import OpenAIAgent
@@ -18,11 +16,13 @@ from llama_index.llms.openai import OpenAI
 from openai.types.chat import ChatCompletionMessageToolCall
 
 import mlflow
+import mlflow.tracking._tracking_service
 from mlflow.entities.span import SpanType
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.llama_index.tracer import remove_llama_index_tracer, set_llama_index_tracer
 from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 
 

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -4,6 +4,8 @@ from dataclasses import asdict
 from typing import List
 from unittest.mock import ANY
 
+import mlflow.tracking._tracking_service
+from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 import openai
 import pytest
 from llama_index.agent.openai import OpenAIAgent
@@ -378,3 +380,16 @@ def test_trace_chat_engine(multi_index, is_stream, is_async):
     assert traces[0].info.status == TraceStatus.OK
     root_span = traces[0].data.spans[0]
     assert root_span.attributes[SpanAttributeKey.INPUTS] == {"message": "Hello"}
+
+
+def test_tracer_handle_tracking_uri_update(tmp_path):
+    OpenAI().complete("Hello")
+    assert len(_get_all_traces()) == 1
+
+    # Set different tracking URI and initialize the tracer
+    with _use_tracking_uri(tmp_path / "dummy"):
+        assert len(_get_all_traces()) == 0
+
+        # The new trace will be logged to the updated tracking URI
+        OpenAI().complete("Hello")
+        assert len(_get_all_traces()) == 1


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12712?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12712/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12712
```

</p>
</details>

### What changes are proposed in this pull request?

An issue was reported that traces are not logged correctly when the tracking URI is updated after calling `mlflow.llama_index.autolog`. This is because the global span handler holds an MLflowClient instance, which uses the tracking URI of when the client is instantiated. Subsequent tracking URI update is not reflected to the handler.

This PR removes the client state from the handler, instead make it create a new client every time it create spans. The overhead of creating client should be negligibly small (only global variable + env var look up).

**Note**: This PR also addresses the issue that traces are generated while model logging (lack of @trace_disabled decorator for logging functions).

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
Validated the below code generates correct traces:
```
mlflow.llama_index.autolog()

mlflow.set_tracking_uri("http://localhost:5000")
mlflow.set_experiment("Llama Testing")

index = VectorStoreIndex.from_documents(docs)
chat_engine = index.as_chat_engine()
response_stream = chat_engine.stream_chat("What did Paul Graham do after YC?")

response_stream.print_response_stream()
```
### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
