### PR TITLE
Make MLflow supporting U2M authentication

### DIFF
--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -414,7 +414,7 @@ class DatabricksConfig:
         self.jobs_api_version = jobs_api_version
         self.client_id = client_id
         self.client_secret = client_secret
-        self.auth_type=auth_type
+        self.auth_type = auth_type
 
     @classmethod
     def from_token(cls, host, token, refresh_token=None, insecure=None, jobs_api_version=None):

--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -1,7 +1,9 @@
 # This module is copied from legacy databricks CLI python library
 # module `databricks_cli.configure.provider`,
 # but with some modification to make `EnvironmentVariableConfigProvider` supporting
-# 'DATABRICKS_CLIENT_ID' and 'DATABRICKS_CLIENT_SECRET' environmental variables.
+# 'DATABRICKS_CLIENT_ID' and 'DATABRICKS_CLIENT_SECRET' environmental variables,
+# and make ProfileConfigProvider supporting 'databricks-cli' authentication way,
+# 'databricks-cli' authentication way is for supporting U2M authentication.
 #
 # This is the original legacy databricks CLI python library provider module code:
 # https://github.com/databricks/databricks-cli/blob/0.18.0/databricks_cli/configure/provider.py
@@ -31,6 +33,7 @@ JOBS_API_VERSION = "jobs-api-version"
 DEFAULT_SECTION = "DEFAULT"
 CLIENT_ID = "client_id"
 CLIENT_SECRET = "client_secret"
+AUTH_TYPE = "auth_type"
 
 # User-provided override for the DatabricksConfigProvider
 _config_provider = None
@@ -308,6 +311,7 @@ class ProfileConfigProvider(DatabricksConfigProvider):
         jobs_api_version = _get_option_if_exists(raw_config, self.profile, JOBS_API_VERSION)
         client_id = _get_option_if_exists(raw_config, self.profile, CLIENT_ID)
         client_secret = _get_option_if_exists(raw_config, self.profile, CLIENT_SECRET)
+        auth_type = _get_option_if_exists(raw_config, self.profile, AUTH_TYPE)
         config = DatabricksConfig(
             host,
             username,
@@ -318,6 +322,7 @@ class ProfileConfigProvider(DatabricksConfigProvider):
             jobs_api_version,
             client_id=client_id,
             client_secret=client_secret,
+            auth_type=auth_type,
         )
         if config.is_valid:
             return config
@@ -398,6 +403,7 @@ class DatabricksConfig:
         jobs_api_version=None,
         client_id=None,
         client_secret=None,
+        auth_type=None,
     ):
         self.host = host
         self.username = username
@@ -408,6 +414,7 @@ class DatabricksConfig:
         self.jobs_api_version = jobs_api_version
         self.client_id = client_id
         self.client_secret = client_secret
+        self.auth_type=auth_type
 
     @classmethod
     def from_token(cls, host, token, refresh_token=None, insecure=None, jobs_api_version=None):
@@ -458,9 +465,14 @@ class DatabricksConfig:
         return self.host and self.client_id and self.client_secret
 
     @property
+    def is_databricks_cli_auth_type(self):
+        return self.auth_type == "databricks-cli"
+
+    @property
     def is_valid(self):
         return (
             self.is_valid_with_token
             or self.is_valid_with_password
             or self.is_valid_with_client_id_secret
+            or self.is_databricks_cli_auth_type
         )

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -500,8 +500,10 @@ def _fail_malformed_databricks_auth(uri):
         "variables DATABRICKS_HOST + DATABRICKS_TOKEN, or set environmental variables "
         "DATABRICKS_HOST + DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET, or you can "
         "edit '~/.databrickscfg' file to set host + token or host + client_id + client_secret "
-        "for specific profile section. For details of these authentication types, please "
-        "refer to document "
+        "for specific profile section, or you can log in by command 'databricks auth login' "
+        "which configures an authentication profile in '~/.databrickscfg' with auth_type of "
+        "'databricks-cli'.\n"
+        "For details of these authentication types, please refer to document "
         "'https://docs.databricks.com/en/dev-tools/auth/index.html#unified-auth'."
     )
 
@@ -910,6 +912,14 @@ def get_databricks_env_vars(tracking_uri):
         return {}
 
     config = _get_databricks_creds_config(tracking_uri)
+
+    if config.auth_type == "databricks-cli":
+        raise MlflowException(
+            "You configured authentication type to 'databricks-cli', in this case, MLflow cannot "
+            "read credential values, so that MLflow cannot construct the databricks environment "
+            "variables for child process authentication."
+        )
+
     # We set these via environment variables so that only the current profile is exposed, rather
     # than all profiles in ~/.databrickscfg; maybe better would be to mount the necessary
     # part of ~/.databrickscfg into the container


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12713?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12713/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12713
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR makes MLflow supports U2M authentication.

To use the feature, you need:
1. Log in databricks account by command `databricks auth login`, for details please see
https://docs.databricks.com/en/dev-tools/cli/authentication.html#oauth-user-to-machine-u2m-authentication
then in your local `~/.databrickscfg` file, it will add a new profile section with auth_type of 'databricks-cli' (assuming the profile name is 'u2m_profile' )

2. then, in Mlflow application, you just need to set Mlflow tracking URI to 'databricks://u2m_profile', then Mlflow can use U2M authentication, it doesn't need any password or token value.


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Make MLflow supporting U2M authentication

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
