### PR TITLE
Fix: Add amazon-bedrock as the synonym to bedrock for providers in the gateway.

### DIFF
--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -28,6 +28,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
         Provider.MLFLOW_MODEL_SERVING: MlflowModelServingProvider,
         Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HFTextGenerationInferenceServerProvider,
         Provider.BEDROCK: AmazonBedrockProvider,
+        Provider.AMAZON_BEDROCK: AmazonBedrockProvider,
         Provider.MISTRAL: MistralProvider,
         Provider.TOGETHERAI: TogetherAIProvider,
     }

--- a/tests/gateway/providers/test_providers.py
+++ b/tests/gateway/providers/test_providers.py
@@ -1,0 +1,15 @@
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.gateway import providers
+from mlflow.gateway.config import Provider
+
+
+def test_check_all_providers_have_a_valid_mapping():
+    for provider in Provider:
+        if "databricks" in provider.lower():
+            continue
+        try:
+            providers.get_provider(provider=provider)
+        except MlflowException:
+            pytest.fail(f"Provide not found {provider}")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/shabie/mlflow/pull/12872?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12872/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12872
```

</p>
</details>

### Related Issues/PRs

#12867

### What changes are proposed in this pull request?

A missing provider was mapped to the corresponding class in the gateway. Also added tests to avoid such regression. Unsure about skipping the databricks providers.

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests


### Does this PR require documentation update?

- [X] No

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` 