### PR TITLE
Fix transformer-dev cross tests

### DIFF
--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 transformers_version = Version(transformers.__version__)
 IS_NEW_FEATURE_EXTRACTION_API = transformers_version >= Version("4.27.0")
 
-chat_template = '{% for message in messages %}{{ message.content }}{{ eos_token }}{% endfor %}'
+CHAT_TEMPLATE = "{% for message in messages %}{{ message.content }}{{ eos_token }}{% endfor %}"
 
 
 def prefetch(func):
@@ -126,7 +126,9 @@ def load_text_generation_pipeline():
     task = "text-generation"
     architecture = "distilgpt2"
     model = transformers.AutoModelWithLMHead.from_pretrained(architecture)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture, chat_template=chat_template)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        architecture, chat_template=CHAT_TEMPLATE
+    )
     return transformers.pipeline(task=task, model=model, tokenizer=tokenizer)
 
 

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -15,6 +15,8 @@ _logger = logging.getLogger(__name__)
 transformers_version = Version(transformers.__version__)
 IS_NEW_FEATURE_EXTRACTION_API = transformers_version >= Version("4.27.0")
 
+chat_template = '{% for message in messages %}{{ message.content }}{{ eos_token }}{% endfor %}'
+
 
 def prefetch(func):
     """
@@ -123,7 +125,7 @@ def load_text2text_generation_pipeline():
 def load_text_generation_pipeline():
     task = "text-generation"
     architecture = "distilgpt2"
-    model = transformers.AutoModelWithLMHead.from_pretrained(architecture)
+    model = transformers.AutoModelWithLMHead.from_pretrained(architecture, chat_template=chat_template)
     tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
     return transformers.pipeline(task=task, model=model, tokenizer=tokenizer)
 

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -125,8 +125,8 @@ def load_text2text_generation_pipeline():
 def load_text_generation_pipeline():
     task = "text-generation"
     architecture = "distilgpt2"
-    model = transformers.AutoModelWithLMHead.from_pretrained(architecture, chat_template=chat_template)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
+    model = transformers.AutoModelWithLMHead.from_pretrained(architecture)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture, chat_template=chat_template)
     return transformers.pipeline(task=task, model=model, tokenizer=tokenizer)
 
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -61,7 +61,7 @@ from tests.helper_functions import (
     pyfunc_scoring_endpoint,
     pyfunc_serve_and_score_model,
 )
-from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API, chat_template
+from tests.transformers.helper import CHAT_TEMPLATE, IS_NEW_FEATURE_EXTRACTION_API
 from tests.transformers.test_transformers_peft_model import SKIP_IF_PEFT_NOT_AVAILABLE
 
 # NB: Some pipelines under test in this suite come very close or outright exceed the
@@ -3329,8 +3329,7 @@ def test_local_custom_model_save_and_load(text_generation_pipeline, model_path, 
 
     locally_loaded_model = transformers.AutoModelWithLMHead.from_pretrained(local_repo_path)
     tokenizer = transformers.AutoTokenizer.from_pretrained(
-        local_repo_path,
-        chat_template=chat_template
+        local_repo_path, chat_template=CHAT_TEMPLATE
     )
     model_dict = {"model": locally_loaded_model, "tokenizer": tokenizer}
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -61,7 +61,7 @@ from tests.helper_functions import (
     pyfunc_scoring_endpoint,
     pyfunc_serve_and_score_model,
 )
-from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API
+from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API, chat_template
 from tests.transformers.test_transformers_peft_model import SKIP_IF_PEFT_NOT_AVAILABLE
 
 # NB: Some pipelines under test in this suite come very close or outright exceed the
@@ -3328,7 +3328,10 @@ def test_local_custom_model_save_and_load(text_generation_pipeline, model_path, 
     text_generation_pipeline.save_pretrained(local_repo_path)
 
     locally_loaded_model = transformers.AutoModelWithLMHead.from_pretrained(local_repo_path)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(local_repo_path)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        local_repo_path,
+        chat_template=chat_template
+    )
     model_dict = {"model": locally_loaded_model, "tokenizer": tokenizer}
 
     # 1. Save local custom model without specifying task -> raises MlflowException


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12800?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12800/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12800
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve -->

Resolved CI failure: https://github.com/mlflow-automation/mlflow/actions/runs/10132036265/job/28018610712#step:12:1442

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix transformer-dev cross tests.
In transformers dev branch, the default chat template has been removed. We have to set it manually.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
