### PR TITLE
Ensure cross version test coverage

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -447,6 +447,7 @@ def expand_config(config):
             "sentence-transformers",
             "torch",
         )
+        validate_test_coverage(name, cfgs)
         for category, cfg in cfgs.items():
             if category not in VALID_CATEGORIES:
                 raise ValueError(

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -31,6 +31,7 @@ import os
 import re
 import shutil
 import sys
+import warnings
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
@@ -402,7 +403,10 @@ def validate_test_coverage(flavor: str, config: Dict):
                 all_test_files -= _get_test_files_from_pytest_command(cmd, test_dir)
 
     if all_test_files:
-        raise ValueError(
+        # TODO: Update this after updating ml-package-versions.yml to
+        # have all test files in the matrix. Since the job pulls the
+        # config file from master branch, we cannot update them at once.
+        warnings.warn(
             f"Flavor '{flavor}' has test files that are not covered by the test matrix. \n"
             + "\n".join(f" - {t}" for t in all_test_files)
             + f"\nPlease update {VERSIONS_YAML_PATH} to execute all test files."

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -45,7 +45,7 @@ VERSIONS_YAML_PATH = "mlflow/ml-package-versions.yml"
 DEV_VERSION = "dev"
 # Treat "dev" as "newer than any existing versions"
 DEV_NUMERIC = "9999.9999.9999"
-
+VALID_CATEGORIES = ["models", "autologging"]
 
 class Version(OriginalVersion):
     def __init__(self, version):
@@ -63,6 +63,7 @@ class Version(OriginalVersion):
 class PackageInfo(BaseModel):
     pip_release: str
     install_dev: Optional[str] = None
+    module_name: Optional[str] = None
 
 
 class TestConfig(BaseModel):
@@ -380,6 +381,9 @@ def expand_config(config):
             "torch",
         )
         for category, cfg in cfgs.items():
+            if category not in VALID_CATEGORIES:
+                raise ValueError(f"Flavor {name} contains an invalid category in ml-package-versions.yml: '{category}'")
+
             cfg = TestConfig(**cfg)
             versions = filter_versions(
                 all_versions,

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -650,8 +650,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    # main(sys.argv[1:])
-    args = parse_args(sys.argv[1:])
-    config = read_yaml(args.versions_yaml)
-    for flavor, cfg in config.items():
-        validate_test_coverage(flavor, cfg)
+    main(sys.argv[1:])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12849?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12849/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12849
```

</p>
</details>

### What changes are proposed in this pull request?

Enhance `set_matrix.py` scripts to check if all test files are covered. The missing CI coverage have caused many issues like https://github.com/mlflow/mlflow/pull/12841, https://github.com/mlflow/mlflow/pull/10903, https://github.com/mlflow/mlflow/pull/11092, so let's automate it.

In this PR, the job only emits warnings for missing tests, instead of exception, because adding all missing test files and fix their errors will make this PR too big. I will add them iteratively as a follow-up, and update the validation to raise an exception after that. Here are the list of missing tests now:
```
dev/set_matrix.py:422: UserWarning: Flavor 'pytorch' has test files that are not covered by the test matrix. 
 - tests/pytorch/test_pytorch_autolog.py
Please update mlflow/ml-package-versions.yml to execute all test files.
  warnings.warn(
dev/set_matrix.py:422: UserWarning: Flavor 'keras' has test files that are not covered by the test matrix. 
 - tests/keras/test_save.py
Please update mlflow/ml-package-versions.yml to execute all test files.
  warnings.warn(
dev/set_matrix.py:422: UserWarning: Flavor 'tensorflow' has test files that are not covered by the test matrix. 
 - tests/tensorflow/test_mlflow_callback.py
Please update mlflow/ml-package-versions.yml to execute all test files.
  warnings.warn(
dev/set_matrix.py:422: UserWarning: Flavor 'spark' has test files that are not covered by the test matrix. 
 - tests/spark/autologging/datasource/test_spark_datasource_autologging_order.py
 - tests/spark/autologging/datasource/test_spark_datasource_autologging_unit.py
 - tests/spark/autologging/datasource/test_spark_datasource_autologging.py
 - tests/spark/autologging/ml/test_pyspark_ml_autologging_custom_allowlist.py
 - tests/spark/autologging/datasource/test_autologging_behavior_without_spark_session.py
 - tests/spark/autologging/datasource/test_spark_datasource_autologging_missing_jar.py
 - tests/spark/autologging/ml/test_pyspark_ml_autologging.py
Please update mlflow/ml-package-versions.yml to execute all test files.
  warnings.warn(
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
