### PR TITLE
Fix transformers dev cross version test

### DIFF
--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -175,12 +175,13 @@ def load_zero_shot_pipeline():
 @prefetch
 @flaky()
 def load_table_question_answering_pipeline():
-    model = transformers.AutoModel.from_pretrained(
+    model = transformers.TapasForQuestionAnswering.from_pretrained(
         "google/tapas-tiny-finetuned-wtq",
         low_cpu_mem_usage=True,
     )
-    tokenizer = transformers.AutoTokenizer.from_pretrained("google/tapas-tiny-finetuned-wtq")
-    return transformers.pipeline(task="table-question-answering", model=model, tokenizer=tokenizer)
+    return transformers.pipeline(
+        task="table-question-answering", model=model, tokenizer="google/tapas-tiny-finetuned-wtq"
+    )
 
 
 @prefetch

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -175,9 +175,11 @@ def load_zero_shot_pipeline():
 @prefetch
 @flaky()
 def load_table_question_answering_pipeline():
-    return transformers.pipeline(
-        task="table-question-answering", model="google/tapas-tiny-finetuned-wtq"
+    model = transformers.AutoModel.from_pretrained(
+        "google/tapas-tiny-finetuned-wtq",
+        low_cpu_mem_usage=True,
     )
+    return transformers.pipeline(task="table-question-answering", model=model)
 
 
 @prefetch

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -179,7 +179,7 @@ def load_table_question_answering_pipeline():
         "google/tapas-tiny-finetuned-wtq",
         low_cpu_mem_usage=True,
     )
-    tokenizer = transformers.AutoTokenizer.from_pretrained("tapas-tiny-finetuned-wtq")
+    tokenizer = transformers.AutoTokenizer.from_pretrained("google/tapas-tiny-finetuned-wtq")
     return transformers.pipeline(task="table-question-answering", model=model, tokenizer=tokenizer)
 
 

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -175,9 +175,14 @@ def load_zero_shot_pipeline():
 @prefetch
 @flaky()
 def load_table_question_answering_pipeline():
+    # transformers>4.42.2 includes a change that causes this
+    # model to fail saving without the low_cpu_mem_usage flag.
+    # see https://github.com/huggingface/transformers/issues/32128
+    low_cpu_mem_usage = Version(transformers.__version__) > Version("4.42.2")
+
     model = transformers.TapasForQuestionAnswering.from_pretrained(
         "google/tapas-tiny-finetuned-wtq",
-        low_cpu_mem_usage=True,
+        low_cpu_mem_usage=low_cpu_mem_usage,
     )
     return transformers.pipeline(
         task="table-question-answering", model=model, tokenizer="google/tapas-tiny-finetuned-wtq"

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -179,7 +179,8 @@ def load_table_question_answering_pipeline():
         "google/tapas-tiny-finetuned-wtq",
         low_cpu_mem_usage=True,
     )
-    return transformers.pipeline(task="table-question-answering", model=model)
+    tokenizer = transformers.AutoTokenizer.from_pretrained("tapas-tiny-finetuned-wtq")
+    return transformers.pipeline(task="table-question-answering", model=model, tokenizer=tokenizer)
 
 
 @prefetch

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1571,9 +1571,12 @@ def test_classifier_pipeline(text_classification_pipeline, model_path, data):
         assert len(inference) == len(data)
         for key in ["score", "label"]:
             for value in range(0, len(data)):
-                assert math.isclose(
-                    native_inference[value][key], inference_dict[key][value], rel_tol=1e-7
-                )
+                if key == "label":
+                    assert inference_dict[key][value] == native_inference[value][key]
+                else:
+                    assert math.isclose(
+                        native_inference[value][key], inference_dict[key][value], rel_tol=1e-7
+                    )
 
 
 @pytest.mark.parametrize(
@@ -1845,7 +1848,12 @@ def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline):
     # validate that the pyfunc served model registers text_pair in the same manner as native
     for key in ["score", "label"]:
         for value in [0, 1]:
-            assert math.isclose(values_dict[key][value], native_predict[value][key], rel_tol=1e-7)
+            if key == "label":
+                assert values_dict[key][value] == native_predict[value][key]
+            else:
+                assert math.isclose(
+                    values_dict[key][value], native_predict[value][key], rel_tol=1e-7
+                )
 
 
 def test_zero_shot_pipeline_pyfunc_predict(zero_shot_pipeline):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2,6 +2,7 @@ import base64
 import gc
 import importlib.util
 import json
+import math
 import os
 import pathlib
 import re
@@ -1570,7 +1571,9 @@ def test_classifier_pipeline(text_classification_pipeline, model_path, data):
         assert len(inference) == len(data)
         for key in ["score", "label"]:
             for value in range(0, len(data)):
-                assert native_inference[value][key] == inference_dict[key][value]
+                assert math.isclose(
+                    native_inference[value][key], inference_dict[key][value], rel_tol=1e-7
+                )
 
 
 @pytest.mark.parametrize(
@@ -1842,7 +1845,7 @@ def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline):
     # validate that the pyfunc served model registers text_pair in the same manner as native
     for key in ["score", "label"]:
         for value in [0, 1]:
-            assert values_dict[key][value] == native_predict[value][key]
+            assert math.isclose(values_dict[key][value], native_predict[value][key], rel_tol=1e-7)
 
 
 def test_zero_shot_pipeline_pyfunc_predict(zero_shot_pipeline):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/12727?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12727/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12727
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

[This commit in transformers](https://github.com/huggingface/transformers/commit/6f40a213eb10e38a5f242d0645519d413d32d798) enabled a new feature to initialize models faster. However, it seems that this causes issues with saving certain types of models. The feature can be disabled by passing in `low_cpu_mem_usage=True` when loading models

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

This test case now passes:

```
tests/transformers/test_transformers_model_export.py::test_table_question_answering_pipeline[query0-result0] PASSED | MEM 2.2/15.6 GB | DISK 47.6/72.5 GB [ 41%]
tests/transformers/test_transformers_model_export.py::test_table_question_answering_pipeline[query1-result1] PASSED | MEM 2.2/15.6 GB | DISK 47.6/72.5 GB [ 41%]
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
