### PR TITLE
Remove adhoc mocking in LangChain test and use fake OpenAI service

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -29,7 +29,6 @@ from packaging.version import Version
 
 import mlflow
 from mlflow import pyfunc
-from mlflow.environment_variables import _MLFLOW_TESTING
 from mlflow.exceptions import MlflowException
 from mlflow.langchain.databricks_dependencies import _detect_databricks_dependencies
 from mlflow.langchain.runnables import _load_runnables, _save_runnables

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -812,77 +812,13 @@ class _LangChainModelWrapper:
         )
 
 
-class _TestLangChainWrapper(_LangChainModelWrapper):
-    """
-    A wrapper class that should be used for testing purposes only.
-    """
-
-    def predict(
-        self,
-        data,
-        params: Optional[Dict[str, Any]] = None,
-    ):
-        """
-        Model input data and additional parameters.
-
-        Args:
-            data: Model input data.
-            params: Additional parameters to pass to the model for inference.
-
-        Returns:
-            Model predictions.
-        """
-        import langchain
-        from langchain.schema.retriever import BaseRetriever
-
-        from mlflow.utils.openai_utils import (
-            TEST_CONTENT,
-            TEST_INTERMEDIATE_STEPS,
-            TEST_SOURCE_DOCUMENTS,
-        )
-
-        from tests.langchain.test_langchain_model_export import _mock_async_request
-
-        if isinstance(
-            self.lc_model,
-            (
-                langchain.chains.llm.LLMChain,
-                langchain.chains.RetrievalQA,
-                BaseRetriever,
-            ),
-        ):
-            mockContent = TEST_CONTENT
-        elif isinstance(self.lc_model, langchain.agents.agent.AgentExecutor):
-            mockContent = f"Final Answer: {TEST_CONTENT}"
-        else:
-            mockContent = TEST_CONTENT
-
-        with _mock_async_request(mockContent):
-            result = super().predict(data)
-        if (
-            hasattr(self.lc_model, "return_source_documents")
-            and self.lc_model.return_source_documents
-        ):
-            for res in result:
-                res["source_documents"] = TEST_SOURCE_DOCUMENTS
-        if (
-            hasattr(self.lc_model, "return_intermediate_steps")
-            and self.lc_model.return_intermediate_steps
-        ):
-            for res in result:
-                res["intermediate_steps"] = TEST_INTERMEDIATE_STEPS
-
-        return result
-
-
 def _load_pyfunc(path: str, model_config: Optional[Dict[str, Any]] = None):
     """Load PyFunc implementation for LangChain. Called by ``pyfunc.load_model``.
 
     Args:
         path: Local filesystem path to the MLflow Model with the ``langchain`` flavor.
     """
-    wrapper_cls = _TestLangChainWrapper if _MLFLOW_TESTING.get() else _LangChainModelWrapper
-    return wrapper_cls(_load_model_from_local_fs(path, model_config), path)
+    return _LangChainModelWrapper(_load_model_from_local_fs(path, model_config), path)
 
 
 def _load_model_from_local_fs(local_model_path, model_config_overrides=None):

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -674,8 +674,8 @@ langchain:
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
-      if [[ $PYDANTIC_VERSION == 1.* && $LANGCHAIN_NEW = "True" ]]; then
-        pip install 'pydantic>2'
+      if [[ $PYDANTIC_VERSION == 1.* ]]; then
+        pip install 'pydantic>2' 'fastapi>=0.100.0'
         echo "Testing langchain model export with pydantic v2"
         pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
       fi
@@ -701,7 +701,7 @@ langchain:
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
       if [[ $PYDANTIC_VERSION == 1.* ]]; then
-        pip install 'pydantic>2'
+        pip install 'pydantic>2' 'fastapi>=0.100.0'
         sleep 10
         echo "Testing langchain autolog with pydantic v2"
         pytest tests/langchain/test_langchain_autolog.py

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -56,7 +56,6 @@ class TraceJSONEncoder(json.JSONEncoder):
                 return obj.dict()
         except ImportError:
             pass
-
         try:
             import pydantic
 

--- a/mlflow/utils/openai_utils.py
+++ b/mlflow/utils/openai_utils.py
@@ -1,33 +1,10 @@
-import json
 import os
 import time
-from contextlib import contextmanager
 from enum import Enum
-from http import HTTPStatus
 from typing import NamedTuple, Optional
-from unittest import mock
-from unittest.mock import AsyncMock, MagicMock
 
 import mlflow
 
-TEST_CONTENT = "test"
-
-TEST_SOURCE_DOCUMENTS = [
-    {
-        "page_content": "We see the unity among leaders ...",
-        "metadata": {"source": "tests/langchain/state_of_the_union.txt"},
-    },
-]
-TEST_INTERMEDIATE_STEPS = (
-    [
-        {
-            "tool": "Search",
-            "tool_input": "High temperature in SF yesterday",
-            "log": " I need to find the temperature first...",
-            "result": "San Francisco...",
-        },
-    ],
-)
 
 REQUEST_URL_CHAT = "https://api.openai.com/v1/chat/completions"
 REQUEST_URL_COMPLETIONS = "https://api.openai.com/v1/completions"
@@ -74,132 +51,6 @@ REQUEST_FIELDS_COMPLETIONS = {
 }
 REQUEST_FIELDS_EMBEDDINGS = {"input", "model", "encoding_format", "user"}
 REQUEST_FIELDS = REQUEST_FIELDS_CHAT | REQUEST_FIELDS_COMPLETIONS | REQUEST_FIELDS_EMBEDDINGS
-
-
-def mock_raise_for_status(status_code):
-    def _func():
-        if 400 <= status_code < 600:
-            raise Exception(f"Mock HTTPX request {status_code} Error")
-
-    return _func
-
-
-class _MockResponse:
-    def __init__(self, status_code, json_data):
-        self.request = MagicMock()
-        self.status_code = status_code
-        self.content = json.dumps(json_data).encode()
-        self.headers = {"content-type": "application/json"}
-        self.text = mlflow.__version__
-        self.json_data = json_data
-        self.reason_phrase = HTTPStatus(status_code).phrase
-        self.raise_for_status = mock_raise_for_status(status_code)
-
-    def json(self):
-        return self.json_data
-
-
-class _MockStreamResponse:
-    def __init__(self, status_code, json_data):
-        self.request = MagicMock()
-        self.status_code = status_code
-        self.reason_phrase = HTTPStatus(status_code).phrase
-        self.iter_lines = lambda: iter([f"data: {json.dumps(json_data)}", "\n"])
-        self.headers = {"content-type": "text/event-stream"}
-        self.raise_for_status = mock_raise_for_status(status_code)
-
-
-def _chat_completion_json_sample(content):
-    # https://platform.openai.com/docs/api-reference/chat/create
-    return {
-        "id": "chatcmpl-123",
-        "object": "chat.completion",
-        "created": 1677652288,
-        "choices": [
-            {
-                "index": 0,
-                "message": {"role": "assistant", "content": content},
-                "finish_reason": "stop",
-                "text": content,
-            }
-        ],
-        "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
-    }
-
-
-def _mock_chat_completion_response(content=TEST_CONTENT):
-    return _MockResponse(200, _chat_completion_json_sample(content))
-
-
-def _chat_completion_stream_chunk(content):
-    return {
-        "id": "chatcmpl-123",
-        "object": "chat.completion.chunk",
-        "created": 1677652288,
-        "choices": [
-            {
-                "index": 0,
-                "delta": {
-                    "content": content,
-                    "function_call": None,
-                    "role": None,
-                    "tool_calls": None,
-                },
-                "finish_reason": "stop",
-            }
-        ],
-        "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
-    }
-
-
-def _mock_chat_completion_stream_response(content=TEST_CONTENT):
-    return _MockStreamResponse(200, _chat_completion_stream_chunk(content))
-
-
-@contextmanager
-def _mock_request(**kwargs):
-    with mock.patch("httpx.Client.send", **kwargs) as m:
-        yield m
-
-
-@contextmanager
-def _mock_openai_arequest(stream=False):
-    with mock.patch("httpx.AsyncClient.send", new_callable=AsyncMock) as m:
-        if stream:
-            m.return_value = _mock_async_chat_completion_stream_response()
-        else:
-            m.return_value = _mock_chat_completion_response()
-        yield m
-
-
-def _mock_async_chat_completion_stream_response():
-    resp = MagicMock()
-    json_data = _chat_completion_stream_chunk(TEST_CONTENT)
-    resp.request = MagicMock()
-    resp.status = 200
-    resp.reason_phrase = HTTPStatus(200).phrase
-
-    class DummyAsyncIter:
-        def __init__(self):
-            # NB: The new line element is required for the OpenAI async client to send an SSE event
-            # https://github.com/openai/openai-python/blob/v1.7.2/src/openai/_streaming.py#L240-L256
-            self._content = [f"data: {json.dumps(json_data)}", "\n"]
-            self._index = 0
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if self._index < len(self._content):
-                self._index += 1
-                return self._content[self._index - 1]
-            else:
-                raise StopAsyncIteration
-
-    # OpenAI uses content instead of iter_lines for async stream parsing
-    resp.aiter_lines.return_value = DummyAsyncIter()
-    resp.headers = {"content-type": "text/event-stream"}
-    return resp
 
 
 def _validate_model_params(task, model, params):

--- a/mlflow/utils/openai_utils.py
+++ b/mlflow/utils/openai_utils.py
@@ -5,7 +5,6 @@ from typing import NamedTuple, Optional
 
 import mlflow
 
-
 REQUEST_URL_CHAT = "https://api.openai.com/v1/chat/completions"
 REQUEST_URL_COMPLETIONS = "https://api.openai.com/v1/completions"
 REQUEST_URL_EMBEDDINGS = "https://api.openai.com/v1/embeddings"

--- a/tests/langchain/conftest.py
+++ b/tests/langchain/conftest.py
@@ -2,15 +2,22 @@ import importlib
 
 import openai
 import pytest
+from tests.helper_functions import start_mock_openai_server
 
 
 @pytest.fixture(autouse=True)
-def set_envs(monkeypatch):
+def set_envs(monkeypatch, mock_openai):
     monkeypatch.setenvs(
         {
-            "MLFLOW_TESTING": "true",
             "OPENAI_API_KEY": "test",
+            "OPENAI_API_BASE": mock_openai,
             "SERPAPI_API_KEY": "test",
         }
     )
     importlib.reload(openai)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_openai():
+    with start_mock_openai_server() as base_url:
+        yield base_url

--- a/tests/langchain/conftest.py
+++ b/tests/langchain/conftest.py
@@ -2,6 +2,7 @@ import importlib
 
 import openai
 import pytest
+
 from tests.helper_functions import start_mock_openai_server
 
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -96,14 +96,13 @@ def create_openai_llmagent():
         }
         llm = OpenAI(temperature=0)
     tools = load_tools(["serpapi", "llm-math"], llm=llm)
-    model = initialize_agent(
+    return initialize_agent(
         tools,
         llm,
         agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
         verbose=True,
         return_intermediate_steps=False,
     )
-    return model
 
 
 def create_retriever(tmp_path):
@@ -593,7 +592,9 @@ def test_unsupported_log_model_models_autolog(tmp_path):
         | StrOutputParser()
     )
     question = "What is MLflow?"
-    with mock.patch("mlflow.langchain._langchain_autolog._logger.info") as logger_mock, mock.patch("mlflow.langchain.log_model") as log_model_mock:
+    with mock.patch("mlflow.langchain._langchain_autolog._logger.info") as logger_mock, mock.patch(
+        "mlflow.langchain.log_model"
+    ) as log_model_mock:
         assert retrieval_chain.invoke(question) == TEST_CONTENT
         logger_mock.assert_called_once_with(UNSUPPORT_LOG_MODEL_MESSAGE)
         log_model_mock.assert_not_called()

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -346,8 +346,8 @@ def test_save_and_load_chat_openai(model_path):
     assert loaded_model == chain
 
     loaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
-    prediction = loaded_pyfunc_model.predict([{"product": "Mlflow"}])
-    assert prediction == ['[{"role": "user", "content": "What is Mlflow?"}]']
+    prediction = loaded_pyfunc_model.predict([{"product": "MLflow"}])
+    assert prediction == ['[{"role": "user", "content": "What is MLflow?"}]']
 
 
 def test_save_and_load_azure_chat_openai(model_path, monkeypatch):
@@ -396,7 +396,7 @@ def test_langchain_agent_model_predict(return_intermediate_steps):
             {
                 "index": 0,
                 "finish_reason": "stop",
-                "text": f"Final Answer: test",
+                "text": "Final Answer: test",
             }
         ],
         "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
@@ -413,15 +413,17 @@ def test_langchain_agent_model_predict(return_intermediate_steps):
     loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
 
     if return_intermediate_steps:
-        langchain_output = [{
-            "output": "test",
-            "intermediate_steps": {
-                "tool": "Search",
-                "tool_input": "High temperature in SF yesterday",
-                "log": " I need to find the temperature first...",
-                "result": "San Francisco...",
-            },
-        }]
+        langchain_output = [
+            {
+                "output": "test",
+                "intermediate_steps": {
+                    "tool": "Search",
+                    "tool_input": "High temperature in SF yesterday",
+                    "log": " I need to find the temperature first...",
+                    "result": "San Francisco...",
+                },
+            }
+        ]
         # hardcoded output key because that is the default for an agent
         # but it is not an attribute of the agent or anything that we log
     else:
@@ -461,7 +463,7 @@ def test_langchain_agent_model_predict_stream():
             {
                 "index": 0,
                 "finish_reason": "stop",
-                "text": f"Final Answer: test",
+                "text": "Final Answer: test",
             }
         ],
         "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
@@ -478,7 +480,7 @@ def test_langchain_agent_model_predict_stream():
         assert list(response) == [
             {
                 "output": "test",
-                "messages": [AIMessage(content=f"Final Answer: test")],
+                "messages": [AIMessage(content="Final Answer: test")],
             }
         ]
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1,10 +1,8 @@
-import importlib
 import inspect
 import json
 import os
 import shutil
 import sqlite3
-from contextlib import contextmanager
 from operator import itemgetter
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 from unittest import mock
@@ -92,14 +90,6 @@ from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_K
 from mlflow.tracing.processor.inference_table import _HEADER_REQUEST_ID_KEY
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import Array, ColSpec, DataType, Object, Property
-from mlflow.utils.openai_utils import (
-    TEST_CONTENT,
-    TEST_INTERMEDIATE_STEPS,
-    TEST_SOURCE_DOCUMENTS,
-    _mock_chat_completion_response,
-    _mock_request,
-    _MockResponse,
-)
 
 from tests.helper_functions import pyfunc_serve_and_score_model
 from tests.tracing.export.test_inference_table_exporter import _REQUEST_ID
@@ -111,12 +101,6 @@ VECTORSTORE_KWARGS = (
 )
 
 
-@contextmanager
-def _mock_async_request(content=TEST_CONTENT):
-    with _mock_request(return_value=_mock_chat_completion_response(content)) as m:
-        yield m
-
-
 @pytest.fixture
 def model_path(tmp_path):
     return tmp_path / "model"
@@ -126,18 +110,6 @@ def model_path(tmp_path):
 def spark():
     with SparkSession.builder.master("local[*]").getOrCreate() as s:
         yield s
-
-
-@pytest.fixture(autouse=True)
-def set_envs(monkeypatch):
-    monkeypatch.setenvs(
-        {
-            "MLFLOW_TESTING": "true",
-            "OPENAI_API_KEY": "test",
-            "SERPAPI_API_KEY": "test",
-        }
-    )
-    importlib.reload(openai)
 
 
 def create_huggingface_model(model_path):
@@ -164,7 +136,7 @@ def create_openai_llmchain():
     llm = OpenAI(temperature=0.9)
     prompt = PromptTemplate(
         input_variables=["product"],
-        template="What is a good name for a company that makes {product}?",
+        template="What is {product}?",
     )
     return LLMChain(llm=llm, prompt=prompt)
 
@@ -313,7 +285,7 @@ def test_langchain_native_save_and_load_model(model_path):
     assert type(loaded_model) == langchain.chains.llm.LLMChain
     assert type(loaded_model.llm) == langchain.llms.openai.OpenAI
     assert type(loaded_model.prompt) == langchain.prompts.PromptTemplate
-    assert loaded_model.prompt.template == "What is a good name for a company that makes {product}?"
+    assert loaded_model.prompt.template == "What is {product}?"
 
 
 def test_langchain_native_log_and_load_model():
@@ -330,39 +302,27 @@ def test_langchain_native_log_and_load_model():
     assert type(loaded_model) == langchain.chains.llm.LLMChain
     assert type(loaded_model.llm) == langchain.llms.openai.OpenAI
     assert type(loaded_model.prompt) == langchain.prompts.PromptTemplate
-    assert loaded_model.prompt.template == "What is a good name for a company that makes {product}?"
-
-
-def test_pyfunc_load_openai_model():
-    model = create_openai_llmchain()
-    with mlflow.start_run():
-        logged_model = mlflow.langchain.log_model(model, "langchain_model")
-
-    loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
-
-    assert "langchain" in logged_model.flavors
-    assert type(loaded_model) == mlflow.pyfunc.PyFuncModel
+    assert loaded_model.prompt.template == "What is {product}?"
 
 
 def test_langchain_model_predict():
-    with _mock_request(return_value=_mock_chat_completion_response()):
-        model = create_openai_llmchain()
-        with mlflow.start_run():
-            logged_model = mlflow.langchain.log_model(model, "langchain_model")
-        loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
-        result = loaded_model.predict([{"product": "MLflow"}])
-        assert result == [TEST_CONTENT]
+    model = create_openai_llmchain()
+    with mlflow.start_run():
+        logged_model = mlflow.langchain.log_model(model, "langchain_model")
+    loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
+    result = loaded_model.predict([{"product": "MLflow"}])
+    # The mock OAI completion endpoint returns payload as it is
+    assert result == ["What is MLflow?"]
 
 
 def test_langchain_model_predict_stream():
-    with _mock_request(return_value=_mock_chat_completion_response()):
-        model = create_openai_llmchain()
-        with mlflow.start_run():
-            logged_model = mlflow.langchain.log_model(model, "langchain_model")
-        loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
-        result = loaded_model.predict_stream([{"product": "MLflow"}])
-        assert inspect.isgenerator(result)
-        assert list(result) == [{"product": "MLflow", "text": "test"}]
+    model = create_openai_llmchain()
+    with mlflow.start_run():
+        logged_model = mlflow.langchain.log_model(model, "langchain_model")
+    loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
+    result = loaded_model.predict_stream([{"product": "MLflow"}])
+    assert inspect.isgenerator(result)
+    assert list(result) == [{"product": "MLflow", "text": "What is MLflow?"}]
 
 
 def test_pyfunc_spark_udf_with_langchain_model(spark):
@@ -373,12 +333,12 @@ def test_pyfunc_spark_udf_with_langchain_model(spark):
     df = spark.createDataFrame([("MLflow",), ("Spark",)], ["product"])
     df = df.withColumn("answer", loaded_model())
     pdf = df.toPandas()
-    assert pdf["answer"].tolist() == [TEST_CONTENT, TEST_CONTENT]
+    assert pdf["answer"].tolist() == ["What is MLflow?", "What is Spark?"]
 
 
 def test_save_and_load_chat_openai(model_path):
     llm = ChatOpenAI(temperature=0.9)
-    prompt = PromptTemplate.from_template("What is a good name for a company that makes {product}?")
+    prompt = PromptTemplate.from_template("What is {product}?")
     chain = LLMChain(llm=llm, prompt=prompt)
     mlflow.langchain.save_model(chain, model_path)
 
@@ -386,13 +346,13 @@ def test_save_and_load_chat_openai(model_path):
     assert loaded_model == chain
 
     loaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
-    prediction = loaded_pyfunc_model.predict([{"product": "Mlflow?"}])
-    assert prediction == [TEST_CONTENT]
+    prediction = loaded_pyfunc_model.predict([{"product": "Mlflow"}])
+    assert prediction == ['[{"role": "user", "content": "What is Mlflow?"}]']
 
 
 def test_save_and_load_azure_chat_openai(model_path, monkeypatch):
     monkeypatch.setenv("OPENAI_API_VERSION", "2023-05-15")
-    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://mlflowtest.foo.bar/")
+    monkeypatch.setenv("OPENAI_API_BASE", "https://mlflowtest.foo.bar/")
 
     llm = AzureChatOpenAI(temperature=0.9)
     prompt = PromptTemplate.from_template("What is a good name for a company that makes {product}?")
@@ -436,7 +396,7 @@ def test_langchain_agent_model_predict(return_intermediate_steps):
             {
                 "index": 0,
                 "finish_reason": "stop",
-                "text": f"Final Answer: {TEST_CONTENT}",
+                "text": f"Final Answer: test",
             }
         ],
         "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
@@ -446,26 +406,34 @@ def test_langchain_agent_model_predict(return_intermediate_steps):
         "input": "What was the high temperature in SF yesterday in Fahrenheit?"
         "What is that number raised to the .023 power?"
     }
-    with _mock_request(return_value=_MockResponse(200, langchain_agent_output)), mlflow.start_run():
+    with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(
             model, "langchain_model", input_example=langchain_input
         )
     loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
 
     if return_intermediate_steps:
-        langchain_output = [{"output": TEST_CONTENT, "intermediate_steps": TEST_INTERMEDIATE_STEPS}]
+        langchain_output = [{
+            "output": "test",
+            "intermediate_steps": {
+                "tool": "Search",
+                "tool_input": "High temperature in SF yesterday",
+                "log": " I need to find the temperature first...",
+                "result": "San Francisco...",
+            },
+        }]
         # hardcoded output key because that is the default for an agent
         # but it is not an attribute of the agent or anything that we log
     else:
-        langchain_output = [TEST_CONTENT]
+        langchain_output = ["test"]
 
-    with _mock_request(return_value=_MockResponse(200, langchain_agent_output)):
+    with mock.patch("openai.OpenAI.completions.create", return_value=langchain_agent_output):
         result = loaded_model.predict([langchain_input])
         assert result == langchain_output
 
     inference_payload = load_serving_example(logged_model.model_uri)
     langchain_agent_output_serving = {"predictions": langchain_agent_output}
-    with _mock_request(return_value=_MockResponse(200, langchain_agent_output_serving)):
+    with mock.patch("openai.OpenAI.completions.create", return_value=langchain_agent_output):
         response = pyfunc_serve_and_score_model(
             logged_model.model_uri,
             data=inference_payload,
@@ -493,7 +461,7 @@ def test_langchain_agent_model_predict_stream():
             {
                 "index": 0,
                 "finish_reason": "stop",
-                "text": f"Final Answer: {TEST_CONTENT}",
+                "text": f"Final Answer: test",
             }
         ],
         "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
@@ -504,13 +472,13 @@ def test_langchain_agent_model_predict_stream():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
     loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
     langchain_input = {"input": "foo"}
-    with _mock_request(return_value=_MockResponse(200, langchain_agent_output)):
+    with mock.patch("openai.OpenAI.completions.create", return_value=langchain_agent_output):
         response = loaded_model.predict_stream([langchain_input])
         assert inspect.isgenerator(response)
         assert list(response) == [
             {
-                "output": TEST_CONTENT,
-                "messages": [AIMessage(content=f"Final Answer: {TEST_CONTENT}")],
+                "output": "test",
+                "messages": [AIMessage(content=f"Final Answer: test")],
             }
         ]
 
@@ -560,7 +528,7 @@ def test_log_and_load_retrieval_qa_chain(tmp_path):
         return vectorstore.as_retriever()
 
     langchain_input = {"query": "What did the president say about Ketanji Brown Jackson"}
-    with _mock_request(return_value=_mock_chat_completion_response()), mlflow.start_run():
+    with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(
             retrievalQA,
             "retrieval_qa_chain",
@@ -577,13 +545,12 @@ def test_log_and_load_retrieval_qa_chain(tmp_path):
     assert loaded_model == retrievalQA
 
     loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model.model_uri)
-    langchain_output = [TEST_CONTENT]
     result = loaded_pyfunc_model.predict([langchain_input])
-    assert result == langchain_output
+    # The mock OpenAI endpoint simply echos the input
+    assert result[0].startswith("Use the following pieces of context")
 
     # Serve the chain
     inference_payload = load_serving_example(logged_model.model_uri)
-    langchain_output_serving = {"predictions": langchain_output}
 
     response = pyfunc_serve_and_score_model(
         logged_model.model_uri,
@@ -591,10 +558,8 @@ def test_log_and_load_retrieval_qa_chain(tmp_path):
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],
     )
-
-    assert (
-        PredictionsResponse.from_json(response.content.decode("utf-8")) == langchain_output_serving
-    )
+    response = PredictionsResponse.from_json(response.content.decode("utf-8"))
+    response["predictions"][0].startswith("Use the following pieces of context")
 
 
 def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
@@ -624,7 +589,7 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
         return vectorstore.as_retriever()
 
     langchain_input = {"query": "What did the president say about Ketanji Brown Jackson"}
-    with _mock_request(return_value=_mock_chat_completion_response()), mlflow.start_run():
+    with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(
             retrievalQA,
             "retrieval_qa_chain",
@@ -641,19 +606,11 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
     assert loaded_model == retrievalQA
 
     loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model.model_uri)
-    langchain_output = [
-        {
-            loaded_model.output_key: TEST_CONTENT,
-            "source_documents": TEST_SOURCE_DOCUMENTS,
-        }
-    ]
     result = loaded_pyfunc_model.predict([langchain_input])
-
-    assert result == langchain_output
+    assert result[0][loaded_model.output_key].startswith("Use the following")
 
     # Serve the chain
     inference_payload = load_serving_example(logged_model.model_uri)
-    langchain_output_serving = {"predictions": langchain_output}
 
     response = pyfunc_serve_and_score_model(
         logged_model.model_uri,
@@ -662,9 +619,8 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
         extra_args=["--env-manager", "local"],
     )
 
-    assert (
-        PredictionsResponse.from_json(response.content.decode("utf-8")) == langchain_output_serving
-    )
+    response = PredictionsResponse.from_json(response.content.decode("utf-8"))
+    assert response["predictions"][0][loaded_model.output_key].startswith("Use the following")
 
 
 # Define a special embedding for testing
@@ -1235,19 +1191,18 @@ def test_simple_chat_model_inference():
 
 
 def test_save_load_complex_runnable_parallel():
-    with _mock_request(return_value=_mock_chat_completion_response()):
-        chain = create_openai_llmchain()
-        runnable = RunnableParallel({"llm": chain})
-        expected_result = {"llm": {"product": "MLflow", "text": TEST_CONTENT}}
-        assert runnable.invoke({"product": "MLflow"}) == expected_result
-        with mlflow.start_run():
-            model_info = mlflow.langchain.log_model(
-                runnable, "model_path", input_example=[{"product": "MLflow"}]
-            )
-        loaded_model = mlflow.langchain.load_model(model_info.model_uri)
-        assert loaded_model.invoke("MLflow") == expected_result
-        pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-        assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
+    chain = create_openai_llmchain()
+    runnable = RunnableParallel({"llm": chain})
+    expected_result = {"llm": {"product": "MLflow", "text": "What is MLflow?"}}
+    assert runnable.invoke({"product": "MLflow"}) == expected_result
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            runnable, "model_path", input_example=[{"product": "MLflow"}]
+        )
+    loaded_model = mlflow.langchain.load_model(model_info.model_uri)
+    assert loaded_model.invoke("MLflow") == expected_result
+    pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
 
     inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
@@ -1370,22 +1325,21 @@ def test_save_load_long_runnable_sequence(model_path):
 
 
 def test_save_load_complex_runnable_sequence():
-    with _mock_request(return_value=_mock_chat_completion_response()):
-        llm_chain = create_openai_llmchain()
-        chain = llm_chain | RunnablePassthrough()
-        expected_result = {"product": "MLflow", "text": TEST_CONTENT}
-        assert chain.invoke({"product": "MLflow"}) == expected_result
+    llm_chain = create_openai_llmchain()
+    chain = llm_chain | RunnablePassthrough()
+    expected_result = {"product": "MLflow", "text": "What is MLflow?"}
+    assert chain.invoke({"product": "MLflow"}) == expected_result
 
-        with mlflow.start_run():
-            model_info = mlflow.langchain.log_model(
-                chain, "model_path", input_example=[{"product": "MLflow"}]
-            )
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            chain, "model_path", input_example=[{"product": "MLflow"}]
+        )
 
-        loaded_model = mlflow.langchain.load_model(model_info.model_uri)
-        result = loaded_model.invoke({"product": "MLflow"})
-        assert result == expected_result
-        pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-        assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
+    loaded_model = mlflow.langchain.load_model(model_info.model_uri)
+    result = loaded_model.invoke({"product": "MLflow"})
+    assert result == expected_result
+    pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
 
     inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
@@ -2116,7 +2070,7 @@ def test_pyfunc_builtin_chat_response_conversion_fails_gracefully():
     llm = OpenAI(temperature=0.9)
     prompt = PromptTemplate(
         input_variables=["messages"],
-        template="What is a good name for a company that makes {messages}?",
+        template="What is {messages}?",
     )
     chain = RunnablePassthrough() | LLMChain(llm=llm, prompt=prompt) | RunnablePassthrough()
 
@@ -2129,29 +2083,24 @@ def test_pyfunc_builtin_chat_response_conversion_fails_gracefully():
     }
     signature = infer_signature(model_input=input_example)
 
-    with _mock_request(return_value=_mock_chat_completion_response()):
-        with mlflow.start_run():
-            logged_model = mlflow.langchain.log_model(
-                chain,
-                "langchain_model",
-                signature=signature,
-                input_example=input_example,
-            )
-        loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
-        result = loaded_model.predict(input_example)
-        # Verify that the chat request format was converted into LangChain messages correctly, but
-        # the response was not converted to the chat response format because it does not have the
-        # expected structure (a nonstandard dict with 'messages' and 'text' fields is returned)
-        assert result == [
-            {
-                "messages": [
-                    SystemMessage(content="You are a helpful assistant."),
-                    AIMessage(content="What would you like to ask?"),
-                    HumanMessage(content="Who owns MLflow?"),
-                ],
-                "text": TEST_CONTENT,
-            }
-        ]
+    with mlflow.start_run():
+        logged_model = mlflow.langchain.log_model(
+            chain,
+            "langchain_model",
+            signature=signature,
+            input_example=input_example,
+        )
+    loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
+    result = loaded_model.predict(input_example)
+    # Verify that the chat request format was converted into LangChain messages correctly, but
+    # the response was not converted to the chat response format because it does not have the
+    # expected structure (a nonstandard dict with 'messages' and 'text' fields is returned)
+    assert result[0]["messages"] == [
+        SystemMessage(content="You are a helpful assistant."),
+        AIMessage(content="What would you like to ask?"),
+        HumanMessage(content="Who owns MLflow?"),
+    ]
+    assert result[0]["text"].startswith("What is ")
 
 
 def test_save_load_chain_that_relies_on_pickle_serialization(monkeypatch, model_path):

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -1,9 +1,9 @@
 import random
 import time
-from unittest import mock
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List, Optional
+from unittest import mock
 from unittest.mock import MagicMock
 
 import langchain
@@ -434,13 +434,13 @@ def test_agent_success(mock_databricks_serving_with_tracing_env):
     assert llm_chain_span.parent_id == root_span_id
     assert llm_chain_span.span_type == "CHAIN"
     assert llm_chain_span.inputs["input"] == langchain_input["input"]
-    assert llm_chain_span.outputs == {"text": f"Final Answer: test"}
+    assert llm_chain_span.outputs == {"text": "Final Answer: test"}
 
     # LLM of the LLMChain
     llm_span = spans[2]
     assert llm_span.parent_id == llm_chain_span.span_id
     assert llm_span.span_type == "LLM"
-    assert llm_span.outputs["generations"][0][0]["text"] == f"Final Answer: test"
+    assert llm_span.outputs["generations"][0][0]["text"] == "Final Answer: test"
 
     _validate_trace_json_serialization(trace)
 

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -1,5 +1,6 @@
 import random
 import time
+from unittest import mock
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List, Optional
@@ -33,28 +34,19 @@ from mlflow.pyfunc.context import Context
 from mlflow.tracing.constant import TRACE_SCHEMA_VERSION_KEY
 from mlflow.tracing.export.inference_table import pop_trace
 from mlflow.tracing.provider import trace_disabled
-from mlflow.utils.openai_utils import (
-    TEST_CONTENT,
-    _mock_chat_completion_response,
-    _mock_request,
-)
 
 from tests.tracing.helper import get_traces
 
-TEST_CONTENT = "test"
-
-
-@pytest.fixture(autouse=True)
-def set_envs(monkeypatch):
-    monkeypatch.setenv("RAG_TRACE_V2_ENABLED", "true")
-    monkeypatch.setenv("OPENAI_API_KEY", "test")
+# The mock OpenAI endpoint simply echos the prompt back as the completion.
+# So the expected output will be the prompt itself.
+TEST_CONTENT = "What is MLflow?"
 
 
 def create_openai_llmchain():
     llm = OpenAI(temperature=0.9)
     prompt = PromptTemplate(
         input_variables=["product"],
-        template="What is a good name for a company that makes {product}?",
+        template="What is {product}?",
     )
     return LLMChain(llm=llm, prompt=prompt)
 
@@ -71,7 +63,21 @@ def create_retriever():
 
 def create_openai_llmagent():
     # First, let's load the language model we're going to use to control the agent.
-    llm = OpenAI(temperature=0)
+    with mock.patch("openai.OpenAI") as mock_openai:
+        mock_openai.return_value.completions.create.return_value = {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "text": "Final Answer: test",
+                }
+            ],
+            "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
+        }
+        llm = OpenAI(temperature=0)
 
     # Next, let's load some tools to use.
     tools = load_tools(["llm-math"], llm=llm)
@@ -362,12 +368,13 @@ def _predict_with_callbacks(lc_model, request_id, data):
     return response, trace_dict
 
 
-def test_e2e_rag_model_tracing_in_serving(mock_databricks_serving_with_tracing_env):
+def test_e2e_rag_model_tracing_in_serving(mock_databricks_serving_with_tracing_env, monkeypatch):
+    monkeypatch.setenv("RAG_TRACE_V2_ENABLED", "true")
+
     llm_chain = create_openai_llmchain()
 
     request_id = "test_request_id"
-    with _mock_request(return_value=_mock_chat_completion_response()):
-        response, trace_dict = _predict_with_callbacks(llm_chain, request_id, ["MLflow"])
+    response, trace_dict = _predict_with_callbacks(llm_chain, request_id, ["MLflow"])
 
     assert response == [{"text": TEST_CONTENT}]
     trace = Trace.from_dict(trace_dict)
@@ -390,7 +397,7 @@ def test_e2e_rag_model_tracing_in_serving(mock_databricks_serving_with_tracing_e
     root_span_id = root_span.span_id
     child_span = spans[1]
     assert child_span.parent_id == root_span_id
-    assert child_span.inputs == ["What is a good name for a company that makes MLflow?"]
+    assert child_span.inputs == ["What is MLflow?"]
     assert child_span.outputs["generations"][0][0]["text"] == TEST_CONTENT
     assert child_span.span_type == "LLM"
 
@@ -400,12 +407,9 @@ def test_e2e_rag_model_tracing_in_serving(mock_databricks_serving_with_tracing_e
 def test_agent_success(mock_databricks_serving_with_tracing_env):
     agent = create_openai_llmagent()
     langchain_input = {"input": "What is 123 raised to the .023 power?"}
-    expected_output = {"output": TEST_CONTENT}
+    expected_output = {"output": "test"}
     request_id = "test_request_id"
-    with _mock_request(
-        return_value=_mock_chat_completion_response(content=f"Final Answer: {TEST_CONTENT}")
-    ):
-        response, trace_dict = _predict_with_callbacks(agent, request_id, langchain_input)
+    response, trace_dict = _predict_with_callbacks(agent, request_id, langchain_input)
 
     assert response == expected_output
     trace = Trace.from_dict(trace_dict)
@@ -430,13 +434,13 @@ def test_agent_success(mock_databricks_serving_with_tracing_env):
     assert llm_chain_span.parent_id == root_span_id
     assert llm_chain_span.span_type == "CHAIN"
     assert llm_chain_span.inputs["input"] == langchain_input["input"]
-    assert llm_chain_span.outputs == {"text": f"Final Answer: {TEST_CONTENT}"}
+    assert llm_chain_span.outputs == {"text": f"Final Answer: test"}
 
     # LLM of the LLMChain
     llm_span = spans[2]
     assert llm_span.parent_id == llm_chain_span.span_id
     assert llm_span.span_type == "LLM"
-    assert llm_span.outputs["generations"][0][0]["text"] == f"Final Answer: {TEST_CONTENT}"
+    assert llm_span.outputs["generations"][0][0]["text"] == f"Final Answer: test"
 
     _validate_trace_json_serialization(trace)
 
@@ -450,11 +454,10 @@ def test_tool_success(mock_databricks_serving_with_tracing_env):
 
     tool_input = {"question": "What up"}
     request_id = "test_request_id"
-    with _mock_request(return_value=_mock_chat_completion_response()):
-        response, trace_dict = _predict_with_callbacks(chain_tool, request_id, tool_input)
+    response, trace_dict = _predict_with_callbacks(chain_tool, request_id, tool_input)
 
     # str output is converted to _ChatResponse
-    assert response["choices"][0]["message"]["content"] == TEST_CONTENT
+    output = response["choices"][0]["message"]["content"]
     trace = Trace.from_dict(trace_dict)
     spans = trace.data.spans
     assert len(spans) == 5
@@ -463,7 +466,7 @@ def test_tool_success(mock_databricks_serving_with_tracing_env):
     tool_span = spans[0]
     assert tool_span.span_type == "TOOL"
     assert tool_span.inputs == str(tool_input)
-    assert tool_span.outputs == TEST_CONTENT
+    assert tool_span.outputs is not None
     tool_span_id = tool_span.span_id
 
     # RunnableSequence
@@ -471,7 +474,7 @@ def test_tool_success(mock_databricks_serving_with_tracing_env):
     assert runnable_sequence_span.parent_id == tool_span_id
     assert runnable_sequence_span.span_type == "CHAIN"
     assert runnable_sequence_span.inputs == tool_input
-    assert runnable_sequence_span.outputs == TEST_CONTENT
+    assert runnable_sequence_span.outputs is not None
 
     # PromptTemplate
     prompt_template_span = spans[2]
@@ -482,7 +485,7 @@ def test_tool_success(mock_databricks_serving_with_tracing_env):
     # StrOutputParser
     output_parser_span = spans[4]
     assert output_parser_span.span_type == "CHAIN"
-    assert output_parser_span.outputs == TEST_CONTENT
+    assert output_parser_span.outputs == output
 
     _validate_trace_json_serialization(trace)
 
@@ -564,12 +567,11 @@ def test_tracer_noop_when_tracing_disabled(monkeypatch):
 
     @trace_disabled
     def _predict():
-        with _mock_request(return_value=_mock_chat_completion_response()):
-            return model._predict_with_callbacks(
-                ["MLflow"],
-                callback_handlers=[MlflowLangchainTracer()],
-                convert_chat_responses=True,
-            )
+        return model._predict_with_callbacks(
+            ["MLflow"],
+            callback_handlers=[MlflowLangchainTracer()],
+            convert_chat_responses=True,
+        )
 
     mock_logger = MagicMock()
     monkeypatch.setattr(mlflow.tracking.client, "_logger", mock_logger)
@@ -591,14 +593,13 @@ def test_tracer_nested_trace():
     llm = OpenAI(temperature=0.9)
     prompt = PromptTemplate(
         input_variables=["product"],
-        template="What is a good name for a company that makes {product}?",
+        template="What is {product}?",
     )
     chain = prompt | llm | StrOutputParser()
 
     @mlflow.trace(name="parent", span_type="SPECIAL")
     def run(message):
-        with _mock_request(return_value=_mock_chat_completion_response()):
-            return chain.invoke(message, config={"callbacks": [MlflowLangchainTracer()]})
+        return chain.invoke(message, config={"callbacks": [MlflowLangchainTracer()]})
 
     response = run("MLflow")
     expected_response = TEST_CONTENT


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12919?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12919/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12919
```

</p>
</details>

### What changes are proposed in this pull request?

Follow-up for https://github.com/mlflow/mlflow/pull/12823#discussion_r1697033045 and preparation for incoming change. The LangChain test relies on patching HTTPX client, which is not robust to OpenAI SDK update. Also cleaning up other adhoc mocking like `_TestLangChainWrapper`.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

This does not contain any user facing change, but excluding it from that patch likely causes a conflict, because this touches many part of the LC test files.