### PR TITLE
Do not warn for unsupported versions for `langchain`

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -133,7 +133,7 @@ def get_default_conda_env():
 
 @experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
-@docstring_version_compatibility_warning(FLAVOR_NAME)
+@docstring_version_compatibility_warning(FLAVOR_NAME, warn=False)
 @trace_disabled  # Suppress traces for internal predict calls while saving model
 def save_model(
     lc_model,
@@ -408,7 +408,7 @@ def save_model(
 
 @experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
-@docstring_version_compatibility_warning(FLAVOR_NAME)
+@docstring_version_compatibility_warning(FLAVOR_NAME, warn=False)
 @trace_disabled  # Suppress traces for internal predict calls while logging model
 def log_model(
     lc_model,
@@ -925,7 +925,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
 
 
 @experimental
-@docstring_version_compatibility_warning(FLAVOR_NAME)
+@docstring_version_compatibility_warning(FLAVOR_NAME, warn=False)
 @trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):
     """

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -381,13 +381,15 @@ def _do_version_compatibility_warning(msg: str):
     warnings.warn(msg, category=UserWarning, stacklevel=2)
 
 
-def docstring_version_compatibility_warning(integration_name):
+def docstring_version_compatibility_warning(integration_name, warn=True):
     """
     Generates a docstring that can be applied as a note stating a version compatibility range for
-    a given flavor.
+    a given flavor and optionally raises a warning if the installed version is outside of the
+    supported range.
 
     Args:
         integration_name: The name of the module as stored within ml-package-versions.yml
+        warn: If True, raise a warning if the installed version is outside of the supported range.
 
     Returns:
         The wrapped function with the additional docstring header applied
@@ -411,7 +413,11 @@ def docstring_version_compatibility_warning(integration_name):
         @wraps(func)
         def version_func(*args, **kwargs):
             installed_version = Version(importlib_metadata.version(module_key))
-            if installed_version < Version(min_ver) or installed_version > Version(max_ver):
+            if (
+                warn
+                and installed_version < Version(min_ver)
+                or installed_version > Version(max_ver)
+            ):
                 _do_version_compatibility_warning(notice)
             return func(*args, **kwargs)
 

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -164,6 +164,10 @@ def test_docstring_version_compatibility_warning():
     def another_func():
         func()
 
+    @docstring_version_compatibility_warning("sklearn", warn=False)
+    def does_not_warn():
+        pass
+
     with mock.patch("importlib_metadata.version", return_value="0.0.0") as mock_version:
         with warnings.catch_warnings(record=True) as w:
             another_func()
@@ -172,3 +176,9 @@ def test_docstring_version_compatibility_warning():
         # Exclude irrelevant warnings
         warns = [x for x in w if "MLflow Models integration is known to be compatible" in str(x)]
         assert len(warns) == 1
+
+        with warnings.catch_warnings(record=True) as w:
+            does_not_warn()
+
+        warns = [x for x in w if "MLflow Models integration is known to be compatible" in str(x)]
+        assert len(warns) == 0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12778?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12778/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12778
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

As discussed offline, avoid raising a warning when `mlflow.langchain.{log_model|save_model|load_mode}` is called with an unsupported langchain version.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
