### PR TITLE
Replace GPT-3.5-turbo with GPT-4o-mini

### DIFF
--- a/docs/gateway_api_docs.py
+++ b/docs/gateway_api_docs.py
@@ -55,7 +55,7 @@ routes:
     route_type: llm/v1/chat
     model:
       provider: openai
-      name: gpt-3.5-turbo
+      name: gpt-4o-mini
       config:
         openai_api_key: key
 
@@ -63,7 +63,7 @@ routes:
     route_type: llm/v1/completions
     model:
       provider: openai
-      name: gpt-3.5-turbo
+      name: gpt-4o-mini
       config:
         openai_api_key: key
 

--- a/docs/source/llms/deployments/guides/step1-create-deployments.rst
+++ b/docs/source/llms/deployments/guides/step1-create-deployments.rst
@@ -48,7 +48,7 @@ configuration file that is defined at server start, permitting dynamic route cre
           endpoint_type: llm/v1/completions
           model:
               provider: openai
-              name: gpt-3.5-turbo
+              name: gpt-4o-mini
               config:
                   openai_api_key: $OPENAI_API_KEY
 
@@ -64,7 +64,7 @@ configuration file that is defined at server start, permitting dynamic route cre
           endpoint_type: llm/v1/chat
           model:
               provider: openai
-              name: gpt-3.5-turbo
+              name: gpt-4o-mini
               config:
                   openai_api_key: $OPENAI_API_KEY
 

--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -102,7 +102,7 @@ For details about the configuration file's parameters (including parameters for 
         endpoint_type: llm/v1/completions
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
         limit:
@@ -113,7 +113,7 @@ For details about the configuration file's parameters (including parameters for 
         endpoint_type: llm/v1/chat
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
 
@@ -179,7 +179,7 @@ Firstly, update the :ref:`MLflow Deployments Server config <deployments_configur
         endpoint_type: llm/v1/completions
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
       - name: completions-gpt4
@@ -358,7 +358,7 @@ Here's an example of an endpoint configuration:
         endpoint_type: llm/v1/chat
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
         limit:
@@ -366,7 +366,7 @@ Here's an example of an endpoint configuration:
           calls: 10
 
 In the example above, a request sent to the completions endpoint would be forwarded to the
-``gpt-3.5-turbo`` model provided by ``openai``.
+``gpt-4o-mini`` model provided by ``openai``.
 
 The endpoints in the configuration file can be updated at any time, and the MLflow Deployments Server will
 automatically update its available endpoints without requiring a restart. This feature provides you
@@ -448,7 +448,7 @@ Here is an example of a single-endpoint configuration:
         endpoint_type: llm/v1/chat
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
         limit:
@@ -457,7 +457,7 @@ Here is an example of a single-endpoint configuration:
 
 
 In this example, we define an endpoint named ``chat`` that corresponds to the ``llm/v1/chat`` type, which
-will use the ``gpt-3.5-turbo`` model from OpenAI to return query responses from the OpenAI service, and accept up to 10 requests per minute.
+will use the ``gpt-4o-mini`` model from OpenAI to return query responses from the OpenAI service, and accept up to 10 requests per minute.
 
 The MLflow Deployments Server configuration is very easy to update.
 Simply edit the configuration file and save your changes, and the MLflow Deployments Server will automatically

--- a/docs/source/llms/gateway/guides/step1-create-gateway.rst
+++ b/docs/source/llms/gateway/guides/step1-create-gateway.rst
@@ -48,7 +48,7 @@ configuration file that is defined at server start, permitting dynamic route cre
             route_type: llm/v1/completions
             model:
                 provider: openai
-                name: gpt-3.5-turbo
+                name: gpt-4o-mini
                 config:
                     openai_api_key: $OPENAI_API_KEY
 
@@ -64,7 +64,7 @@ configuration file that is defined at server start, permitting dynamic route cre
             route_type: llm/v1/chat
             model:
                 provider: openai
-                name: gpt-3.5-turbo
+                name: gpt-4o-mini
                 config:
                     openai_api_key: $OPENAI_API_KEY
 

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -97,7 +97,7 @@ For details about the configuration file's parameters (including parameters for 
         route_type: llm/v1/completions
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
 
@@ -105,7 +105,7 @@ For details about the configuration file's parameters (including parameters for 
         route_type: llm/v1/chat
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
 
@@ -216,7 +216,7 @@ Firstly, update the :ref:`MLflow AI Gateway config <gateway_configuration>` YAML
         route_type: llm/v1/completions
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
       - name: completions-gpt4
@@ -228,7 +228,7 @@ Firstly, update the :ref:`MLflow AI Gateway config <gateway_configuration>` YAML
             openai_api_key: $OPENAI_API_KEY
 
 This updated configuration adds a new completions route ``completions-gpt4`` while still preserving the original ``completions``
-route that was configured with the ``gpt-3.5-turbo``  model.
+route that was configured with the ``gpt-4o-mini``  model.
 
 Once the configuration file is updated, simply save your changes. The Gateway will automatically create the new route with zero downtime.
 
@@ -386,12 +386,12 @@ Here's an example of a route configuration:
         type: chat/completions
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
 
 In the example above, a request sent to the completions route would be forwarded to the
-``gpt-3.5-turbo`` model provided by ``openai``.
+``gpt-4o-mini`` model provided by ``openai``.
 
 The routes in the configuration file can be updated at any time, and the MLflow AI Gateway will
 automatically update its available routes without requiring a restart. This feature provides you
@@ -473,13 +473,13 @@ Here is an example of a single-route configuration:
         route_type: llm/v1/chat
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
 
 
 In this example, we define a route named ``chat`` that corresponds to the ``llm/v1/chat`` type, which
-will use the ``gpt-3.5-turbo`` model from OpenAI to return query responses from the OpenAI service.
+will use the ``gpt-4o-mini`` model from OpenAI to return query responses from the OpenAI service.
 
 The Gateway configuration is very easy to update.
 Simply edit the configuration file and save your changes, and the MLflow AI Gateway service will automatically

--- a/docs/source/llms/gateway/migration.rst
+++ b/docs/source/llms/gateway/migration.rst
@@ -19,7 +19,7 @@ Deprecated:
         route_type: llm/v1/chat
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
 
@@ -32,7 +32,7 @@ New:
         endpoint_type: llm/v1/chat  # Renamed to "endpoint_type"
         model:
           provider: openai
-          name: gpt-3.5-turbo
+          name: gpt-4o-mini
           config:
             openai_api_key: $OPENAI_API_KEY
 

--- a/docs/source/llms/llama-index/index.rst
+++ b/docs/source/llms/llama-index/index.rst
@@ -243,7 +243,7 @@ models to be used by engines.
     from llama_index.core import Settings
     from llama_index.llms.openai import OpenAI
 
-    Settings.llm = OpenAI("gpt-3.5-turbo")
+    Settings.llm = OpenAI("gpt-4o-mini")
 
     # MLflow saves GPT-3.5-turbo as the LLM to use for inference
     with mlflow.start_run():
@@ -261,7 +261,7 @@ However, sometimes you may want to use a different LLM for inference. In such ca
 
     # Load the index back
     loaded_index = mlflow.llama_index.load_model(model_info.model_uri)
-    assert Settings.llm.model == "gpt-3.5-turbo"
+    assert Settings.llm.model == "gpt-4o-mini"
 
     # Update the settings to use GPT-4 instead
     Settings.llm = OpenAI("gpt-4")

--- a/docs/source/llms/llm-evaluate/index.rst
+++ b/docs/source/llms/llm-evaluate/index.rst
@@ -427,9 +427,9 @@ to evaluate your model as an MLflow model, we recommend following the steps belo
 
         with mlflow.start_run():
             system_prompt = "Answer the following question in two sentences"
-            # Wrap "gpt-3.5-turbo" as an MLflow model.
+            # Wrap "gpt-4o-mini" as an MLflow model.
             logged_model_info = mlflow.openai.log_model(
-                model="gpt-3.5-turbo",
+                model="gpt-4o-mini",
                 task=openai.chat.completions,
                 artifact_path="model",
                 messages=[
@@ -479,7 +479,7 @@ up OpenAI authentication to run the code below.
         system_prompt = "Please answer the following question in formal language."
         for index, row in inputs.iterrows():
             completion = openai.chat.completions.create(
-                model="gpt-3.5-turbo",
+                model="gpt-4o-mini",
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": "{row}"},

--- a/docs/source/llms/llm-evaluate/notebooks/question-answering-evaluation.ipynb
+++ b/docs/source/llms/llm-evaluate/notebooks/question-answering-evaluation.ipynb
@@ -132,7 +132,7 @@
     }
    },
    "source": [
-    "Create a simple OpenAI model that asks gpt-3.5 to answer the question in two sentences. Call `mlflow.evaluate()` with the model and evaluation dataframe. "
+    "Create a simple OpenAI model that asks gpt-4o to answer the question in two sentences. Call `mlflow.evaluate()` with the model and evaluation dataframe. "
    ]
   },
   {
@@ -190,7 +190,7 @@
     "with mlflow.start_run() as run:\n",
     "    system_prompt = \"Answer the following question in two sentences\"\n",
     "    basic_qa_model = mlflow.openai.log_model(\n",
-    "        model=\"gpt-3.5-turbo\",\n",
+    "        model=\"gpt-4o-mini\",\n",
     "        task=openai.chat.completions,\n",
     "        artifact_path=\"model\",\n",
     "        messages=[\n",
@@ -1205,7 +1205,7 @@
     "with mlflow.start_run() as run:\n",
     "    system_prompt = \"Answer the following question using extreme formality.\"\n",
     "    professional_qa_model = mlflow.openai.log_model(\n",
-    "        model=\"gpt-3.5-turbo\",\n",
+    "        model=\"gpt-4o-mini\",\n",
     "        task=openai.chat.completions,\n",
     "        artifact_path=\"model\",\n",
     "        messages=[\n",

--- a/docs/source/llms/rag/notebooks/mlflow-e2e-evaluation.ipynb
+++ b/docs/source/llms/rag/notebooks/mlflow-e2e-evaluation.ipynb
@@ -317,7 +317,7 @@
     "            {\n",
     "                \"name\": \"test-gpt\",  # Provide a unique identifying name for your deployments endpoint\n",
     "                \"external_model\": {\n",
-    "                    \"name\": \"gpt-3.5-turbo\",\n",
+    "                    \"name\": \"gpt-4o-mini\",\n",
     "                    \"provider\": \"openai\",\n",
     "                    \"task\": \"llm/v1/completions\",\n",
     "                    \"openai_config\": {\n",

--- a/docs/source/llms/rag/notebooks/question-generation-retrieval-evaluation.ipynb
+++ b/docs/source/llms/rag/notebooks/question-generation-retrieval-evaluation.ipynb
@@ -656,7 +656,7 @@
     "\n",
     "The prompt below instructs the LLM to generate a question for each given chunk, and also generate an answer to the question to make it easier to do human validation. Also, return the results in a structured format.\n",
     "\n",
-    "This example uses OpenAI's gpt-3.5-turbo model to generate the questions, you can replace it with the LLM that works best for your use case."
+    "This example uses OpenAI's gpt-4o-mini model to generate the questions, you can replace it with the LLM that works best for your use case."
    ]
   },
   {
@@ -713,7 +713,7 @@
     "\n",
     "    return cached_openai_ChatCompletion_create(\n",
     "        messages=messages,\n",
-    "        model=\"gpt-3.5-turbo\",\n",
+    "        model=\"gpt-4o-mini\",\n",
     "        functions=[submit_function],\n",
     "        function_call=\"auto\",\n",
     "        temperature=0.0,\n",

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2410,7 +2410,7 @@ in your current system environment in order to run the example):
     )
     mlflow.log_param("system_prompt", system_prompt)
     logged_model = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[

--- a/docs/source/python_api/openai/messages.rst
+++ b/docs/source/python_api/openai/messages.rst
@@ -32,7 +32,7 @@ Single variable
     with mlflow.start_run():
         model_info = mlflow.openai.log_model(
             artifact_path="model",
-            model="gpt-3.5-turbo",
+            model="gpt-4o-mini",
             task=openai.chat.completions,
             messages=[
                 {
@@ -73,7 +73,7 @@ Payload sent to OpenAI chat completion API:
 .. code-block:: python
 
     {
-        "model": "gpt-3.5-turbo",
+        "model": "gpt-4o-mini",
         "messages": [
             {
                 "role": "user",
@@ -94,7 +94,7 @@ Multiple variables
     with mlflow.start_run():
         model_info = mlflow.openai.log_model(
             artifact_path="model",
-            model="gpt-3.5-turbo",
+            model="gpt-4o-mini",
             task=openai.chat.completions,
             messages=[
                 {
@@ -134,7 +134,7 @@ Payload sent to OpenAI chat completion API:
 .. code-block:: python
 
     {
-        "model": "gpt-3.5-turbo",
+        "model": "gpt-4o-mini",
         "messages": [
             {
                 "role": "user",
@@ -155,7 +155,7 @@ with ``role = user``.
     with mlflow.start_run():
         model_info = mlflow.openai.log_model(
             artifact_path="model",
-            model="gpt-3.5-turbo",
+            model="gpt-4o-mini",
             task=openai.chat.completions,
             messages=[
                 {
@@ -187,7 +187,7 @@ Payload sent to OpenAI chat completion API:
 .. code-block:: python
 
     {
-        "model": "gpt-3.5-turbo",
+        "model": "gpt-4o-mini",
         "messages": [
             {
                 "role": "system",
@@ -215,7 +215,7 @@ sent to the OpenAI chat completion API as-is with ``role = user``.
     with mlflow.start_run():
         model_info = mlflow.openai.log_model(
             artifact_path="model",
-            model="gpt-3.5-turbo",
+            model="gpt-4o-mini",
             task=openai.chat.completions,
         )
 
@@ -246,7 +246,7 @@ Payload sent to OpenAI chat completion API:
 .. code-block:: python
 
     {
-        "model": "gpt-3.5-turbo",
+        "model": "gpt-4o-mini",
         "messages": [
             {
                 "role": "user",

--- a/examples/deployments/deployments_server/openai/config.yaml
+++ b/examples/deployments/deployments_server/openai/config.yaml
@@ -3,7 +3,7 @@ endpoints:
     endpoint_type: llm/v1/chat
     model:
       provider: openai
-      name: gpt-3.5-turbo
+      name: gpt-4o-mini
       config:
         openai_api_key: $OPENAI_API_KEY
     limit:
@@ -14,7 +14,7 @@ endpoints:
     endpoint_type: llm/v1/completions
     model:
       provider: openai
-      name: gpt-3.5-turbo
+      name: gpt-4o-mini
       config:
         openai_api_key: $OPENAI_API_KEY
 

--- a/examples/evaluation/evaluate_with_custom_code_metrics.py
+++ b/examples/evaluation/evaluate_with_custom_code_metrics.py
@@ -48,7 +48,7 @@ with mlflow.start_run() as run:
         "Generate code that is less than 50 characters. Return only python code and nothing else."
     )
     logged_model = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[

--- a/examples/evaluation/evaluate_with_llm_judge.py
+++ b/examples/evaluation/evaluate_with_llm_judge.py
@@ -9,7 +9,7 @@ from mlflow.metrics.genai import EvaluationExample, answer_similarity
 assert "OPENAI_API_KEY" in os.environ, "Please set the OPENAI_API_KEY environment variable."
 
 
-# testing with OpenAI gpt-3.5-turbo
+# testing with OpenAI gpt-4o-mini
 example = EvaluationExample(
     input="What is MLflow?",
     output="MLflow is an open-source platform for managing machine "
@@ -47,7 +47,7 @@ eval_df = pd.DataFrame(
 with mlflow.start_run() as run:
     system_prompt = "Answer the following question in two sentences"
     logged_model = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[

--- a/examples/evaluation/evaluate_with_qa_metrics.py
+++ b/examples/evaluation/evaluate_with_qa_metrics.py
@@ -21,7 +21,7 @@ eval_df = pd.DataFrame(
 with mlflow.start_run() as run:
     system_prompt = "Answer the following question in two sentences"
     logged_model = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[

--- a/examples/evaluation/qa-evaluation.ipynb
+++ b/examples/evaluation/qa-evaluation.ipynb
@@ -125,7 +125,7 @@
     }
    },
    "source": [
-    "Create a simple OpenAI model that asks gpt-3.5 to answer the question in two sentences. Call `mlflow.evaluate()` with the model and evaluation dataframe. "
+    "Create a simple OpenAI model that asks gpt-4o to answer the question in two sentences. Call `mlflow.evaluate()` with the model and evaluation dataframe. "
    ]
   },
   {
@@ -183,7 +183,7 @@
     "with mlflow.start_run() as run:\n",
     "    system_prompt = \"Answer the following question in two sentences\"\n",
     "    basic_qa_model = mlflow.openai.log_model(\n",
-    "        model=\"gpt-3.5-turbo\",\n",
+    "        model=\"gpt-4o-mini\",\n",
     "        task=openai.chat.completions,\n",
     "        artifact_path=\"model\",\n",
     "        messages=[\n",
@@ -1334,7 +1334,7 @@
     "with mlflow.start_run() as run:\n",
     "    system_prompt = \"Answer the following question using extreme formality.\"\n",
     "    professional_qa_model = mlflow.openai.log_model(\n",
-    "        model=\"gpt-3.5-turbo\",\n",
+    "        model=\"gpt-4o-mini\",\n",
     "        task=openai.chat.completions,\n",
     "        artifact_path=\"model\",\n",
     "        messages=[\n",

--- a/examples/llms/RAG/question-generation-retrieval-evaluation.ipynb
+++ b/examples/llms/RAG/question-generation-retrieval-evaluation.ipynb
@@ -643,7 +643,7 @@
     "\n",
     "The prompt below instructs the LLM to generate a question for each given chunk, and also generate an answer to the question to make it easier to do human validation. Also, return the results in a structured format.\n",
     "\n",
-    "This example uses OpenAI's gpt-3.5-turbo model to generate the questions, you can replace it with the LLM that works best for your use case."
+    "This example uses OpenAI's gpt-4o-mini model to generate the questions, you can replace it with the LLM that works best for your use case."
    ]
   },
   {
@@ -700,7 +700,7 @@
     "\n",
     "    return cached_openai_ChatCompletion_create(\n",
     "        messages=messages,\n",
-    "        model=\"gpt-3.5-turbo\",\n",
+    "        model=\"gpt-4o-mini\",\n",
     "        functions=[submit_function],\n",
     "        function_call=\"auto\",\n",
     "        temperature=0.0,\n",

--- a/examples/llms/question_answering/question_answering.py
+++ b/examples/llms/question_answering/question_answering.py
@@ -17,7 +17,7 @@ def build_and_evalute_model_with_prompt(system_prompt):
     # Create a question answering model using prompt engineering with OpenAI. Log the model
     # to MLflow Tracking
     logged_model = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[

--- a/examples/openai/autologging/instantiated_client.py
+++ b/examples/openai/autologging/instantiated_client.py
@@ -27,7 +27,7 @@ messages = [
 ]
 
 output = client.chat.completions.create(
-    model="gpt-3.5-turbo",
+    model="gpt-4o-mini",
     messages=messages,
     temperature=0,
 )

--- a/examples/openai/autologging/module_client.py
+++ b/examples/openai/autologging/module_client.py
@@ -21,7 +21,7 @@ messages = [
 ]
 
 output = openai.chat.completions.create(
-    model="gpt-3.5-turbo",
+    model="gpt-4o-mini",
     messages=messages,
     temperature=0,
 )

--- a/examples/openai/azure_openai.py
+++ b/examples/openai/azure_openai.py
@@ -17,7 +17,7 @@ export OPENAI_DEPLOYMENT_NAME="<AZURE OPENAI DEPLOYMENT ID OR NAME>"
 
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
-        # Your Azure OpenAI model e.g. gpt-3.5-turbo
+        # Your Azure OpenAI model e.g. gpt-4o-mini
         model="<YOUR AZURE OPENAI MODEL>",
         task=openai.chat.completions,
         artifact_path="model",

--- a/examples/openai/chat_completions.py
+++ b/examples/openai/chat_completions.py
@@ -26,7 +26,7 @@ print(
 )
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[{"role": "user", "content": "Tell me a joke about {animal}."}],
@@ -64,7 +64,7 @@ print(
 )
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[{"role": "user", "content": "Tell me a {adjective} joke about {animal}."}],
@@ -96,7 +96,7 @@ print(
 )
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[
@@ -131,7 +131,7 @@ print(
 )
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[{"role": "system", "content": "You are Elon Musk"}],
@@ -172,7 +172,7 @@ print(
 )
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         artifact_path="model",
         messages=[{"role": "user", "content": "Tell me a joke about {animal}."}],

--- a/examples/openai/spark_udf.py
+++ b/examples/openai/spark_udf.py
@@ -9,7 +9,7 @@ assert "OPENAI_API_KEY" in os.environ, "Please set the OPENAI_API_KEY environmen
 
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         task=openai.chat.completions,
         messages=[{"role": "user", "content": "Tell me a {adjective} joke about {animal}."}],
         artifact_path="model",

--- a/examples/promptflow/basic/flow.dag.yaml
+++ b/examples/promptflow/basic/flow.dag.yaml
@@ -30,7 +30,7 @@ nodes:
       path: hello.py
     inputs:
       prompt: ${hello_prompt.output}
-      deployment_name: gpt-3.5-turbo
+      deployment_name: gpt-4o-mini
       max_tokens: "120"
 environment:
   image: mcr.microsoft.com/azureml/promptflow/promptflow-runtime:latest

--- a/examples/pyfunc/model_as_code.py
+++ b/examples/pyfunc/model_as_code.py
@@ -33,7 +33,7 @@ class AIModel(pyfunc.PythonModel):
         from openai import OpenAI
 
         return OpenAI().chat.completions.create(
-            model="gpt-3.5-turbo",
+            model="gpt-4o-mini",
             messages=[
                 {
                     "role": "system",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Acksout/mlflow/pull/12740?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12740/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12740
```

</p>
</details>

This PR addresses #12724

This commit completes the migration from GPT-3.5-turbo to GPT-4o-mini across the codebase. However, a few references to the old model still remain:
gpt-3.5-turbo-xxxx
GPT-35-Turbo
GPT-3.5-Instruct
GPT 3.5
These instances have been left intentionally. 

Changes have been made in the following directories:
docs/
examples/

Summary:
OpenAI recently released the GPT-4o mini model. It is cheaper and more performant than GPT-3.5 Turbo, and they are planning to deprecate the GPT-3.5 Turbo in favor of the new one.

We still have many references to the old model in the documentation, examples, and tutorials. This PR updates those references to the new gpt-4o-mini model.

### What changes are proposed in this pull request?

- Update references from gpt-3.5-turbo to gpt-4o-mini in documentation
- Update examples and tutorials to use the new gpt-4o-mini model
- Maintain specific references to GPT-3.5 variants where necessary for backwards compatibility or historical context

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (manual review of updated documentation and examples)

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Description: Update documentation and examples to reflect the use of GPT-4o-mini instead of GPT-3.5-turbo.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
