### PR TITLE
Update doc for Spark ML vector type

### DIFF
--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -156,6 +156,7 @@ Column-based signatures support data primitives defined within the :py:class:`ML
 Column-based signature also support composite data types of these primitives.
 
 - Array (list, numpy arrays)
+- Spark ML vector (it inherits ``Array[double]`` type)
 - Object (dictionary)
 
 .. warning::
@@ -163,6 +164,7 @@ Column-based signature also support composite data types of these primitives.
     Support for Array and Object types was introduced in MLflow version **2.10.0**. These types will not be recognized in previous versions of MLflow. 
     If you are saving a model that uses these signature types, you should ensure that any other environment that attempts to load these models 
     has a version of MLflow installed that is at least 2.10.0.
+    Support for Spark ML vector type was introduced in MLflow version **2.15.0**, These type will not be recognized in previous versions of MLflow.
 
 Additional examples for composite data types can be seen by viewing the `signature examples notebook <notebooks/signature_examples.html>`_.
 

--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -161,10 +161,8 @@ Column-based signature also support composite data types of these primitives.
 
 .. warning::
 
-    Support for Array and Object types was introduced in MLflow version **2.10.0**. These types will not be recognized in previous versions of MLflow. 
-    If you are saving a model that uses these signature types, you should ensure that any other environment that attempts to load these models 
-    has a version of MLflow installed that is at least 2.10.0.
-    Support for Spark ML vector type was introduced in MLflow version **2.15.0**, These type will not be recognized in previous versions of MLflow.
+    * Support for Array and Object types was introduced in MLflow version **2.10.0**. These types will not be recognized in previous versions of MLflow.  If you are saving a model that uses these signature types, you should ensure that any other environment that attempts to load these models  has a version of MLflow installed that is at least 2.10.0.
+    * Support for Spark ML vector type was introduced in MLflow version **2.15.0**, These type will not be recognized in previous versions of MLflow.
 
 Additional examples for composite data types can be seen by viewing the `signature examples notebook <notebooks/signature_examples.html>`_.
 

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -182,10 +182,60 @@ def log_model(
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.
-        signature: {{ signature }}
-            If your Spark model contains Spark ML vector type input or output column,
+        signature: A Model Signature object that describes the input and output Schema of the
+            model. The model signature can be inferred using `infer_signature` function
+            of `mlflow.models.signature`.
+            Note if your Spark model contains Spark ML vector type input or output column,
             you should create ``SparkMLVector`` vector type for the column,
-            or you can simply invoke ````
+            `infer_signature` function can also infer ``SparkMLVector`` vector type correctly
+            from Spark Dataframe input / output.
+            When loading a Spark ML model with ``SparkMLVector`` vector type input as MLflow
+            pyfunc model, it accepts ``Array[double]`` type input and internally converts
+            array into Spark ML vector, and then invoke Spark model ``transform`` method to do
+            inference, similarly, if the Spark ML pyfunc model has vector type output, Mlflow
+            internally converts Spark ML vector output data into ``Array[double]`` type
+            inference result.
+
+            Example:
+
+            .. code-block:: python
+
+                from mlflow.models import infer_signature
+                from pyspark.sql.functions import col
+                from pyspark.ml.classification import LogisticRegression
+                from pyspark.ml.functions import array_to_vector
+                import pandas as pd
+                import mlflow
+
+                train_df = spark.createDataFrame(
+                    [([3.0, 4.0], 0), ([5.0, 6.0], 1)], schema="features array<double>, label long"
+                ).select(array_to_vector("features").alias("features"), col("label"))
+                lor = (
+                    LogisticRegression(maxIter=2).setPredictionCol("").setProbabilityCol("prediction")
+                )
+                lor_model = lor.fit(train_df)
+
+                test_df = train_df.select("features")
+                prediction_df = lor_model.transform(train_df).select("prediction")
+
+                signature = infer_signature(test_df, prediction_df)
+
+                with mlflow.start_run() as run:
+                    mlflow.spark.log_model(
+                        lor_model,
+                        "model",
+                        signature=signature,
+                    )
+
+                model_uri = f"runs:/{run.info.run_id}/model"
+                loaded = mlflow.pyfunc.load_model(model_uri)
+
+                test_dataset = pd.DataFrame({"features": [[1.0, 2.0]]})
+
+                # `loaded.predict` accepts `Array[double]` type input column,
+                # and generates `Array[double]` type output column.
+                print(loaded.predict(test_dataset))
+
         input_example: {{ input_example }}
         await_registration_for: Number of seconds to wait for the model version to finish
             being created and is in ``READY`` status. By default, the function
@@ -666,7 +716,60 @@ def save_model(
         sample_input: A sample input that is used to add the MLeap flavor to the model.
             This must be a PySpark DataFrame that the model can evaluate. If
             ``sample_input`` is ``None``, the MLeap flavor is not added.
-        signature: {{ signature }}
+        signature: A Model Signature object that describes the input and output Schema of the
+            model. The model signature can be inferred using `infer_signature` function
+            of `mlflow.models.signature`.
+            Note if your Spark model contains Spark ML vector type input or output column,
+            you should create ``SparkMLVector`` vector type for the column,
+            `infer_signature` function can also infer ``SparkMLVector`` vector type correctly
+            from Spark Dataframe input / output.
+            When loading a Spark ML model with ``SparkMLVector`` vector type input as MLflow
+            pyfunc model, it accepts ``Array[double]`` type input and internally converts
+            array into Spark ML vector, and then invoke Spark model ``transform`` method to do
+            inference, similarly, if the Spark ML pyfunc model has vector type output, Mlflow
+            internally converts Spark ML vector output data into ``Array[double]`` type
+            inference result.
+
+            Example:
+
+            .. code-block:: python
+
+                from mlflow.models import infer_signature
+                from pyspark.sql.functions import col
+                from pyspark.ml.classification import LogisticRegression
+                from pyspark.ml.functions import array_to_vector
+                import pandas as pd
+                import mlflow
+
+                train_df = spark.createDataFrame(
+                    [([3.0, 4.0], 0), ([5.0, 6.0], 1)], schema="features array<double>, label long"
+                ).select(array_to_vector("features").alias("features"), col("label"))
+                lor = (
+                    LogisticRegression(maxIter=2).setPredictionCol("").setProbabilityCol("prediction")
+                )
+                lor_model = lor.fit(train_df)
+
+                test_df = train_df.select("features")
+                prediction_df = lor_model.transform(train_df).select("prediction")
+
+                signature = infer_signature(test_df, prediction_df)
+
+                with mlflow.start_run() as run:
+                    mlflow.spark.log_model(
+                        lor_model,
+                        "model",
+                        signature=signature,
+                    )
+
+                model_uri = f"runs:/{run.info.run_id}/model"
+                loaded = mlflow.pyfunc.load_model(model_uri)
+
+                test_dataset = pd.DataFrame({"features": [[1.0, 2.0]]})
+
+                # `loaded.predict` accepts `Array[double]` type input column,
+                # and generates `Array[double]` type output column.
+                print(loaded.predict(test_dataset))
+
         input_example: {{ input_example }}
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -183,6 +183,9 @@ def log_model(
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.
         signature: {{ signature }}
+            If your Spark model contains Spark ML vector type input or output column,
+            you should create ``SparkMLVector`` vector type for the column,
+            or you can simply invoke ````
         input_example: {{ input_example }}
         await_registration_for: Number of seconds to wait for the model version to finish
             being created and is in ``READY`` status. By default, the function

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -190,11 +190,10 @@ def log_model(
             `infer_signature` function can also infer ``SparkMLVector`` vector type correctly
             from Spark Dataframe input / output.
             When loading a Spark ML model with ``SparkMLVector`` vector type input as MLflow
-            pyfunc model, it accepts ``Array[double]`` type input and internally converts
-            array into Spark ML vector, and then invoke Spark model ``transform`` method to do
-            inference, similarly, if the Spark ML pyfunc model has vector type output, Mlflow
-            internally converts Spark ML vector output data into ``Array[double]`` type
-            inference result.
+            pyfunc model, it accepts ``Array[double]`` type input. MLflow internally converts
+            the array into Spark ML vector and then invoke Spark model for inference. Similarly,
+            if the model has vector type output, Mlflow internally converts Spark ML vector
+            output data into ``Array[double]`` type inference result.
 
             Example:
 
@@ -221,14 +220,20 @@ def log_model(
                 signature = infer_signature(test_df, prediction_df)
 
                 with mlflow.start_run() as run:
-                    mlflow.spark.log_model(
+                    model_info = mlflow.spark.log_model(
                         lor_model,
                         "model",
                         signature=signature,
                     )
 
-                model_uri = f"runs:/{run.info.run_id}/model"
-                loaded = mlflow.pyfunc.load_model(model_uri)
+                # The following signature is outputed:
+                # inputs:
+                #   ['features': SparkML vector (required)]
+                # outputs:
+                #   ['prediction': SparkML vector (required)]
+                print(model_info.signature)
+
+                loaded = mlflow.pyfunc.load_model(model_info.model_uri)
 
                 test_dataset = pd.DataFrame({"features": [[1.0, 2.0]]})
 
@@ -716,60 +721,7 @@ def save_model(
         sample_input: A sample input that is used to add the MLeap flavor to the model.
             This must be a PySpark DataFrame that the model can evaluate. If
             ``sample_input`` is ``None``, the MLeap flavor is not added.
-        signature: A Model Signature object that describes the input and output Schema of the
-            model. The model signature can be inferred using `infer_signature` function
-            of `mlflow.models.signature`.
-            Note if your Spark model contains Spark ML vector type input or output column,
-            you should create ``SparkMLVector`` vector type for the column,
-            `infer_signature` function can also infer ``SparkMLVector`` vector type correctly
-            from Spark Dataframe input / output.
-            When loading a Spark ML model with ``SparkMLVector`` vector type input as MLflow
-            pyfunc model, it accepts ``Array[double]`` type input and internally converts
-            array into Spark ML vector, and then invoke Spark model ``transform`` method to do
-            inference, similarly, if the Spark ML pyfunc model has vector type output, Mlflow
-            internally converts Spark ML vector output data into ``Array[double]`` type
-            inference result.
-
-            Example:
-
-            .. code-block:: python
-
-                from mlflow.models import infer_signature
-                from pyspark.sql.functions import col
-                from pyspark.ml.classification import LogisticRegression
-                from pyspark.ml.functions import array_to_vector
-                import pandas as pd
-                import mlflow
-
-                train_df = spark.createDataFrame(
-                    [([3.0, 4.0], 0), ([5.0, 6.0], 1)], schema="features array<double>, label long"
-                ).select(array_to_vector("features").alias("features"), col("label"))
-                lor = (
-                    LogisticRegression(maxIter=2).setPredictionCol("").setProbabilityCol("prediction")
-                )
-                lor_model = lor.fit(train_df)
-
-                test_df = train_df.select("features")
-                prediction_df = lor_model.transform(train_df).select("prediction")
-
-                signature = infer_signature(test_df, prediction_df)
-
-                with mlflow.start_run() as run:
-                    mlflow.spark.log_model(
-                        lor_model,
-                        "model",
-                        signature=signature,
-                    )
-
-                model_uri = f"runs:/{run.info.run_id}/model"
-                loaded = mlflow.pyfunc.load_model(model_uri)
-
-                test_dataset = pd.DataFrame({"features": [[1.0, 2.0]]})
-
-                # `loaded.predict` accepts `Array[double]` type input column,
-                # and generates `Array[double]` type output column.
-                print(loaded.predict(test_dataset))
-
+        signature: See the document of argument ``signature`` in :py:func:`mlflow.spark.log_model`.
         input_example: {{ input_example }}
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -192,7 +192,7 @@ def log_model(
             When loading a Spark ML model with ``SparkMLVector`` vector type input as MLflow
             pyfunc model, it accepts ``Array[double]`` type input. MLflow internally converts
             the array into Spark ML vector and then invoke Spark model for inference. Similarly,
-            if the model has vector type output, Mlflow internally converts Spark ML vector
+            if the model has vector type output, MLflow internally converts Spark ML vector
             output data into ``Array[double]`` type inference result.
 
             Example:
@@ -209,9 +209,8 @@ def log_model(
                 train_df = spark.createDataFrame(
                     [([3.0, 4.0], 0), ([5.0, 6.0], 1)], schema="features array<double>, label long"
                 ).select(array_to_vector("features").alias("features"), col("label"))
-                lor = (
-                    LogisticRegression(maxIter=2).setPredictionCol("").setProbabilityCol("prediction")
-                )
+                lor = LogisticRegression(maxIter=2)
+                lor.setPredictionCol("").setProbabilityCol("prediction")
                 lor_model = lor.fit(train_df)
 
                 test_df = train_df.select("features")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12827?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12827/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12827
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Update doc for Spark ML vector type

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
