### PR TITLE
Replace `pkg_resources` with `importlib.metadata`

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -173,7 +173,7 @@ def _iter_requires(name: str):
     except importlib.metadata.PackageNotFoundError:
         return
 
-    if not reqs:
+    if reqs is None:
         return
 
     for req in reqs:

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -187,7 +187,8 @@ def _iter_requires(name: str):
 
     for req in reqs:
         # Skip extra dependencies
-        if "extra ==" in req:
+        semi_colon_idx = req.find(";")
+        if (semi_colon_idx != -1) and req[semi_colon_idx:].startswith("; extra =="):
             continue
 
         req = Requirement(req)

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -201,7 +201,7 @@ def _iter_requires(name: str):
 def _get_requires(pkg_name):
     norm_pkg_name = _normalize_package_name(pkg_name)
     for req in _iter_requires(norm_pkg_name):
-        yield _normalize_package_name(req.name)
+        yield _normalize_package_name(req)
 
 
 def _get_requires_recursive(pkg_name, seen_before=None):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -168,6 +168,15 @@ def _normalize_package_name(pkg_name):
 
 
 def _iter_requires(name: str):
+    """
+    Iterates over the requirements of the specified package.
+
+    Args:
+        name: The name of the package.
+
+    Yields:
+        The names of the required packages.
+    """
     try:
         reqs = importlib.metadata.requires(name)
     except importlib.metadata.PackageNotFoundError:
@@ -177,7 +186,7 @@ def _iter_requires(name: str):
         return
 
     for req in reqs:
-        # Ignore extra dependencies
+        # Skip extra dependencies
         if "extra ==" in req:
             continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,7 @@ ban-relative-imports = "all"
 forced-separate = ["tests"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
-"pkg_resources".msg = "We're migrating away from pkg_resources. Please use importlib.resources or importlib.metadata instead."
+"pkg_resources".msg = "Do not use pkg_resources. Use importlib.resources or importlib.metadata instead."
 "pip".msg = "Importing pip can cause undesired side effects such as https://github.com/scikit-learn/scikit-learn/issues/26992. Consider using `subprocess.run([sys.executable, '-m', 'pip', ...])` instead."
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12853?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12853/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12853
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #11330
Resolve #9585
Resolve #8605

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Related to the recent `pkg_resources` issue:

https://github.com/mlflow/mlflow/actions/runs/10178796725/job/28153157356

```
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/mlflow/pyfunc/_mlflow_pyfunc_backend_predict.py", line 6, in <module>
    from mlflow.pyfunc.scoring_server import _predict
  File "/usr/share/miniconda/envs/mlflow-6c49ae93743397928d5cd618d7b0a6c17118ecc3/lib/python3.8/site-packages/mlflow/__init__.py", line 34, in <module>
    from mlflow import (
  File "/usr/share/miniconda/envs/mlflow-6c49ae93743397928d5cd618d7b0a6c17118ecc3/lib/python3.8/site-packages/mlflow/models/__init__.py", line 44, in <module>
    from mlflow.models.model import Model, get_model_info, set_model
  File "/usr/share/miniconda/envs/mlflow-6c49ae93743397928d5cd618d7b0a6c17118ecc3/lib/python3.8/site-packages/mlflow/models/model.py", line 28, in <module>
    from mlflow.utils.environment import (
  File "/usr/share/miniconda/envs/mlflow-6c49ae93743397928d5cd618d7b0a6c17118ecc3/lib/python3.8/site-packages/mlflow/utils/environment.py", line 24, in <module>
    from mlflow.utils.requirements_utils import (
  File "/usr/share/miniconda/envs/mlflow-6c49ae93743397928d5cd618d7b0a6c17118ecc3/lib/python3.8/site-packages/mlflow/utils/requirements_utils.py", line 20, in <module>
    import pkg_resources  # noqa: TID251
ModuleNotFoundError: No module named 'pkg_resources'
```

`pkg_resources` is installed with `setuptools`. As it's not a built-in package, there is no guarantee that it can be imported. As documented in https://setuptools.pypa.io/en/latest/pkg_resources.html, Use of `pkg_resources` is deprecated and should be replaced with [`importlib.resources`](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources) or  [`importlib.metadata`](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Ran this code and compared the results:

```python
import numpy as np
from sklearn.linear_model import LinearRegression
from sklearn.pipeline import Pipeline
from sklearn.preprocessing import StandardScaler
import mlflow


X = np.array([[1, 1], [1, 2], [2, 2], [2, 3]])
y = np.dot(X, np.array([1, 2])) + 3

pipe = Pipeline([("scaler", StandardScaler()), ("lr", LinearRegression())])
pipe.fit(X, y)

with mlflow.start_run():
    mlflow.sklearn.log_model(pipe, "model")

```

master branch:

```
mlflow==2.15.0
cloudpickle==3.0.0
lz4==4.3.3
numpy==1.24.3
packaging==23.2
psutil==5.9.0
pyyaml==6.0.1
scikit-learn==1.3.2
scipy==1.10.1
```

this PR:

```
mlflow==2.15.0
cloudpickle==3.0.0
lz4==4.3.3
numpy==1.24.3
packaging==23.2
psutil==5.9.0
pyyaml==6.0.1
scikit-learn==1.3.2
scipy==1.10.1
```

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
