### PR TITLE
Introduce span_type property and update tests

### DIFF
--- a/docs/source/llms/tracing/index.rst
+++ b/docs/source/llms/tracing/index.rst
@@ -393,6 +393,9 @@ To set a span type, you can pass the ``span_type`` parameter to the :py:func:`@m
         z = x + y
         span.set_outputs({"z": z})
 
+        print(span.span_type)
+        # Output: MATH
+
 
 Context Handler
 ###############

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -144,6 +144,11 @@ class Span:
         return self.get_attribute(SpanAttributeKey.OUTPUTS)
 
     @property
+    def span_type(self) -> str:
+        """The type of the span."""
+        return self.get_attribute(SpanAttributeKey.SPAN_TYPE)
+
+    @property
     def _trace_id(self) -> str:
         """
         The OpenTelemetry trace ID of the span. Note that this should not be exposed to

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -697,11 +697,11 @@ class MlflowClient:
             parsed_span = {}
 
             parsed_span["name"] = span.name
-            parsed_span["type"] = span.get_attribute(SpanAttributeKey.SPAN_TYPE)
-            span_inputs = span.get_attribute(SpanAttributeKey.INPUTS)
+            parsed_span["type"] = span.span_type
+            span_inputs = span.inputs
             if span_inputs and isinstance(span_inputs, dict):
                 parsed_span["inputs"] = list(span_inputs.keys())
-            span_outputs = span.get_attribute(SpanAttributeKey.OUTPUTS)
+            span_outputs = span.outputs
             if span_outputs and isinstance(span_outputs, dict):
                 parsed_span["outputs"] = list(span_outputs.keys())
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -33,7 +33,7 @@ from mlflow.models.dependencies_schemas import DependenciesSchemasType, set_retr
 from mlflow.models.signature import infer_signature
 from mlflow.models.utils import _read_example
 from mlflow.pyfunc.context import Context, set_prediction_context
-from mlflow.tracing.constant import SpanAttributeKey, TraceMetadataKey, TraceTagKey
+from mlflow.tracing.constant import TraceMetadataKey, TraceTagKey
 from mlflow.utils.openai_utils import (
     TEST_CONTENT,
     _mock_chat_completion_response,
@@ -197,10 +197,10 @@ def test_autolog_manage_run():
     traces = get_traces()
     assert len(traces) == 2
     for trace in traces:
-        attrs = trace.data.spans[0].attributes
-        assert attrs[SpanAttributeKey.SPAN_TYPE] == "CHAIN"
-        assert attrs[SpanAttributeKey.INPUTS] == {"product": "MLflow"}
-        assert attrs[SpanAttributeKey.OUTPUTS] == {"text": TEST_CONTENT}
+        span = trace.data.spans[0]
+        assert span.inputs == "CHAIN"
+        assert span.outputs == {"product": "MLflow"}
+        assert span.span_type == {"text": TEST_CONTENT}
 
 
 def test_autolog_manage_run_no_active_run():
@@ -287,18 +287,15 @@ def test_llmchain_autolog():
         spans = trace.data.spans
         assert len(spans) == 2  # chain + llm
         assert spans[0].name == "LLMChain"
-        attrs = spans[0].attributes
-        assert attrs[SpanAttributeKey.SPAN_TYPE] == "CHAIN"
-        assert attrs[SpanAttributeKey.INPUTS] == {"product": "MLflow"}
-        assert attrs[SpanAttributeKey.OUTPUTS] == {"text": TEST_CONTENT}
+        assert spans[0].span_type == "CHAIN"
+        assert spans[0].inputs == {"product": "MLflow"}
+        assert spans[0].outputs == {"text": TEST_CONTENT}
         assert spans[1].name == "OpenAI"
         assert spans[1].parent_id == spans[0].span_id
+        assert spans[1].span_type == "LLM"
+        assert spans[1].inputs == ["What is a good name for a company that makes MLflow?"]
+        assert spans[1].outputs["generations"][0][0]["text"] == "test"
         attrs = spans[1].attributes
-        assert attrs[SpanAttributeKey.SPAN_TYPE] == "LLM"
-        assert attrs[SpanAttributeKey.INPUTS] == [
-            "What is a good name for a company that makes MLflow?"
-        ]
-        assert attrs[SpanAttributeKey.OUTPUTS]["generations"][0][0]["text"] == "test"
         assert attrs["invocation_params"]["model_name"] == "gpt-3.5-turbo-instruct"
         assert attrs["invocation_params"]["temperature"] == 0.9
 
@@ -474,15 +471,14 @@ def test_agent_autolog():
     traces = get_traces()
     assert len(traces) == 4
     for trace in traces:
-        spans = [(s.name, s.attributes[SpanAttributeKey.SPAN_TYPE]) for s in trace.data.spans]
+        spans = [(s.name, s.span_type) for s in trace.data.spans]
         assert spans == [
             ("AgentExecutor", "CHAIN"),
             ("LLMChain", "CHAIN"),
             ("OpenAI", "LLM"),
         ]
-        attrs = trace.data.spans[0].attributes
-        assert attrs[SpanAttributeKey.INPUTS] == input
-        assert attrs[SpanAttributeKey.OUTPUTS] == {"output": TEST_CONTENT}
+        assert trace.data.spans[0].inputs == input
+        assert trace.data.spans[0].outputs == {"output": TEST_CONTENT}
 
 
 def test_loaded_agent_autolog():
@@ -551,7 +547,7 @@ def test_runnable_sequence_autolog():
     traces = get_traces()
     assert len(traces) == 2
     for trace in traces:
-        spans = {(s.name, s.attributes[SpanAttributeKey.SPAN_TYPE]) for s in trace.data.spans}
+        spans = {(s.name, s.span_type) for s in trace.data.spans}
         # Since the chain includes parallel execution, the order of some
         # spans is not deterministic.
         assert spans == {
@@ -637,12 +633,9 @@ def test_retriever_autolog(tmp_path):
     spans = traces[0].data.spans
     assert len(spans) == 1
     assert spans[0].name == "VectorStoreRetriever"
-    attrs = spans[0].attributes
-    assert attrs[SpanAttributeKey.SPAN_TYPE] == "RETRIEVER"
-    assert attrs[SpanAttributeKey.INPUTS] == query
-    assert attrs[SpanAttributeKey.OUTPUTS][0]["metadata"] == {
-        "source": "tests/langchain/state_of_the_union.txt"
-    }
+    assert spans[0].span_type == "RETRIEVER"
+    assert spans[0].inputs == query
+    assert spans[0].outputs[0]["metadata"] == {"source": "tests/langchain/state_of_the_union.txt"}
 
 
 def test_retriever_autlog_inputs_outputs(tmp_path):
@@ -1117,7 +1110,7 @@ def test_langchain_tracer_injection_for_arbitrary_runnables(log_traces):
     traces = get_traces()
     if should_log_traces:
         assert len(traces) == 1
-        assert traces[0].data.spans[0].attributes[SpanAttributeKey.SPAN_TYPE] == "CHAIN"
+        assert traces[0].data.spans[0].span_type == "CHAIN"
     else:
         assert len(traces) == 0
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -198,9 +198,9 @@ def test_autolog_manage_run():
     assert len(traces) == 2
     for trace in traces:
         span = trace.data.spans[0]
-        assert span.inputs == "CHAIN"
-        assert span.outputs == {"product": "MLflow"}
-        assert span.span_type == {"text": TEST_CONTENT}
+        assert span.span_type == "CHAIN"
+        assert span.inputs == {"product": "MLflow"}
+        assert span.outputs == {"text": TEST_CONTENT}
 
 
 def test_autolog_manage_run_no_active_run():

--- a/tests/openai/test_openai_tracing.py
+++ b/tests/openai/test_openai_tracing.py
@@ -2,7 +2,6 @@ import openai
 import pytest
 
 import mlflow
-from mlflow.tracing.constant import SpanAttributeKey
 
 from tests.openai.conftest import is_v1
 
@@ -29,8 +28,8 @@ def test_chat_completions_autolog_tracing_success(client, monkeypatch):
     assert len(trace.data.spans) == 1
     span = trace.data.spans[0]
     assert span.name == "Completions"
-    assert span.attributes[SpanAttributeKey.INPUTS]["messages"][0]["content"] == "test"
-    assert span.attributes[SpanAttributeKey.OUTPUTS]["id"] == "chatcmpl-123"
+    assert span.inputs["messages"][0]["content"] == "test"
+    assert span.outputs["id"] == "chatcmpl-123"
 
 
 @pytest.mark.skipif(not is_v1, reason="Requires OpenAI SDK v1")
@@ -52,8 +51,8 @@ def test_chat_completions_autolog_tracing_error(client, monkeypatch):
     assert len(trace.data.spans) == 1
     span = trace.data.spans[0]
     assert span.name == "Completions"
-    assert span.attributes[SpanAttributeKey.INPUTS]["messages"][0]["content"] == "test"
-    assert span.attributes.get(SpanAttributeKey.OUTPUTS) is None
+    assert span.inputs["messages"][0]["content"] == "test"
+    assert span.outputs is None
 
     assert span.events[0].name == "exception"
     assert span.events[0].attributes["exception.type"] == "openai.BadRequestError"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12737?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12737/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12737
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Follow-up for https://github.com/mlflow/mlflow/pull/12726#discussion_r1686002282. Adding `span.span_type` property for convenient access and use it in tests for conciseness.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
