### PR TITLE
Pin `incremental` to fix error in circleci

### DIFF
--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -16,4 +16,5 @@ torchvision>=0.12.0
 lightning>=1.8.1
 scrapy
 ipywidgets>=8.1.1
+# incremental==24.7.0 requires setuptools>=61.0, which causes https://github.com/mlflow/mlflow/issues/8635
 incremental<24.7.0

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -16,3 +16,4 @@ torchvision>=0.12.0
 lightning>=1.8.1
 scrapy
 ipywidgets>=8.1.1
+incremental<24.7.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12792?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12792/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12792
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://app.circleci.com/pipelines/github/mlflow/mlflow/39405/workflows/f804d518-8b70-4b8e-9d61-dbdbf145876d/jobs/116741:

```
____________________ test[ mlflow/tracking/fluent.py:2180 ] ____________________

_ = ' mlflow/tracking/fluent.py:2180 '

    @pytest.mark.parametrize('_', [' mlflow/tracking/fluent.py:2180 '])
    def test(_):
        import mlflow
    
        mlflow.autolog(log_models=False, exclusive=True)
    
        import sklearn
    
>       mlflow.sklearn.autolog(log_models=True)

_          = ' mlflow/tracking/fluent.py:2180 '
mlflow     = <module 'mlflow' from '/home/circleci/project/mlflow/__init__.py'>
sklearn    = <module 'sklearn' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/__init__.py'>

.examples/test_mlflow_tracking_fluent_autolog_22.py:13: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../mlflow/utils/autologging_utils/__init__.py:453: in autolog
    return _autolog(*args, **kwargs)
        _autolog   = <function autolog at 0x7f1a53000820>
        args       = ()
        config_to_store = {'disable': False, 'disable_for_unsupported_versions': False, 'exclusive': False, 'extra_tags': None, ...}
        default_params = {'disable': False, 'disable_for_unsupported_versions': False, 'exclusive': False, 'extra_tags': None, ...}
        is_silent_mode = False
        kwargs     = {'log_models': True}
        name       = 'sklearn'
        param_spec = mappingproxy(OrderedDict([('log_input_examples', <Parameter "log_input_examples=False">), ('log_model_signatures', <Pa...tered_model_name=None">), ('pos_label', <Parameter "pos_label=None">), ('extra_tags', <Parameter "extra_tags=None">)]))
../mlflow/sklearn/__init__.py:1280: in autolog
    _autolog(
        disable    = False
        disable_for_unsupported_versions = False
        exclusive  = False
        extra_tags = None
        log_datasets = True
        log_input_examples = False
        log_model_signatures = True
        log_models = True
        log_post_training_metrics = True
        max_tuning_runs = 5
        pos_label  = None
        registered_model_name = None
        serialization_format = 'cloudpickle'
        silent     = False
../mlflow/sklearn/__init__.py:1842: in _autolog
    estimators_to_patch = _gen_estimators_to_patch()
        _TRAINING_PREFIX = 'training_'
        _apply_sklearn_descriptor_unbound_method_call_fix = <function _autolog.<locals>._apply_sklearn_descriptor_unbound_method_call_fix at 0x7f1a5293b8b0>
        _create_child_runs_for_parameter_search = <function _create_child_runs_for_parameter_search at 0x7f1a529c79d0>
        _gen_lightgbm_sklearn_estimators_to_patch = <function _gen_lightgbm_sklearn_estimators_to_patch at 0x7f1a529bbf70>
        _gen_xgboost_sklearn_estimators_to_patch = <function _gen_xgboost_sklearn_estimators_to_patch at 0x7f1a529bbee0>
        _get_X_y_and_sample_weight = <function _get_X_y_and_sample_weight at 0x7f1a529c70d0>
        _get_estimator_info_tags = <function _get_estimator_info_tags at 0x7f1a529c7040>
        _is_parameter_search_estimator = <function _is_parameter_search_estimator at 0x7f1a529c7820>
        _log_estimator_content = <function _log_estimator_content at 0x7f1a529c7700>
        _log_parameter_search_results_as_artifact = <function _log_parameter_search_results_as_artifact at 0x7f1a529c78b0>
        _log_posttraining_metadata = <function _autolog.<locals>._log_posttraining_metadata at 0x7f1a528b71f0>
        _log_pretraining_metadata = <function _autolog.<locals>._log_pretraining_metadata at 0x7f1a528b7160>
        context_registry = <module 'mlflow.tracking.context.registry' from '/home/circleci/project/mlflow/tracking/context/registry.py'>
        disable    = False
        disable_for_unsupported_versions = False
        exclusive  = False
        extra_tags = None
        fit_mlflow = <function _autolog.<locals>.fit_mlflow at 0x7f1b177e90d0>
        fit_mlflow_xgboost_and_lightgbm = <function _autolog.<locals>.fit_mlflow_xgboost_and_lightgbm at 0x7f1a70f44a60>
        flavor_name = 'sklearn'
        infer_signature = <function infer_signature at 0x7f1a943c8a60>
        log_datasets = True
        log_input_examples = False
        log_model_signatures = True
        log_models = True
        log_post_training_metrics = True
        max_tuning_runs = 5
        patched_fit = <function _autolog.<locals>.patched_fit at 0x7f1a528b70d0>
        patched_metric_api = <function _autolog.<locals>.patched_metric_api at 0x7f1a5293b790>
        patched_model_score = <function _autolog.<locals>.patched_model_score at 0x7f1a5293b820>
        patched_predict = <function _autolog.<locals>.patched_predict at 0x7f1aa538f0d0>
        pd         = <module 'pandas' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/pandas/__init__.py'>
        pos_label  = None
        serialization_format = 'cloudpickle'
        silent     = False
        sklearn    = <module 'sklearn' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/__init__.py'>
../mlflow/sklearn/__init__.py:100: in _gen_estimators_to_patch
    _, estimators_to_patch = zip(*_all_estimators())
        _all_estimators = <function _all_estimators at 0x7f1a529c7b80>
        _get_meta_estimators_for_autologging = <function _get_meta_estimators_for_autologging at 0x7f1a529c7790>
../mlflow/sklearn/utils.py:876: in _all_estimators
    return all_estimators()
        all_estimators = <function all_estimators at 0x7f1a530c0430>
../../.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/utils/discovery.py:63: in all_estimators
    for _, module_name, _ in pkgutil.walk_packages(path=[root], prefix="sklearn."):
        BaseEstimator = <class 'sklearn.base.BaseEstimator'>
        ClassifierMixin = <class 'sklearn.base.ClassifierMixin'>
        ClusterMixin = <class 'sklearn.base.ClusterMixin'>
        IS_PYPY    = False
        RegressorMixin = <class 'sklearn.base.RegressorMixin'>
        TransformerMixin = <class 'sklearn.base.TransformerMixin'>
        _          = True
        all_classes = []
        ignore_warnings = <function ignore_warnings at 0x7f1a529dcc10>
        is_abstract = <function all_estimators.<locals>.is_abstract at 0x7f1a5293b940>
        module_name = 'sklearn._build_utils'
        module_parts = ['sklearn', '_build_utils']
        root       = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn'
        type_filter = None
../../.pyenv/versions/3.8.16/lib/python3.8/pkgutil.py:92: in walk_packages
    __import__(info.name)
        info       = ModuleInfo(module_finder=FileFinder('/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn'), name='sklearn._build_utils', ispkg=True)
        onerror    = None
        path       = ['/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/__check_build']
        prefix     = 'sklearn.'
        seen       = <function walk_packages.<locals>.seen at 0x7f1a5293ba60>
../../.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/__init__.py:15: in <module>
    from .openmp_helpers import check_openmp_support
        CYTHON_MIN_VERSION = '0.29.33'
        __builtins__ = <builtins>
        __cached__ = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/__pycache__/__init__.cpython-38.pyc'
        __doc__    = '\nUtilities useful during the build.\n'
        __file__   = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/__init__.py'
        __loader__ = <_frozen_importlib_external.SourceFileLoader object at 0x7f1a528b0610>
        __name__   = 'sklearn._build_utils'
        __package__ = 'sklearn._build_utils'
        __path__   = ['/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils']
        __spec__   = ModuleSpec(name='sklearn._build_utils', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7f1a528b0610>,... submodule_search_locations=['/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils'])
        contextlib = <module 'contextlib' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/contextlib.py'>
        os         = <module 'os' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/os.py'>
        parse      = <function parse at 0x7f1a531163a0>
        sklearn    = <module 'sklearn' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/__init__.py'>
../../.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/openmp_helpers.py:12: in <module>
    from .pre_build_helpers import compile_test_program
        __builtins__ = <builtins>
        __cached__ = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/__pycache__/openmp_helpers.cpython-38.pyc'
        __doc__    = 'Helpers for OpenMP support during the build.'
        __file__   = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/openmp_helpers.py'
        __loader__ = <_frozen_importlib_external.SourceFileLoader object at 0x7f1a528b0f40>
        __name__   = 'sklearn._build_utils.openmp_helpers'
        __package__ = 'sklearn._build_utils'
        __spec__   = ModuleSpec(name='sklearn._build_utils.openmp_helpers', loader=<_frozen_importlib_external.SourceFileLoader object at 0...40>, origin='/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/openmp_helpers.py')
        os         = <module 'os' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/os.py'>
        sys        = <module 'sys' (built-in)>
        textwrap   = <module 'textwrap' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/textwrap.py'>
        warnings   = <module 'warnings' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/warnings.py'>
../../.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/pre_build_helpers.py:10: in <module>
    from setuptools.command.build_ext import customize_compiler, new_compiler
        __builtins__ = <builtins>
        __cached__ = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/__pycache__/pre_build_helpers.cpython-38.pyc'
        __doc__    = 'Helpers to check build environment before actual build of scikit-learn'
        __file__   = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/pre_build_helpers.py'
        __loader__ = <_frozen_importlib_external.SourceFileLoader object at 0x7f1aa51f7fd0>
        __name__   = 'sklearn._build_utils.pre_build_helpers'
        __package__ = 'sklearn._build_utils'
        __spec__   = ModuleSpec(name='sklearn._build_utils.pre_build_helpers', loader=<_frozen_importlib_external.SourceFileLoader object a..., origin='/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/sklearn/_build_utils/pre_build_helpers.py')
        glob       = <module 'glob' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/glob.py'>
        os         = <module 'os' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/os.py'>
        subprocess = <module 'subprocess' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/subprocess.py'>
        sys        = <module 'sys' (built-in)>
        tempfile   = <module 'tempfile' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/tempfile.py'>
        textwrap   = <module 'textwrap' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/textwrap.py'>
../../.pyenv/versions/3.8.16/lib/python3.8/site-packages/setuptools/__init__.py:13: in <module>
    import _distutils_hack.override  # noqa: F401
        TYPE_CHECKING = False
        __builtins__ = <builtins>
        __cached__ = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/setuptools/__pycache__/__init__.cpython-38.pyc'
        __doc__    = "Extensions to the 'distutils' for large or complex distributions"
        __file__   = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/setuptools/__init__.py'
        __loader__ = <_frozen_importlib_external.SourceFileLoader object at 0x7f1a52931910>
        __name__   = 'setuptools'
        __package__ = 'setuptools'
        __path__   = ['/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/setuptools']
        __spec__   = ModuleSpec(name='setuptools', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7f1a52931910>, origin='/...nit__.py', submodule_search_locations=['/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/setuptools'])
        functools  = <module 'functools' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/functools.py'>
        os         = <module 'os' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/os.py'>
        re         = <module 're' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/re.py'>
        sys        = <module 'sys' (built-in)>
        vendor_path = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/setuptools/_vendor'
../../.pyenv/versions/3.8.16/lib/python3.8/site-packages/_distutils_hack/override.py:1: in <module>
    __import__('_distutils_hack').do_override()
        __builtins__ = <builtins>
        __cached__ = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/_distutils_hack/__pycache__/override.cpython-38.pyc'
        __doc__    = None
        __file__   = '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/_distutils_hack/override.py'
        __loader__ = <_frozen_importlib_external.SourceFileLoader object at 0x7f1a52931f10>
        __name__   = '_distutils_hack.override'
        __package__ = '_distutils_hack'
        __spec__   = ModuleSpec(name='_distutils_hack.override', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7f1a52931f10>, origin='/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages/_distutils_hack/override.py')
../../.pyenv/versions/3.8.16/lib/python3.8/site-packages/_distutils_hack/__init__.py:91: in do_override
    ensure_local_distutils()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def ensure_local_distutils():
        import importlib
    
        clear_distutils()
    
        # With the DistutilsMetaFinder in place,
        # perform an import to cause distutils to be
        # loaded from setuptools._distutils. Ref #2906.
        with shim():
            importlib.import_module('distutils')
    
        # check that submodules load as expected
        core = importlib.import_module('distutils.core')
>       assert '_distutils' in core.__file__, core.__file__
E       AssertionError: /home/circleci/.pyenv/versions/3.8.16/lib/python3.8/distutils/core.py

core       = <module 'distutils.core' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/distutils/core.py'>
importlib  = <module 'importlib' from '/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/importlib/__init__.py'>
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
