### PR TITLE
Set `ensure_ascii=False` to avoid escaping non-ascii characters when serializing tracing data

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -515,7 +515,7 @@ class _SpanAttributesRegistry:
         # NB: OpenTelemetry attribute can store not only string but also a few primitives like
         #   int, float, bool, and list of them. However, we serialize all into JSON string here
         #   for the simplicity in deserialization process.
-        self._span.set_attribute(key, json.dumps(value, cls=TraceJSONEncoder))
+        self._span.set_attribute(key, json.dumps(value, cls=TraceJSONEncoder, ensure_ascii=False))
 
 
 class _CachedSpanAttributesRegistry(_SpanAttributesRegistry):

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -14,7 +14,8 @@ def _serialize_trace_list(traces: List[Trace]):
         # we can't just call trace.to_json() because this
         # will cause the trace to be serialized twice (once
         # by to_json and once by json.dumps)
-        [json.loads(trace._serialize_for_mimebundle()) for trace in traces]
+        [json.loads(trace._serialize_for_mimebundle()) for trace in traces],
+        ensure_ascii=False,
     )
 
 

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -817,7 +817,7 @@ class TrackingServiceClient:
 
     def _upload_trace_data(self, trace_info: TraceInfo, trace_data: TraceData) -> None:
         artifact_repo = self._get_artifact_repo_for_trace(trace_info)
-        trace_data_json = json.dumps(trace_data.to_dict(), cls=TraceJSONEncoder)
+        trace_data_json = json.dumps(trace_data.to_dict(), cls=TraceJSONEncoder, ensure_ascii=False)
         return artifact_repo.upload_trace_data(trace_data_json)
 
     def _log_artifact_async(self, run_id, filename, artifact_path=None, artifact=None):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -709,7 +709,9 @@ class MlflowClient:
 
         # Directly set the tag on the trace in the backend
         self._tracking_client.set_trace_tag(
-            trace_info.request_id, TraceTagKey.TRACE_SPANS, json.dumps(parsed_spans)
+            trace_info.request_id,
+            TraceTagKey.TRACE_SPANS,
+            json.dumps(parsed_spans, ensure_ascii=False),
         )
 
     @experimental

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1032,5 +1032,5 @@ def test_non_ascii_characters_not_escaped():
     data = Path(trace.info.tags["mlflow.artifactLocation"], "traces.json").read_text()
     assert "あ" in data
     assert "👍" in data
-    assert json.dumps("あ") not in data
-    assert json.dumps("👍") not in data
+    assert json.dumps("あ").strip('"') not in data
+    assert json.dumps("👍").strip('"') not in data

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -30,6 +30,7 @@ from mlflow.tracing.constant import (
 )
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.provider import _get_tracer
+from mlflow.utils.file_utils import local_file_uri_to_path
 
 from tests.tracing.helper import create_test_trace_info, create_trace, get_traces
 
@@ -1021,7 +1022,7 @@ def test_get_last_active_trace():
     assert original_trace.info.status == TraceStatus.OK
 
 
-def test_non_ascii_characters_not_escaped():
+def test_non_ascii_characters_not_encoded_as_unicode():
     with mlflow.start_span() as span:
         span.set_inputs({"japanese": "あ", "emoji": "👍"})
 
@@ -1029,7 +1030,8 @@ def test_non_ascii_characters_not_escaped():
     span = trace.data.spans[0]
     assert span.inputs == {"japanese": "あ", "emoji": "👍"}
 
-    data = Path(trace.info.tags["mlflow.artifactLocation"], "traces.json").read_text()
+    artifact_location = local_file_uri_to_path(trace.info.tags["mlflow.artifactLocation"])
+    data = Path(artifact_location, "traces.json").read_text()
     assert "あ" in data
     assert "👍" in data
     assert json.dumps("あ").strip('"') not in data


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12897?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12897/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12897
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `ensure_ascii=False` when serializing tracing data with `json.dumps` to preserve non-ascii characters so UI can just render them without any conversion.

```python
>>> import json
>>> json.dumps({"test": "ありがとう"})
'{"test": "\\u3042\\u308a\\u304c\\u3068\\u3046"}'
>>> json.dumps({"test": "ありがとう"}, ensure_ascii=False)
'{"test": "ありがとう"}'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


The first two traces: logged on master
The last two traces: logged on this PR branch

<img width="900" alt="image" src="https://github.com/user-attachments/assets/16cd32f3-d2fb-4745-a1c5-3743de1170f6">


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
