### PR TITLE
Add support for extracting databricks dependencies for various retriever types

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -47,6 +47,7 @@ def _get_vectorstore_from_retriever(retriever) -> Generator[Resource, None, None
         if isinstance(embeddings, (DatabricksEmbeddings, LegacyDatabricksEmbeddings)):
             yield DatabricksServingEndpoint(endpoint_name=embeddings.endpoint)
 
+
 def _extract_databricks_dependencies_from_retriever(retriever) -> Generator[Resource, None, None]:
     if hasattr(retriever, "base_retriever"):
         retriever = getattr(retriever, "base_retriever", None)
@@ -56,13 +57,13 @@ def _extract_databricks_dependencies_from_retriever(retriever) -> Generator[Reso
 
     if hasattr(retriever, "retrievers"):
         retriever = getattr(retriever, "retrievers", None)
-    
+
     if isinstance(retriever, list):
         for single_retriever in retriever:
             yield from _get_vectorstore_from_retriever(single_retriever)
     else:
         yield from _get_vectorstore_from_retriever(retriever)
-    
+
 
 def _extract_databricks_dependencies_from_llm(llm) -> Generator[Resource, None, None]:
     try:

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -18,7 +18,7 @@ def _get_embedding_model_endpoint_names(index):
     return embedding_model_endpoint_names
 
 
-def _extract_databricks_dependencies_from_retriever(retriever) -> Generator[Resource, None, None]:
+def _get_vectorstore_from_retriever(retriever) -> Generator[Resource, None, None]:
     try:
         from langchain.embeddings import DatabricksEmbeddings as LegacyDatabricksEmbeddings
         from langchain.vectorstores import (
@@ -47,6 +47,22 @@ def _extract_databricks_dependencies_from_retriever(retriever) -> Generator[Reso
         if isinstance(embeddings, (DatabricksEmbeddings, LegacyDatabricksEmbeddings)):
             yield DatabricksServingEndpoint(endpoint_name=embeddings.endpoint)
 
+def _extract_databricks_dependencies_from_retriever(retriever) -> Generator[Resource, None, None]:
+    if hasattr(retriever, "base_retriever"):
+        retriever = getattr(retriever, "base_retriever", None)
+
+    if hasattr(retriever, "retriever"):
+        retriever = getattr(retriever, "retriever", None)
+
+    if hasattr(retriever, "retrievers"):
+        retriever = getattr(retriever, "retrievers", None)
+    
+    if isinstance(retriever, list):
+        for single_retriever in retriever:
+            yield from _get_vectorstore_from_retriever(single_retriever)
+    else:
+        yield from _get_vectorstore_from_retriever(retriever)
+    
 
 def _extract_databricks_dependencies_from_llm(llm) -> Generator[Resource, None, None]:
     try:

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -124,7 +124,9 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 
     vsc = MockVectorSearchClient()
     vs_index_1 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_1")
-    vs_index_2 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_2", has_embedding_endpoint=True)
+    vs_index_2 = vsc.get_index(
+        endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_2", has_embedding_endpoint=True
+    )
     mock_get_deploy_client = MagicMock()
 
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
@@ -136,7 +138,9 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
 
     # set embedding model
-    vectorstore_1 = DatabricksVectorSearch(vs_index_1, text_column="content", embedding=embedding_model)
+    vectorstore_1 = DatabricksVectorSearch(
+        vs_index_1, text_column="content", embedding=embedding_model
+    )
     retriever_1 = vectorstore_1.as_retriever()
 
     # vs_index_2 has builtin embedding endpoint "embedding-model"
@@ -144,6 +148,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     retriever_2 = vectorstore_2.as_retriever()
 
     from langchain.chat_models import ChatOpenAI
+
     llm = ChatOpenAI(temperature=0)
 
     assert list(_extract_databricks_dependencies_from_retriever(retriever_1)) == [
@@ -157,6 +162,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     ]
 
     from langchain.retrievers.multi_query import MultiQueryRetriever
+
     multi_query_retriever = MultiQueryRetriever.from_llm(retriever=retriever_1, llm=llm)
     assert list(_extract_databricks_dependencies_from_retriever(multi_query_retriever)) == [
         DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
@@ -176,6 +182,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     ]
 
     from langchain.retrievers import EnsembleRetriever
+
     ensemble_retriever = EnsembleRetriever(
         retrievers=[retriever_1, retriever_2], weights=[0.5, 0.5]
     )
@@ -186,14 +193,8 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
         DatabricksServingEndpoint(endpoint_name="embedding-model"),
     ]
 
-    from langchain.retrievers.self_query.base import SelfQueryRetriever
-    self_query_retriever = SelfQueryRetriever.from_llm(llm, vectorstore_1)
-    assert list(_extract_databricks_dependencies_from_retriever(self_query_retriever)) == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
-        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
-    ]
-
     from langchain.retrievers import TimeWeightedVectorStoreRetriever
+
     time_weighted_retriever = TimeWeightedVectorStoreRetriever(
         vectorstore=vectorstore_1, decay_rate=0.0000000000000000000000001, k=1
     )
@@ -212,7 +213,9 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 
     vsc = MockVectorSearchClient()
     vs_index_1 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_1")
-    vs_index_2 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_2", has_embedding_endpoint=True)
+    vs_index_2 = vsc.get_index(
+        endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_2", has_embedding_endpoint=True
+    )
     mock_get_deploy_client = MagicMock()
 
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
@@ -224,7 +227,9 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
 
     # set embedding model
-    vectorstore_1 = DatabricksVectorSearch(vs_index_1, text_column="content", embedding=embedding_model)
+    vectorstore_1 = DatabricksVectorSearch(
+        vs_index_1, text_column="content", embedding=embedding_model
+    )
     retriever_1 = vectorstore_1.as_retriever()
 
     # vs_index_2 has builtin embedding endpoint "embedding-model"
@@ -232,6 +237,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     retriever_2 = vectorstore_2.as_retriever()
 
     from langchain.chat_models import ChatOpenAI
+
     llm = ChatOpenAI(temperature=0)
 
     assert list(_extract_databricks_dependencies_from_retriever(retriever_1)) == [
@@ -245,6 +251,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     ]
 
     from langchain.retrievers.multi_query import MultiQueryRetriever
+
     multi_query_retriever = MultiQueryRetriever.from_llm(retriever=retriever_1, llm=llm)
     assert list(_extract_databricks_dependencies_from_retriever(multi_query_retriever)) == [
         DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
@@ -264,6 +271,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     ]
 
     from langchain.retrievers import EnsembleRetriever
+
     ensemble_retriever = EnsembleRetriever(
         retrievers=[retriever_1, retriever_2], weights=[0.5, 0.5]
     )
@@ -275,6 +283,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     ]
 
     from langchain.retrievers import TimeWeightedVectorStoreRetriever
+
     time_weighted_retriever = TimeWeightedVectorStoreRetriever(
         vectorstore=vectorstore_1, decay_rate=0.0000000000000000000000001, k=1
     )

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -123,7 +123,8 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     from langchain.vectorstores import DatabricksVectorSearch
 
     vsc = MockVectorSearchClient()
-    vs_index = vsc.get_index(endpoint_name="dbdemos_vs_endpoint", index_name="mlflow.rag.vs_index")
+    vs_index_1 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_1")
+    vs_index_2 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_2", has_embedding_endpoint=True)
     mock_get_deploy_client = MagicMock()
 
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
@@ -134,11 +135,70 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 
     monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
 
-    vectorstore = DatabricksVectorSearch(vs_index, text_column="content", embedding=embedding_model)
-    retriever = vectorstore.as_retriever()
-    resources = list(_extract_databricks_dependencies_from_retriever(retriever))
-    assert resources == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
+    # set embedding model
+    vectorstore_1 = DatabricksVectorSearch(vs_index_1, text_column="content", embedding=embedding_model)
+    retriever_1 = vectorstore_1.as_retriever()
+
+    # vs_index_2 has builtin embedding endpoint "embedding-model"
+    vectorstore_2 = DatabricksVectorSearch(vs_index_2, text_column="content")
+    retriever_2 = vectorstore_2.as_retriever()
+
+    from langchain.chat_models import ChatOpenAI
+    llm = ChatOpenAI(temperature=0)
+
+    assert list(_extract_databricks_dependencies_from_retriever(retriever_1)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
+        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+    ]
+
+    assert list(_extract_databricks_dependencies_from_retriever(retriever_2)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_2"),
+        DatabricksServingEndpoint(endpoint_name="embedding-model"),
+    ]
+
+    from langchain.retrievers.multi_query import MultiQueryRetriever
+    multi_query_retriever = MultiQueryRetriever.from_llm(retriever=retriever_1, llm=llm)
+    assert list(_extract_databricks_dependencies_from_retriever(multi_query_retriever)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
+        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+    ]
+
+    from langchain.retrievers import ContextualCompressionRetriever
+    from langchain.retrievers.document_compressors import LLMChainExtractor
+
+    compressor = LLMChainExtractor.from_llm(llm)
+    compression_retriever = ContextualCompressionRetriever(
+        base_compressor=compressor, base_retriever=retriever_1
+    )
+    assert list(_extract_databricks_dependencies_from_retriever(compression_retriever)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
+        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+    ]
+
+    from langchain.retrievers import EnsembleRetriever
+    ensemble_retriever = EnsembleRetriever(
+        retrievers=[retriever_1, retriever_2], weights=[0.5, 0.5]
+    )
+    assert list(_extract_databricks_dependencies_from_retriever(ensemble_retriever)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
+        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_2"),
+        DatabricksServingEndpoint(endpoint_name="embedding-model"),
+    ]
+
+    from langchain.retrievers.self_query.base import SelfQueryRetriever
+    self_query_retriever = SelfQueryRetriever.from_llm(llm, vectorstore_1)
+    assert list(_extract_databricks_dependencies_from_retriever(self_query_retriever)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
+        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+    ]
+
+    from langchain.retrievers import TimeWeightedVectorStoreRetriever
+    time_weighted_retriever = TimeWeightedVectorStoreRetriever(
+        vectorstore=vectorstore_1, decay_rate=0.0000000000000000000000001, k=1
+    )
+    assert list(_extract_databricks_dependencies_from_retriever(time_weighted_retriever)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
         DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
     ]
 
@@ -151,7 +211,8 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     from langchain_community.vectorstores import DatabricksVectorSearch
 
     vsc = MockVectorSearchClient()
-    vs_index = vsc.get_index(endpoint_name="dbdemos_vs_endpoint", index_name="mlflow.rag.vs_index")
+    vs_index_1 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_1")
+    vs_index_2 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_2", has_embedding_endpoint=True)
     mock_get_deploy_client = MagicMock()
 
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
@@ -162,11 +223,63 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 
     monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
 
-    vectorstore = DatabricksVectorSearch(vs_index, text_column="content", embedding=embedding_model)
-    retriever = vectorstore.as_retriever()
-    resources = list(_extract_databricks_dependencies_from_retriever(retriever))
-    assert resources == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
+    # set embedding model
+    vectorstore_1 = DatabricksVectorSearch(vs_index_1, text_column="content", embedding=embedding_model)
+    retriever_1 = vectorstore_1.as_retriever()
+
+    # vs_index_2 has builtin embedding endpoint "embedding-model"
+    vectorstore_2 = DatabricksVectorSearch(vs_index_2, text_column="content")
+    retriever_2 = vectorstore_2.as_retriever()
+
+    from langchain.chat_models import ChatOpenAI
+    llm = ChatOpenAI(temperature=0)
+
+    assert list(_extract_databricks_dependencies_from_retriever(retriever_1)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
+        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+    ]
+
+    assert list(_extract_databricks_dependencies_from_retriever(retriever_2)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_2"),
+        DatabricksServingEndpoint(endpoint_name="embedding-model"),
+    ]
+
+    from langchain.retrievers.multi_query import MultiQueryRetriever
+    multi_query_retriever = MultiQueryRetriever.from_llm(retriever=retriever_1, llm=llm)
+    assert list(_extract_databricks_dependencies_from_retriever(multi_query_retriever)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
+        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+    ]
+
+    from langchain.retrievers import ContextualCompressionRetriever
+    from langchain.retrievers.document_compressors import LLMChainExtractor
+
+    compressor = LLMChainExtractor.from_llm(llm)
+    compression_retriever = ContextualCompressionRetriever(
+        base_compressor=compressor, base_retriever=retriever_1
+    )
+    assert list(_extract_databricks_dependencies_from_retriever(compression_retriever)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
+        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+    ]
+
+    from langchain.retrievers import EnsembleRetriever
+    ensemble_retriever = EnsembleRetriever(
+        retrievers=[retriever_1, retriever_2], weights=[0.5, 0.5]
+    )
+    assert list(_extract_databricks_dependencies_from_retriever(ensemble_retriever)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
+        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_2"),
+        DatabricksServingEndpoint(endpoint_name="embedding-model"),
+    ]
+
+    from langchain.retrievers import TimeWeightedVectorStoreRetriever
+    time_weighted_retriever = TimeWeightedVectorStoreRetriever(
+        vectorstore=vectorstore_1, decay_rate=0.0000000000000000000000001, k=1
+    )
+    assert list(_extract_databricks_dependencies_from_retriever(time_weighted_retriever)) == [
+        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
         DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
     ]
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/12722?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12722/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12722
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Add casing in `_extract_databricks_dependencies_from_retriever` for more types of retrievers from langchain.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
   - only manual tested for EnsembleRetriever so far, planning to do manual tests for other types

<img width="1644" alt="Screenshot 2024-07-19 at 3 37 41 PM" src="https://github.com/user-attachments/assets/6f914a8f-b413-43f5-8ee1-b1e96774adba">
<img width="774" alt="Screenshot 2024-07-19 at 3 39 13 PM" src="https://github.com/user-attachments/assets/f8c78bfc-a702-442a-ae79-9866f99467e7">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
