### PR TITLE
Prevent test name typos

### DIFF
--- a/.github/workflows/matchers/clint.json
+++ b/.github/workflows/matchers/clint.json
@@ -5,7 +5,7 @@
       "severity": "error",
       "pattern": [
         {
-          "regexp": "^(.+):(\\d+):(\\d+):\\s(([A-Z]\\d{4}):\\s.+)$",
+          "regexp": "^(.+):(\\d+):(\\d+):\\s(([A-Z]+\\d{4}):\\s.+)$",
           "file": 1,
           "line": 2,
           "column": 3,

--- a/dev/clint/src/clint/__init__.py
+++ b/dev/clint/src/clint/__init__.py
@@ -8,6 +8,7 @@ import re
 import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 from clint.config import Config
@@ -34,7 +35,7 @@ def main():
     args = Args.parse()
     with ProcessPoolExecutor() as pool:
         futures = [
-            pool.submit(lint_file, f)
+            pool.submit(lint_file, Path(f))
             for f in args.files
             if not EXCLUDE_REGEX.match(f) and os.path.exists(f)
         ]

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -83,7 +83,7 @@ MLFLOW_CLASS_NAME = Rule(
 TEST_NAME_TYPO = Rule(
     "MLF0004",
     "test-name-typo",
-    "This function looks like a test, but its name does not start with `test_`.",
+    "This function looks like a test, but its name does not start with 'test_'.",
 )
 
 

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -133,7 +133,6 @@ class Linter(ast.NodeVisitor):
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.stack.append(node)
         self._no_rst(node)
-        self._test_name_typo(node)
         self._mlflow_class_name(node)
         self.generic_visit(node)
         self.stack.pop()

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -4,6 +4,7 @@ import ast
 import re
 import tokenize
 from dataclasses import dataclass
+from pathlib import Path
 
 from clint.builtin import BUILTIN_MODULES
 
@@ -41,7 +42,7 @@ class Rule:
 @dataclass
 class Violation:
     rule: Rule
-    path: str
+    path: Path
     lineno: int
     col_offset: int
 
@@ -57,7 +58,7 @@ class Violation:
             "column": self.col_offset,
             "endLine": self.lineno,
             "endColumn": self.col_offset,
-            "path": self.path,
+            "path": str(self.path),
             "symbol": self.rule.name,
             "message": self.rule.message,
             "message-id": self.rule.id,
@@ -65,24 +66,29 @@ class Violation:
 
 
 NO_RST = Rule(
-    "Z0001",
+    "MLF0001",
     "no-rst",
     "Do not use RST style. Use Google style instead.",
 )
 LAZY_BUILTIN_IMPORT = Rule(
-    "Z0002",
+    "MLF0002",
     "lazy-builtin-import",
     "Builtin modules must be imported at the top level.",
 )
 MLFLOW_CLASS_NAME = Rule(
-    "Z0003",
+    "MLF0003",
     "mlflow-class-name",
     "Should use `Mlflow` in class name, not `MLflow` or `MLFlow`.",
+)
+TEST_NAME_TYPO = Rule(
+    "MLF0004",
+    "test-name-typo",
+    "This function looks like a test, but its name does not start with `test_`.",
 )
 
 
 class Linter(ast.NodeVisitor):
-    def __init__(self, path: str, ignore: dict[str, set[int]]):
+    def __init__(self, path: Path, ignore: dict[str, set[int]]):
         self.stack: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
         self.path = path
         self.ignore = ignore
@@ -113,6 +119,13 @@ class Linter(ast.NodeVisitor):
     def _is_in_function(self) -> bool:
         return bool(self.stack)
 
+    def _test_name_typo(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        if not self.path.name.startswith("test_") or self._is_in_function():
+            return
+
+        if node.name.startswith("test") and not node.name.startswith("test_"):
+            self._check(node, TEST_NAME_TYPO)
+
     def _mlflow_class_name(self, node: ast.ClassDef) -> None:
         if "MLflow" in node.name or "MLFlow" in node.name:
             self._check(node, MLFLOW_CLASS_NAME)
@@ -120,17 +133,20 @@ class Linter(ast.NodeVisitor):
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.stack.append(node)
         self._no_rst(node)
+        self._test_name_typo(node)
         self._mlflow_class_name(node)
         self.generic_visit(node)
         self.stack.pop()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._test_name_typo(node)
         self.stack.append(node)
         self._no_rst(node)
         self.generic_visit(node)
         self.stack.pop()
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._test_name_typo(node)
         self.stack.append(node)
         self._no_rst(node)
         self.generic_visit(node)
@@ -149,7 +165,7 @@ class Linter(ast.NodeVisitor):
         self.generic_visit(node)
 
 
-def lint_file(path: str) -> list[Violation]:
+def lint_file(path: Path) -> list[Violation]:
     with open(path) as f:
         code = f.read()
         linter = Linter(path, ignore_map(code))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12864?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12864/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12864
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

A follow-up PR for #12862 to prevent test name typos. Pytest only runs tests starting with `test_`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
