### PR TITLE
Bump OpenAI version in LangChain tests

### DIFF
--- a/mlflow/langchain/utils/__init__.py
+++ b/mlflow/langchain/utils/__init__.py
@@ -62,10 +62,7 @@ _UNSUPPORTED_LLM_WARNING_MESSAGE = (
     "MLflow does not guarantee support for LLMs outside of HuggingFacePipeline and OpenAI, found %s"
 )
 
-# Minimum version of langchain required to support ChatOpenAI and AzureChatOpenAI in MLflow
-# Before this version, our hacky patching to support loading ChatOpenAI and AzureChatOpenAI
-# will not work.
-_LC_MIN_VERSION_SUPPORT_CHAT_OPEN_AI = Version("0.0.307")
+
 _LC_MIN_VERSION_SUPPORT_RUNNABLE = Version("0.0.311")
 _CHAT_MODELS_ERROR_MSG = re.compile("Loading (openai-chat|azure-openai-chat) LLM not supported")
 
@@ -614,7 +611,11 @@ def patch_langchain_type_to_cls_dict():
     # NB: get_type_to_cls_dict() method is defined in the following two modules with the same
     # name but with slight different elements. This is most likely just a mistake in the
     # LangChain codebase, but we patch them separately to avoid any potential issues.
-    modules_to_patch = ["langchain.llms", "langchain_community.llms.loading"]
+    modules_to_patch = [
+        "langchain.llms",
+        "langchain.llms.loading",  # Required for LangChain version < 0.0.349
+        "langchain_community.llms.loading",
+    ]
     originals = {}
     for module_name in modules_to_patch:
         try:

--- a/mlflow/langchain/utils/__init__.py
+++ b/mlflow/langchain/utils/__init__.py
@@ -63,7 +63,6 @@ _UNSUPPORTED_LLM_WARNING_MESSAGE = (
 )
 
 
-_LC_MIN_VERSION_SUPPORT_RUNNABLE = Version("0.0.311")
 _CHAT_MODELS_ERROR_MSG = re.compile("Loading (openai-chat|azure-openai-chat) LLM not supported")
 
 
@@ -101,71 +100,39 @@ def picklable_runnable_types():
     """
     from langchain.chat_models.base import SimpleChatModel
     from langchain.prompts import ChatPromptTemplate
+    from langchain.schema.runnable import RunnableLambda, RunnablePassthrough
 
-    types = (
+    return (
         SimpleChatModel,
         ChatPromptTemplate,
+        RunnablePassthrough,
+        RunnableLambda,
     )
-
-    try:
-        from langchain.schema.runnable import (
-            RunnableLambda,
-            RunnablePassthrough,
-        )
-
-        types += (RunnableLambda, RunnablePassthrough)
-    except ImportError:
-        pass
-
-    return types
 
 
 @lru_cache
 def lc_runnable_with_steps_types():
-    # import them separately because they are added
-    # in different versions of langchain
-    try:
-        from langchain.schema.runnable import RunnableSequence
+    from langchain.schema.runnable import RunnableParallel, RunnableSequence
 
-        types = (RunnableSequence,)
-    except ImportError:
-        types = ()
-
-    try:
-        from langchain.schema.runnable import RunnableParallel
-
-        types += (RunnableParallel,)
-    except ImportError:
-        pass
-
-    return types
+    return (RunnableParallel, RunnableSequence)
 
 
 def lc_runnable_assign_types():
-    try:
-        from langchain.schema.runnable.passthrough import RunnableAssign
+    from langchain.schema.runnable.passthrough import RunnableAssign
 
-        return (RunnableAssign,)
-    except ImportError:
-        return ()
+    return (RunnableAssign,)
 
 
 def lc_runnable_branch_types():
-    try:
-        from langchain.schema.runnable import RunnableBranch
+    from langchain.schema.runnable import RunnableBranch
 
-        return (RunnableBranch,)
-    except ImportError:
-        return ()
+    return (RunnableBranch,)
 
 
 def lc_runnable_binding_types():
-    try:
-        from langchain.schema.runnable import RunnableBinding
+    from langchain.schema.runnable import RunnableBinding
 
-        return (RunnableBinding,)
-    except ImportError:
-        return ()
+    return (RunnableBinding,)
 
 
 def lc_runnables_types():

--- a/mlflow/langchain/utils/__init__.py
+++ b/mlflow/langchain/utils/__init__.py
@@ -578,11 +578,7 @@ def patch_langchain_type_to_cls_dict():
     # NB: get_type_to_cls_dict() method is defined in the following two modules with the same
     # name but with slight different elements. This is most likely just a mistake in the
     # LangChain codebase, but we patch them separately to avoid any potential issues.
-    modules_to_patch = [
-        "langchain.llms",
-        "langchain.llms.loading",  # Required for LangChain version < 0.0.349
-        "langchain_community.llms.loading",
-    ]
+    modules_to_patch = ["langchain.llms", "langchain_community.llms.loading"]
     originals = {}
     for module_name in modules_to_patch:
         try:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -649,7 +649,7 @@ langchain:
           "transformers",
           "torch",
           "torchvision",
-          # TODO: he LLM saving/loading logic does not handle partner packages such as langchain-openai
+          # TODO: The LLM saving/loading logic does not handle partner packages such as langchain-openai
           # and always load llms from the legacy community package. Particularly for OpenAI LLM,
           # the legacy version is not comptible with OpenAI SDK >= 1.8.0, so we need to pin the
           # version here until resolving the loading issue.

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -657,7 +657,6 @@ langchain:
           "psutil",
           "faiss-cpu",
           "langchain-experimental",
-          "langchain-openai",
           "numexpr",
           "hf_transfer",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -640,7 +640,8 @@ langchain:
     install_dev: |
       pip install git+https://github.com/hwchase17/langchain#subdirectory=libs/langchain
   models:
-    minimum: "0.0.334"
+    # Where the large package update was made (langchain-core, community, ...)
+    minimum: "0.0.349"
     maximum: "0.2.11"
     requirements:
       ">= 0.0.0": [
@@ -678,7 +679,8 @@ langchain:
     requirements:
       ">= 0.0.0": [
           "pyspark",
-          "openai",
+          # Pinning for the same reason as in the models section
+          "openai<1.8.0",
           "google-search-results",
           "psutil",
           "faiss-cpu",

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -657,6 +657,7 @@ langchain:
           "psutil",
           "faiss-cpu",
           "langchain-experimental",
+          "langchain-openai",
           "numexpr",
           "hf_transfer",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -641,7 +641,7 @@ langchain:
       pip install git+https://github.com/hwchase17/langchain#subdirectory=libs/langchain
   models:
     # Where the large package update was made (langchain-core, community, ...)
-    minimum: "0.0.349"
+    minimum: "0.0.354"
     maximum: "0.2.11"
     requirements:
       ">= 0.0.0": [

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -640,7 +640,7 @@ langchain:
     install_dev: |
       pip install git+https://github.com/hwchase17/langchain#subdirectory=libs/langchain
   models:
-    minimum: "0.0.244"
+    minimum: "0.0.334"
     maximum: "0.2.11"
     requirements:
       ">= 0.0.0": [
@@ -648,7 +648,11 @@ langchain:
           "transformers",
           "torch",
           "torchvision",
-          "openai",
+          # TODO: he LLM saving/loading logic does not handle partner packages such as langchain-openai
+          # and always load llms from the legacy community package. Particularly for OpenAI LLM,
+          # the legacy version is not comptible with OpenAI SDK >= 1.8.0, so we need to pin the
+          # version here until resolving the loading issue.
+          "openai<1.8.0",
           "google-search-results",
           "psutil",
           "faiss-cpu",
@@ -659,12 +663,8 @@ langchain:
         ]
       ">= 0.2": ["langchain-huggingface"]
     run: |
-      LANGCHAIN_NEW=$(python -c "from packaging.version import Version;import langchain;print(Version(langchain.__version__) >= Version('0.0.267'))")
       # Run all langchain tests except autologging
-      pytest tests/langchain --ignore tests/langchain/test_langchain_tracer.py --ignore tests/langchain/test_langchain_autolog.py
-      if [[ $LANGCHAIN_NEW = "True" ]]; then
-        pytest tests/langchain/test_langchain_tracer.py
-      fi
+      pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
       if [[ $PYDANTIC_VERSION == 1.* && $LANGCHAIN_NEW = "True" ]]; then

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -262,7 +262,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "langchain"
         },
         "models": {
-            "minimum": "0.0.334",
+            "minimum": "0.0.349",
             "maximum": "0.2.11"
         },
         "autologging": {

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -262,7 +262,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "langchain"
         },
         "models": {
-            "minimum": "0.0.349",
+            "minimum": "0.0.354",
             "maximum": "0.2.11"
         },
         "autologging": {

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -262,7 +262,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "langchain"
         },
         "models": {
-            "minimum": "0.0.244",
+            "minimum": "0.0.334",
             "maximum": "0.2.11"
         },
         "autologging": {

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -61,8 +61,7 @@ librosa
 ffmpeg
 accelerate
 # Required by mlflow.openai
-# TODO: Unpin once we support openai 1.0
-openai<1.0
+openai
 tiktoken
 tenacity
 # Required by mlflow.llama_index

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -41,8 +41,7 @@ tiktoken
 ipywidgets
 tqdm
 # Required for LLM eval in `mlflow.evaluate`
-# TODO: Unpin once we support openai 1.0
-openai<1.0
+openai
 # Required for showing pytest stats
 psutil
 # SQLAlchemy == 2.0.25 requires typing_extensions >= 4.6.0

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -3,6 +3,7 @@ from operator import itemgetter
 from typing import Any, Dict, List, Optional
 from unittest import mock
 
+import openai
 import pandas as pd
 import pytest
 from langchain.chains.llm import LLMChain
@@ -17,6 +18,7 @@ from langchain_core.callbacks.base import (
     BaseCallbackHandler,
     BaseCallbackManager,
 )
+from packaging.version import Version
 from test_langchain_model_export import FAISS, DeterministicDummyEmbeddings
 
 import mlflow
@@ -492,6 +494,11 @@ def test_agent_autolog():
         assert trace.data.spans[0].outputs == {"output": TEST_CONTENT}
 
 
+# TODO: Fix the AgentExecutor saving issue and remove the skip
+@pytest.mark.skipif(
+    Version(openai.__version__) >= Version("1.0"),
+    reason="OpenAI Client since 1.0 contains thread lock object that cannot be pickled.",
+)
 def test_loaded_agent_autolog():
     mlflow.langchain.autolog(log_models=True, log_input_examples=True)
     model, input, mock_response = create_openai_llmagent()

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -2,7 +2,9 @@ import sys
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
+import langchain
 import pytest
+from packaging.version import Version
 
 from mlflow.langchain.databricks_dependencies import (
     _detect_databricks_dependencies,
@@ -302,6 +304,9 @@ def remove_langchain_modules():
         sys.modules.update(saved_modules)  # Restore all removed modules safely
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.1.0"), reason="feature not existing"
+)
 def test_parsing_dependency_correct_loads_langchain_modules():
     with remove_langchain_modules():
         import langchain_community

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -2,9 +2,7 @@ import sys
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
-import langchain
 import pytest
-from packaging.version import Version
 
 from mlflow.langchain.databricks_dependencies import (
     _detect_databricks_dependencies,
@@ -32,9 +30,6 @@ class MockDatabricksServingEndpointClient:
         self.task = task
 
 
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
-)
 def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch):
     from langchain.llms import Databricks
 
@@ -115,9 +110,6 @@ class MockVectorSearchClient:
         return MockVectorSearchIndex(endpoint_name, index_name, has_embedding_endpoint)
 
 
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
-)
 @pytest.mark.parametrize("module_name", ["langchain", "langchain_community"])
 def test_parsing_dependency_from_databricks_retriever(module_name, monkeypatch: pytest.MonkeyPatch):
     if module_name == "langchain":
@@ -209,9 +201,6 @@ def test_parsing_dependency_from_databricks_retriever(module_name, monkeypatch: 
     ]
 
 
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
-)
 @pytest.mark.parametrize("module_name", ["langchain", "langchain_community"])
 def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in_index(
     module_name,
@@ -246,9 +235,6 @@ def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in
     ]
 
 
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
-)
 def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
     from langchain_community.chat_models import ChatDatabricks
 
@@ -261,9 +247,6 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch
     assert resources == [DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat")]
 
 
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
-)
 def test_parsing_dependency_from_databricks(monkeypatch: pytest.MonkeyPatch):
     from langchain_community.chat_models import ChatDatabricks
     from langchain_community.vectorstores import DatabricksVectorSearch
@@ -319,9 +302,6 @@ def remove_langchain_modules():
         sys.modules.update(saved_modules)  # Restore all removed modules safely
 
 
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.1.0"), reason="feature not existing"
-)
 def test_parsing_dependency_correct_loads_langchain_modules():
     with remove_langchain_modules():
         import langchain_community
@@ -366,9 +346,6 @@ def test_parsing_dependency_correct_loads_langchain_modules():
         langchain_community.chat_models.ChatDatabricks
 
 
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
-)
 def test_module_removal():
     import langchain_community.llms
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1,10 +1,10 @@
-from contextlib import contextmanager
 import importlib
 import inspect
 import json
 import os
 import shutil
 import sqlite3
+from contextlib import contextmanager
 from operator import itemgetter
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 from unittest import mock
@@ -106,6 +106,7 @@ from tests.tracing.export.test_inference_table_exporter import _REQUEST_ID
 VECTORSTORE_KWARGS = (
     {"allow_dangerous_deserialization": True} if IS_PICKLE_SERIALIZATION_RESTRICTED else {}
 )
+
 
 @contextmanager
 def _mock_async_request(content=TEST_CONTENT):

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -353,10 +353,6 @@ def test_langchain_model_predict():
         assert result == [TEST_CONTENT]
 
 
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.354"),
-    reason="LLMChain does not support streaming before LangChain 0.0.354",
-)
 def test_langchain_model_predict_stream():
     with _mock_request(return_value=_mock_chat_completion_response()):
         model = create_openai_llmchain()
@@ -486,10 +482,6 @@ def test_langchain_agent_model_predict(return_intermediate_steps):
 @pytest.mark.skipif(
     Version(openai.__version__) >= Version("1.0"),
     reason="OpenAI Client since 1.0 contains thread lock object that cannot be pickled.",
-)
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.0.354"),
-    reason="AgentExecutor does not support streaming before LangChain 0.0.354",
 )
 def test_langchain_agent_model_predict_stream():
     langchain_agent_output = {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12823?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12823/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12823
```

</p>
</details>

### What changes are proposed in this pull request?

Update `openai` version for LangChain CI tests from `0.28` to `1.7.2` so we run more realistic tests. Several critical compatibility issues were found, but this PR doesn't try to solve them.

#### Why 1.7.2?

This is due to a critical issues in current chain loading/saving logic. The logic does not load modules form the partner packages like `langchain-openai`, and always look for the `langchain-community` package. For example, when the customer saves `OpenAI` LLM imported from `langchain_openai` and load it back later, MLflow loads `OpenAI` from the `langchain-community` instead.

The issue is that their community counterparts are deprecated and no longer maintained. Regarding to OpenAI, their LLM implementation in `langchain-community` does not work with `openai >= 1.8.0` due to the breaking change in response type. This is resolved in `langchain-openai`.

Therefore, this PR can only bump the version up to 1.7.2. Once we address the loading issue soon, we should be able to fully remove the pinning.

#### Other notable changes

* Bumping up the lowest supported version to `0.0.354`.
    * Initial plan was to updated to `0.0.334`, where Runnables were introduced.
    * However, 
        * The [large module split](https://github.com/langchain-ai/langchain/commit/ed58eeb9c50b16c9927b6c395518cf610c963f5d) (core, community, etc) happened at `0.0.349`. Also there were many failed tests for runnables (which have not been caught because of *lucky* versions selected by cross version tests. Basically, all runnable tests were skipped for < 0.0.311, and no version between 0.0.311 - 0.0.349 was selected). This means practically our runnable support begins from 0.0.349.
        * Databricks dependency extraction does not work for runnables with `< 0.0.354`. I could add skip flag for old versions and keep the lower bound to 0.0.349, but I felt it's not worthwhile just for 5 super old minor versions.
* Change mocking method to HTTPX based.
    * We will eventually want to use OpenAI fake service to be more robust (not relying on their internal code). But it requires more code changes.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
