### PR TITLE
Llama index fix for 0.10.57

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -707,7 +707,7 @@ llama_index:
   models:
     # New event/span framework is fully implemented in 0.10.44
     minimum: "0.10.44"
-    maximum: "0.10.56"
+    maximum: "0.10.57"
     requirements:
       ">= 0.0.0": [
           "openai",
@@ -715,9 +715,13 @@ llama_index:
           "llama-index-llms-databricks",
           "llama-index-embeddings-databricks",
         ]
-    run:
-      # TODO: Add --ignore flag for autologging test once it's implemented
-      pytest tests/llama_index
+    run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
+  autologging:
+    minimum: "0.10.44"
+    maximum: "0.10.57"
+    requirements:
+      ">= 0.0.0": ["openai"]
+    run: pytest tests/llama_index/test_llama_index_autolog.py tests/llama_index/test_llama_index_tracer.py
 
 sentence_transformers:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -707,7 +707,7 @@ llama_index:
   models:
     # New event/span framework is fully implemented in 0.10.44
     minimum: "0.10.44"
-    maximum: "0.10.57"
+    maximum: "0.10.58"
     requirements:
       ">= 0.0.0": [
           "openai",
@@ -718,7 +718,7 @@ llama_index:
     run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
   autologging:
     minimum: "0.10.44"
-    maximum: "0.10.57"
+    maximum: "0.10.58"
     requirements:
       ">= 0.0.0": ["openai"]
     run: pytest tests/llama_index/test_llama_index_autolog.py tests/llama_index/test_llama_index_tracer.py

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -276,7 +276,11 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "0.10.44",
-            "maximum": "0.10.56"
+            "maximum": "0.10.57"
+        },
+        "autologging": {
+            "minimum": "0.10.44",
+            "maximum": "0.10.57"
         }
     },
     "sentence_transformers": {

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -276,11 +276,11 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "0.10.44",
-            "maximum": "0.10.57"
+            "maximum": "0.10.58"
         },
         "autologging": {
             "minimum": "0.10.44",
-            "maximum": "0.10.57"
+            "maximum": "0.10.58"
         }
     },
     "sentence_transformers": {

--- a/tests/llama_index/conftest.py
+++ b/tests/llama_index/conftest.py
@@ -12,7 +12,7 @@ from llama_index.core import (
     Settings,
     VectorStoreIndex,
 )
-from llama_index.core.callbacks import CallbackManager, TokenCountingHandler
+from llama_index.core.callbacks import CallbackManager, LlamaDebugHandler
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.openai import OpenAI
@@ -72,7 +72,7 @@ def settings(monkeypatch, mock_openai):
     )
     monkeypatch.setattr(Settings, "llm", OpenAI())
     monkeypatch.setattr(Settings, "embed_model", OpenAIEmbedding())
-    monkeypatch.setattr(Settings, "callback_manager", CallbackManager([TokenCountingHandler()]))
+    monkeypatch.setattr(Settings, "callback_manager", CallbackManager([LlamaDebugHandler()]))
     monkeypatch.setattr(Settings, "_tokenizer", _mock_tokenizer)  # must bypass setter
     monkeypatch.setattr(Settings, "context_window", 4096)  # this enters the _prompt_helper field
     monkeypatch.setattr(Settings, "node_parser", SentenceSplitter(chunk_size=1024))


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix [cross version test failure](https://github.com/mlflow-automation/mlflow/actions/runs/10077443988/job/27873958577) for LlamaIndex >= 0.10.57.

1. `AttributeError: 'ChatCompletionChunk' object has no attribute 'get'` - This is test only issue. We use the built-in [TokenCountingHandler](https://github.com/run-llama/llama_index/blob/34dec27b7df959e05f9aa5a5859fb4c1d10e2b21/llama-index-core/llama_index/core/callbacks/token_counting.py#L96) for saving callback saving/loading, but `0.10.57` release broke it. They [fixed](https://github.com/run-llama/llama_index/pull/14937) it in `0.10.58` already, but I replaced it with a different callback example to avoid future issue (e.g. cross version test may pick 0.10.57).
2. `KeyError: 'usage'` - This is tracing issue. The trace doesn't contain the expected token usage attribute for LLM completion. Our tracer extracts the usage from the raw model response [here](https://github.com/mlflow/mlflow/blob/master/mlflow/llama_index/tracer.py#L370-L371). However, the `response.raw` from OpenAI model became a pydantic model rather than dictionary since 0.10.57. Updated the logic to handle pydantic model as well.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests
Tested tracing functionality in staging.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
