### PR TITLE
Add model serving input validation section in UI

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -446,7 +446,9 @@ def convert_input_example_to_serving_input(
     can be used for model inference in the scoring server.
 
     Args:
-        input_example: model input example
+        input_example: model input example. Supported types are pandas.DataFrame, numpy.ndarray,
+            dictionary of (name -> numpy.ndarray), list, scalars, and any json-seriazable objects
+            if example_no_conversion is set to True.
         example_no_conversion: If True, the input example is not converted and directly
             saved as a json object. Default to False.
 

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
@@ -152,7 +152,9 @@ flavors:
     wrapper = mountWithIntl(<ShowArtifactLoggedModelView {...props} />);
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.find('.artifact-logged-model-view-code-content').at(1).html()).toContain('runs:/fakeUuid/modelPath');
+      expect(wrapper.find('.artifact-logged-model-view-code-content').at(1).html()).toContain(
+        'runs:/fakeUuid/modelPath',
+      );
       done();
     });
   });
@@ -162,7 +164,9 @@ flavors:
     wrapper = mountWithIntl(<ShowArtifactLoggedModelView {...props} />);
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.find('.artifact-logged-model-view-code-content').at(0).html()).toContain('validate_serving_input(model_uri, serving_payload)');
+      expect(wrapper.find('.artifact-logged-model-view-code-content').at(0).html()).toContain(
+        'validate_serving_input(model_uri, serving_payload)',
+      );
       done();
     });
   });
@@ -239,14 +243,17 @@ flavors:
   });
 
   test('should render serving validation code snippet if serving_input_payload exists', (done) => {
-    const getArtifact = jest.fn().mockImplementationOnce((artifactLocation) => {
-      return Promise.resolve(`
+    const getArtifact = jest
+      .fn()
+      .mockImplementationOnce((artifactLocation) => {
+        return Promise.resolve(`
 flavors:
   sklearn:
     version: 1.2.3
 `);
-    }).mockImplementationOnce((artifactLocation) => {
-      return Promise.resolve(`
+      })
+      .mockImplementationOnce((artifactLocation) => {
+        return Promise.resolve(`
 {
   "dataframe_split": {
     "columns": [
@@ -265,7 +272,7 @@ flavors:
   }
 }
 `);
-    });
+      });
     const props = { ...minimalProps, getArtifact };
     wrapper = mountWithIntl(<ShowArtifactLoggedModelView {...props} />);
     setImmediate(() => {
@@ -281,15 +288,18 @@ flavors:
   });
 
   test('should render serving validation code snippet if serving_input_payload does not exist', (done) => {
-    const getArtifact = jest.fn().mockImplementationOnce((artifactLocation) => {
-      return Promise.resolve(`
+    const getArtifact = jest
+      .fn()
+      .mockImplementationOnce((artifactLocation) => {
+        return Promise.resolve(`
 flavors:
   sklearn:
     version: 1.2.3
 `);
-    }).mockImplementationOnce((artifactLocation) => {
-      return Promise.reject(new Error('file not existing'));
-    });
+      })
+      .mockImplementationOnce((artifactLocation) => {
+        return Promise.reject(new Error('file not existing'));
+      });
     const props = { ...minimalProps, getArtifact };
     wrapper = mountWithIntl(<ShowArtifactLoggedModelView {...props} />);
     setImmediate(() => {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
@@ -142,7 +142,7 @@ flavors:
     setImmediate(() => {
       wrapper.update();
       expect(wrapper.find('.artifact-logged-model-view-code-group').length).toBe(1);
-      expect(wrapper.find('.artifact-logged-model-view-code-content').length).toBe(1);
+      expect(wrapper.find('.artifact-logged-model-view-code-content').length).toBe(2);
       done();
     });
   });
@@ -152,7 +152,17 @@ flavors:
     wrapper = mountWithIntl(<ShowArtifactLoggedModelView {...props} />);
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.find('.artifact-logged-model-view-code-content').html()).toContain('runs:/fakeUuid/modelPath');
+      expect(wrapper.find('.artifact-logged-model-view-code-content').at(1).html()).toContain('runs:/fakeUuid/modelPath');
+      done();
+    });
+  });
+
+  test('should render serving input validation in code snippet', (done) => {
+    const props = { ...commonProps, path: 'modelPath', artifactRootUri: 'some/root' };
+    wrapper = mountWithIntl(<ShowArtifactLoggedModelView {...props} />);
+    setImmediate(() => {
+      wrapper.update();
+      expect(wrapper.find('.artifact-logged-model-view-code-content').at(0).html()).toContain('validate_serving_input(model_uri, serving_payload)');
       done();
     });
   });
@@ -182,9 +192,11 @@ flavors:
   test('should fetch artifacts on component update', () => {
     instance = wrapper.instance();
     instance.fetchLoggedModelMetadata = jest.fn();
+    instance.fetchServingInputExample = jest.fn();
     wrapper.setProps({ path: 'newpath', runUuid: 'newRunId' });
     expect(instance.fetchLoggedModelMetadata).toBeCalled();
     expect(instance.props.getArtifact).toBeCalled();
+    expect(instance.fetchServingInputExample).toBeCalled();
   });
 
   test('should render code snippet with original flavor when no pyfunc flavor', (done) => {
@@ -201,8 +213,8 @@ flavors:
       wrapper.update();
       expect(wrapper.state().flavor).toBe('sklearn');
       const codeContent = wrapper.find('.artifact-logged-model-view-code-content');
-      expect(codeContent.length).toBe(1);
-      expect(codeContent.text().includes('mlflow.sklearn.load_model')).toBe(true);
+      expect(codeContent.length).toBe(2);
+      expect(codeContent.at(1).text().includes('mlflow.sklearn.load_model')).toBe(true);
       done();
     });
   });
@@ -220,7 +232,74 @@ flavors:
     setImmediate(() => {
       wrapper.update();
       expect(wrapper.state().flavor).toBe('mleap');
-      expect(wrapper.find('.artifact-logged-model-view-code-content').length).toBe(0);
+      // Only validate model serving code snippet is rendered
+      expect(wrapper.find('.artifact-logged-model-view-code-content').length).toBe(1);
+      done();
+    });
+  });
+
+  test('should render serving validation code snippet if serving_input_payload exists', (done) => {
+    const getArtifact = jest.fn().mockImplementationOnce((artifactLocation) => {
+      return Promise.resolve(`
+flavors:
+  sklearn:
+    version: 1.2.3
+`);
+    }).mockImplementationOnce((artifactLocation) => {
+      return Promise.resolve(`
+{
+  "dataframe_split": {
+    "columns": [
+      "messages"
+    ],
+    "data": [
+      [
+        [
+          {
+            "role": "user",
+            "content": "some question"
+          }
+        ]
+      ]
+    ]
+  }
+}
+`);
+    });
+    const props = { ...minimalProps, getArtifact };
+    wrapper = mountWithIntl(<ShowArtifactLoggedModelView {...props} />);
+    setImmediate(() => {
+      wrapper.update();
+      expect(wrapper.state().serving_input).toBeDefined();
+      const codeContent = wrapper.find('.artifact-logged-model-view-code-content');
+      expect(codeContent.length).toBe(2);
+      const codeContentText = codeContent.at(0).text();
+      expect(codeContentText.includes('# The model is logged with input_example')).toBe(true);
+      expect(codeContentText.includes('validate_serving_input(model_uri, serving_payload)')).toBe(true);
+      done();
+    });
+  });
+
+  test('should render serving validation code snippet if serving_input_payload does not exist', (done) => {
+    const getArtifact = jest.fn().mockImplementationOnce((artifactLocation) => {
+      return Promise.resolve(`
+flavors:
+  sklearn:
+    version: 1.2.3
+`);
+    }).mockImplementationOnce((artifactLocation) => {
+      return Promise.reject(new Error('file not existing'));
+    });
+    const props = { ...minimalProps, getArtifact };
+    wrapper = mountWithIntl(<ShowArtifactLoggedModelView {...props} />);
+    setImmediate(() => {
+      wrapper.update();
+      expect(wrapper.state().serving_input).toBeDefined();
+      const codeContent = wrapper.find('.artifact-logged-model-view-code-content');
+      expect(codeContent.length).toBe(2);
+      const codeContentText = codeContent.at(0).text();
+      expect(codeContentText.includes('# The model logged does not contain input_example')).toBe(true);
+      expect(codeContentText.includes('validate_serving_input(model_uri, serving_payload)')).toBe(true);
       done();
     });
   });

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
@@ -281,7 +281,7 @@ flavors:
       const codeContent = wrapper.find('.artifact-logged-model-view-code-content');
       expect(codeContent.length).toBe(2);
       const codeContentText = codeContent.at(0).text();
-      expect(codeContentText.includes('# The model is logged with input_example')).toBe(true);
+      expect(codeContentText.includes('# The model is logged with an input example')).toBe(true);
       expect(codeContentText.includes('validate_serving_input(model_uri, serving_payload)')).toBe(true);
       done();
     });

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
@@ -308,7 +308,7 @@ flavors:
       const codeContent = wrapper.find('.artifact-logged-model-view-code-content');
       expect(codeContent.length).toBe(2);
       const codeContentText = codeContent.at(0).text();
-      expect(codeContentText.includes('# The model logged does not contain input_example')).toBe(true);
+      expect(codeContentText.includes('# The logged model does not contain an input_example')).toBe(true);
       expect(codeContentText.includes('validate_serving_input(model_uri, serving_payload)')).toBe(true);
       done();
     });

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -162,8 +162,9 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
         `from mlflow.models import validate_serving_input\n\n` +
         `model_uri = '${modelPath}'\n\n` +
         `# The model logged does not contain input_example, you need to manually generate a serving payload\n` +
-        `from mlflow.models import convert_input_example_to_serving_input\n` +
+        `from mlflow.models import convert_input_example_to_serving_input\n\n` +
         `# Replace INPUT_EXAMPLE with your own input example to the model\n` +
+        `# A valid input example is a data instance that can be passed for pyfunc predict\n` +
         `serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)\n\n` +
         `# Validate the serving payload works on the model\n` +
         `validate_serving_input(model_uri, serving_payload)`
@@ -173,7 +174,9 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
         `import mlflow\n` +
         `from mlflow.models import validate_serving_input\n\n` +
         `model_uri = '${modelPath}'\n\n` +
-        `# The model is logged with input_example, 'serving_input_payload.json' file saves a valid serving payload\n` +
+        `# The model is logged with an input example. MLflow converts\n` +
+        `# it into a request payload format for deployed model endpoint,\n` +
+        `# and saves it to 'serving_input_payload.json' file\n` +
         `serving_payload = """${servingInput}"""\n\n` +
         `# Validate the serving payload works on the model\n` +
         `validate_serving_input(model_uri, serving_payload)`
@@ -309,7 +312,10 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
           </span>
           <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span>{' '}
           convert_input_example_to_serving_input{`\n\n`}
-          <span className="code-comment">{'# Replace INPUT_EXAMPLE with your own input example to the model\n'}</span>
+          <span className="code-comment">
+            {`# Replace INPUT_EXAMPLE with your own input example to the model
+# A valid input example is a data instance that can be passed for pyfunc predict\n`}
+          </span>
           serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)
         </div>
       );
@@ -317,9 +323,9 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
       return (
         <div>
           <span className="code-comment">
-            {
-              '# The model is logged with input_example, `serving_input_payload.json` file saves a valid serving payload\n'
-            }
+            {`# The model is logged with an input example. MLflow converts
+# it into a request payload format for the deployed model endpoint,
+# and saves it to \`serving_input_payload.json\` file\n`}
           </span>
           serving_payload = <span className="code-string">{`"""${servingInput}"""`}</span>
         </div>
@@ -333,7 +339,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
       <div css={styles.item}>
         <Text>
           <FormattedMessage
-            defaultMessage="Run below code to validate the model works on the serving payload prior to serving" // eslint-disable-next-line max-len
+            defaultMessage="Run below code to validate model inference works on the example payload, prior to deploying it to a serving endpoint" // eslint-disable-next-line max-len
             description="Section heading to display the code block on how we can use validate an input against registered model prior to serving"
           />
         </Text>

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -339,7 +339,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
       <div css={styles.item}>
         <Text>
           <FormattedMessage
-            defaultMessage="Run below code to validate model inference works on the example payload, prior to deploying it to a serving endpoint" // eslint-disable-next-line max-len
+            defaultMessage="Run the following code to validate model inference works on the example payload, prior to deploying it to a serving endpoint" // eslint-disable-next-line max-len
             description="Section heading to display the code block on how we can use validate an input against registered model prior to serving"
           />
         </Text>

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -157,30 +157,24 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
 
   validateModelForServingText(modelPath: any, servingInput?: string) {
     if (servingInput === null) {
-      return (
-        `import mlflow\n` +
-        `from mlflow.models import validate_serving_input\n\n` +
-        `model_uri = '${modelPath}'\n\n` +
-        `# The model logged does not contain input_example, you need to manually generate a serving payload\n` +
-        `from mlflow.models import convert_input_example_to_serving_input\n\n` +
-        `# Replace INPUT_EXAMPLE with your own input example to the model\n` +
-        `# A valid input example is a data instance that can be passed for pyfunc predict\n` +
-        `serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)\n\n` +
-        `# Validate the serving payload works on the model\n` +
-        `validate_serving_input(model_uri, serving_payload)`
-      );
+      return `from mlflow.models import validate_serving_input\n
+model_uri = '${modelPath}'\n
+# The model logged does not contain input_example, you need to manually generate a serving payload
+from mlflow.models import convert_input_example_to_serving_input\n
+# Replace INPUT_EXAMPLE with your own input example to the model
+# A valid input example is a data instance that can be passed for pyfunc predict
+serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)\n
+# Validate the serving payload works on the model
+validate_serving_input(model_uri, serving_payload)`;
     } else {
-      return (
-        `import mlflow\n` +
-        `from mlflow.models import validate_serving_input\n\n` +
-        `model_uri = '${modelPath}'\n\n` +
-        `# The model is logged with an input example. MLflow converts\n` +
-        `# it into a request payload format for deployed model endpoint,\n` +
-        `# and saves it to 'serving_input_payload.json' file\n` +
-        `serving_payload = """${servingInput}"""\n\n` +
-        `# Validate the serving payload works on the model\n` +
-        `validate_serving_input(model_uri, serving_payload)`
-      );
+      return `from mlflow.models import validate_serving_input\n
+model_uri = '${modelPath}'\n
+# The model is logged with an input example. MLflow converts
+# it into the serving payload format for deployed model endpoint,
+# and saves it to 'serving_input_payload.json' file
+serving_payload = """${servingInput}"""\n
+# Validate the serving payload works on the model
+validate_serving_input(model_uri, serving_payload)`;
     }
   }
 
@@ -324,7 +318,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
         <div>
           <span className="code-comment">
             {`# The model is logged with an input example. MLflow converts
-# it into a request payload format for the deployed model endpoint,
+# it into the serving payload format for the deployed model endpoint,
 # and saves it to \`serving_input_payload.json\` file\n`}
           </span>
           serving_payload = <span className="code-string">{`"""${servingInput}"""`}</span>
@@ -350,7 +344,6 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
         >
           <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
             <div className="code">
-              <span className="code-keyword">import</span> mlflow{`\n`}
               <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span>{' '}
               validate_serving_input{`\n\n`}
               model_uri = <span className="code-string">{`'${modelPath}'\n\n`}</span>

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -307,20 +307,23 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
           <span className="code-comment">
             {'# The model logged does not contain input_example, you need to manually generate a serving payload\n'}
           </span>
-          <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span> convert_input_example_to_serving_input{`\n\n`}
+          <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span>{' '}
+          convert_input_example_to_serving_input{`\n\n`}
           <span className="code-comment">{'# Replace INPUT_EXAMPLE with your own input example to the model\n'}</span>
           serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)
         </div>
-      )
+      );
     } else {
       return (
         <div>
           <span className="code-comment">
-            {'# The model is logged with input_example, `serving_input_payload.json` file saves a valid serving payload\n'}
+            {
+              '# The model is logged with input_example, `serving_input_payload.json` file saves a valid serving payload\n'
+            }
           </span>
           serving_payload = <span className="code-string">{`"""${servingInput}"""`}</span>
         </div>
-      )
+      );
     }
   }
 
@@ -342,7 +345,8 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
           <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
             <div className="code">
               <span className="code-keyword">import</span> mlflow{`\n`}
-              <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span> validate_serving_input{`\n\n`}
+              <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span>{' '}
+              validate_serving_input{`\n\n`}
               model_uri = <span className="code-string">{`'${modelPath}'\n\n`}</span>
               {this.renderServingPayload(servingInput)}
             </div>
@@ -383,7 +387,6 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
       </>
     );
   }
-
 
   renderPyfuncCodeSnippet() {
     if (this.state.loader_module === 'mlflow.spark') {
@@ -649,17 +652,19 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
   }
 
   fetchServingInputExample() {
-    const servingInputFileLocation = getArtifactLocationUrl(`${this.props.path}/${SERVING_INPUT_FILE_NAME}`, this.props.runUuid);
+    const servingInputFileLocation = getArtifactLocationUrl(
+      `${this.props.path}/${SERVING_INPUT_FILE_NAME}`,
+      this.props.runUuid,
+    );
     this.props
       .getArtifact(servingInputFileLocation)
       .then((response: any) => {
         this.setState({ serving_input: response });
       })
       .catch(() => {
-        this.setState({ serving_input: null});
+        this.setState({ serving_input: null });
       });
   }
-
 }
 
 const styles = {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -156,23 +156,31 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
   }
 
   validateModelForServingText(modelPath: any, servingInput?: string) {
-    if (servingInput === null) {
-      return `from mlflow.models import validate_serving_input\n
-model_uri = '${modelPath}'\n
-# The model logged does not contain input_example, you need to manually generate a serving payload
-from mlflow.models import convert_input_example_to_serving_input\n
-# Replace INPUT_EXAMPLE with your own input example to the model
-# A valid input example is a data instance that can be passed for pyfunc predict
-serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)\n
+    if (servingInput) {
+      return `from mlflow.models import validate_serving_input
+
+model_uri = '${modelPath}'
+
+# The model is logged with an input example. MLflow converts
+# it into the serving payload format for the deployed model endpoint,
+# and saves it to 'serving_input_payload.json'
+serving_payload = """${servingInput}"""
+
 # Validate the serving payload works on the model
 validate_serving_input(model_uri, serving_payload)`;
     } else {
-      return `from mlflow.models import validate_serving_input\n
-model_uri = '${modelPath}'\n
-# The model is logged with an input example. MLflow converts
-# it into the serving payload format for deployed model endpoint,
-# and saves it to 'serving_input_payload.json' file
-serving_payload = """${servingInput}"""\n
+      return `from mlflow.models import validate_serving_input
+
+model_uri = '${modelPath}'
+
+# The logged model does not contain an input_example.
+# Manually generate a serving payload to verify your model prior to deployment.
+from mlflow.models import convert_input_example_to_serving_input
+
+# Define INPUT_EXAMPLE via assignment with your own input example to the model
+# A valid input example is a data instance suitable for pyfunc prediction
+serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)
+
 # Validate the serving payload works on the model
 validate_serving_input(model_uri, serving_payload)`;
     }
@@ -298,30 +306,31 @@ validate_serving_input(model_uri, serving_payload)`;
   }
 
   renderServingPayload(servingInput?: string) {
-    if (servingInput === null) {
-      return (
-        <div className="code">
-          <span className="code-comment">
-            {'# The model logged does not contain input_example, you need to manually generate a serving payload\n'}
-          </span>
-          <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span>{' '}
-          convert_input_example_to_serving_input{`\n\n`}
-          <span className="code-comment">
-            {`# Replace INPUT_EXAMPLE with your own input example to the model
-# A valid input example is a data instance that can be passed for pyfunc predict\n`}
-          </span>
-          serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)
-        </div>
-      );
-    } else {
+    if (servingInput) {
       return (
         <div>
           <span className="code-comment">
             {`# The model is logged with an input example. MLflow converts
 # it into the serving payload format for the deployed model endpoint,
-# and saves it to \`serving_input_payload.json\` file\n`}
+# and saves it to 'serving_input_payload.json'\n`}
           </span>
           serving_payload = <span className="code-string">{`"""${servingInput}"""`}</span>
+        </div>
+      );
+    } else {
+      return (
+        <div className="code">
+          <span className="code-comment">
+            {`# The logged model does not contain an input_example. 
+# Manually generate a serving payload to verify your model prior to deployment.\n`}
+          </span>
+          <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span>{' '}
+          convert_input_example_to_serving_input{`\n\n`}
+          <span className="code-comment">
+            {`# Define INPUT_EXAMPLE via assignment with your own input example to the model
+# A valid input example is a data instance suitable for pyfunc prediction\n`}
+          </span>
+          serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)
         </div>
       );
     }

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -8,7 +8,7 @@
 import React, { Component } from 'react';
 import yaml from 'js-yaml';
 import '../../../common/styles/CodeSnippet.css';
-import { MLMODEL_FILE_NAME } from '../../constants';
+import { MLMODEL_FILE_NAME, SERVING_INPUT_FILE_NAME } from '../../constants';
 import { getArtifactContent, getArtifactLocationUrl } from '../../../common/utils/ArtifactUtils';
 import { SchemaTable } from '../../../model-registry/components/SchemaTable';
 import {
@@ -42,6 +42,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.fetchLoggedModelMetadata = this.fetchLoggedModelMetadata.bind(this);
+    this.fetchServingInputExample = this.fetchServingInputExample.bind(this);
   }
 
   static defaultProps = {
@@ -55,15 +56,18 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
     outputs: undefined,
     flavor: undefined,
     loader_module: undefined,
+    serving_input: undefined,
   };
 
   componentDidMount() {
     this.fetchLoggedModelMetadata();
+    this.fetchServingInputExample();
   }
 
   componentDidUpdate(prevProps: Props) {
     if (this.props.path !== prevProps.path || this.props.runUuid !== prevProps.runUuid) {
       this.fetchLoggedModelMetadata();
+      this.fetchServingInputExample();
     }
   }
   static getLearnModelRegistryLinkUrl = () => RegisteringModelDocUrl;
@@ -149,6 +153,32 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
       `# Perform inference via model.transform()\n` +
       `loaded_model.transform(data)`
     );
+  }
+
+  validateModelForServingText(modelPath: any, servingInput?: string) {
+    if (servingInput === null) {
+      return (
+        `import mlflow\n` +
+        `from mlflow.models import validate_serving_input\n\n` +
+        `model_uri = '${modelPath}'\n\n` +
+        `# The model logged does not contain input_example, you need to manually generate a serving payload\n` +
+        `from mlflow.models import convert_input_example_to_serving_input\n` +
+        `# Replace INPUT_EXAMPLE with your own input example to the model\n` +
+        `serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)\n\n` +
+        `# Validate the serving payload works on the model\n` +
+        `validate_serving_input(model_uri, serving_payload)`
+      );
+    } else {
+      return (
+        `import mlflow\n` +
+        `from mlflow.models import validate_serving_input\n\n` +
+        `model_uri = '${modelPath}'\n\n` +
+        `# The model is logged with input_example, 'serving_input_payload.json' file saves a valid serving payload\n` +
+        `serving_payload = """${servingInput}"""\n\n` +
+        `# Validate the serving payload works on the model\n` +
+        `validate_serving_input(model_uri, serving_payload)`
+      );
+    }
   }
 
   renderNonPyfuncCodeSnippet() {
@@ -270,6 +300,91 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
     );
   }
 
+  renderServingPayload(servingInput?: string) {
+    if (servingInput === null) {
+      return (
+        <div className="code">
+          <span className="code-comment">
+            {'# The model logged does not contain input_example, you need to manually generate a serving payload\n'}
+          </span>
+          <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span> convert_input_example_to_serving_input{`\n\n`}
+          <span className="code-comment">{'# Replace INPUT_EXAMPLE with your own input example to the model\n'}</span>
+          serving_payload = convert_input_example_to_serving_input(INPUT_EXAMPLE)
+        </div>
+      )
+    } else {
+      return (
+        <div>
+          <span className="code-comment">
+            {'# The model is logged with input_example, `serving_input_payload.json` file saves a valid serving payload\n'}
+          </span>
+          serving_payload = <span className="code-string">{`"""${servingInput}"""`}</span>
+        </div>
+      )
+    }
+  }
+
+  renderValidateServingInput(modelPath: any, servingInput?: string) {
+    return (
+      // @ts-expect-error TS(2322): Type '{ position: string; pre: { margin: number; }... Remove this comment to see the full error message
+      <div css={styles.item}>
+        <Text>
+          <FormattedMessage
+            defaultMessage="Run below code to validate the model works on the serving payload prior to serving" // eslint-disable-next-line max-len
+            description="Section heading to display the code block on how we can use validate an input against registered model prior to serving"
+          />
+        </Text>
+        <Paragraph
+          dangerouslySetAntdProps={{
+            copyable: { text: this.validateModelForServingText(modelPath, servingInput) },
+          }}
+        >
+          <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
+            <div className="code">
+              <span className="code-keyword">import</span> mlflow{`\n`}
+              <span className="code-keyword">from</span> mlflow.models <span className="code-keyword">import</span> validate_serving_input{`\n\n`}
+              model_uri = <span className="code-string">{`'${modelPath}'\n\n`}</span>
+              {this.renderServingPayload(servingInput)}
+            </div>
+            <br />
+            <div className="code">
+              <span className="code-comment">
+                {'# '}
+                <FormattedMessage
+                  defaultMessage="Validate the serving payload works on the model"
+                  description="Code comment which states how to validate serving payload"
+                />
+              </span>
+              {`\n`}
+              validate_serving_input(model_uri, serving_payload)
+            </div>
+            <br />
+          </pre>
+        </Paragraph>
+      </div>
+    );
+  }
+
+  renderValidateServingInputCodeSnippet() {
+    const { runUuid, path } = this.props;
+    const modelPath = `runs:/${runUuid}/${path}`;
+    return (
+      <>
+        <Title level={3}>
+          <FormattedMessage
+            defaultMessage="Validate the model before deployment"
+            // eslint-disable-next-line max-len
+            description="Heading text for validating the model before deploying it for serving"
+          />
+        </Title>
+        <div className="artifact-logged-model-view-code-content">
+          {this.renderValidateServingInput(modelPath, this.state.serving_input)}
+        </div>
+      </>
+    );
+  }
+
+
   renderPyfuncCodeSnippet() {
     if (this.state.loader_module === 'mlflow.spark') {
       return this.renderMlflowSparkCodeSnippet();
@@ -286,6 +401,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
           />
         </Title>
         <div className="artifact-logged-model-view-code-content">
+          {this.renderPandasDataFramePrediction(modelPath)}
           {/* @ts-expect-error TS(2322): Type '{ position: string; pre: { margin: number; }... Remove this comment to see the full error message */}
           <div css={styles.item}>
             <Text>
@@ -336,7 +452,6 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
               </pre>
             </Paragraph>
           </div>
-          {this.renderPandasDataFramePrediction(modelPath)}
         </div>
       </>
     );
@@ -355,6 +470,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
           />
         </Title>
         <div className="artifact-logged-model-view-code-content">
+          {this.renderPandasDataFramePrediction(modelPath)}
           {/* @ts-expect-error TS(2322): Type '{ position: string; pre: { margin: number; }... Remove this comment to see the full error message */}
           <div css={styles.item}>
             <Paragraph
@@ -396,7 +512,6 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
               </pre>
             </Paragraph>
           </div>
-          {this.renderPandasDataFramePrediction(modelPath)}
         </div>
       </>
     );
@@ -484,6 +599,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
               className="artifact-logged-model-view-code-group"
               style={{ width: '50%', marginRight: 16, float: 'right' }}
             >
+              {this.renderValidateServingInputCodeSnippet()}
               {this.state.flavor === 'pyfunc' ? this.renderPyfuncCodeSnippet() : this.renderNonPyfuncCodeSnippet()}
             </div>
           </div>
@@ -531,6 +647,19 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
         this.setState({ error: error, loading: false });
       });
   }
+
+  fetchServingInputExample() {
+    const servingInputFileLocation = getArtifactLocationUrl(`${this.props.path}/${SERVING_INPUT_FILE_NAME}`, this.props.runUuid);
+    this.props
+      .getArtifact(servingInputFileLocation)
+      .then((response: any) => {
+        this.setState({ serving_input: response });
+      })
+      .catch(() => {
+        this.setState({ serving_input: null});
+      });
+  }
+
 }
 
 const styles = {

--- a/mlflow/server/js/src/experiment-tracking/constants.ts
+++ b/mlflow/server/js/src/experiment-tracking/constants.ts
@@ -5,7 +5,7 @@ export const COLUMN_TYPES = {
   TAGS: 'tags',
 };
 export const MLMODEL_FILE_NAME = 'MLmodel';
-export const SERVING_INPUT_FILE_NAME = "serving_input_payload.json";
+export const SERVING_INPUT_FILE_NAME = 'serving_input_payload.json';
 export const ONE_MB = 1024 * 1024;
 
 export const ATTRIBUTE_COLUMN_LABELS = {

--- a/mlflow/server/js/src/experiment-tracking/constants.ts
+++ b/mlflow/server/js/src/experiment-tracking/constants.ts
@@ -5,6 +5,7 @@ export const COLUMN_TYPES = {
   TAGS: 'tags',
 };
 export const MLMODEL_FILE_NAME = 'MLmodel';
+export const SERVING_INPUT_FILE_NAME = "serving_input_payload.json";
 export const ONE_MB = 1024 * 1024;
 
 export const ATTRIBUTE_COLUMN_LABELS = {

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -291,6 +291,10 @@
     "defaultMessage": "This version",
     "description": "Model registry > model version alias select > Indicator for alias of selected version"
   },
+  "4S2N8w": {
+    "defaultMessage": "Run below code to validate the model works on the serving payload prior to serving",
+    "description": "Section heading to display the code block on how we can use validate an input against registered model prior to serving"
+  },
   "4idqpX": {
     "defaultMessage": "Add",
     "description": "Add button text in editable tags table view in MLflow"
@@ -310,6 +314,10 @@
   "58xhem": {
     "defaultMessage": "Click to pin the run",
     "description": "A tooltip for the pin icon button in the runs chart tooltip next to the not pinned run"
+  },
+  "5B5dhT": {
+    "defaultMessage": "Validate the model before deployment",
+    "description": "Heading text for validating the model before deploying it for serving"
   },
   "5GCYzy": {
     "defaultMessage": "Experiment Runs - Databricks",
@@ -1326,6 +1334,10 @@
   "RzZVxC": {
     "defaultMessage": "An error occurred while rendering this component.",
     "description": "Description of error fallback component"
+  },
+  "S0Qif0": {
+    "defaultMessage": "Validate the serving payload works on the model",
+    "description": "Code comment which states how to validate serving payload"
   },
   "S7ESYH": {
     "defaultMessage": "Visualizations",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -291,10 +291,6 @@
     "defaultMessage": "This version",
     "description": "Model registry > model version alias select > Indicator for alias of selected version"
   },
-  "4S2N8w": {
-    "defaultMessage": "Run below code to validate the model works on the serving payload prior to serving",
-    "description": "Section heading to display the code block on how we can use validate an input against registered model prior to serving"
-  },
   "4idqpX": {
     "defaultMessage": "Add",
     "description": "Add button text in editable tags table view in MLflow"
@@ -2194,6 +2190,10 @@
   "jkeYf8": {
     "defaultMessage": "Unpin group",
     "description": "A tooltip for the pin icon button in the runs table next to the pinned run group"
+  },
+  "jm6p+r": {
+    "defaultMessage": "Run below code to validate model inference works on the example payload, prior to deploying it to a serving endpoint",
+    "description": "Section heading to display the code block on how we can use validate an input against registered model prior to serving"
   },
   "jq95vC": {
     "defaultMessage": "Group: {groupName}",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2191,10 +2191,6 @@
     "defaultMessage": "Unpin group",
     "description": "A tooltip for the pin icon button in the runs table next to the pinned run group"
   },
-  "jm6p+r": {
-    "defaultMessage": "Run below code to validate model inference works on the example payload, prior to deploying it to a serving endpoint",
-    "description": "Section heading to display the code block on how we can use validate an input against registered model prior to serving"
-  },
   "jq95vC": {
     "defaultMessage": "Group: {groupName}",
     "description": "Experiment page > grouped runs table > run group header label"
@@ -2650,6 +2646,10 @@
   "tLb7+M": {
     "defaultMessage": "{timeSince, plural, =1 {1 day} other {# days}} ago",
     "description": "Text for time in days since given date for MLflow views"
+  },
+  "tNySO0": {
+    "defaultMessage": "Run the following code to validate model inference works on the example payload, prior to deploying it to a serving endpoint",
+    "description": "Section heading to display the code block on how we can use validate an input against registered model prior to serving"
   },
   "tbAlJg": {
     "defaultMessage": "Go to external location",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12729?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12729/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12729
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add a section to display how to validate the logged model against a valid serving input example prior to serving.

If the model is logged with an input_example (with latest MLflow version), then `serving_input_payload.json` file exists, and we can directly copy the code snippet to run and check:

https://github.com/user-attachments/assets/7e5a56ea-c370-49b8-ae27-c388269f36be

If the model logged doesn't contain an input_example, or the model is logged with an old MLflow version which hasn't included such feature, then no `serving_input_payload.json` file exist, but we still generate a code snippet that user can easily try out by replacing `INPUT_EXAMPLE` with a valid value:

https://github.com/user-attachments/assets/c8356970-2037-4408-971b-a97ab51c4ea3

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
