### PR TITLE
Safely unwrap `Optional` in `_get_extra_context`

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -166,7 +166,7 @@ def is_in_databricks_notebook():
     if _get_property_from_spark_context("spark.databricks.notebook.id") is not None:
         return True
     try:
-        return acl_path_of_acl_root().startswith("/workspace")
+        return path.startswith("/workspace") if (path := acl_path_of_acl_root()) else False
     except Exception:
         return False
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -123,7 +123,8 @@ def _get_command_context():
 
 
 def _get_extra_context(context_key):
-    return _get_command_context().extraContext().get(context_key).get()
+    opt = _get_command_context().extraContext().get(context_key)
+    return opt.get() if opt.isDefined() else None
 
 
 def _get_context_tag(context_tag_key):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -294,8 +294,7 @@ def is_in_cluster():
 @_use_repl_context_if_available("notebookId")
 def get_notebook_id():
     """Should only be called if is_in_databricks_notebook is true"""
-    notebook_id = _get_property_from_spark_context("spark.databricks.notebook.id")
-    if notebook_id is not None:
+    if notebook_id := _get_property_from_spark_context("spark.databricks.notebook.id"):
         return notebook_id
     if (path := acl_path_of_acl_root()) and path.startswith("/workspace"):
         return path.split("/")[-1]

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -297,9 +297,8 @@ def get_notebook_id():
     notebook_id = _get_property_from_spark_context("spark.databricks.notebook.id")
     if notebook_id is not None:
         return notebook_id
-    acl_path = acl_path_of_acl_root()
-    if acl_path.startswith("/workspace"):
-        return acl_path.split("/")[-1]
+    if (path := acl_path_of_acl_root()) and path.startswith("/workspace"):
+        return path.split("/")[-1]
     return None
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12755?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12755/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12755
```

</p>
</details>



### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix the following error that occurs when `mlflow.pyfunc.load_model` is called in a Databricks job.

```
Py4JJavaError: An error occurred while calling o1272.get.
: java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:529)
	at sun.reflect.GeneratedMethodAccessor295.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:397)
	at py4j.Gateway.invoke(Gateway.java:306)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:199)
	at py4j.ClientServerConnection.run(ClientServerConnection.java:119)
	at java.lang.Thread.run(Thread.java:750)
---------------------------------------------------------------------------
Py4JJavaError                             Traceback (most recent call last)
File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.10/site-packages/mlflow/utils/databricks_utils.py:136, in acl_path_of_acl_root()
    135 try:
--> 136     return _get_command_context().aclPathOfAclRoot().get()
    137 except Exception:

File /databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py:1355, in JavaMember.__call__(self, *args)
   1354 answer = self.gateway_client.send_command(command)
-> 1355 return_value = get_return_value(
   1356     answer, self.gateway_client, self.target_id, self.name)
   1358 for temp_arg in temp_args:

File /databricks/spark/python/pyspark/errors/exceptions/captured.py:224, in capture_sql_exception.<locals>.deco(*a, **kw)
    223 try:
--> 224     return f(*a, **kw)
    225 except Py4JJavaError as e:

File /databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/protocol.py:326, in get_return_value(answer, gateway_client, target_id, name)
    325 if answer[1] == REFERENCE_TYPE:
--> 326     raise Py4JJavaError(
    327         "An error occurred while calling {0}{1}{2}.\n".
    328         format(target_id, ".", name), value)
    329 else:

Py4JJavaError: An error occurred while calling o1266.get.
: java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:529)
	at sun.reflect.GeneratedMethodAccessor295.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:397)
	at py4j.Gateway.invoke(Gateway.java:306)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:199)
	at py4j.ClientServerConnection.run(ClientServerConnection.java:119)
	at java.lang.Thread.run(Thread.java:750)


During handling of the above exception, another exception occurred:

Py4JJavaError                             Traceback (most recent call last)
File ~/.ipykernel/3939/command--1-528621869:8
      5 del sys
      7 with open(filename, "rb") as f:
----> 8   exec(compile(f.read(), filename, 'exec'))

File /Workspace/Shared/sensxpert-ml/files/mlops/model_monitoring.py:306
    304 logging.info("transform id: %s", transform_id)
    305 conf.reset_data_identifier_for_databricks(transform_id)
--> 306 main(conf)

File /Workspace/Shared/sensxpert-ml/files/mlops/model_monitoring.py:222, in main(modeling_config)
    219 dataset_to_score.populate_samples_targets(deployed_model_conf, batch_size=1)
    220 dataset_to_score.apply_scaling()
--> 222 model_unwrapped = load_model(
    223     modeling_config=modeling_config, dataset=dataset_to_score
    224 )
    225 if model_unwrapped is None:
    226     logging.error("Unable to load selected model, quitting...")

File /Workspace/Shared/sensxpert-ml/files/mlops/model_monitoring.py:142, in load_model(modeling_config, dataset)
    132 """Download model from model registry and fallback to artifact loading if not possible
    133 
    134 Args:
   (...)
    139     The selected model object. The returned object can be None, in case an exception occurs.
    140 """
    141 try:
--> 142     model_unwrapped = _load_model_from_registry(modeling_config)
    143 except FileNotFoundError:
    144     print("Model pickle file not not found")

File /Workspace/Shared/sensxpert-ml/files/mlops/model_monitoring.py:169, in _load_model_from_registry(modeling_config)
    166 latest_version = np.max([int(x.version) for x in search_run])
    167 model_uri = f"models:/{model_name}/{latest_version}"
--> 169 model = mlflow.pyfunc.load_model(model_uri=model_uri)
    170 model_unwrapped = model.unwrap_python_model()
    171 return model_unwrapped

File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.10/site-packages/mlflow/tracing/provider.py:237, in trace_disabled.<locals>.wrapper(*args, **kwargs)
    235 disable()
    236 try:
--> 237     is_func_called, result = True, f(*args, **kwargs)
    238 finally:
    239     enable()

File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.10/site-packages/mlflow/pyfunc/__init__.py:975, in load_model(model_uri, suppress_warnings, dst_path, model_config)
    973 entity_list = []
    974 # Get notebook id and job id, pack them into lineage_header_info
--> 975 if notebook_id := databricks_utils.get_notebook_id():
    976     notebook_entity = Notebook(id=notebook_id)
    977     entity_list.append(Entity(notebook=notebook_entity))

File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.10/site-packages/mlflow/utils/databricks_utils.py:54, in _use_repl_context_if_available.<locals>.decorator.<locals>.wrapper(*args, **kwargs)
     52 except Exception:
     53     pass
---> 54 return f(*args, **kwargs)

File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.10/site-packages/mlflow/utils/databricks_utils.py:278, in get_notebook_id()
    276 if notebook_id is not None:
    277     return notebook_id
--> 278 acl_path = acl_path_of_acl_root()
    279 if acl_path.startswith("/workspace"):
    280     return acl_path.split("/")[-1]

File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.10/site-packages/mlflow/utils/databricks_utils.py:54, in _use_repl_context_if_available.<locals>.decorator.<locals>.wrapper(*args, **kwargs)
     52 except Exception:
     53     pass
---> 54 return f(*args, **kwargs)

File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.10/site-packages/mlflow/utils/databricks_utils.py:138, in acl_path_of_acl_root()
    136     return _get_command_context().aclPathOfAclRoot().get()
    137 except Exception:
--> 138     return _get_extra_context("aclPathOfAclRoot")

File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.10/site-packages/mlflow/utils/databricks_utils.py:119, in _get_extra_context(context_key)
    118 def _get_extra_context(context_key):
--> 119     return _get_command_context().extraContext().get(context_key).get()

File /databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py:1355, in JavaMember.__call__(self, *args)
   1349 command = proto.CALL_COMMAND_NAME +\
   1350     self.command_header +\
   1351     args_command +\
   1352     proto.END_COMMAND_PART
   1354 answer = self.gateway_client.send_command(command)
-> 1355 return_value = get_return_value(
   1356     answer, self.gateway_client, self.target_id, self.name)
   1358 for temp_arg in temp_args:
   1359     if hasattr(temp_arg, "_detach"):

File /databricks/spark/python/pyspark/errors/exceptions/captured.py:224, in capture_sql_exception.<locals>.deco(*a, **kw)
    222 def deco(*a: Any, **kw: Any) -> Any:
    223     try:
--> 224         return f(*a, **kw)
    225     except Py4JJavaError as e:
    226         converted = convert_exception(e.java_exception)

File /databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/protocol.py:326, in get_return_value(answer, gateway_client, target_id, name)
    324 value = OUTPUT_CONVERTER[type](answer[2:], gateway_client)
    325 if answer[1] == REFERENCE_TYPE:
--> 326     raise Py4JJavaError(
    327         "An error occurred while calling {0}{1}{2}.\n".
    328         format(target_id, ".", name), value)
    329 else:
    330     raise Py4JError(
    331         "An error occurred while calling {0}{1}{2}. Trace:\n{3}\n".
    332         format(target_id, ".", name, value))

Py4JJavaError: An error occurred while calling o1272.get.
: java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:529)
	at sun.reflect.GeneratedMethodAccessor295.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:397)
	at py4j.Gateway.invoke(Gateway.java:306)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:199)
	at py4j.ClientServerConnection.run(ClientServerConnection.java:119)
	at java.lang.Thread.run(Thread.java:750)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
