### PR TITLE
Fix Spark UDF permission denied issue in Databricks runtime

### DIFF
--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -33,13 +33,9 @@ def _remove_inaccesible_python_path(env):
     """
     Remove inaccessible path from PYTHONPATH environment variable.
     """
-    if python_path_env := env.get("PYTHONPATH"):
-        python_paths = python_path_env.split(":")
-        filtered_paths = []
-        for p in python_paths:
-            if os.access(p, os.R_OK):
-                filtered_paths.append(p)
-        env["PYTHONPATH"] = ":".join(filtered_paths)
+    if python_path := env.get("PYTHONPATH"):
+        paths = [p for p in python_path.split(":") if os.access(p, os.R_OK)]
+        env["PYTHONPATH"] = ":".join(paths)
     return env
 
 
@@ -90,7 +86,7 @@ def _exec_cmd(
         )
 
     # Copy current `os.environ` or passed in `env` to avoid mutating it.
-    env = os.environ.copy() if env is None else env.copy()
+    env = env or os.environ.copy()
     if extra_env is not None:
         env.update(extra_env)
 

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 
+from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.os import is_windows
 
 
@@ -88,12 +89,13 @@ def _exec_cmd(
             "`capture_output=True` and `stream_output=True` cannot be specified at the same time"
         )
 
-    # Copy current `os.environ` or passed in `env` to avoid mutate it.
+    # Copy current `os.environ` or passed in `env` to avoid mutating it.
     env = os.environ.copy() if env is None else env.copy()
     if extra_env is not None:
         env.update(extra_env)
 
-    env = _remove_inaccesible_python_path(env)
+    if is_in_databricks_runtime():
+        env = _remove_inaccesible_python_path(env)
 
     # In Python < 3.8, `subprocess.Popen` doesn't accept a command containing path-like
     # objects (e.g. `["ls", pathlib.Path("abc")]`) on Windows. To avoid this issue,

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -77,7 +77,6 @@ def _exec_cmd(
         otherwise return a Popen instance.
 
     """
-    from mlflow.utils.databricks_utils import is_in_databricks_runtime
 
     illegal_kwargs = set(kwargs.keys()).intersection({"text"})
     if illegal_kwargs:

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -85,7 +85,7 @@ def _exec_cmd(
                 try:
                     os.stat(p)
                     filtered_paths.append(p)
-                except PermissionError:
+                except (PermissionError, FileNotFoundError):
                     pass
             os.environ["PYTHONPATH"] = ":".join(filtered_paths)
 

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -78,15 +78,16 @@ def _exec_cmd(
     env = env if extra_env is None else {**os.environ, **extra_env}
 
     if is_in_databricks_runtime():
-        python_paths = os.environ["PYTHONPATH"].split(":")
-        filtered_paths = []
-        for p in python_paths:
-            try:
-                os.stat(p)
-                filtered_paths.append(p)
-            except PermissionError:
-                pass
-        os.environ["PYTHONPATH"] = ":".join(filtered_paths)
+        if python_path_env := os.environ.get("PYTHONPATH"):
+            python_paths = python_path_env.split(":")
+            filtered_paths = []
+            for p in python_paths:
+                try:
+                    os.stat(p)
+                    filtered_paths.append(p)
+                except PermissionError:
+                    pass
+            os.environ["PYTHONPATH"] = ":".join(filtered_paths)
 
     # In Python < 3.8, `subprocess.Popen` doesn't accept a command containing path-like
     # objects (e.g. `["ls", pathlib.Path("abc")]`) on Windows. To avoid this issue,

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -32,9 +32,6 @@ def _remove_inaccesible_python_path(env):
     """
     Remove inaccessible path from PYTHONPATH environment variable.
     """
-    if env is None:
-        env = os.environ.copy()
-
     if python_path_env := env.get("PYTHONPATH"):
         python_paths = python_path_env.split(":")
         filtered_paths = []
@@ -91,7 +88,10 @@ def _exec_cmd(
             "`capture_output=True` and `stream_output=True` cannot be specified at the same time"
         )
 
-    env = env if extra_env is None else {**os.environ, **extra_env}
+    # Copy current `os.environ` or passed in `env` to avoid mutate it.
+    env = os.environ.copy() if env is None else env.copy()
+    if extra_env is not None:
+        env.update(extra_env)
 
     env = _remove_inaccesible_python_path(env)
 

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -29,7 +29,7 @@ class ShellCommandException(Exception):
         return cls("\n".join(lines))
 
 
-def _remove_inaccesible_python_path(env):
+def _remove_inaccessible_python_path(env):
     """
     Remove inaccessible path from PYTHONPATH environment variable.
     """
@@ -94,7 +94,7 @@ def _exec_cmd(
         # in databricks runtime, the PYTHONPATH might contain inaccessible path
         # which causes virtualenv python environment creation subprocess failure.
         # as a workaround, we remove inaccessible path out of python path.
-        env = _remove_inaccesible_python_path(env)
+        env = _remove_inaccessible_python_path(env)
 
     # In Python < 3.8, `subprocess.Popen` doesn't accept a command containing path-like
     # objects (e.g. `["ls", pathlib.Path("abc")]`) on Windows. To avoid this issue,

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -32,6 +32,9 @@ def _remove_inaccesible_python_path(env):
     """
     Remove inaccessible path from PYTHONPATH environment variable.
     """
+    if env is None:
+        env = os.environ.copy()
+
     if python_path_env := env.get("PYTHONPATH"):
         python_paths = python_path_env.split(":")
         filtered_paths = []
@@ -39,6 +42,7 @@ def _remove_inaccesible_python_path(env):
             if os.access(p, os.R_OK):
                 filtered_paths.append(p)
         env["PYTHONPATH"] = ":".join(filtered_paths)
+    return env
 
 
 def _exec_cmd(
@@ -90,7 +94,7 @@ def _exec_cmd(
 
     env = env if extra_env is None else {**os.environ, **extra_env}
 
-    _remove_inaccesible_python_path(env)
+    env = _remove_inaccesible_python_path(env)
 
     # In Python < 3.8, `subprocess.Popen` doesn't accept a command containing path-like
     # objects (e.g. `["ls", pathlib.Path("abc")]`) on Windows. To avoid this issue,

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -91,6 +91,9 @@ def _exec_cmd(
         env.update(extra_env)
 
     if is_in_databricks_runtime():
+        # in databricks runtime, the PYTHONPATH might contain inaccessible path
+        # which causes virtualenv python environment creation subprocess failure.
+        # as a workaround, we remove inaccessible path out of python path.
         env = _remove_inaccesible_python_path(env)
 
     # In Python < 3.8, `subprocess.Popen` doesn't accept a command containing path-like

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1547,30 +1547,32 @@ def test_spark_udf_env_manager_with_invalid_pythonpath(
     unreadable_file = tmp_path / "unreadable_file"
     unreadable_file.write_text("unreadable file content")
     unreadable_file.chmod(0o000)
-    with pytest.raises(PermissionError):
+    with pytest.raises(PermissionError, match="Permission denied"):
         with unreadable_file.open():
             pass
     non_exist_file = tmp_path / "does_not_exist"
     origin_python_path = os.environ.get("PYTHONPATH", "")
     monkeypatch.setenv("PYTHONPATH", f"{origin_python_path}:{non_exist_file}:{unreadable_file}")
+
+    model, inference_data = sklearn_model
+
+    mlflow.sklearn.save_model(model, model_path)
+    expected_pred_result = model.predict(inference_data)
+
+    infer_data = pd.DataFrame(inference_data, columns=["a", "b"])
+    infer_spark_df = spark.createDataFrame(infer_data)
+
     with mock.patch(
         "mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True
     ), mock.patch("mlflow.utils.virtualenv._is_pyenv_available", return_value=True), mock.patch(
         "mlflow.utils.virtualenv._get_pyenv_bin_path", return_value="pyenv"
     ):
-        model, inference_data = sklearn_model
-
-        mlflow.sklearn.save_model(model, model_path)
-        expected_pred_result = model.predict(inference_data)
-
-        infer_data = pd.DataFrame(inference_data, columns=["a", "b"])
-        infer_spark_df = spark.createDataFrame(infer_data)
-
         pyfunc_udf = spark_udf(spark, model_path, env_manager="virtualenv")
-        result = (
-            infer_spark_df.select(pyfunc_udf("a", "b").alias("predictions"))
-            .toPandas()
-            .predictions.to_numpy()
-        )
+
+    result = (
+        infer_spark_df.select(pyfunc_udf("a", "b").alias("predictions"))
+        .toPandas()
+        .predictions.to_numpy()
+    )
 
     np.testing.assert_allclose(result, expected_pred_result, rtol=1e-5)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1543,13 +1543,16 @@ def test_spark_udf_infer_return_type(spark, tmp_path):
 def test_spark_udf_env_manager_with_invalid_pythonpath(
     spark, sklearn_model, model_path, tmp_path, monkeypatch
 ):
-    # create an unredable file
-    unredable_file = tmp_path / "unredable_file"
-    unredable_file.write_text("unredable file content")
-    unredable_file.chmod(0o000)
-    non_exist_file = "/tmp/abcdefg"
+    # create an unreadable file
+    unreadable_file = tmp_path / "unreadable_file"
+    unreadable_file.write_text("unreadable file content")
+    unreadable_file.chmod(0o000)
+    with pytest.raises(PermissionError):
+        with unreadable_file.open():
+            pass
+    non_exist_file = tmp_path / "does_not_exist"
     origin_python_path = os.environ.get("PYTHONPATH", "")
-    monkeypatch.setenv("PYTHONPATH", f"{origin_python_path}:{non_exist_file}:{unredable_file}")
+    monkeypatch.setenv("PYTHONPATH", f"{origin_python_path}:{non_exist_file}:{unreadable_file}")
     with mock.patch(
         "mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True
     ), mock.patch("mlflow.utils.virtualenv._is_pyenv_available", return_value=True), mock.patch(

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1541,10 +1541,15 @@ def test_spark_udf_infer_return_type(spark, tmp_path):
 
 
 def test_spark_udf_env_manager_with_invalid_pythonpath(
-    spark, sklearn_model, model_path, monkeypatch
+    spark, sklearn_model, model_path, tmp_path, monkeypatch
 ):
+    # create an unredable file
+    unredable_file = tmp_path / "unredable_file"
+    unredable_file.write_text("unredable file content")
+    unredable_file.chmod(0o000)
+    non_exist_file = "/tmp/abcdefg"
     origin_python_path = os.environ.get("PYTHONPATH", "")
-    monkeypatch.setenv("PYTHONPATH", f"{origin_python_path}:/tmp/abcdefg:/tmp/12345")
+    monkeypatch.setenv("PYTHONPATH", f"{origin_python_path}:{non_exist_file}:{unredable_file}")
     with mock.patch(
         "mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True
     ), mock.patch("mlflow.utils.virtualenv._is_pyenv_available", return_value=True), mock.patch(

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1540,7 +1540,9 @@ def test_spark_udf_infer_return_type(spark, tmp_path):
     assert pdf["output"][1] == ("b", [1], (False, ("another_string",)), [(0.2,), (0.3,)])
 
 
-def test_spark_udf_env_manager_with_invalid_pythonpath(spark, sklearn_model, model_path, monkeypatch):
+def test_spark_udf_env_manager_with_invalid_pythonpath(
+    spark, sklearn_model, model_path, monkeypatch
+):
     monkeypatch.setenv("PYTHONPATH", "/tmp/abcdefg:/tmp/12345")
     model, inference_data = sklearn_model
 

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1544,6 +1544,7 @@ def test_spark_udf_env_manager_with_invalid_pythonpath(
     spark, sklearn_model, model_path, monkeypatch
 ):
     monkeypatch.setenv("PYTHONPATH", "/tmp/abcdefg:/tmp/12345")
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "15.0")
     model, inference_data = sklearn_model
 
     mlflow.sklearn.save_model(model, model_path)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12774?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12774/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12774
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
In databricks runtime, the `PYTHONPATH` might include path that python process doesn't have permission to read, this is causing spark UDF python environment set up failure like:
``` 
File "/local_disk0/.ephemeral_nfs/user_tmp_data/spark-93ae92c8-d297-4105-bfd1-6c/mlflow/envs/virtualenv_envs/mlflow-0ab6aaa270a70a58ac6809362724db1e3f95d7fc/lib/python3.11/site-packages/pip/_internal/metadata/base.py", line 612, in iter_all_di
    for dist in self._iter_distributions():^@
  File "/local_disk0/.ephemeral_nfs/user_tmp_data/spark-93ae92c8-d297-4105-bfd1-6c/mlflow/envs/virtualenv_envs/mlflow-0ab6aaa270a70a58ac6809362724db1e3f95d7fc/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 180, in
    yield from finder.find_linked(location)^@
  File "/local_disk0/.ephemeral_nfs/user_tmp_data/spark-93ae92c8-d297-4105-bfd1-6c/mlflow/envs/virtualenv_envs/mlflow-0ab6aaa270a70a58ac6809362724db1e3f95d7fc/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 96, in f
    if not path.is_dir():^@
           ^^^^^^^^^^^^^^@
  File "/local_disk0/.ephemeral_nfs/user_tmp_data/spark-93ae92c8-d297-4105-bfd1-6c/mlflow/envs/pyenv_root/versions/3.11.0/lib/python3.11/pathlib.py", line 1250, in is_dir^@
    return S_ISDIR(self.stat().st_mode)^@
                   ^^^^^^^^^^^^@
  File "/local_disk0/.ephemeral_nfs/user_tmp_data/spark-93ae92c8-d297-4105-bfd1-6c/mlflow/envs/pyenv_root/versions/3.11.0/lib/python3.11/pathlib.py", line 1013, in stat^@
    return os.stat(self, follow_symlinks=follow_symlinks)^@
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^@
PermissionError: [Errno 13] Permission denied: \'/databricks/jars/spark--driver--driver-spark_3.5_2.12_deploy.jar
```
This PR fixes the issue.

Repro code:
```
from pyspark.sql import SparkSession
from sklearn import datasets
from sklearn.neighbors import KNeighborsClassifier

import mlflow
from mlflow.models import infer_signature

X, y = datasets.load_iris(as_frame=True, return_X_y=True)
model = KNeighborsClassifier()
model.fit(X, y)
predictions = model.predict(X)
signature = infer_signature(X, predictions)

with mlflow.start_run():
    model_info = mlflow.sklearn.log_model(model, "model", signature=signature)
    
    infer_spark_df = spark.createDataFrame(X)
    
    pyfunc_udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, env_manager="virtualenv")
    result = infer_spark_df.select(pyfunc_udf(*X.columns).alias("predictions")).toPandas()
    
    print(result)
```
Runs on DBR 15.3 shared mode cluster with latest released mlflow version.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
