### PR TITLE
Issue a warning when the LangChain model includes a class from partner packages

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -664,12 +664,13 @@ langchain:
           "psutil",
           "faiss-cpu",
           "langchain-experimental",
-          "langchain-openai",
           "numexpr",
           "hf_transfer",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
         ]
       ">= 0.2": ["langchain-huggingface"]
+      # We cannot use install langchain-openai with langchain >= 0.2.0, while pinning openai to <1.8.0
+      "< 0.2.0": ["langchain-openai"]
     run: |
       # Run all langchain tests except autologging
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -664,6 +664,7 @@ langchain:
           "psutil",
           "faiss-cpu",
           "langchain-experimental",
+          "langchain-openai",
           "numexpr",
           "hf_transfer",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -365,6 +365,65 @@ def test_save_and_load_azure_chat_openai(model_path, monkeypatch):
     assert loaded_model == chain
 
 
+def test_save_model_with_partner_package(tmp_path):
+    from langchain_community.chat_models import ChatOpenAI as ChatOpenAICommunity
+    from langchain_openai import ChatOpenAI as ChatOpenAIPartner
+
+    def _is_partner_pkg_warning_issued(warnings):
+        return any(
+            str(w.message).startswith(
+                "Your model contains a class imported from the LangChain "
+                "partner package `langchain-openai`."
+            )
+            for w in warnings
+        )
+
+    # 1. Saving a model with LLM from a community package
+    #    -> no warning should be raised
+    chain = ChatOpenAICommunity() | StrOutputParser()
+
+    with pytest.warns() as warnings:
+        mlflow.langchain.save_model(chain, tmp_path / "community-model")
+        assert not _is_partner_pkg_warning_issued(warnings)
+
+    # 2. Saving a model with LLM from a partner package
+    #    -> a warning should be raised and incorrect class is loaded
+    chain = ChatOpenAIPartner() | StrOutputParser()
+
+    with pytest.warns() as warnings:
+        mlflow.langchain.save_model(chain, tmp_path / "partner-model")
+        assert _is_partner_pkg_warning_issued(warnings)
+
+    loaded_model = mlflow.langchain.load_model(tmp_path / "partner-model")
+    loaded_llm = loaded_model.steps[0]
+    assert type(loaded_llm) == ChatOpenAICommunity
+
+    # 3. Saving a model using model-from-code
+    #    -> no warning should be raised and the correct class is loaded
+    with open(tmp_path / "model.py", "w") as f:
+        f.write(
+            """
+from langchain_openai import ChatOpenAI
+from langchain.schema.output_parser import StrOutputParser
+import mlflow
+
+chain = ChatOpenAI() | StrOutputParser()
+mlflow.models.set_model(chain)
+"""
+        )
+
+    with pytest.warns() as warnings:
+        mlflow.langchain.save_model(
+            lc_model=str(tmp_path / "model.py"),
+            path=tmp_path / "model-from-code",
+        )
+        assert not _is_partner_pkg_warning_issued(warnings)
+
+    loaded_model = mlflow.langchain.load_model(tmp_path / "model-from-code")
+    loaded_llm = loaded_model.steps[0]
+    assert type(loaded_llm) == ChatOpenAIPartner
+
+
 def test_langchain_log_huggingface_hub_model_metadata(model_path):
     model = create_huggingface_model(model_path)
     with mlflow.start_run():

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 import sqlite3
+import warnings
 from operator import itemgetter
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 from unittest import mock
@@ -365,34 +366,41 @@ def test_save_and_load_azure_chat_openai(model_path, monkeypatch):
     assert loaded_model == chain
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) >= Version("0.2.0"),
+    reason="There is no langchain-openai version satisfies both langchain>=0.2.0 and openai<1.8.0",
+)
 def test_save_model_with_partner_package(tmp_path):
     from langchain_community.chat_models import ChatOpenAI as ChatOpenAICommunity
     from langchain_openai import ChatOpenAI as ChatOpenAIPartner
 
-    def _is_partner_pkg_warning_issued(warnings):
+    def _is_partner_pkg_warning_issued(ws):
+        # Dummy warning to ensure at least one warning is issued. Otherwise the pytest.warns
+        # context manager will raise an exception at exit.
+        warnings.warn("dummy")
         return any(
             str(w.message).startswith(
                 "Your model contains a class imported from the LangChain "
                 "partner package `langchain-openai`."
             )
-            for w in warnings
+            for w in ws
         )
 
     # 1. Saving a model with LLM from a community package
     #    -> no warning should be raised
     chain = ChatOpenAICommunity() | StrOutputParser()
 
-    with pytest.warns() as warnings:
+    with pytest.warns() as ws:
         mlflow.langchain.save_model(chain, tmp_path / "community-model")
-        assert not _is_partner_pkg_warning_issued(warnings)
+        assert not _is_partner_pkg_warning_issued(ws)
 
     # 2. Saving a model with LLM from a partner package
     #    -> a warning should be raised and incorrect class is loaded
     chain = ChatOpenAIPartner() | StrOutputParser()
 
-    with pytest.warns() as warnings:
+    with pytest.warns() as ws:
         mlflow.langchain.save_model(chain, tmp_path / "partner-model")
-        assert _is_partner_pkg_warning_issued(warnings)
+        assert _is_partner_pkg_warning_issued(ws)
 
     loaded_model = mlflow.langchain.load_model(tmp_path / "partner-model")
     loaded_llm = loaded_model.steps[0]
@@ -412,12 +420,12 @@ mlflow.models.set_model(chain)
 """
         )
 
-    with pytest.warns() as warnings:
+    with pytest.warns() as ws:
         mlflow.langchain.save_model(
             lc_model=str(tmp_path / "model.py"),
             path=tmp_path / "model-from-code",
         )
-        assert not _is_partner_pkg_warning_issued(warnings)
+        assert not _is_partner_pkg_warning_issued(ws)
 
     loaded_model = mlflow.langchain.load_model(tmp_path / "model-from-code")
     loaded_llm = loaded_model.steps[0]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12931?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12931/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12931
```

</p>
</details>

### What changes are proposed in this pull request?

Currently, MLflow LangChain flavor does not handle partner packages correctly when loading the model back. This is because we rely on the LangChain's `load_chain` / `load_llm` functions that only loads classes from the community package.

We explored options to fix this issue, but none of them seem to be a good solution. For example, using [their new serialization method](https://python.langchain.com/v0.2/docs/how_to/serialization/) appeared to be a feasible option, but it turned out that the method has too many unsupported objects e.g. AgentExecutor, RunnableLambda. Another option was to do patching for class loading like what we did for ChatOpenAI, but it is not realistic to patch for each of 10> partner packages.

Therefore, our conclusion was just to promote [model-from-code](https://mlflow.org/docs/latest/models.html#models-from-code) instead of solving the issue. When users defines the model as code, it has explicit class path and does not suffer from this issue. This is not perfect solution but good-enough as a temporary solution and eventually LangChain will remove those community implementation at all and fix the import path.


**Note**: This PR only issues a warning for runnables, not for legacy chains, because they are on deprecation path.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

![Screenshot 2024-08-13 at 17 54 13](https://github.com/user-attachments/assets/d3bf7b4f-84d4-4536-806d-6189be037504)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
