### PR TITLE
Fix flaky `test_get_deployment_successful`

### DIFF
--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1519,7 +1519,7 @@ def test_deploy_cli_deletes_sagemaker_deployment(pretrained_model, sagemaker_cli
     assert len(response["Endpoints"]) == 0
 
 
-@pytest.mark.parametrize("i", range(500))
+@pytest.mark.parametrize("i", range(500))  # temporary change to ensure this is not flaky
 @mock_sagemaker_aws_services
 def test_get_deployment_successful(i, pretrained_model, sagemaker_client):
     name = "test-app"
@@ -1532,12 +1532,15 @@ def test_get_deployment_successful(i, pretrained_model, sagemaker_client):
     endpoint_description = sagemaker_deployment_client.get_deployment(name)
 
     expected_description = sagemaker_client.describe_endpoint(EndpointName=name)
+    # The date header value is not deterministic. Use `mock.ANY` to match any value.
+    expected_description["ResponseMetadata"]["HTTPHeaders"]["date"] = mock.ANY
     assert endpoint_description == expected_description
 
 
 @mock_sagemaker_aws_services
+@pytest.mark.parametrize("i", range(500))  # temporary change to ensure this is not flaky
 def test_get_deployment_with_assumed_role_arn(
-    pretrained_model, sagemaker_client, sagemaker_deployment_client
+    i, pretrained_model, sagemaker_client, sagemaker_deployment_client
 ):
     name = "test-app"
     sagemaker_deployment_client.create_deployment(name=name, model_uri=pretrained_model.model_uri)
@@ -1545,6 +1548,8 @@ def test_get_deployment_with_assumed_role_arn(
     endpoint_description = sagemaker_deployment_client.get_deployment(name)
 
     expected_description = sagemaker_client.describe_endpoint(EndpointName=name)
+    # The date header value is not deterministic. Use `mock.ANY` to match any value.
+    expected_description["ResponseMetadata"]["HTTPHeaders"]["date"] = mock.ANY
     assert endpoint_description == expected_description
 
 

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1519,9 +1519,8 @@ def test_deploy_cli_deletes_sagemaker_deployment(pretrained_model, sagemaker_cli
     assert len(response["Endpoints"]) == 0
 
 
-@pytest.mark.parametrize("i", range(500))  # temporary change to ensure this is not flaky
 @mock_sagemaker_aws_services
-def test_get_deployment_successful(i, pretrained_model, sagemaker_client):
+def test_get_deployment_successful(pretrained_model, sagemaker_client):
     name = "test-app"
     region_name = sagemaker_client.meta.region_name
     sagemaker_deployment_client = mfs.SageMakerDeploymentClient(f"sagemaker:/{region_name}")
@@ -1532,15 +1531,15 @@ def test_get_deployment_successful(i, pretrained_model, sagemaker_client):
     endpoint_description = sagemaker_deployment_client.get_deployment(name)
 
     expected_description = sagemaker_client.describe_endpoint(EndpointName=name)
-    # The date header value is not deterministic. Use `mock.ANY` to match any value.
+    # The date header value in `expected_description` is occasionally one second ahead of
+    # `endpoint_description`. To avoid flakiness, use `mock.ANY` to match any value.
     expected_description["ResponseMetadata"]["HTTPHeaders"]["date"] = mock.ANY
     assert endpoint_description == expected_description
 
 
 @mock_sagemaker_aws_services
-@pytest.mark.parametrize("i", range(500))  # temporary change to ensure this is not flaky
 def test_get_deployment_with_assumed_role_arn(
-    i, pretrained_model, sagemaker_client, sagemaker_deployment_client
+    pretrained_model, sagemaker_client, sagemaker_deployment_client
 ):
     name = "test-app"
     sagemaker_deployment_client.create_deployment(name=name, model_uri=pretrained_model.model_uri)
@@ -1548,7 +1547,8 @@ def test_get_deployment_with_assumed_role_arn(
     endpoint_description = sagemaker_deployment_client.get_deployment(name)
 
     expected_description = sagemaker_client.describe_endpoint(EndpointName=name)
-    # The date header value is not deterministic. Use `mock.ANY` to match any value.
+    # The date header value in `expected_description` is occasionally one second ahead of
+    # `endpoint_description`. To avoid flakiness, use `mock.ANY` to match any value.
     expected_description["ResponseMetadata"]["HTTPHeaders"]["date"] = mock.ANY
     assert endpoint_description == expected_description
 

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1519,8 +1519,9 @@ def test_deploy_cli_deletes_sagemaker_deployment(pretrained_model, sagemaker_cli
     assert len(response["Endpoints"]) == 0
 
 
+@pytest.mark.parametrize("i", range(100))
 @mock_sagemaker_aws_services
-def test_get_deployment_successful(pretrained_model, sagemaker_client):
+def test_get_deployment_successful(i, pretrained_model, sagemaker_client):
     name = "test-app"
     region_name = sagemaker_client.meta.region_name
     sagemaker_deployment_client = mfs.SageMakerDeploymentClient(f"sagemaker:/{region_name}")

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1519,7 +1519,7 @@ def test_deploy_cli_deletes_sagemaker_deployment(pretrained_model, sagemaker_cli
     assert len(response["Endpoints"]) == 0
 
 
-@pytest.mark.parametrize("i", range(100))
+@pytest.mark.parametrize("i", range(500))
 @mock_sagemaker_aws_services
 def test_get_deployment_successful(i, pretrained_model, sagemaker_client):
     name = "test-app"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12795?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12795/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12795
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix flaky `test_get_deployment_successful`:

https://github.com/mlflow/mlflow/actions/runs/10106285415/job/27948147950#step:9:147

```
________________________ test_get_deployment_successful ________________________

pretrained_model = TrainedModel(model_path='model', run_id='1b65171f8b46421f8dd7f3ef1b7725e8', model_uri='runs:/1b65171f8b46421f8dd7f3ef1b7725e8/model')
sagemaker_client = <botocore.client.SageMaker object at 0x7f093b5fb040>

    @mock_sagemaker_aws_services
    def test_get_deployment_successful(pretrained_model, sagemaker_client):
        name = "test-app"
        region_name = sagemaker_client.meta.region_name
        sagemaker_deployment_client = mfs.SageMakerDeploymentClient(f"sagemaker:/{region_name}")
        sagemaker_deployment_client.create_deployment(
            name=name, model_uri=pretrained_model.model_uri, config={"region_name": region_name}
        )
    
        endpoint_description = sagemaker_deployment_client.get_deployment(name)
    
        expected_description = sagemaker_client.describe_endpoint(EndpointName=name)
>       assert endpoint_description == expected_description
E       AssertionError: assert {'CreationTim...est-app', ...} == {'CreationTim...est-app', ...}
E         
E         Omitting 7 identical items, use -vv to show
E         Differing items:
E         {'ResponseMetadata': {'HTTPHeaders': {'date': 'Fri, 26 Jul 2024 05:53:12 GMT', 'server': 'amazon.com'}, 'HTTPStatusCode': 200, 'RetryAttempts': 0}} != {'ResponseMetadata': {'HTTPHeaders': {'date': 'Fri, 26 Jul 2024 05:53:13 GMT', 'server': 'amazon.com'}, 'HTTPStatusCode': 200, 'RetryAttempts': 0}}
E         
E         Full diff:
E           {
E               'CreationTime': datetime.datetime(2024, 7, 26, 5, 53, 12, 990813, tzinfo=tzlocal()),
E               'EndpointArn': 'arn:aws:sagemaker:us-west-2:123456789012::endpoint/test-app',
E               'EndpointConfigName': 'test-app-config-450d4b185e244adeb50e',
E               'EndpointName': 'test-app',
E               'EndpointStatus': 'InService',
E               'LastModifiedTime': datetime.datetime(2024, 7, 26, 5, 53, 12, 990813, tzinfo=tzlocal()),
E               'ProductionVariants': [
E                   {
E                       'VariantName': 'test-app-model-68baccfeaf67462ab627',
E                   },
E               ],
E               'ResponseMetadata': {
E                   'HTTPHeaders': {
E         -             'date': 'Fri, 26 Jul 2024 05:53:13 GMT',
E         ?                                              ^
E         +             'date': 'Fri, 26 Jul 2024 05:53:12 GMT',
E         ?                                              ^
E                       'server': 'amazon.com',
E                   },
E                   'HTTPStatusCode': 200,
E                   'RetryAttempts': 0,
E               },
E           }
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
