### PR TITLE
Serving example file rename

### DIFF
--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -923,7 +923,7 @@ The following example demonstrates how to load the serving payload from a logged
 .. code-block:: python
 
     import mlflow
-    from mlflow.models.utils import load_serving_example_from_uri
+    from mlflow.models.utils import load_serving_example
 
     input_example = {
         "messages": [
@@ -934,7 +934,7 @@ The following example demonstrates how to load the serving payload from a logged
     }
     model_info = mlflow.langchain.log_model(..., input_example=input_example)
     print(f"model_uri: {model_info.model_uri}")
-    serving_example = load_serving_example_from_uri(model_info.model_uri)
+    serving_example = load_serving_example(model_info.model_uri)
     print(f"serving_example: {serving_example}")
 
 You can validate the input example works prior to serving:

--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -752,7 +752,7 @@ model signatures in log_model calls when signatures aren't specified.
 Since MLflow 2.16.0, when logging a model with an input example, there are two files saved into the model's artifacts directory:
 
 - ``input_example.json``: The input example in JSON format.
-- ``serving_input_payload.json``: The input example in JSON format, with additional transformation to have compatible schema for querying a deployed model REST endpoint.
+- ``serving_input_example.json``: The input example in JSON format, with additional transformation to have compatible schema for querying a deployed model REST endpoint.
 
 The following example demonstrates the difference between the two files:
 
@@ -791,7 +791,7 @@ Example files logged by MLflow:
             }
 
      - The input example in its original format.
-   * - serving_input_payload.json
+   * - serving_input_example.json
      - 
         .. code-block:: json
 
@@ -914,7 +914,7 @@ Model Serving Payload Example
 -----------------------------
 Once an MLflow model is deployed to a REST endpoint for inference, the request payload will be
 JSON serialized and may have subtle difference from in-memory representation.
-To validate your model works for inference, you can use the ``serving_input_payload.json`` file.
+To validate your model works for inference, you can use the ``serving_input_example.json`` file.
 It is automatically logged along with the model when an ``input_example`` is provided and contains
 a json format of the given input example for querying a deployed model endpoint.
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -125,7 +125,7 @@ In MLflow, understanding the intricacies of model signatures and input examples 
 
 - **Model Signature**: Defines the schema for model inputs, outputs, and additional inference parameters, promoting a standardized interface for model interaction.
 - **Model Input Example**: Provides a concrete instance of valid model input, aiding in understanding and testing model requirements. Additionally, if an input example is provided when logging a model, a model signature will be automatically inferred and stored if not explicitly provided.
-- **Model Serving Payload Example**: Provides a json payload example for querying a deployed model endpoint. If an input example is provided when logging a model, a serving paylod example is automatically generated from the input example and saved as ``serving_input_payload.json``.
+- **Model Serving Payload Example**: Provides a json payload example for querying a deployed model endpoint. If an input example is provided when logging a model, a serving paylod example is automatically generated from the input example and saved as ``serving_input_example.json``.
 
 Our documentation delves into several key areas:
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -572,7 +572,7 @@ def _load_serving_input_example(mlflow_model: Model, path: str):
         return handle.read()
 
 
-def load_serving_example_from_uri(model_uri_or_path: str):
+def load_serving_example(model_uri_or_path: str):
     """
     Load serving input example from a model directory or URI.
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -71,7 +71,7 @@ EXAMPLE_DATA_KEY = "inputs"
 EXAMPLE_PARAMS_KEY = "params"
 EXAMPLE_FILENAME = "input_example.json"
 SERVING_INPUT_PATH = "serving_input_path"
-SERVING_INPUT_FILENAME = "serving_input_payload.json"
+SERVING_INPUT_FILENAME = "serving_input_example.json"
 
 # TODO: import from scoring_server after refactoring
 DF_SPLIT = "dataframe_split"

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.enzyme.test.tsx
@@ -242,7 +242,7 @@ flavors:
     });
   });
 
-  test('should render serving validation code snippet if serving_input_payload exists', (done) => {
+  test('should render serving validation code snippet if serving_input_example exists', (done) => {
     const getArtifact = jest
       .fn()
       .mockImplementationOnce((artifactLocation) => {
@@ -287,7 +287,7 @@ flavors:
     });
   });
 
-  test('should render serving validation code snippet if serving_input_payload does not exist', (done) => {
+  test('should render serving validation code snippet if serving_input_example does not exist', (done) => {
     const getArtifact = jest
       .fn()
       .mockImplementationOnce((artifactLocation) => {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -163,7 +163,7 @@ model_uri = '${modelPath}'
 
 # The model is logged with an input example. MLflow converts
 # it into the serving payload format for the deployed model endpoint,
-# and saves it to 'serving_input_payload.json'
+# and saves it to 'serving_input_example.json'
 serving_payload = """${servingInput}"""
 
 # Validate the serving payload works on the model
@@ -312,7 +312,7 @@ validate_serving_input(model_uri, serving_payload)`;
           <span className="code-comment">
             {`# The model is logged with an input example. MLflow converts
 # it into the serving payload format for the deployed model endpoint,
-# and saves it to 'serving_input_payload.json'\n`}
+# and saves it to 'serving_input_example.json'\n`}
           </span>
           serving_payload = <span className="code-string">{`"""${servingInput}"""`}</span>
         </div>

--- a/mlflow/server/js/src/experiment-tracking/constants.ts
+++ b/mlflow/server/js/src/experiment-tracking/constants.ts
@@ -5,7 +5,7 @@ export const COLUMN_TYPES = {
   TAGS: 'tags',
 };
 export const MLMODEL_FILE_NAME = 'MLmodel';
-export const SERVING_INPUT_FILE_NAME = 'serving_input_payload.json';
+export const SERVING_INPUT_FILE_NAME = 'serving_input_example.json';
 export const ONE_MB = 1024 * 1024;
 
 export const ATTRIBUTE_COLUMN_LABELS = {

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -17,7 +17,7 @@ import mlflow.catboost
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -433,7 +433,7 @@ def test_pyfunc_serve_and_score(reg_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -455,7 +455,7 @@ def test_pyfunc_serve_and_score_sklearn(reg_model):
             model, artifact_path="model", input_example=inference_dataframe.head(3)
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -17,7 +17,7 @@ import mlflow.catboost
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -32,7 +32,6 @@ from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -434,7 +433,7 @@ def test_pyfunc_serve_and_score(reg_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -456,7 +455,7 @@ def test_pyfunc_serve_and_score_sklearn(reg_model):
             model, artifact_path="model", input_example=inference_dataframe.head(3)
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -16,7 +16,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
 from mlflow.models.model import MLMODEL_FILE_NAME
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -29,7 +29,6 @@ from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -406,7 +405,7 @@ def test_pmdarima_pyfunc_serve_and_score(grouped_prophet):
 
     local_predict = grouped_prophet.forecast(horizon=10, frequency="W")
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -16,7 +16,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
 from mlflow.models.model import MLMODEL_FILE_NAME
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -405,7 +405,7 @@ def test_pmdarima_pyfunc_serve_and_score(grouped_prophet):
 
     local_predict = grouped_prophet.forecast(horizon=10, frequency="W")
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -17,7 +17,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.utils
 from mlflow import pyfunc
 from mlflow.models import Model, infer_signature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -371,7 +371,7 @@ def test_pyfunc_serve_and_score(fastai_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -17,7 +17,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.utils
 from mlflow import pyfunc
 from mlflow.models import Model, infer_signature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -30,7 +30,6 @@ from tests.helper_functions import (
     _compare_logged_code_paths,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -372,7 +371,7 @@ def test_pyfunc_serve_and_score(fastai_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -18,7 +18,7 @@ import mlflow.h2o
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
 from mlflow.types.schema import ColSpec, Schema
@@ -339,7 +339,7 @@ def test_pyfunc_serve_and_score(h2o_iris_model):
             model, artifact_path, input_example=inference_dataframe.as_data_frame()
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -18,7 +18,7 @@ import mlflow.h2o
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
 from mlflow.types.schema import ColSpec, Schema
@@ -31,7 +31,6 @@ from tests.helper_functions import (
     _compare_conda_env_requirements,
     _compare_logged_code_paths,
     _mlflow_major_version_string,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -340,7 +339,7 @@ def test_pyfunc_serve_and_score(h2o_iris_model):
             model, artifact_path, input_example=inference_dataframe.as_data_frame()
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -20,7 +20,6 @@ import requests
 import yaml
 
 import mlflow
-from mlflow.models import Model
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import (
@@ -204,12 +203,6 @@ def pyfunc_serve_from_docker_image_with_env_override(
     if extra_args is not None:
         scoring_cmd += extra_args
     return _start_scoring_proc(cmd=scoring_cmd, env=env)
-
-
-def get_serving_input_example(model_uri):
-    mlflow_model = Model.load(model_uri)
-    local_path = _download_artifact_from_uri(model_uri)
-    return mlflow_model.get_serving_input(local_path)
 
 
 def pyfunc_serve_and_score_model(

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -86,6 +86,7 @@ from mlflow.models import Model
 from mlflow.models.dependencies_schemas import DependenciesSchemasType
 from mlflow.models.resources import DatabricksServingEndpoint, DatabricksVectorSearchIndex
 from mlflow.models.signature import ModelSignature, Schema, infer_signature
+from mlflow.models.utils import load_serving_example_from_uri
 from mlflow.pyfunc.context import Context
 from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_KEY
 from mlflow.tracing.processor.inference_table import _HEADER_REQUEST_ID_KEY
@@ -100,7 +101,7 @@ from mlflow.utils.openai_utils import (
     _MockResponse,
 )
 
-from tests.helper_functions import get_serving_input_example, pyfunc_serve_and_score_model
+from tests.helper_functions import pyfunc_serve_and_score_model
 from tests.tracing.export.test_inference_table_exporter import _REQUEST_ID
 
 # this kwarg was added in langchain_community 0.0.27, and
@@ -462,7 +463,7 @@ def test_langchain_agent_model_predict(return_intermediate_steps):
         result = loaded_model.predict([langchain_input])
         assert result == langchain_output
 
-    inference_payload = get_serving_input_example(logged_model.model_uri)
+    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
     langchain_agent_output_serving = {"predictions": langchain_agent_output}
     with _mock_request(return_value=_MockResponse(200, langchain_agent_output_serving)):
         response = pyfunc_serve_and_score_model(
@@ -581,7 +582,7 @@ def test_log_and_load_retrieval_qa_chain(tmp_path):
     assert result == langchain_output
 
     # Serve the chain
-    inference_payload = get_serving_input_example(logged_model.model_uri)
+    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
     langchain_output_serving = {"predictions": langchain_output}
 
     response = pyfunc_serve_and_score_model(
@@ -651,7 +652,7 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
     assert result == langchain_output
 
     # Serve the chain
-    inference_payload = get_serving_input_example(logged_model.model_uri)
+    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
     langchain_output_serving = {"predictions": langchain_output}
 
     response = pyfunc_serve_and_score_model(
@@ -765,7 +766,7 @@ def test_log_and_load_retriever_chain(tmp_path):
     assert result == [expected_result]
 
     # Serve the retriever
-    inference_payload = get_serving_input_example(logged_model.model_uri)
+    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
     response = pyfunc_serve_and_score_model(
         logged_model.model_uri,
         data=inference_payload,
@@ -966,7 +967,7 @@ def test_save_load_runnable_passthrough():
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict(["hello"]) == ["hello"]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1006,7 +1007,7 @@ def test_save_load_runnable_lambda(spark):
     pdf = df.toPandas()
     assert pdf["answer"].tolist() == [2, 3, 4]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1039,7 +1040,7 @@ def test_save_load_runnable_lambda_in_sequence():
     assert pyfunc_loaded_model.predict(1) == [4]
     assert pyfunc_loaded_model.predict([1, 2, 3]) == [4, 6, 8]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1096,7 +1097,7 @@ def test_predict_with_callbacks(fake_chat_model):
     assert callback_handler1.num_llm_start_calls == 1
     assert callback_handler2.num_llm_start_calls == 1
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1179,7 +1180,7 @@ def test_save_load_runnable_parallel():
         {"llm": "completion"},
     ]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1248,7 +1249,7 @@ def tests_save_load_complex_runnable_parallel():
         pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
         assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1284,7 +1285,7 @@ def test_save_load_runnable_parallel_and_assign_in_sequence():
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict(["hello"]) == [expected_result]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1322,7 +1323,7 @@ def test_save_load_complex_runnable_assign(fake_chat_model):
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict([input_example]) == [expected_result]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1386,7 +1387,7 @@ def test_save_load_complex_runnable_sequence():
         pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
         assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1439,7 +1440,7 @@ def test_save_load_simple_chat_model(spark, fake_chat_model):
     pdf = df.toPandas()
     assert pdf["answer"].tolist() == ["Databricks", "Databricks"]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1512,7 +1513,7 @@ def test_save_load_rag(tmp_path, spark, fake_chat_model):
     pdf = df.toPandas()
     assert pdf["answer"].tolist() == [answer, answer]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1619,7 +1620,7 @@ def test_complex_runnable_branch_save_load(fake_chat_model, fake_classifier_chat
         "Something went wrong."
     ]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1692,7 +1693,7 @@ def test_chat_with_history(spark, fake_chat_model):
     pdf = df.toPandas()
     assert pdf["answer"].tolist() == ["Databricks"]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1946,7 +1947,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
             == content
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2288,7 +2289,7 @@ def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert answer == _get_message_content(pyfunc_loaded_model.predict(input_example))
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2548,7 +2549,7 @@ def test_save_load_chain_as_code_optional_code_path(chain_model_signature, chain
         == answer
     )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2794,7 +2795,7 @@ def test_langchain_model_save_load_with_listeners(fake_chat_model):
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict(input_example) == ["Databricks"]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2902,7 +2903,7 @@ def test_save_model_as_code_correct_streamable(chain_model_signature, chain_path
             },
         }
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2937,7 +2938,7 @@ def test_save_load_langchain_binding(fake_chat_model):
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict("hello") == ["Databricks"]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2982,7 +2983,7 @@ def test_langchain_bindings_save_load_with_config_and_types(fake_chat_model):
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict("hello") == ["Databricks"]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -86,7 +86,7 @@ from mlflow.models import Model
 from mlflow.models.dependencies_schemas import DependenciesSchemasType
 from mlflow.models.resources import DatabricksServingEndpoint, DatabricksVectorSearchIndex
 from mlflow.models.signature import ModelSignature, Schema, infer_signature
-from mlflow.models.utils import load_serving_example_from_uri
+from mlflow.models.utils import load_serving_example
 from mlflow.pyfunc.context import Context
 from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_KEY
 from mlflow.tracing.processor.inference_table import _HEADER_REQUEST_ID_KEY
@@ -463,7 +463,7 @@ def test_langchain_agent_model_predict(return_intermediate_steps):
         result = loaded_model.predict([langchain_input])
         assert result == langchain_output
 
-    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
+    inference_payload = load_serving_example(logged_model.model_uri)
     langchain_agent_output_serving = {"predictions": langchain_agent_output}
     with _mock_request(return_value=_MockResponse(200, langchain_agent_output_serving)):
         response = pyfunc_serve_and_score_model(
@@ -582,7 +582,7 @@ def test_log_and_load_retrieval_qa_chain(tmp_path):
     assert result == langchain_output
 
     # Serve the chain
-    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
+    inference_payload = load_serving_example(logged_model.model_uri)
     langchain_output_serving = {"predictions": langchain_output}
 
     response = pyfunc_serve_and_score_model(
@@ -652,7 +652,7 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
     assert result == langchain_output
 
     # Serve the chain
-    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
+    inference_payload = load_serving_example(logged_model.model_uri)
     langchain_output_serving = {"predictions": langchain_output}
 
     response = pyfunc_serve_and_score_model(
@@ -766,7 +766,7 @@ def test_log_and_load_retriever_chain(tmp_path):
     assert result == [expected_result]
 
     # Serve the retriever
-    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
+    inference_payload = load_serving_example(logged_model.model_uri)
     response = pyfunc_serve_and_score_model(
         logged_model.model_uri,
         data=inference_payload,
@@ -967,7 +967,7 @@ def test_save_load_runnable_passthrough():
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict(["hello"]) == ["hello"]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1007,7 +1007,7 @@ def test_save_load_runnable_lambda(spark):
     pdf = df.toPandas()
     assert pdf["answer"].tolist() == [2, 3, 4]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1040,7 +1040,7 @@ def test_save_load_runnable_lambda_in_sequence():
     assert pyfunc_loaded_model.predict(1) == [4]
     assert pyfunc_loaded_model.predict([1, 2, 3]) == [4, 6, 8]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1097,7 +1097,7 @@ def test_predict_with_callbacks(fake_chat_model):
     assert callback_handler1.num_llm_start_calls == 1
     assert callback_handler2.num_llm_start_calls == 1
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1180,7 +1180,7 @@ def test_save_load_runnable_parallel():
         {"llm": "completion"},
     ]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1249,7 +1249,7 @@ def tests_save_load_complex_runnable_parallel():
         pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
         assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1285,7 +1285,7 @@ def test_save_load_runnable_parallel_and_assign_in_sequence():
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict(["hello"]) == [expected_result]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1323,7 +1323,7 @@ def test_save_load_complex_runnable_assign(fake_chat_model):
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict([input_example]) == [expected_result]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1387,7 +1387,7 @@ def test_save_load_complex_runnable_sequence():
         pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
         assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1440,7 +1440,7 @@ def test_save_load_simple_chat_model(spark, fake_chat_model):
     pdf = df.toPandas()
     assert pdf["answer"].tolist() == ["Databricks", "Databricks"]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1513,7 +1513,7 @@ def test_save_load_rag(tmp_path, spark, fake_chat_model):
     pdf = df.toPandas()
     assert pdf["answer"].tolist() == [answer, answer]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1620,7 +1620,7 @@ def test_complex_runnable_branch_save_load(fake_chat_model, fake_classifier_chat
         "Something went wrong."
     ]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1693,7 +1693,7 @@ def test_chat_with_history(spark, fake_chat_model):
     pdf = df.toPandas()
     assert pdf["answer"].tolist() == ["Databricks"]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -1947,7 +1947,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
             == content
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2289,7 +2289,7 @@ def test_save_load_chain_as_code(chain_model_signature, chain_path, model_config
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert answer == _get_message_content(pyfunc_loaded_model.predict(input_example))
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2549,7 +2549,7 @@ def test_save_load_chain_as_code_optional_code_path(chain_model_signature, chain
         == answer
     )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2795,7 +2795,7 @@ def test_langchain_model_save_load_with_listeners(fake_chat_model):
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict(input_example) == ["Databricks"]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2903,7 +2903,7 @@ def test_save_model_as_code_correct_streamable(chain_model_signature, chain_path
             },
         }
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2938,7 +2938,7 @@ def test_save_load_langchain_binding(fake_chat_model):
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict("hello") == ["Databricks"]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -2983,7 +2983,7 @@ def test_langchain_bindings_save_load_with_config_and_types(fake_chat_model):
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict("hello") == ["Databricks"]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -17,7 +17,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.utils
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -403,7 +403,7 @@ def test_pyfunc_serve_and_score(lgb_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -430,7 +430,7 @@ def test_pyfunc_serve_and_score_sklearn(model):
     with mlflow.start_run():
         model_info = mlflow.sklearn.log_model(model, artifact_path="model", input_example=X.head(3))
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -17,7 +17,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.utils
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -33,7 +33,6 @@ from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -404,7 +403,7 @@ def test_pyfunc_serve_and_score(lgb_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -431,7 +430,7 @@ def test_pyfunc_serve_and_score_sklearn(model):
     with mlflow.start_run():
         model_info = mlflow.sklearn.log_model(model, artifact_path="model", input_example=X.head(3))
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -24,6 +24,7 @@ from mlflow.environment_variables import MLFLOW_DISABLE_ENV_MANAGER_CONDA_WARNIN
 from mlflow.exceptions import MlflowException
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.models.model import get_model_requirements_files
+from mlflow.models.utils import load_serving_example_from_uri
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, ErrorCode
 from mlflow.pyfunc.backend import PyFuncBackend
 from mlflow.pyfunc.scoring_server import (
@@ -45,7 +46,6 @@ from tests.helper_functions import (
     PROTOBUF_REQUIREMENT,
     RestEndpoint,
     get_safe_port,
-    get_serving_input_example,
     pyfunc_build_image,
     pyfunc_generate_dockerfile,
     pyfunc_serve_and_score_model,
@@ -157,7 +157,7 @@ def test_serve_gunicorn_opts(iris_data, sk_model):
     for model_uri in model_uris:
         with TempDir() as tpm:
             output_file_path = tpm.path("stoudt")
-            inference_payload = get_serving_input_example(model_uri)
+            inference_payload = load_serving_example_from_uri(model_uri)
             with open(output_file_path, "w") as output_file:
                 scoring_response = pyfunc_serve_and_score_model(
                     model_uri,

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -24,7 +24,7 @@ from mlflow.environment_variables import MLFLOW_DISABLE_ENV_MANAGER_CONDA_WARNIN
 from mlflow.exceptions import MlflowException
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.models.model import get_model_requirements_files
-from mlflow.models.utils import load_serving_example_from_uri
+from mlflow.models.utils import load_serving_example
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, ErrorCode
 from mlflow.pyfunc.backend import PyFuncBackend
 from mlflow.pyfunc.scoring_server import (
@@ -157,7 +157,7 @@ def test_serve_gunicorn_opts(iris_data, sk_model):
     for model_uri in model_uris:
         with TempDir() as tpm:
             output_file_path = tpm.path("stoudt")
-            inference_payload = load_serving_example_from_uri(model_uri)
+            inference_payload = load_serving_example(model_uri)
             with open(output_file_path, "w") as output_file:
                 scoring_response = pyfunc_serve_and_score_model(
                     model_uri,

--- a/tests/models/test_wheeled_model.py
+++ b/tests/models/test_wheeled_model.py
@@ -14,6 +14,7 @@ import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.exceptions import MlflowException
 from mlflow.models.model import METADATA_FILES
+from mlflow.models.utils import load_serving_example_from_uri
 from mlflow.models.wheeled_model import _ORIGINAL_REQ_FILE_NAME, _WHEELS_FOLDER_NAME, WheeledModel
 from mlflow.pyfunc.model import MLMODEL_FILE_NAME, Model
 from mlflow.store.artifact.utils.models import _improper_model_uri_msg
@@ -28,7 +29,6 @@ from mlflow.utils.environment import (
 from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -339,7 +339,7 @@ def test_serving_wheeled_model(sklearn_knn_model):
     with mlflow.start_run():
         WheeledModel.log_model(model_uri=model_uri)
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         wheeled_model_uri,
         data=inference_payload,

--- a/tests/models/test_wheeled_model.py
+++ b/tests/models/test_wheeled_model.py
@@ -14,7 +14,7 @@ import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.exceptions import MlflowException
 from mlflow.models.model import METADATA_FILES
-from mlflow.models.utils import load_serving_example_from_uri
+from mlflow.models.utils import load_serving_example
 from mlflow.models.wheeled_model import _ORIGINAL_REQ_FILE_NAME, _WHEELS_FOLDER_NAME, WheeledModel
 from mlflow.pyfunc.model import MLMODEL_FILE_NAME, Model
 from mlflow.store.artifact.utils.models import _improper_model_uri_msg
@@ -339,7 +339,7 @@ def test_serving_wheeled_model(sklearn_knn_model):
     with mlflow.start_run():
         WheeledModel.log_model(model_uri=model_uri)
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         wheeled_model_uri,
         data=inference_payload,

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -13,9 +13,10 @@ import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.exceptions import MlflowException
 from mlflow.models.signature import ModelSignature
+from mlflow.models.utils import load_serving_example_from_uri
 from mlflow.types.schema import ColSpec, ParamSchema, ParamSpec, Schema, TensorSpec
 
-from tests.helper_functions import get_serving_input_example, pyfunc_serve_and_score_model
+from tests.helper_functions import pyfunc_serve_and_score_model
 from tests.openai.conftest import is_v1
 
 
@@ -546,7 +547,7 @@ def test_embeddings_pyfunc_server_and_score():
             artifact_path="model",
             input_example=df,
         )
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -13,7 +13,7 @@ import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.exceptions import MlflowException
 from mlflow.models.signature import ModelSignature
-from mlflow.models.utils import load_serving_example_from_uri
+from mlflow.models.utils import load_serving_example
 from mlflow.types.schema import ColSpec, ParamSchema, ParamSpec, Schema, TensorSpec
 
 from tests.helper_functions import pyfunc_serve_and_score_model
@@ -547,7 +547,7 @@ def test_embeddings_pyfunc_server_and_score():
             artifact_path="model",
             input_example=df,
         )
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -19,7 +19,7 @@ import mlflow.paddle
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -570,7 +570,7 @@ def test_pyfunc_serve_and_score(pd_model):
             input_example=pd.DataFrame(inference_dataframe),
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -19,7 +19,7 @@ import mlflow.paddle
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -34,7 +34,6 @@ from tests.helper_functions import (
     _compare_logged_code_paths,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -571,7 +570,7 @@ def test_pyfunc_serve_and_score(pd_model):
             input_example=pd.DataFrame(inference_dataframe),
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/pmdarima/test_pmdarima_model_export.py
+++ b/tests/pmdarima/test_pmdarima_model_export.py
@@ -14,7 +14,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature, infer_signature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -29,7 +29,6 @@ from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 from tests.prophet.test_prophet_model_export import DataGeneration
@@ -360,7 +359,7 @@ def test_pmdarima_pyfunc_serve_and_score(auto_arima_model):
         )
     local_predict = auto_arima_model.predict(30)
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/pmdarima/test_pmdarima_model_export.py
+++ b/tests/pmdarima/test_pmdarima_model_export.py
@@ -14,7 +14,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature, infer_signature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -359,7 +359,7 @@ def test_pmdarima_pyfunc_serve_and_score(auto_arima_model):
         )
     local_predict = auto_arima_model.predict(30)
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/promptflow/test_promptflow_model_export.py
+++ b/tests/promptflow/test_promptflow_model_export.py
@@ -7,7 +7,7 @@ from pyspark.sql import SparkSession
 import mlflow
 from mlflow import MlflowException
 from mlflow.deployments import PredictionsResponse
-from mlflow.models.utils import load_serving_example_from_uri
+from mlflow.models.utils import load_serving_example
 from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 
 from tests.helper_functions import pyfunc_serve_and_score_model
@@ -88,7 +88,7 @@ def test_promptflow_model_predict_pyfunc():
 def test_promptflow_model_serve_predict():
     # Assert predict with promptflow model
     logged_model = log_promptflow_example_model(with_input_example=True)
-    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
+    inference_payload = load_serving_example(logged_model.model_uri)
     response = pyfunc_serve_and_score_model(
         logged_model.model_uri,
         data=inference_payload,

--- a/tests/promptflow/test_promptflow_model_export.py
+++ b/tests/promptflow/test_promptflow_model_export.py
@@ -7,9 +7,10 @@ from pyspark.sql import SparkSession
 import mlflow
 from mlflow import MlflowException
 from mlflow.deployments import PredictionsResponse
+from mlflow.models.utils import load_serving_example_from_uri
 from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 
-from tests.helper_functions import get_serving_input_example, pyfunc_serve_and_score_model
+from tests.helper_functions import pyfunc_serve_and_score_model
 
 
 @pytest.fixture(scope="module")
@@ -87,7 +88,7 @@ def test_promptflow_model_predict_pyfunc():
 def test_promptflow_model_serve_predict():
     # Assert predict with promptflow model
     logged_model = log_promptflow_example_model(with_input_example=True)
-    inference_payload = get_serving_input_example(logged_model.model_uri)
+    inference_payload = load_serving_example_from_uri(logged_model.model_uri)
     response = pyfunc_serve_and_score_model(
         logged_model.model_uri,
         data=inference_payload,

--- a/tests/prophet/test_prophet_model_export.py
+++ b/tests/prophet/test_prophet_model_export.py
@@ -19,7 +19,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.utils
 from mlflow import pyfunc
 from mlflow.models import Model, infer_signature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -412,7 +412,7 @@ def test_pyfunc_serve_and_score(prophet_model):
         prophet_model.model.make_future_dataframe(FORECAST_HORIZON)
     )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/prophet/test_prophet_model_export.py
+++ b/tests/prophet/test_prophet_model_export.py
@@ -19,7 +19,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.utils
 from mlflow import pyfunc
 from mlflow.models import Model, infer_signature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -32,7 +32,6 @@ from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -413,7 +412,7 @@ def test_pyfunc_serve_and_score(prophet_model):
         prophet_model.model.make_future_dataframe(FORECAST_HORIZON)
     )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -23,7 +23,7 @@ import requests
 import mlflow
 from mlflow.environment_variables import _MLFLOW_RUN_SLOW_TESTS
 from mlflow.models.flavor_backend_registry import get_flavor_backend
-from mlflow.models.utils import load_serving_example_from_uri
+from mlflow.models.utils import load_serving_example
 
 # Only import model fixtures if when MLFLOW_RUN_SLOW_TESTS environment variable is set to true
 if _MLFLOW_RUN_SLOW_TESTS.get():
@@ -168,7 +168,7 @@ def test_build_image_and_serve(flavor, request):
     port = get_safe_port()
     with start_container(port):
         # Make a scoring request with a saved serving input example
-        inference_payload = load_serving_example_from_uri(model_path)
+        inference_payload = load_serving_example(model_path)
 
         response = requests.post(
             url=f"http://localhost:{port}/invocations",

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -10,7 +10,7 @@ import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.models.model import Model
 from mlflow.models.signature import ModelSignature
-from mlflow.models.utils import load_serving_example_from_uri
+from mlflow.models.utils import load_serving_example
 from mlflow.pyfunc.loaders.chat_model import _ChatModelPyfuncWrapper
 from mlflow.tracing.constant import TraceTagKey
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -254,7 +254,7 @@ def test_chat_model_works_in_serving():
             input_example=(messages, params_subset),
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -296,7 +296,7 @@ def test_chat_model_works_with_infer_signature_input_example(tmp_path):
     assert mlflow_model.load_input_example(local_path)["messages"] == input_example["messages"]
     assert mlflow_model.load_input_example_params(local_path) == {**DEFAULT_PARAMS, **params_subset}
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -330,7 +330,7 @@ def test_chat_model_works_with_chat_message_input_example(tmp_path):
         "messages": [message.to_dict() for message in input_example]
     }
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -375,7 +375,7 @@ def test_chat_model_works_with_infer_signature_multi_input_example(tmp_path):
     }
     assert mlflow_model.load_input_example(local_path)["messages"] == input_example["messages"]
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -10,6 +10,7 @@ import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.models.model import Model
 from mlflow.models.signature import ModelSignature
+from mlflow.models.utils import load_serving_example_from_uri
 from mlflow.pyfunc.loaders.chat_model import _ChatModelPyfuncWrapper
 from mlflow.tracing.constant import TraceTagKey
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -24,7 +25,6 @@ from mlflow.types.schema import ColSpec, DataType, Schema
 
 from tests.helper_functions import (
     expect_status_code,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 from tests.tracing.helper import get_traces
@@ -254,7 +254,7 @@ def test_chat_model_works_in_serving():
             input_example=(messages, params_subset),
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -296,7 +296,7 @@ def test_chat_model_works_with_infer_signature_input_example(tmp_path):
     assert mlflow_model.load_input_example(local_path)["messages"] == input_example["messages"]
     assert mlflow_model.load_input_example_params(local_path) == {**DEFAULT_PARAMS, **params_subset}
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -330,7 +330,7 @@ def test_chat_model_works_with_chat_message_input_example(tmp_path):
         "messages": [message.to_dict() for message in input_example]
     }
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -375,7 +375,7 @@ def test_chat_model_works_with_infer_signature_multi_input_example(tmp_path):
     }
     assert mlflow_model.load_input_example(local_path)["messages"] == input_example["messages"]
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -21,7 +21,7 @@ import mlflow.pytorch
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.pytorch import get_default_conda_env
 from mlflow.pytorch import pickle_module as mlflow_pytorch_pickle_module
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
@@ -40,7 +40,6 @@ from tests.helper_functions import (
     _mlflow_major_version_string,
     assert_array_almost_equal,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
 )
 
 _logger = logging.getLogger(__name__)
@@ -563,7 +562,7 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
             input_example=data[0],
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -600,7 +599,7 @@ def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickl
             input_example=data[0],
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -655,7 +654,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
 
     # Deploy the custom pyfunc model and ensure that it is able to successfully load its
     # constituent PyTorch model via `mlflow.pytorch.load_model`
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -847,7 +846,7 @@ def test_pyfunc_serve_and_score(data):
     with mlflow.start_run():
         model_info = mlflow.pytorch.log_model(model, artifact_path="model", input_example=data[0])
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,
@@ -888,7 +887,7 @@ def test_pyfunc_serve_and_score_transformers():
             model, artifact_path="model", input_example=np.array(input_ids.tolist())
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,
@@ -1238,7 +1237,7 @@ def test_model_log_with_signature_inference(sequential_model, data):
         inputs=Schema([TensorSpec(np.dtype("float32"), (-1, 4))]),
         outputs=Schema([TensorSpec(np.dtype("float32"), (-1, 1))]),
     )
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -21,7 +21,7 @@ import mlflow.pytorch
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.pytorch import get_default_conda_env
 from mlflow.pytorch import pickle_module as mlflow_pytorch_pickle_module
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
@@ -562,7 +562,7 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
             input_example=data[0],
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -599,7 +599,7 @@ def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickl
             input_example=data[0],
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -654,7 +654,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
 
     # Deploy the custom pyfunc model and ensure that it is able to successfully load its
     # constituent PyTorch model via `mlflow.pytorch.load_model`
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -846,7 +846,7 @@ def test_pyfunc_serve_and_score(data):
     with mlflow.start_run():
         model_info = mlflow.pytorch.log_model(model, artifact_path="model", input_example=data[0])
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,
@@ -887,7 +887,7 @@ def test_pyfunc_serve_and_score_transformers():
             model, artifact_path="model", input_example=np.array(input_ids.tolist())
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,
@@ -1237,7 +1237,7 @@ def test_model_log_with_signature_inference(sequential_model, data):
         inputs=Schema([TensorSpec(np.dtype("float32"), (-1, 4))]),
         outputs=Schema([TensorSpec(np.dtype("float32"), (-1, 1))]),
     )
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -18,7 +18,7 @@ import mlflow.sentence_transformers
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.utils.environment import _mlflow_conda_env
 
@@ -27,7 +27,6 @@ from tests.helper_functions import (
     _compare_logged_code_paths,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -456,7 +455,7 @@ def test_pyfunc_serve_and_score(input1, input2, basic_model):
     local_predict = loaded_pyfunc.predict(input1)
 
     # Check that the giving the same string to the served model results in the same result
-    inference_data = get_serving_input_example(model_info.model_uri)
+    inference_data = load_serving_example_from_uri(model_info.model_uri)
     assert json.loads(inference_data) == {"inputs": input1}
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -18,7 +18,7 @@ import mlflow.sentence_transformers
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.utils.environment import _mlflow_conda_env
 
@@ -455,7 +455,7 @@ def test_pyfunc_serve_and_score(input1, input2, basic_model):
     local_predict = loaded_pyfunc.predict(input1)
 
     # Check that the giving the same string to the served model results in the same result
-    inference_data = load_serving_example_from_uri(model_info.model_uri)
+    inference_data = load_serving_example(model_info.model_uri)
     assert json.loads(inference_data) == {"inputs": input1}
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -27,7 +27,7 @@ from mlflow import pyfunc
 from mlflow.entities.model_registry.model_version import ModelVersion, ModelVersionStatus
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, ErrorCode
 from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
@@ -669,7 +669,7 @@ def test_pyfunc_serve_and_score(sklearn_knn_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -27,7 +27,7 @@ from mlflow import pyfunc
 from mlflow.entities.model_registry.model_version import ModelVersion, ModelVersionStatus
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, ErrorCode
 from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
@@ -46,7 +46,6 @@ from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 from tests.store._unity_catalog.conftest import (
@@ -670,7 +669,7 @@ def test_pyfunc_serve_and_score(sklearn_knn_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -18,7 +18,7 @@ import mlflow.spacy
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
@@ -31,7 +31,6 @@ from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
     allow_infer_pip_requirements_fallback_if,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -403,7 +402,7 @@ def test_pyfunc_serve_and_score(spacy_model_with_data):
             input_example=inference_dataframe,
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -18,7 +18,7 @@ import mlflow.spacy
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
@@ -402,7 +402,7 @@ def test_pyfunc_serve_and_score(spacy_model_with_data):
             input_example=inference_dataframe,
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -13,7 +13,7 @@ import mlflow.statsmodels
 import mlflow.utils
 from mlflow import pyfunc
 from mlflow.models import Model
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -27,7 +27,6 @@ from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 from tests.statsmodels.model_fixtures import (
@@ -404,7 +403,7 @@ def test_pyfunc_serve_and_score():
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -13,7 +13,7 @@ import mlflow.statsmodels
 import mlflow.utils
 from mlflow import pyfunc
 from mlflow.models import Model
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -403,7 +403,7 @@ def test_pyfunc_serve_and_score():
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -22,7 +22,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.deployments import PredictionsResponse
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import Schema, TensorSpec
@@ -219,7 +219,7 @@ def test_pyfunc_serve_and_score(data):
     with mlflow.start_run():
         model_info = mlflow.tensorflow.log_model(model, artifact_path="model", input_example=x)
     expected = model.predict(x)
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -662,7 +662,7 @@ def test_pyfunc_serve_and_score_transformers():
             input_example=dummy_inputs,
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -22,7 +22,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.deployments import PredictionsResponse
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import Schema, TensorSpec
@@ -41,7 +41,6 @@ from tests.helper_functions import (
     _mlflow_major_version_string,
     assert_array_almost_equal,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 from tests.pyfunc.test_spark import score_model_as_udf
@@ -220,7 +219,7 @@ def test_pyfunc_serve_and_score(data):
     with mlflow.start_run():
         model_info = mlflow.tensorflow.log_model(model, artifact_path="model", input_example=x)
     expected = model.predict(x)
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,
         data=inference_payload,
@@ -663,7 +662,7 @@ def test_pyfunc_serve_and_score_transformers():
             input_example=dummy_inputs,
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,

--- a/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
+++ b/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
@@ -22,7 +22,7 @@ else:
 import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.models import ModelSignature
-from mlflow.models.utils import load_serving_example_from_uri
+from mlflow.models.utils import load_serving_example
 from mlflow.pyfunc import spark_udf
 from mlflow.types.schema import Schema, TensorSpec
 
@@ -382,7 +382,7 @@ def test_scoring_server_successfully_on_single_multidim_input_model(
 
     inp_dict = json.dumps({"instances": test_input.tolist()})
     test_input_df = pd.DataFrame({"x": test_input.reshape((-1, 4 * 3)).tolist()})
-    serving_input_example = load_serving_example_from_uri(model_info.model_uri)
+    serving_input_example = load_serving_example(model_info.model_uri)
 
     for input_data in (inp_dict, test_input_df, serving_input_example):
         response_records_content_type = pyfunc_serve_and_score_model(
@@ -418,7 +418,7 @@ def test_scoring_server_successfully_on_multi_multidim_input_model(
         model_info = mlflow.tensorflow.log_model(model, "model", input_example=input_example)
     assert model_info.signature.inputs == signature.inputs
 
-    serving_input_example = load_serving_example_from_uri(model_info.model_uri)
+    serving_input_example = load_serving_example(model_info.model_uri)
     for input_data in (inp_dict, test_input_df, serving_input_example):
         response_records_content_type = pyfunc_serve_and_score_model(
             model_uri=model_info.model_uri,

--- a/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
+++ b/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
@@ -22,13 +22,13 @@ else:
 import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.models import ModelSignature
+from mlflow.models.utils import load_serving_example_from_uri
 from mlflow.pyfunc import spark_udf
 from mlflow.types.schema import Schema, TensorSpec
 
 from tests.helper_functions import (
     _is_available_on_pypi,
     expect_status_code,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 from tests.utils.test_file_utils import spark_session  # noqa: F401
@@ -382,7 +382,7 @@ def test_scoring_server_successfully_on_single_multidim_input_model(
 
     inp_dict = json.dumps({"instances": test_input.tolist()})
     test_input_df = pd.DataFrame({"x": test_input.reshape((-1, 4 * 3)).tolist()})
-    serving_input_example = get_serving_input_example(model_info.model_uri)
+    serving_input_example = load_serving_example_from_uri(model_info.model_uri)
 
     for input_data in (inp_dict, test_input_df, serving_input_example):
         response_records_content_type = pyfunc_serve_and_score_model(
@@ -418,7 +418,7 @@ def test_scoring_server_successfully_on_multi_multidim_input_model(
         model_info = mlflow.tensorflow.log_model(model, "model", input_example=input_example)
     assert model_info.signature.inputs == signature.inputs
 
-    serving_input_example = get_serving_input_example(model_info.model_uri)
+    serving_input_example = load_serving_example_from_uri(model_info.model_uri)
     for input_data in (inp_dict, test_input_df, serving_input_example):
         response_records_content_type = pyfunc_serve_and_score_model(
             model_uri=model_info.model_uri,

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -17,7 +17,7 @@ import mlflow.utils
 import mlflow.xgboost
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example, load_serving_example_from_uri
+from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -445,7 +445,7 @@ def test_pyfunc_serve_and_score(xgb_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -472,7 +472,7 @@ def test_pyfunc_serve_and_score_sklearn(model):
     with mlflow.start_run():
         model_info = mlflow.sklearn.log_model(model, artifact_path="model", input_example=X.head(3))
 
-    inference_payload = load_serving_example_from_uri(model_info.model_uri)
+    inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -17,7 +17,7 @@ import mlflow.utils
 import mlflow.xgboost
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature
-from mlflow.models.utils import _read_example
+from mlflow.models.utils import _read_example, load_serving_example_from_uri
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType
@@ -34,7 +34,6 @@ from tests.helper_functions import (
     _is_available_on_pypi,
     _mlflow_major_version_string,
     assert_register_model_called_with_local_model_path,
-    get_serving_input_example,
     pyfunc_serve_and_score_model,
 )
 
@@ -446,7 +445,7 @@ def test_pyfunc_serve_and_score(xgb_model):
             model, artifact_path, input_example=inference_dataframe
         )
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         data=inference_payload,
@@ -473,7 +472,7 @@ def test_pyfunc_serve_and_score_sklearn(model):
     with mlflow.start_run():
         model_info = mlflow.sklearn.log_model(model, artifact_path="model", input_example=X.head(3))
 
-    inference_payload = get_serving_input_example(model_info.model_uri)
+    inference_payload = load_serving_example_from_uri(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(
         model_info.model_uri,
         inference_payload,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12851?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12851/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12851
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Rename the file to `serving_input_example.json`.
Another refactoring for tests only is to reuse load_serving_example_from_uri function.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
