### PR TITLE
Fix `docstring_version_compatibility_warning` to show the warning only once

### DIFF
--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -374,6 +374,13 @@ def get_module_min_and_max_supported_ranges(module_name):
     return min_version, max_version
 
 
+def _do_version_compatibility_warning(msg: str):
+    """
+    Isolate the warn call to show the warning only once.
+    """
+    warnings.warn(msg, category=UserWarning, stacklevel=2)
+
+
 def docstring_version_compatibility_warning(integration_name):
     """
     Generates a docstring that can be applied as a note stating a version compatibility range for
@@ -405,7 +412,7 @@ def docstring_version_compatibility_warning(integration_name):
         def version_func(*args, **kwargs):
             installed_version = Version(importlib_metadata.version(module_key))
             if installed_version < Version(min_ver) or installed_version > Version(max_ver):
-                warnings.warn(notice, category=FutureWarning, stacklevel=2)
+                _do_version_compatibility_warning(notice)
             return func(*args, **kwargs)
 
         version_func.__doc__ = (

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -168,8 +168,6 @@ def test_docstring_version_compatibility_warning():
         with warnings.catch_warnings(record=True) as w:
             another_func()
 
-            # Exclude irrelevant warnings
-            warns = [
-                x for x in w if "MLflow Models integration is known to be compatible" in str(x)
-            ]
-            assert len(warns) == 1
+        # Exclude irrelevant warnings
+        warns = [x for x in w if "MLflow Models integration is known to be compatible" in str(x)]
+        assert len(warns) == 1

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -1,4 +1,12 @@
-from mlflow.utils.docstring_utils import ParamDocs, _indent, format_docstring
+import warnings
+from unittest import mock
+
+from mlflow.utils.docstring_utils import (
+    ParamDocs,
+    _indent,
+    docstring_version_compatibility_warning,
+    format_docstring,
+)
 
 
 def test_indent_empty():
@@ -145,3 +153,23 @@ Another line\n    Another indented line""",
 
     assert f.__doc__ == expected
     assert f.__name__ == "f"
+
+
+def test_docstring_version_compatibility_warning():
+    @docstring_version_compatibility_warning("sklearn")
+    def func():
+        pass
+
+    @docstring_version_compatibility_warning("sklearn")
+    def another_func():
+        func()
+
+    with mock.patch("importlib_metadata.version", return_value="0.0.0"):
+        with warnings.catch_warnings(record=True) as w:
+            another_func()
+
+            # Exclude irrelevant warnings
+            warns = [
+                x for x in w if "MLflow Models integration is known to be compatible" in str(x)
+            ]
+            assert len(warns) == 1

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -168,7 +168,7 @@ def test_docstring_version_compatibility_warning():
         with warnings.catch_warnings(record=True) as w:
             another_func()
 
-        assert mock_version.call_count == 2
+        mock_version.assert_called()
         # Exclude irrelevant warnings
         warns = [x for x in w if "MLflow Models integration is known to be compatible" in str(x)]
         assert len(warns) == 1

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -169,7 +169,6 @@ def test_docstring_version_compatibility_warning():
             another_func()
 
         assert mock_version.call_count == 2
-
         # Exclude irrelevant warnings
         warns = [x for x in w if "MLflow Models integration is known to be compatible" in str(x)]
         assert len(warns) == 1

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -164,9 +164,11 @@ def test_docstring_version_compatibility_warning():
     def another_func():
         func()
 
-    with mock.patch("importlib_metadata.version", return_value="0.0.0"):
+    with mock.patch("importlib_metadata.version", return_value="0.0.0") as mock_version:
         with warnings.catch_warnings(record=True) as w:
             another_func()
+
+        assert mock_version.call_count == 2
 
         # Exclude irrelevant warnings
         warns = [x for x in w if "MLflow Models integration is known to be compatible" in str(x)]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12753?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12753/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12753
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Title. The following code shows the warning twice (once from `save_model` and once from `log_model`). This PR fixes it.

```python
mlflow.transformers.log_model(...)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
