### PR TITLE
Adding a way to use decorator instead of set_model for model_as_code

### DIFF
--- a/tests/langchain/sample_code/no_config/chain_decorator.py
+++ b/tests/langchain/sample_code/no_config/chain_decorator.py
@@ -1,0 +1,80 @@
+from typing import Any, List, Optional
+
+from langchain.document_loaders import TextLoader
+from langchain.prompts import ChatPromptTemplate
+from langchain.schema.output_parser import StrOutputParser
+from langchain.schema.runnable import RunnablePassthrough
+from langchain.text_splitter import CharacterTextSplitter
+from langchain.vectorstores import FAISS
+from langchain_community.embeddings import FakeEmbeddings
+
+from mlflow.models import set_model
+
+
+def get_fake_chat_model(endpoint="fake-endpoint"):
+    from langchain.callbacks.manager import CallbackManagerForLLMRun
+    from langchain.chat_models import ChatDatabricks, ChatMlflow
+    from langchain.schema.messages import BaseMessage
+    from langchain_core.outputs import ChatResult
+
+    class FakeChatModel(ChatDatabricks):
+        """Fake Chat Model wrapper for testing purposes."""
+
+        endpoint: str = "fake-endpoint"
+
+        def _generate(
+            self,
+            messages: List[BaseMessage],
+            stop: Optional[List[str]] = None,
+            run_manager: Optional[CallbackManagerForLLMRun] = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            response = {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Databricks",
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            return ChatMlflow._create_chat_result(response)
+
+        @property
+        def _llm_type(self) -> str:
+            return "fake chat model"
+
+    return FakeChatModel(endpoint=endpoint)
+
+
+text_path = "tests/langchain/state_of_the_union.txt"
+loader = TextLoader(text_path)
+documents = loader.load()
+text_splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=0)
+docs = text_splitter.split_documents(documents)
+embeddings = FakeEmbeddings(size=5)
+vectorstore = FAISS.from_documents(docs, embeddings)
+retriever = vectorstore.as_retriever()
+
+prompt = ChatPromptTemplate.from_template(
+    "Answer the following question based on the context: {context}\nQuestion: {question}"
+)
+
+
+@set_model
+def retrieval_chain():
+    return (
+        {
+            "context": retriever,
+            "question": RunnablePassthrough(),
+        }
+        | prompt
+        | get_fake_chat_model()
+        | StrOutputParser()
+    )
+
+
+retrieval_chain()

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2515,6 +2515,7 @@ def test_save_load_chain_errors(chain_model_signature, chain_path):
     [
         os.path.abspath("tests/langchain/sample_code/no_config/chain.py"),
         "tests/langchain/../langchain/sample_code/no_config/chain.py",
+        "tests/langchain/../langchain/sample_code/no_config/chain_decorator.py",
     ],
 )
 def test_save_load_chain_as_code_optional_code_path(chain_model_signature, chain_path):
@@ -2866,6 +2867,7 @@ def test_langchain_model_not_inject_callback_when_disabled(monkeypatch, model_pa
     [
         os.path.abspath("tests/langchain/sample_code/no_config/chain.py"),
         "tests/langchain/../langchain/sample_code/no_config/chain.py",
+        "tests/langchain/../langchain/sample_code/no_config/chain_decorator.py",
     ],
 )
 def test_save_model_as_code_correct_streamable(chain_model_signature, chain_path):

--- a/tests/pyfunc/sample_code/python_model_decorator.py
+++ b/tests/pyfunc/sample_code/python_model_decorator.py
@@ -1,0 +1,11 @@
+from mlflow.models import set_model
+from mlflow.pyfunc import PythonModel
+
+
+@set_model
+class MyModel(PythonModel):
+    def predict(self, context, model_input):
+        return f"This was the input: {model_input}"
+
+
+MyModel()

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1728,6 +1728,19 @@ def test_pyfunc_as_code_log_and_load():
     assert loaded_model.predict(model_input) == expected_output
 
 
+def test_pyfunc_as_code_log_and_load_as_decorator():
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model="tests/pyfunc/sample_code/python_model_decorator.py",
+            artifact_path="model",
+        )
+
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    model_input = "asdf"
+    expected_output = f"This was the input: {model_input}"
+    assert loaded_model.predict(model_input) == expected_output
+
+
 def test_pyfunc_as_code_log_and_load_with_path():
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/12911?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12911/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12911
```

</p>
</details>

### What changes are proposed in this pull request?
Adding a way to use decorator instead of set_model for model_as_code

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adding a way to use decorator instead of set_model for model_as_code

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
