### PR TITLE
[Bug bash] Improve serde logic and log messages for LlamaIndex

### DIFF
--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -107,8 +107,6 @@ def save_model(
 ) -> None:
     """Save ``llama_index`` index to a path on the local file system.
 
-    TODO: add note on supported model types
-
     Args:
         index: llama_index index to be saved.
         path: Local path where the serialized model (as YAML) is to be saved.

--- a/mlflow/llama_index/serialize_objects.py
+++ b/mlflow/llama_index/serialize_objects.py
@@ -6,35 +6,9 @@ from typing import Any, Callable, Dict
 
 from llama_index.core import PromptTemplate
 from llama_index.core.base.embeddings.base import BaseEmbedding
-from llama_index.core.base.llms.base import BaseLLM
-from llama_index.core.indices.prompt_helper import PromptHelper
-from llama_index.core.node_parser.interface import NodeParser
-
-from mlflow.exceptions import INTERNAL_ERROR, MlflowException
+from llama_index.core.schema import BaseComponent
 
 _logger = logging.getLogger(__name__)
-
-OBJECT_DICT_METHOD_MAP = {
-    BaseLLM: ("to_dict", "from_dict"),
-    BaseEmbedding: ("to_dict", "from_dict"),
-    NodeParser: ("to_dict", "from_dict"),
-    PromptHelper: ("to_dict", "from_dict"),
-}
-
-
-def _object_to_dict(obj: object) -> Dict[str, any]:
-    for k, v in OBJECT_DICT_METHOD_MAP.items():
-        if isinstance(obj, k):
-            if not hasattr(obj, v[0]):
-                raise MlflowException(
-                    f"Failed to deserialize object {obj}. This is likely an unsupported "
-                    "object in the MLflow Llama-Index flavor.",
-                    error_code=INTERNAL_ERROR,
-                )
-
-            return getattr(obj, v[0])()
-
-    return {}
 
 
 def _get_object_import_path(o: object) -> str:
@@ -53,32 +27,28 @@ def _get_object_import_path(o: object) -> str:
 
 
 def _sanitize_api_key(object_as_dict: Dict[str, str]) -> Dict[str, str]:
-    keys_to_remove = [k for k in object_as_dict.keys() if "api_key" in k.lower()]
-
-    for k in keys_to_remove:
-        if object_as_dict.pop(k, None):
-            _logger.info(
-                "API key removed from object serialization. At inference time,"
-                " the key must be passed as an environment variable or via inference"
-                " parameters."
-            )
-
-    return object_as_dict
+    return {k: v for k, v in object_as_dict.items() if "api_key" not in k.lower()}
 
 
-def object_to_dict(o: object) -> None:
-    o_state_as_dict = _object_to_dict(o)
+def _object_to_dict(o: object):
+    if isinstance(o, (list, tuple)):
+        return [_object_to_dict(v) for v in o]
 
-    if o_state_as_dict != {}:
-        o_state_as_dict = _sanitize_api_key(o_state_as_dict)
-        o_state_as_dict.pop("class_name")
+    if isinstance(o, BaseComponent):
+        o_state_as_dict = o.to_dict()
+
+        if o_state_as_dict != {}:
+            o_state_as_dict = _sanitize_api_key(o_state_as_dict)
+            o_state_as_dict.pop("class_name")
+        else:
+            return o_state_as_dict
+
+        return {
+            "object_constructor": _get_object_import_path(o),
+            "object_kwargs": o_state_as_dict,
+        }
     else:
-        return o_state_as_dict
-
-    return {
-        "object_constructor": _get_object_import_path(o),
-        "object_kwargs": o_state_as_dict,
-    }
+        return None
 
 
 def _construct_prompt_template_object(
@@ -101,7 +71,7 @@ def _construct_prompt_template_object(
         )
 
 
-def dict_to_object(object_representation: Dict[str, Any]) -> object:
+def _dict_to_object(object_representation: Dict[str, Any]) -> object:
     if "object_constructor" not in object_representation:
         raise ValueError("'object_constructor' key not found in dict.")
     if "object_kwargs" not in object_representation:
@@ -118,31 +88,20 @@ def dict_to_object(object_representation: Dict[str, Any]) -> object:
     else:
         object_class = getattr(module, class_name)
 
-        for k, v in OBJECT_DICT_METHOD_MAP.items():
-            if issubclass(object_class, k):
-                if not hasattr(object_class, v[1]):
-                    raise MlflowException(
-                        f"Failed to deserialize an object of class {object_class}. The "
-                        f"class {object_class} does not have the {v[1]} method.",
-                        error_code=INTERNAL_ERROR,
-                    )
+        # Many embeddings model accepts parameter `model`, while BaseEmbedding accepts `model_name`.
+        # Both parameters will be serialized as kwargs, but passing both to the constructor will
+        # raise duplicate argument error. Some class like OpenAIEmbedding handles this in its
+        # constructor, but not all integrations do. Therefore, we have to handle it here.
+        # E.g. https://github.com/run-llama/llama_index/blob/2b18eb4654b14c68d63f6239cddb10740668fbc8/llama-index-integrations/embeddings/llama-index-embeddings-openai/llama_index/embeddings/openai/base.py#L316-L320
+        if (
+            issubclass(object_class, BaseEmbedding)
+            and (model := kwargs.get("model"))
+            and (model_name := kwargs.get("model_name"))
+            and model == model_name
+        ):
+            kwargs.pop("model_name")
 
-                # Many embeddings model accepts parameter `model`, while BaseEmbedding accepts
-                # `model_name`. Both parameters will be serialized as kwargs, but passing both
-                # to the constructor will raise duplicate argument error. Some class like
-                # OpenAIEmbedding handles this in its constructor, but not all integrations do.
-                # Therefore, we have to handle it here.
-                # E.g. https://github.com/run-llama/llama_index/blob/2b18eb4654b14c68d63f6239cddb10740668fbc8/llama-index-integrations/embeddings/llama-index-embeddings-openai/llama_index/embeddings/openai/base.py#L316-L320
-                if (
-                    k == BaseEmbedding
-                    and (model := kwargs.get("model"))
-                    and (model_name := kwargs.get("model_name"))
-                    and model == model_name
-                ):
-                    kwargs.pop("model_name")
-                return object_class.from_dict(kwargs)
-
-        return object_class(**kwargs)
+        return object_class.from_dict(kwargs)
 
 
 def _deserialize_dict_of_objects(path: str) -> Dict[str, any]:
@@ -152,45 +111,63 @@ def _deserialize_dict_of_objects(path: str) -> Dict[str, any]:
         output = {}
         for k, v in to_deserialize.items():
             if isinstance(v, list):
-                output.update({k: [dict_to_object(vv) for vv in v]})
+                output.update({k: [_dict_to_object(vv) for vv in v]})
             else:
-                output.update({k: dict_to_object(v)})
+                output.update({k: _dict_to_object(v)})
 
         return output
 
 
-def _serialize_dict_of_objects(dict_of_objects: Dict[str, object], path: str) -> None:
+def serialize_settings(path: str) -> None:
+    """Serialize the global LlamaIndex Settings object to a JSON file at the given path."""
+    from llama_index.core import Settings
+
+    _logger.info(
+        "API key(s) will be deducted from the global Settings object during serialization. "
+        "At inference time, the key(s) must be passed as environment variables."
+    )
+
     to_serialize = {}
     unsupported_objects = []
 
-    for k, v in dict_of_objects.items():
-        object_json = [object_to_dict(vv) for vv in v] if isinstance(v, list) else object_to_dict(v)
+    for k, v in Settings.__dict__.items():
+        if v is None:
+            continue
 
-        if object_json == {}:
-            unsupported_objects.append(k)
+        def _convert(obj):
+            object_json = _object_to_dict(obj)
+            if object_json is None:
+                prop_name = k[1:] if k.startswith("_") else k
+                unsupported_objects.append((prop_name, v))
+            return object_json
+
+        if isinstance(v, list):
+            to_serialize[k] = [_convert(obj) for obj in v if v is not None]
         else:
-            to_serialize.update({k: object_json})
+            if (object_json := _convert(v)) and (object_json is not None):
+                to_serialize[k] = object_json
 
     if unsupported_objects:
-        _logger.info(
-            "Serialization of the following objects are not supported and will not be logged with "
-            f"your model: {', '.join(unsupported_objects)}"
+        msg = (
+            "The following objects in Settings are not supported for serialization and will not "
+            "be logged with your model. MLflow only supports serialization of objects that inherit "
+            "from llama_index.core.schema.BaseComponent.\n"
         )
+        msg += "\n".join(f" - {type(v).__name__} for Settings.{k}" for k, v in unsupported_objects)
+        _logger.info(msg)
 
     with open(path, "w") as f:
         json.dump(to_serialize, f, indent=2)
 
 
-def serialize_settings(path: str) -> None:
-    from llama_index.core import Settings
-
-    _serialize_dict_of_objects(Settings.__dict__, path)
-
-
 def deserialize_settings(path: str):
+    """Deserialize the global LlamaIndex Settings object from a JSON file at the given path."""
     settings_dict = _deserialize_dict_of_objects(path)
 
     from llama_index.core import Settings
 
     for k, v in settings_dict.items():
+        # To use the property setter rather than directly setting the private attribute e.g. _llm
+        if k.startswith("_"):
+            k = k[1:]
         setattr(Settings, k, v)

--- a/mlflow/llama_index/serialize_objects.py
+++ b/mlflow/llama_index/serialize_objects.py
@@ -124,8 +124,9 @@ def serialize_settings(path: str) -> None:
     from llama_index.core import Settings
 
     _logger.info(
-        "API key(s) will be deducted from the global Settings object during serialization. "
-        "At inference time, the key(s) must be passed as environment variables."
+        "API key(s) will be removed from the global Settings object during serialization "
+        "to protect against key leakage. At inference time, the key(s) must be passed as "
+        "environment variables."
     )
 
     to_serialize = {}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12716?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12716/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12716
```

</p>
</details>

### What changes are proposed in this pull request?

1. Remove the static mapping and use the standard `BaseComponent` class for checking if the object is serializable or not for better maintainability (ref: [comment](https://github.com/mlflow/mlflow/pull/12704#discussion_r1682254152))
2. Avoid showing `API key removed` warning multiple times.
3. Avoid showing `Serialization of the following objects are not supported` warning for `None` (or empty default callback manager) for the Setting.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Before PR**
```
2024/07/19 11:03:49 INFO mlflow.llama_index.serialize_objects: API key removed from object serialization. At inference time, the key must be passed as an environment variable or via inference parameters.
2024/07/19 11:03:49 INFO mlflow.llama_index.serialize_objects: API key removed from object serialization. At inference time, the key must be passed as an environment variable or via inference parameters.
2024/07/19 11:03:49 INFO mlflow.llama_index.serialize_objects: Serialization of the following objects are not supported and will not be logged with your model: _callback_manager, _tokenizer, _prompt_helper
```

**After PR**
```
2024/07/19 11:25:31 INFO mlflow.llama_index.serialize_objects: API key(s) will be deducted from the global Settings object during serialization. At inference time, the key(s) must be passed as environment variables.
```


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
