### PR TITLE
langchain: load code from code_paths to system path

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -890,6 +890,8 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
     pyfunc_flavor_conf = _get_flavor_configuration(
         model_path=local_model_path, flavor_name=PYFUNC_FLAVOR_NAME
     )
+    # Add code from the langchain flavor to the system path
+    _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     # The model_code_path and the model_config were previously saved langchain flavor but now we
     # also save them inside the pyfunc flavor. For backwards compatibility of previous models,
     # we need to check both places.
@@ -909,7 +911,6 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
             local_model_path,
             os.path.basename(flavor_code_path),
         )
-        _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
         try:
             model = _load_model_code_path(
                 model_code_path, {**(model_config or {}), **(model_config_overrides or {})}

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -885,10 +885,10 @@ def _load_pyfunc(path: str, model_config: Optional[Dict[str, Any]] = None):
     return wrapper_cls(_load_model_from_local_fs(path, model_config), path)
 
 
-def _load_model_from_local_fs(model_code_path, model_config_overrides=None):
-    flavor_conf = _get_flavor_configuration(model_path=model_code_path, flavor_name=FLAVOR_NAME)
+def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     pyfunc_flavor_conf = _get_flavor_configuration(
-        model_path=model_code_path, flavor_name=PYFUNC_FLAVOR_NAME
+        model_path=local_model_path, flavor_name=PYFUNC_FLAVOR_NAME
     )
     # The model_code_path and the model_config were previously saved langchain flavor but now we
     # also save them inside the pyfunc flavor. For backwards compatibility of previous models,
@@ -897,7 +897,7 @@ def _load_model_from_local_fs(model_code_path, model_config_overrides=None):
         model_config = pyfunc_flavor_conf.get(MODEL_CONFIG, flavor_conf.get(MODEL_CONFIG, None))
         if isinstance(model_config, str):
             config_path = os.path.join(
-                model_code_path,
+                local_model_path,
                 os.path.basename(model_config),
             )
             model_config = _validate_and_get_model_config_from_file(config_path)
@@ -905,14 +905,14 @@ def _load_model_from_local_fs(model_code_path, model_config_overrides=None):
         flavor_code_path = pyfunc_flavor_conf.get(
             MODEL_CODE_PATH, flavor_conf.get(MODEL_CODE_PATH, None)
         )
-        code_path = os.path.join(
-            model_code_path,
+        model_code_path = os.path.join(
+            local_model_path,
             os.path.basename(flavor_code_path),
         )
-        _add_code_from_conf_to_system_path(model_code_path, flavor_conf)
+        _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
         try:
             model = _load_model_code_path(
-                code_path, {**(model_config or {}), **(model_config_overrides or {})}
+                model_code_path, {**(model_config or {}), **(model_config_overrides or {})}
             )
         finally:
             # We would like to clean up the dependencies schema which is set to global
@@ -921,7 +921,7 @@ def _load_model_from_local_fs(model_code_path, model_config_overrides=None):
         return model
     else:
         with patch_langchain_type_to_cls_dict():
-            return _load_model(model_code_path, flavor_conf)
+            return _load_model(local_model_path, flavor_conf)
 
 
 @experimental

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -911,6 +911,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
         )
 
         try:
+            _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
             model = _load_model_code_path(
                 code_path, {**(model_config or {}), **(model_config_overrides or {})}
             )
@@ -918,7 +919,6 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
             # We would like to clean up the dependencies schema which is set to global
             # after loading the mode to avoid the schema being used in the next model loading
             _clear_dependencies_schemas()
-        _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
         return model
     else:
         _add_code_from_conf_to_system_path(local_model_path, flavor_conf)

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -918,7 +918,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
             # We would like to clean up the dependencies schema which is set to global
             # after loading the mode to avoid the schema being used in the next model loading
             _clear_dependencies_schemas()
-
+        _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
         return model
     else:
         _add_code_from_conf_to_system_path(local_model_path, flavor_conf)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harshilprajapati96/mlflow/pull/12923?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12923/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12923
```

</p>
</details>

Signed-off-by: Harshil Prajapati <harshil.prajapati@gmail.com>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> closes #12922 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
