### PR TITLE
Fix duplicate tests for langchain and langchain_community

### DIFF
--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -250,10 +250,7 @@ def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in
 )
 @pytest.mark.parametrize("module_name", ["langchain", "langchain_community"])
 def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
-    if module_name == "langchain":
-        from langchain.chat_models import ChatDatabricks
-    elif module_name == "langchain_community":
-        from langchain_community.chat_models import ChatDatabricks
+    from langchain_community.chat_models import ChatDatabricks
 
     mock_get_deploy_client = MagicMock()
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -214,7 +214,8 @@ def test_parsing_dependency_from_databricks_retriever(module_name, monkeypatch: 
 )
 @pytest.mark.parametrize("module_name", ["langchain", "langchain_community"])
 def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in_index(
-    module_name, monkeypatch: pytest.MonkeyPatch,
+    module_name,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     if module_name == "langchain":
         from langchain.vectorstores import DatabricksVectorSearch

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -248,7 +248,6 @@ def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-@pytest.mark.parametrize("module_name", ["langchain", "langchain_community"])
 def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
     from langchain_community.chat_models import ChatDatabricks
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -118,9 +118,14 @@ class MockVectorSearchClient:
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.MonkeyPatch):
-    from langchain.embeddings import DatabricksEmbeddings
-    from langchain.vectorstores import DatabricksVectorSearch
+@pytest.mark.parametrize("module_name", ["langchain", "langchain_community"])
+def test_parsing_dependency_from_databricks_retriever(module_name, monkeypatch: pytest.MonkeyPatch):
+    if module_name == "langchain":
+        from langchain.embeddings import DatabricksEmbeddings
+        from langchain.vectorstores import DatabricksVectorSearch
+    elif module_name == "langchain_community":
+        from langchain_community.embeddings import DatabricksEmbeddings
+        from langchain_community.vectorstores import DatabricksVectorSearch
 
     vsc = MockVectorSearchClient()
     vs_index_1 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_1")
@@ -207,99 +212,14 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.MonkeyPatch):
-    from langchain_community.embeddings import DatabricksEmbeddings
-    from langchain_community.vectorstores import DatabricksVectorSearch
-
-    vsc = MockVectorSearchClient()
-    vs_index_1 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_1")
-    vs_index_2 = vsc.get_index(
-        endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_2", has_embedding_endpoint=True
-    )
-    mock_get_deploy_client = MagicMock()
-
-    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
-    embedding_model = DatabricksEmbeddings(endpoint="databricks-bge-large-en")
-
-    mock_module = MagicMock()
-    mock_module.VectorSearchIndex = MockVectorSearchIndex
-
-    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
-
-    # set embedding model
-    vectorstore_1 = DatabricksVectorSearch(
-        vs_index_1, text_column="content", embedding=embedding_model
-    )
-    retriever_1 = vectorstore_1.as_retriever()
-
-    # vs_index_2 has builtin embedding endpoint "embedding-model"
-    vectorstore_2 = DatabricksVectorSearch(vs_index_2, text_column="content")
-    retriever_2 = vectorstore_2.as_retriever()
-
-    from langchain.chat_models import ChatOpenAI
-
-    llm = ChatOpenAI(temperature=0)
-
-    assert list(_extract_databricks_dependencies_from_retriever(retriever_1)) == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
-        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
-    ]
-
-    assert list(_extract_databricks_dependencies_from_retriever(retriever_2)) == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_2"),
-        DatabricksServingEndpoint(endpoint_name="embedding-model"),
-    ]
-
-    from langchain.retrievers.multi_query import MultiQueryRetriever
-
-    multi_query_retriever = MultiQueryRetriever.from_llm(retriever=retriever_1, llm=llm)
-    assert list(_extract_databricks_dependencies_from_retriever(multi_query_retriever)) == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
-        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
-    ]
-
-    from langchain.retrievers import ContextualCompressionRetriever
-    from langchain.retrievers.document_compressors import LLMChainExtractor
-
-    compressor = LLMChainExtractor.from_llm(llm)
-    compression_retriever = ContextualCompressionRetriever(
-        base_compressor=compressor, base_retriever=retriever_1
-    )
-    assert list(_extract_databricks_dependencies_from_retriever(compression_retriever)) == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
-        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
-    ]
-
-    from langchain.retrievers import EnsembleRetriever
-
-    ensemble_retriever = EnsembleRetriever(
-        retrievers=[retriever_1, retriever_2], weights=[0.5, 0.5]
-    )
-    assert list(_extract_databricks_dependencies_from_retriever(ensemble_retriever)) == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
-        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_2"),
-        DatabricksServingEndpoint(endpoint_name="embedding-model"),
-    ]
-
-    from langchain.retrievers import TimeWeightedVectorStoreRetriever
-
-    time_weighted_retriever = TimeWeightedVectorStoreRetriever(
-        vectorstore=vectorstore_1, decay_rate=0.0000000000000000000000001, k=1
-    )
-    assert list(_extract_databricks_dependencies_from_retriever(time_weighted_retriever)) == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index_1"),
-        DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
-    ]
-
-
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
-)
+@pytest.mark.parametrize("module_name", ["langchain", "langchain_community"])
 def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in_index(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    from langchain.vectorstores import DatabricksVectorSearch
+    if module_name == "langchain":
+        from langchain.vectorstores import DatabricksVectorSearch
+    elif module_name == "langchain_community":
+        from langchain_community.vectorstores import DatabricksVectorSearch
 
     vsc = MockVectorSearchClient()
     vs_index = vsc.get_index(
@@ -328,55 +248,12 @@ def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in_index(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from langchain_community.vectorstores import DatabricksVectorSearch
-
-    vsc = MockVectorSearchClient()
-    vs_index = vsc.get_index(
-        endpoint_name="dbdemos_vs_endpoint",
-        index_name="mlflow.rag.vs_index",
-        has_embedding_endpoint=True,
-    )
-    mock_get_deploy_client = MagicMock()
-
-    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
-
-    mock_module = MagicMock()
-    mock_module.VectorSearchIndex = MockVectorSearchIndex
-
-    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
-
-    vectorstore = DatabricksVectorSearch(vs_index, text_column="content")
-    retriever = vectorstore.as_retriever()
-    resources = list(_extract_databricks_dependencies_from_retriever(retriever))
-    assert resources == [
-        DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
-        DatabricksServingEndpoint(endpoint_name="embedding-model"),
-    ]
-
-
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
-)
+@pytest.mark.parametrize("module_name", ["langchain", "langchain_community"])
 def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
-    from langchain.chat_models import ChatDatabricks
-
-    mock_get_deploy_client = MagicMock()
-
-    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
-
-    chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
-    resources = list(_extract_databricks_dependencies_from_chat_model(chat_model))
-    assert resources == [DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat")]
-
-
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
-)
-def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
-    from langchain_community.chat_models import ChatDatabricks
+    if module_name == "langchain":
+        from langchain.chat_models import ChatDatabricks
+    elif module_name == "langchain_community":
+        from langchain_community.chat_models import ChatDatabricks
 
     mock_get_deploy_client = MagicMock()
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -214,7 +214,7 @@ def test_parsing_dependency_from_databricks_retriever(module_name, monkeypatch: 
 )
 @pytest.mark.parametrize("module_name", ["langchain", "langchain_community"])
 def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in_index(
-    monkeypatch: pytest.MonkeyPatch,
+    module_name, monkeypatch: pytest.MonkeyPatch,
 ):
     if module_name == "langchain":
         from langchain.vectorstores import DatabricksVectorSearch


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/12804?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12804/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12804
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Fix tests that had duplicated names with parameterization

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
