### PR TITLE
Make MLflow project Databricks spark job supporting setting param-list and entry-point CLI argument

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -146,7 +146,9 @@ def _run(
                 work_dir=work_dir,
                 experiment_id=experiment_id,
                 cluster_spec=backend_config,
-                databricks_spark_job_spec=project.databricks_spark_job_spec,
+                project_spec=project,
+                entry_point=entry_point,
+                parameters=parameters,
             )
 
         return run_databricks(

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -217,6 +217,11 @@ class Project:
 
     def get_entry_point(self, entry_point):
         if self.databricks_spark_job_spec:
+            if self.databricks_spark_job_spec.python_file is not None:
+                # If Databricks Spark job is configured with python_file field,
+                # it does not need to configure entry_point section
+                # and the 'entry_point' param in 'mlflow run' command is ignored
+                return None
             if self._entry_points is None or entry_point not in self._entry_points:
                 raise MlflowException(
                     f"The entry point '{entry_point}' is not defined in Databricks spark job "

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -60,8 +60,8 @@ def load_project(directory):
             )
         if python_file is not None and entry_points:
             raise MlflowException(
-                "Databricks Spark job does not allow 'databricks_spark_job.python_file' "
-                "setting and 'entry_points' setting coexisting."
+                "Databricks Spark job does not allow setting both "
+                "'databricks_spark_job.python_file' and 'entry_points'."
             )
 
         for entry_point in entry_points.values():
@@ -69,7 +69,7 @@ def load_project(directory):
                 if param.type == "path":
                     raise MlflowException(
                         "Databricks Spark job does not support entry point parameter of 'path' "
-                        f"type but got 'path' type parameter '{param.name}'."
+                        f"type. '{param.name}' value type is invalid."
                     )
 
         if env_type.DOCKER in yaml_obj:

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -95,6 +95,7 @@ def load_project(directory):
         return Project(
             databricks_spark_job_spec=databricks_spark_job_spec,
             name=project_name,
+            entry_points=entry_points,
         )
 
     # Validate config if docker_env parameter is present
@@ -222,6 +223,7 @@ class Project:
                 # it does not need to configure entry_point section
                 # and the 'entry_point' param in 'mlflow run' command is ignored
                 return None
+
             if self._entry_points is None or entry_point not in self._entry_points:
                 raise MlflowException(
                     f"The entry point '{entry_point}' is not defined in Databricks spark job "

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -226,7 +226,7 @@ class Project:
 
             if self._entry_points is None or entry_point not in self._entry_points:
                 raise MlflowException(
-                    f"The entry point '{entry_point}' is not defined in Databricks spark job "
+                    f"The entry point '{entry_point}' is not defined in the Databricks spark job "
                     f"MLproject file."
                 )
 

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -515,14 +515,26 @@ def run_databricks(
 
 
 def run_databricks_spark_job(
-    remote_run, uri, work_dir, experiment_id, cluster_spec, project_spec,
-    entry_point, parameters,
+    remote_run,
+    uri,
+    work_dir,
+    experiment_id,
+    cluster_spec,
+    project_spec,
+    entry_point,
+    parameters,
 ):
     run_id = remote_run.info.run_id
     db_job_runner = DatabricksJobRunner(databricks_profile_uri=tracking.get_tracking_uri())
     db_run_id = db_job_runner.run_databricks_spark_job(
-        uri, work_dir, experiment_id, cluster_spec, run_id, project_spec,
-        entry_point, parameters,
+        uri,
+        work_dir,
+        experiment_id,
+        cluster_spec,
+        run_id,
+        project_spec,
+        entry_point,
+        parameters,
     )
     submitted_run = DatabricksSubmittedRun(db_run_id, run_id, db_job_runner)
     submitted_run._print_description_and_log_tags()

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -266,7 +266,9 @@ class DatabricksJobRunner:
         experiment_id,
         cluster_spec,
         run_id,
-        databricks_spark_job_spec,
+        project_spec,
+        entry_point,
+        parameters,
     ):
         from mlflow.utils.file_utils import get_or_create_tmp_dir
 
@@ -281,8 +283,28 @@ class DatabricksJobRunner:
             "=== Running databricks spark job of project %s on Databricks ===", project_uri
         )
 
+        if project_spec.databricks_spark_job_spec.python_file is not None:
+            if entry_point != "main" or parameters:
+                _logger.warning(
+                    "You configured Databricks spark job python_file and parameters in "
+                    "MLProject file databricks_spark_job section, the '--entry-point' "
+                    "and '--param-list' arguments specified in 'mlflow run' command are ignored."
+                )
+            job_code_file = project_spec.databricks_spark_job_spec.python_file
+            job_parameters = project_spec.databricks_spark_job_spec.parameters
+        else:
+            command = project_spec.get_entry_point(entry_point).compute_command(parameters, None)
+            command_splits = command.split(" ")
+            if command_splits[0] != "python":
+                raise MlflowException(
+                    "Databricks spark job only supports 'python' command in entry point "
+                    "configuration."
+                )
+            job_code_file = command_splits[1]
+            job_parameters = command_splits[2:]
+
         tmp_dir = Path(get_or_create_tmp_dir())
-        origin_job_code = (Path(work_dir) / databricks_spark_job_spec.python_file).read_text()
+        origin_job_code = (Path(work_dir) / job_code_file).read_text()
         job_code_filename = f"{uuid.uuid4().hex}.py"
         new_job_code_file = tmp_dir / job_code_filename
 
@@ -319,7 +341,7 @@ os.chdir('{project_dir}')
 
         libraries_config = [
             {"pypi": {"package": python_lib}}
-            for python_lib in databricks_spark_job_spec.python_libraries
+            for python_lib in project_spec.databricks_spark_job_spec.python_libraries
         ]
         # Make Databricks Spark jobs API request to launch run.
         req_body_json = {
@@ -328,7 +350,7 @@ os.chdir('{project_dir}')
             "libraries": libraries_config,
             "spark_python_task": {
                 "python_file": f"dbfs:/{dbfs_job_code_file_path}",
-                "parameters": databricks_spark_job_spec.parameters,
+                "parameters": job_parameters,
             },
         }
 
@@ -492,12 +514,14 @@ def run_databricks(
 
 
 def run_databricks_spark_job(
-    remote_run, uri, work_dir, experiment_id, cluster_spec, databricks_spark_job_spec
+    remote_run, uri, work_dir, experiment_id, cluster_spec, project_spec,
+    entry_point, parameters,
 ):
     run_id = remote_run.info.run_id
     db_job_runner = DatabricksJobRunner(databricks_profile_uri=tracking.get_tracking_uri())
     db_run_id = db_job_runner.run_databricks_spark_job(
-        uri, work_dir, experiment_id, cluster_spec, run_id, databricks_spark_job_spec
+        uri, work_dir, experiment_id, cluster_spec, run_id, project_spec,
+        entry_point, parameters,
     )
     submitted_run = DatabricksSubmittedRun(db_run_id, run_id, db_job_runner)
     submitted_run._print_description_and_log_tags()

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -286,9 +286,10 @@ class DatabricksJobRunner:
         if project_spec.databricks_spark_job_spec.python_file is not None:
             if entry_point != "main" or parameters:
                 _logger.warning(
-                    "You configured Databricks spark job python_file and parameters in "
-                    "MLProject file databricks_spark_job section, the '--entry-point' "
-                    "and '--param-list' arguments specified in 'mlflow run' command are ignored."
+                    "You configured Databricks spark job python_file and parameters within the "
+                    "MLProject file's databricks_spark_job section. '--entry-point' "
+                    "and '--param-list' arguments specified in the 'mlflow run' command are "
+                    "ignored."
                 )
             job_code_file = project_spec.databricks_spark_job_spec.python_file
             job_parameters = project_spec.databricks_spark_job_spec.parameters
@@ -297,7 +298,7 @@ class DatabricksJobRunner:
             command_splits = command.split(" ")
             if command_splits[0] != "python":
                 raise MlflowException(
-                    "Databricks spark job only supports 'python' command in entry point "
+                    "Databricks spark job only supports 'python' command in the entry point "
                     "configuration."
                 )
             job_code_file = command_splits[1]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/12854?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12854/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12854
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

For MLflow project Databricks spark job, allow user to add "entry_point" configuration , user can add parameter and any python command. Example:

https://github.com/WeichenXu123/mlflow-job-test2

```
name: tutorial

name: tutorial

databricks_spark_job:
    python_libraries: # dependencies to be installed as databricks cluster libraries
      - mlflow==2.4.1
      - scikit-learn
      - pandas
      - dynaconf
      - numpy

entry_points:
  main:
    parameters:
      model_name: {type: string, default: model}
      build_id: {type: string, default: local}
      timestamp: {type: string, default: local}
      environment: {type: string, default: local}
      config: {type: string, default: 'local'}
      script_name: {type: string, default: train.py}
    command: "python {script_name} {model_name} {build_id} {timestamp} {environment} {config}"
```

Project run command:

```
cd <PROJECT_DIR>
export MLFLOW_TRACKING_URI=databricks
mlflow run . -b databricks --backend-config cluster-spec.json\
 -P script_name=train.py -P model_name=model123\   # pass param values here
 --experiment-id <experiment-id>
```

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Make MLflow project Databricks spark job supporting setting param-list and entry-point CLI argument

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [X] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
