### PR TITLE
Document multipart upload for proxied artifact access

### DIFF
--- a/docs/source/tracking/artifacts-stores.rst
+++ b/docs/source/tracking/artifacts-stores.rst
@@ -210,3 +210,36 @@ Deletion Behavior
 In order to allow MLflow Runs to be restored, Run metadata and artifacts are not automatically removed
 from the backend store or artifact store when a Run is deleted. The :ref:`mlflow gc <cli>` CLI is provided
 for permanently removing Run metadata and artifacts for deleted runs.
+
+Multipart upload for proxied artifact access
+============================================
+
+.. note::
+    This feature is experimental and may be changed or removed in a future release without notice.
+
+Tracking Server supports uploading large artifacts using multipart upload for proxied artifact access.
+To enable this feature, set ``MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD`` to ``true``.
+
+.. code-block:: bash
+
+    export MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD=true
+
+Under the hood, the Tracking Server will create a multipart upload request with the underlying storage,
+generate presigned urls for each part, and let the client upload the parts directly to the storage.
+Once all parts are uploaded, the Tracking Server will complete the multipart upload.
+None of the data will pass through the Tracking Server.
+
+If the underlying storage does not support multipart upload, the Tracking Server will fallback to a single part upload.
+If multipart upload is supported but fails for any reason, an exception will be thrown.
+
+MLflow supports multipart upload for the following storage for proxied artifact access:
+
+- Amazon S3
+- Google Cloud Storage
+
+You can configure the following environment variables:
+
+- ``MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE`` - Specifies the minimum file size in bytes to use multipart upload
+  when logging artifacts (Default: 500 MB)
+- ``MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE`` - Specifies the chunk size in bytes to use when performing multipart upload
+  (Default: 100 MB)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12786?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12786/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12786
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #12776

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

https://github.com/mlflow/mlflow/commit/d0062b2dbac7e4eb5013040c31ce1202dfb71865 added docs for multipart upload for proxied artifact access, but it was accidentally removed in https://github.com/mlflow/mlflow/pull/10471. This PR restores the docs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
