### PR TITLE
Add label_list in evaluator_config

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1522,6 +1522,8 @@ class DefaultEvaluator(ModelEvaluator):
             self.is_binomial = self.num_classes <= 2
 
             if self.is_binomial:
+                # sort label_list ASC to make sure the last one is pos label
+                self.label_list.sort()
                 if self.pos_label is None:
                     self.pos_label = self.label_list[-1]
                 else:
@@ -1532,8 +1534,8 @@ class DefaultEvaluator(ModelEvaluator):
                     self.label_list = np.append(self.label_list, self.pos_label)
                 if len(self.label_list) < 2:
                     raise MlflowException(
-                        f"The evaluation dataset contains {len(self.label_list)} unique labels, "
-                        "it is not a valid classification dataset.",
+                        "Evaluation dataset for classification must contain at least two unique "
+                        f"labels, but only {len(self.label_list)} unique labels were found.",
                     )
                 with _suppress_class_imbalance_errors(IndexError, log_warning=False):
                     _logger.info(

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1518,12 +1518,12 @@ class DefaultEvaluator(ModelEvaluator):
 
             if self.label_list is None:
                 self.label_list = np.unique(np.concatenate([self.y, self.y_pred]))
+            # sort label_list ASC, for binary classification it makes sure the last one is pos label
+            self.label_list.sort()
             self.num_classes = len(self.label_list)
             self.is_binomial = self.num_classes <= 2
 
             if self.is_binomial:
-                # sort label_list ASC to make sure the last one is pos label
-                self.label_list.sort()
                 if self.pos_label is None:
                     self.pos_label = self.label_list[-1]
                 else:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -344,14 +344,14 @@ def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels, sample_we
             positive_class_index, positive_class, y, y_pred, None
         )
         per_class_metrics = {"positive_class": positive_class}
-        per_class_metrics.update(
-            _get_binary_classifier_metrics(
-                y_true=y_bin,
-                y_pred=y_pred_bin,
-                pos_label=1,
-                sample_weights=sample_weights,
-            )
+        binary_classifier_metrics = _get_binary_classifier_metrics(
+            y_true=y_bin,
+            y_pred=y_pred_bin,
+            pos_label=1,
+            sample_weights=sample_weights,
         )
+        if binary_classifier_metrics:
+            per_class_metrics.update(binary_classifier_metrics)
         per_class_metrics_list.append(per_class_metrics)
 
     return pd.DataFrame(per_class_metrics_list)

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -4332,3 +4332,36 @@ def test_xgboost_model_evaluate_work_with_shap_explainer():
                 for call_arg in mock_warning.call_args
                 if isinstance(call_arg, tuple)
             )
+
+
+@pytest.mark.parametrize(
+    "evaluator_config",
+    [
+        None,
+        {"default": {"pos_label": 1}},
+        {"default": {"label_list": [0, 1]}},
+        {"default": {"label_list": [0, 1], "pos_label": 1}},
+    ],
+)
+def test_evaluate_classifier_calculate_label_list_correctly(evaluator_config):
+    data = pd.DataFrame({"target": [0, 0, 1, 0], "prediction": [0, 1, 0, 0]})
+
+    result = mlflow.evaluate(
+        data=data,
+        model_type="classifier",
+        targets="target",
+        predictions="prediction",
+        evaluator_config=evaluator_config,
+    )
+    for metric in [
+        "true_negatives",
+        "false_positives",
+        "false_negatives",
+        "true_positives",
+        "example_count",
+        "accuracy_score",
+        "recall_score",
+        "precision_score",
+        "f1_score",
+    ]:
+        assert metric in result.metrics

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -4343,7 +4343,7 @@ def test_xgboost_model_evaluate_work_with_shap_explainer():
         {"default": {"label_list": [0, 1], "pos_label": 1}},
     ],
 )
-def test_evaluate_classifier_calculate_label_list_correctly(evaluator_config):
+def test_evaluate_binary_classifier_calculate_label_list_correctly(evaluator_config):
     data = pd.DataFrame({"target": [0, 0, 1, 0], "prediction": [0, 1, 0, 0]})
 
     result = mlflow.evaluate(
@@ -4365,3 +4365,38 @@ def test_evaluate_classifier_calculate_label_list_correctly(evaluator_config):
         "f1_score",
     ]:
         assert metric in result.metrics
+
+
+@pytest.mark.parametrize(
+    "evaluator_config",
+    [
+        None,
+        {"default": {"label_list": [0, 1, 2]}},
+    ],
+)
+def test_evaluate_multi_classifier_calculate_label_list_correctly(evaluator_config):
+    data = pd.DataFrame({"target": [1, 0, 1, 1], "prediction": [1, 2, 0, 0]})
+
+    result = mlflow.evaluate(
+        data=data,
+        model_type="classifier",
+        targets="target",
+        predictions="prediction",
+        evaluator_config=evaluator_config,
+    )
+    for metric in [
+        "example_count",
+        "accuracy_score",
+        "recall_score",
+        "precision_score",
+        "f1_score",
+    ]:
+        assert metric in result.metrics
+
+    for metric in [
+        "true_negatives",
+        "false_positives",
+        "false_negatives",
+        "true_positives",
+    ]:
+        assert metric not in result.metrics

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -4400,9 +4400,8 @@ def test_evaluate_multi_classifier_calculate_label_list_correctly(
         "f1_score",
     }
     assert metrics_set.issubset(result.metrics)
-    assert all(
-        metric not in result.metrics
-        for metric in ["true_negatives", "false_positives", "false_negatives", "true_positives"]
+    assert {"true_negatives", "false_positives", "false_negatives", "true_positives"}.isdisjoint(
+        result.metrics
     )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12825?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12825/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12825
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve  #12790

### What changes are proposed in this pull request?
Support manually passing `label_list` in `evaluator_config`, and update default calculation of labels on both target and predictions.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
