### PR TITLE
Initial AutoGen Tracing Implementation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -164,6 +164,7 @@ def pytest_ignore_collect(collection_path, config):
         # Ignored files and directories must be included in dev/run-python-flavor-tests.sh
         model_flavors = [
             # Tests of flavor modules.
+            "tests/autogen",
             "tests/azureml",
             "tests/catboost",
             "tests/diviner",

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -46,6 +46,7 @@ from mlflow.utils.lazy_load import LazyLoader
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
 
 # Lazily load mlflow flavors to avoid excessive dependencies.
+autogen = LazyLoader("mlflow.autogen", globals(), "mlflow.autogen")
 catboost = LazyLoader("mlflow.catboost", globals(), "mlflow.catboost")
 diviner = LazyLoader("mlflow.diviner", globals(), "mlflow.diviner")
 fastai = LazyLoader("mlflow.fastai", globals(), "mlflow.fastai")

--- a/mlflow/autogen/__init__.py
+++ b/mlflow/autogen/__init__.py
@@ -1,0 +1,50 @@
+from mlflow.autogen.autogen_logger import MlflowAutogenLogger
+from mlflow.utils.annotations import experimental
+from mlflow.utils.autologging_utils import autologging_integration
+
+FLAVOR_NAME = "autogen"
+
+
+@experimental
+def autolog(
+    log_traces: bool = True,
+    disable: bool = False,
+    silent: bool = False,
+):
+    """
+    Enables (or disables) and configures autologging from Autogen to MLflow. Currently, MLflow
+    only supports tracing for Autogen agents.
+
+    Args:
+        log_traces: If ``True``, traces are logged for Autogen agents by using runtime logging.
+            If ``False``, no traces are collected during inference. Default to ``True``.
+        disable: If ``True``, disables the Autogen autologging. Default to ``False``.
+        silent: If ``True``, suppress all event logs and warnings from MLflow during Autogen
+            autologging. If ``False``, show all events and warnings.
+    """
+    from autogen import runtime_logging
+
+    # NB: The @autologging_integration annotation is used for adding shared logic. However, one
+    # caveat is that the wrapped function is NOT executed when disable=True is passed. This prevents
+    # us from running cleaning up logging when autologging is turned off. To workaround this, we
+    # annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
+    if log_traces and not disable:
+        runtime_logging.start(logger=MlflowAutogenLogger())
+    else:
+        runtime_logging.stop()
+
+    _autolog(log_traces=log_traces, disable=disable, silent=silent)
+
+
+@autologging_integration(FLAVOR_NAME)
+def _autolog(
+    log_traces: bool = True,
+    disable: bool = False,
+    silent: bool = False,
+):
+    """
+    This is a dummy function only for the purpose of adding the autologging_integration annotation.
+    We cannot add the annotation directly to the autolog() function above due to the reason
+    mentioned in the comment above. Note that this function MUST declare the same signature as the
+    autolog(), otherwise the annotation will not work properly.
+    """

--- a/mlflow/autogen/autogen_logger.py
+++ b/mlflow/autogen/autogen_logger.py
@@ -1,0 +1,227 @@
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from autogen import Agent, ConversableAgent
+from autogen.logger.base_logger import BaseLogger
+from openai.types.chat import ChatCompletion
+
+from mlflow import MlflowClient
+from mlflow.entities.span import Span, SpanType
+from mlflow.exceptions import MlflowException
+from mlflow.tracing.utils import capture_function_input_args
+
+_EXCLUDED_MESSAGE_SENDERS = ["chat_manager", "checking_agent"]
+
+
+@dataclass
+class ChatState:
+    """
+    Represents the state of a chat session.
+    """
+
+    # The root span object that scopes the entire single chat session. All spans
+    # such as LLM, function calls, in the chat session should be children of this span.
+    session_span: Optional[Span] = None
+    # The last message object in the chat session.
+    last_message: Optional[Any] = None
+    # The timestamp (ns) of the last message in the chat session.
+    last_message_timestamp: int = 0
+    # LLM/Tool Spans created after the last message in the chat session.
+    # We consider them as operations for generating the next message and
+    # re-locate them under the corresponding message span.
+    pended_spans: List[Span] = field(default_factory=list)
+
+    def clear(self):
+        self.session_span = None
+        self.last_message = None
+        self.last_message_timestamp = 0
+        self.pended_spans = []
+
+
+class MlflowAutogenLogger(BaseLogger):
+    def __init__(self):
+        self._client = MlflowClient()
+        self._chat_state = ChatState()
+
+    def start(self) -> str:
+        return "session_id"
+
+    def log_new_agent(self, agent: ConversableAgent, init_args: Dict[str, Any]) -> None:
+        """
+        This handler is called whenever a new agent instance is created.
+        Here we patch the agent's methods to start and end a trace around its chat session.
+        """
+        if hasattr(agent, "initiate_chat"):
+            original = agent.initiate_chat
+            # Setting root_only = True because sometimes compounded agent calls initiate_chat()
+            # method of its sub-agents, which should not start a new trace.
+            agent.initiate_chat = self._patch_function_call(
+                original, "initiate_chat", root_only=True
+            )
+        # TODO: Patch generate_reply() method as well
+        if hasattr(agent, "_wrap_function"):
+            # Wrap function (tool) use to create a span
+            original = agent._wrap_function
+
+            def _patched(func):
+                wrapped = original(func)
+                return self._patch_function_call(wrapped, span_type=SpanType.TOOL)
+
+            agent._wrap_function = _patched
+
+    def _patch_function_call(
+        self,
+        f: Callable,
+        span_name=None,
+        span_type: str = SpanType.UNKNOWN,
+        root_only: bool = False,
+    ):
+        """
+        Patch a function to start and end a span around its invocation.
+
+        Args:
+            f: The function to patch.
+            span_name: The name of the span. If None, the function name is used.
+            span_type: The type of the span. Default is SpanType.UNKNOWN.
+            root_only: If True, only create a span if it is the root of the chat session.
+                When there is an existing root span for the chat session, the function will
+                not create a new span.
+        """
+
+        def _wrapper(*args, **kwargs):
+            if self._chat_state.session_span is None:
+                # Create the trace per chat session
+                self._chat_state.session_span = self._client.start_trace(
+                    name=span_name or f.__name__,
+                    span_type=span_type,
+                    inputs=capture_function_input_args(f, args, kwargs),
+                )
+                result = f(*args, **kwargs)
+                self._client.end_trace(self._chat_state.session_span.request_id, result)
+                # Clear the state to start a new chat session
+                self._chat_state.clear()
+            elif not root_only:
+                span = self._start_span_in_session(
+                    name=span_name or f.__name__,
+                    span_type=span_type,
+                    inputs=capture_function_input_args(f, args, kwargs),
+                )
+                result = f(*args, **kwargs)
+                self._client.end_span(span.request_id, span.span_id, result)
+                self._chat_state.pended_spans.append(span)
+            else:
+                result = f(*args, **kwargs)
+            return result
+
+        return _wrapper
+
+    def _start_span_in_session(
+        self,
+        name: str,
+        span_type: str,
+        inputs: Dict[str, Any],
+        attributes: Optional[Dict[str, Any]] = None,
+        start_time_ns: Optional[int] = None,
+    ) -> Span:
+        """
+        Start a span in the current chat session.
+        """
+        if self._chat_state.session_span is None:
+            raise MlflowException("No active chat session to start a span.")
+        return self._client.start_span(
+            request_id=self._chat_state.session_span.request_id,
+            # Tentatively set the parent ID to the session root span, because we
+            # cannot create a span without a parent span (otherwise it will start
+            # a new trace). The actual parent will be determined once the chat
+            # message is received.
+            parent_id=self._chat_state.session_span.span_id,
+            name=name,
+            span_type=span_type,
+            inputs=inputs,
+            attributes=attributes,
+            start_time_ns=start_time_ns,
+        )
+
+    def log_event(self, source: Union[str, Agent], name: str, **kwargs: Dict[str, Any]):
+        event_end_time = time.time_ns()
+        # received_message event indicates
+        if name == "received_message":
+            if (self._chat_state.last_message is not None) and (
+                kwargs.get("sender") not in _EXCLUDED_MESSAGE_SENDERS
+            ):
+                span = self._start_span_in_session(
+                    name=kwargs["sender"],
+                    # Last message is recorded as the input of the next message
+                    inputs=self._chat_state.last_message,
+                    span_type=SpanType.AGENT,
+                    start_time_ns=self._chat_state.last_message_timestamp,
+                )
+                self._client.end_span(
+                    request_id=span.request_id,
+                    span_id=span.span_id,
+                    outputs=kwargs,
+                    end_time_ns=event_end_time,
+                )
+
+                # Re-locate the pended spans under this message span
+                for child_span in self._chat_state.pended_spans:
+                    child_span._span._parent = span._span.context
+                self._chat_state.pended_spans = []
+
+            self._chat_state.last_message = kwargs
+            self._chat_state.last_message_timestamp = event_end_time
+
+    def log_chat_completion(
+        self,
+        invocation_id: uuid.UUID,
+        client_id: int,
+        wrapper_id: int,
+        source: Union[str, Agent],
+        request: Dict[str, Union[float, str, List[Dict[str, str]]]],
+        response: Union[str, ChatCompletion],
+        is_cached: int,
+        cost: float,
+        start_time: str,
+    ) -> None:
+        start_time_epoch = datetime.strptime(start_time, "%Y-%m-%d %H:%M:%S.%f").timestamp()
+        start_time_epoch_ns = int(start_time_epoch * 1e9)
+        end_time = time.time_ns()
+        span = self._start_span_in_session(
+            name="chat_completion",
+            span_type=SpanType.LLM,
+            inputs=request,
+            attributes={
+                "source": source,
+                "client_id": client_id,
+                "invocation_id": invocation_id,
+                "wrapper_id": wrapper_id,
+                "cost": cost,
+                "is_cached": is_cached,
+            },
+            start_time_ns=start_time_epoch_ns,
+        )
+        # TODO: Error handling
+        self._client.end_span(
+            request_id=span.request_id, span_id=span.span_id, outputs=response, end_time_ns=end_time
+        )
+        self._chat_state.pended_spans.append(span)
+
+    def log_function_use(
+        self, source: Union[str, Agent], function, args: Dict[str, Any], returns: any
+    ):
+        pass
+
+    def log_new_wrapper(self, wrapper, init_args):
+        pass
+
+    def log_new_client(self, client, wrapper, init_args):
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def get_connection(self):
+        pass

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -360,7 +360,7 @@ class LiveSpan(Span):
         """
         self._span.add_event(event.name, event.attributes, event.timestamp)
 
-    def end(self):
+    def end(self, end_time: Optional[int] = None):
         """
         End the span. This is a thin wrapper around the OpenTelemetry's end method but just
         to handle the status update.
@@ -377,7 +377,7 @@ class LiveSpan(Span):
         if self.status.status_code != SpanStatusCode.ERROR:
             self.set_status(SpanStatus(SpanStatusCode.OK))
 
-        self._span.end()
+        self._span.end(end_time=end_time)
 
     def from_dict(cls, data: Dict[str, Any]) -> "Span":
         raise NotImplementedError("The `from_dict` method is not supported for the LiveSpan class.")

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -741,7 +741,7 @@ autogen:
     # Tool call logging is implemented in autogen 0.2.29
     minimum: "0.2.29"
     maximum: "0.2.33"
-    run: pytest/tests/autogen
+    run: pytest tests/autogen
 
 sentence_transformers:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -732,6 +732,16 @@ llama_index:
       ">= 0.0.0": ["openai"]
     run: pytest tests/llama_index/test_llama_index_autolog.py tests/llama_index/test_llama_index_tracer.py
 
+autogen:
+  package_info:
+    pip_release: "autogen"
+    install_dev: |
+      pip install git+https://github.com/microsoft/autogen
+  autologging:
+    # Tool call logging is implemented in autogen 0.2.29
+    minimum: "0.2.29"
+    maximum: "0.2.33"
+
 sentence_transformers:
   package_info:
     pip_release: "sentence-transformers"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -734,13 +734,14 @@ llama_index:
 
 autogen:
   package_info:
-    pip_release: "autogen"
+    pip_release: "pyautogen"
     install_dev: |
       pip install git+https://github.com/microsoft/autogen
   autologging:
     # Tool call logging is implemented in autogen 0.2.29
     minimum: "0.2.29"
     maximum: "0.2.33"
+    run: pytest/tests/autogen
 
 sentence_transformers:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -740,7 +740,7 @@ autogen:
   autologging:
     # Tool call logging is implemented in autogen 0.2.29
     minimum: "0.2.29"
-    maximum: "0.2.33"
+    maximum: "0.2.34"
     run: pytest tests/autogen
 
 sentence_transformers:

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -292,7 +292,7 @@ _ML_PACKAGE_VERSIONS = {
     },
     "autogen": {
         "package_info": {
-            "pip_release": "autogen"
+            "pip_release": "pyautogen"
         },
         "autologging": {
             "minimum": "0.2.29",

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -296,7 +296,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.2.29",
-            "maximum": "0.2.33"
+            "maximum": "0.2.34"
         }
     },
     "sentence_transformers": {

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -290,6 +290,15 @@ _ML_PACKAGE_VERSIONS = {
             "maximum": "0.10.58"
         }
     },
+    "autogen": {
+        "package_info": {
+            "pip_release": "autogen"
+        },
+        "autologging": {
+            "minimum": "0.2.29",
+            "maximum": "0.2.33"
+        }
+    },
     "sentence_transformers": {
         "package_info": {
             "pip_release": "sentence-transformers"
@@ -339,5 +348,6 @@ FLAVOR_TO_MODULE_NAME = {
     "openai": "openai",
     "langchain": "langchain",
     "llama_index": "llama_index.core",
+    "autogen": "autogen",
     "pyspark.ml": "pyspark"
 }

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -52,7 +52,10 @@ def start_span_in_context(name: str) -> trace.Span:
 
 
 def start_detached_span(
-    name: str, parent: Optional[trace.Span] = None, experiment_id: Optional[str] = None
+    name: str,
+    parent: Optional[trace.Span] = None,
+    experiment_id: Optional[str] = None,
+    start_time_ns: Optional[int] = None,
 ) -> Optional[Tuple[str, trace.Span]]:
     """
     Start a new OpenTelemetry span that is not part of the current trace context, but with the
@@ -64,6 +67,8 @@ def start_detached_span(
                 span.
         experiment_id: The ID of the experiment. This is used to associate the span with a specific
             experiment in MLflow.
+        start_time_ns: The start time of the span in nanoseconds.
+            If not provided, the current timestamp is used.
 
     Returns:
         The newly created OpenTelemetry span.
@@ -73,7 +78,7 @@ def start_detached_span(
     attributes = (
         {SpanAttributeKey.EXPERIMENT_ID: json.dumps(experiment_id)} if experiment_id else None
     )
-    return tracer.start_span(name, context=context, attributes=attributes)
+    return tracer.start_span(name, context=context, attributes=attributes, start_time=start_time_ns)
 
 
 def _get_tracer(module_name: str):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -861,8 +861,13 @@ class MlflowClient:
 
         try:
             otel_span = mlflow.tracing.provider.start_detached_span(
-                name=name, parent=parent_span._span, start_time_ns=start_time_ns
+                name=name, parent=parent_span._span
             )
+
+            # We have to set the custom start time here after the span is created,
+            # because span processor may override the start time in the on_start() method.
+            if start_time_ns is not None:
+                otel_span._start_time = start_time_ns
 
             span = create_mlflow_span(otel_span, request_id, span_type)
             span.set_attributes(attributes or {})

--- a/tests/autogen/test_autogen_autolog.py
+++ b/tests/autogen/test_autogen_autolog.py
@@ -1,0 +1,257 @@
+import contextlib
+import time
+from typing import List
+from unittest.mock import patch
+
+import pytest
+from autogen import ConversableAgent, GroupChat, GroupChatManager, UserProxyAgent, io
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import ChatCompletionMessage, Choice
+
+import mlflow
+from mlflow.entities.span import SpanType
+
+from tests.helper_functions import start_mock_openai_server
+from tests.tracing.helper import get_traces
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_openai():
+    with start_mock_openai_server() as base_url:
+        yield base_url
+
+
+@pytest.fixture
+def llm_config(mock_openai):
+    return {
+        "config_list": [
+            {
+                "model": "gpt-4o-mini",
+                "base_url": mock_openai,
+                "api_key": "test",
+                "temperature": 0.5,
+                "max_tokens": 100,
+            },
+        ]
+    }
+
+
+@contextlib.contextmanager
+def mock_user_input(messages: List[str]):
+    with patch.object(io.IOStream.get_default(), "input", side_effect=messages):
+        yield
+
+
+def get_simple_agent(llm_config):
+    assistant = ConversableAgent("agent", llm_config=llm_config)
+    user_proxy = UserProxyAgent("user", code_execution_config=False)
+    return assistant, user_proxy
+
+
+def test_tracing_agent_chat(llm_config):
+    mlflow.autogen.autolog()
+
+    with mock_user_input(
+        ["What is the capital of Tokyo?", "How long is it take from San Francisco?", "exit"]
+    ):
+        assistant, user_proxy = get_simple_agent(llm_config)
+        response = assistant.initiate_chat(user_proxy, message="How can I help you today?")
+
+    # Check if the initiate_chat method is patched
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert traces[0].info.execution_time_ms > 0
+    # 7 spans are expected:
+    # initiate_chat
+    #    |-- user_1
+    #    |-- assistant_1 -- chat_completion
+    #    |-- user_2
+    #    |-- assistant_2 -- chat_completion
+    assert len(traces[0].data.spans) == 7
+
+    span_name_to_dict = {span.name: span for span in traces[0].data.spans}
+    session_span = span_name_to_dict["initiate_chat"]
+    assert session_span.name == "initiate_chat"
+    assert session_span.span_type == SpanType.UNKNOWN
+    assert session_span.inputs["message"] == "How can I help you today?"
+    assert session_span.outputs["chat_history"] == response.chat_history
+    user_span = span_name_to_dict["user_1"]
+    assert user_span.span_type == SpanType.AGENT
+    assert user_span.parent_id == session_span.span_id
+    assert user_span.inputs["message"] == "How can I help you today?"
+    assert user_span.outputs["message"]["content"] == "What is the capital of Tokyo?"
+    agent_span = span_name_to_dict["agent_1"]
+    assert agent_span.span_type == SpanType.AGENT
+    assert agent_span.parent_id == session_span.span_id
+    assert agent_span.inputs["message"]["content"] == "What is the capital of Tokyo?"
+    assert agent_span.outputs is not None
+    llm_span = span_name_to_dict["chat_completion_1"]
+    assert llm_span.span_type == SpanType.LLM
+    assert llm_span.parent_id == agent_span.span_id
+    assert llm_span.inputs["messages"][-1]["content"] == "What is the capital of Tokyo?"
+    assert llm_span.outputs is not None
+    assert llm_span.attributes["cost"] >= 0
+    user_span_2 = span_name_to_dict["user_2"]
+    assert user_span_2.parent_id == session_span.span_id
+    agent_span_2 = span_name_to_dict["agent_2"]
+    assert agent_span_2.parent_id == session_span.span_id
+    llm_span_2 = span_name_to_dict["chat_completion_2"]
+    assert llm_span_2.parent_id == agent_span_2.span_id
+
+
+def test_tracing_create_trace_per_chat_session(llm_config):
+    mlflow.autogen.autolog()
+
+    with mock_user_input(["Hi", "exit", "Hello", "exit", "Hola", "exit"]):
+        assistant, user_proxy = get_simple_agent(llm_config)
+        assistant.initiate_chat(user_proxy, message="foo")
+        assistant.initiate_chat(user_proxy, message="bar")
+        assistant.initiate_chat(user_proxy, message="baz")
+
+    traces = get_traces()
+    assert len(traces) == 3
+
+
+def test_enable_disable_autolog(llm_config):
+    mlflow.autogen.autolog()
+    with mock_user_input(["Hi", "exit"]):
+        assistant, user_proxy = get_simple_agent(llm_config)
+        assistant.initiate_chat(user_proxy, message="foo")
+
+    traces = get_traces()
+    assert len(traces) == 1
+
+    mlflow.autogen.autolog(disable=True)
+    with mock_user_input(["Hi", "exit"]):
+        assistant, user_proxy = get_simple_agent(llm_config)
+        assistant.initiate_chat(user_proxy, message="foo")
+
+    # No new trace should be created
+    traces = get_traces()
+    assert len(traces) == 1
+
+
+def test_tracing_agent_with_function_calling(llm_config):
+    mlflow.autogen.autolog()
+
+    # Define a simple tool and register it with the assistant agent
+    def sum(a: int, b: int) -> int:
+        time.sleep(1)
+        return a + b
+
+    assistant = ConversableAgent(
+        name="assistant",
+        system_message="You are a helpful AI assistant. "
+        "You can help with simple calculations. "
+        "Return 'TERMINATE' when the task is done.",
+        llm_config=llm_config,
+    )
+    user_proxy = ConversableAgent(
+        name="tool_agent",
+        llm_config=False,
+        is_termination_msg=lambda msg: msg.get("content") is not None
+        and "TERMINATE" in msg["content"],
+        human_input_mode="NEVER",
+    )
+    assistant.register_for_llm(name="sum", description="A simple sum calculator")(sum)
+    user_proxy.register_for_execution(name="sum")(sum)
+
+    # Start a chat session. We mock OpenAI response to simulate function calling response.
+    with patch(
+        "autogen.oai.client.OpenAIClient.create",
+        side_effect=[
+            ChatCompletion(
+                id="chat_1",
+                created=0,
+                object="chat.completion",
+                model="gpt-4o-mini",
+                choices=[
+                    Choice(
+                        index=1,
+                        finish_reason="stop",
+                        message=ChatCompletionMessage(
+                            role="assistant",
+                            tool_calls=[
+                                {
+                                    "id": "call_1",
+                                    "function": {"arguments": '{"a": 1, "b": 1}', "name": "sum"},
+                                    "type": "function",
+                                },
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+            ChatCompletion(
+                id="chat_2",
+                created=0,
+                object="chat.completion",
+                model="gpt-4o-mini",
+                choices=[
+                    Choice(
+                        index=2,
+                        finish_reason="stop",
+                        message=ChatCompletionMessage(
+                            role="assistant",
+                            content="The result of the calculation is 2. \n\nTERMINATE",
+                        ),
+                    ),
+                ],
+            ),
+        ],
+    ):
+        response = user_proxy.initiate_chat(assistant, message="What is 1 + 1?")
+
+    assert response.summary.startswith("The result of the calculation is 2.")
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    span_name_to_dict = {span.name: span for span in traces[0].data.spans}
+    assistant_span = span_name_to_dict["assistant_1"]
+    assert assistant_span.span_type == SpanType.AGENT
+    tool_agent_span = span_name_to_dict["tool_agent"]
+    assert tool_agent_span.span_type == SpanType.AGENT
+    tool_span = span_name_to_dict["sum"]
+    assert tool_span.span_type == SpanType.TOOL
+    assert tool_span.parent_id == tool_agent_span.span_id
+    assert tool_span.inputs["a"] == 1
+    assert tool_span.inputs["b"] == 1
+    assert tool_span.outputs == "2"
+    assert tool_span.end_time_ns - tool_span.start_time_ns >= 1e9  # 1 second
+
+
+def test_tracing_composite_agent(llm_config):
+    # Composite agent can call initiate_chat() or generate_reply() method of its sub-agents.
+    # This test is to ensure that won't create a new trace for the sub-agent's method call.
+    mlflow.autogen.autolog()
+
+    agent_1 = ConversableAgent("agent_1", llm_config=llm_config)
+    agent_2 = ConversableAgent("agent_2", llm_config=llm_config)
+    group_chat = GroupChat(
+        agents=[agent_1, agent_2],
+        messages=[],
+        max_round=3,
+        speaker_selection_method="round_robin",
+    )
+    group_chat_manager = GroupChatManager(
+        groupchat=group_chat,
+        llm_config=llm_config,
+    )
+    agent_1.initiate_chat(group_chat_manager, message="Hello")
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    spans = traces[0].data.spans
+    # 1 for the root initiate_chat, 2 for the messages and 2 for the corresponding LLM calls.
+    assert len(spans) == 5
+    span_names = {span.name for span in spans}
+    assert span_names == {
+        "initiate_chat",
+        "agent_1",
+        "chat_completion_1",
+        "agent_2",
+        "chat_completion_2",
+    }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12913?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12913/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12913
```

</p>
</details>

### What changes are proposed in this pull request?

### What is AutoGen?

Implement the tracing capability for [AutoGen](https://github.com/microsoft/autogen). AutoGen is a library for building single/multi agent system with ease. The core of the library is [ConversableAgent](https://microsoft.github.io/autogen/docs/reference/agentchat/conversable_agent/) interface that has several methods like `send` `receive` to communicate with other agent. The AutoGen application is designed as a "chat" between multiple agents. 

![Autogen Agent Concept](https://github.com/user-attachments/assets/7f5c7277-2784-48ea-bf82-9f0a1da2d7fe)

Even user input is modeled as a type of agent (`UserProxyAgent`) that simply propagate user input to other agents.

```
assistant = AssistantAgent("assistant", llm_config=llm_config)
# UserProxyAgent is a subclass of ConversableAgent, but it simply ask user input instead of using LLM/Tools/etc.
user_proxy = UserProxyAgent("user_proxy", code_execution_config=False)

# Start the chat with `initiate_chat` call. 
user_proxy.initiate_chat(
    assistant,
    message="Tell me a joke about Japan.",
)
```

### Challenges in their instrumentation mechanism

Given the increasing popularity of the library and request from fields, this PR adds a basic tracing functionality for AutoGen. Fortunately, they provide a tool called [runtime logging](https://microsoft.github.io/autogen/docs/notebooks/agentchat_logging/) for instrumentation, where we can register a custom logger and AutoGen automatically call them upon some events such as LLM call, tool use, etc.

While it sounds similar to the callback system in LangChain/LlamaIndex, there are two critical missing pieces for using it for tracing.

1. There is no parent-child indication available in the logger.
2. The logger is only called at the end of the operation - no info about the operation start.

### Proposed Solution

This PR tackles these problems by having a fixed structure of traces: `Session` -> `Message` -> `LLM/Functions`. One great thing in AutoGen is everything is centered around the abstraction of "chat between agents", so this fixed structure works even for complex use cases like multi-agents system. More concretely, 

1. User start a chat "session" by calling one of the agent's `initiate_chat()` method.
2. The agent receives the message.
3. The calls LLM or Function (Tool) to generate the new message.
4. The agent sends the message to another agent.
5. Loop 2-4 until termination.

So the entire 1-5 corresponds to "Session" span, the single execution of 2-4 is "Message", and the step 3 is "LLM/Functions". The following screenshot displays this structure in actual chat session started with `initiate_chat()`.


<img width="1086" alt="Screenshot 2024-08-09 at 10 38 03" src="https://github.com/user-attachments/assets/d21d8dc4-8f9b-4872-9285-e4123ba2d3cf">


### Known TODOs
* Patch `generate_reply()` API not only `initiate_chat()`. That API is sometimes used to get an agent reply instantly ([ref](https://microsoft.github.io/autogen/docs/tutorial/code-executors#local-execution)). I briefly checked that the patch works for the API, but will do in a follow-up to avoid making this PR too big.
* Update MLflow doc
* Update AutoGen doc with this integration

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Simple Chat**
<img width="1024" alt="Screenshot 2024-08-09 at 11 37 33" src="https://github.com/user-attachments/assets/bea9551f-e66d-425d-ba15-bfe45328f973">


**Tool Calling Agent**
<img width="1014" alt="Screenshot 2024-08-09 at 11 36 53" src="https://github.com/user-attachments/assets/eb33ac5b-415c-4fe0-ac32-6625978533bf">

**Group Chat**

<img width="1048" alt="Screenshot 2024-08-09 at 11 37 17" src="https://github.com/user-attachments/assets/9f205f92-8570-4000-8e8e-4ee8e404718b">



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Implement auto-tracing for AutoGen library.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
