### PR TITLE
Allow colon in mlflow param and metric names

### DIFF
--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -274,7 +274,7 @@ def _validate_param_name(name):
         )
     if not validate_param_and_metric_name(name):
         raise MlflowException(
-            f"Invalid parameter name: '{name}'. {bad_path_message()}",
+            f"Invalid parameter name: '{name}'. {bad_character_message()}",
             INVALID_PARAMETER_VALUE,
         )
     if path_not_unique(name):
@@ -294,7 +294,7 @@ def _validate_tag_name(name):
         )
     if not validate_param_and_metric_name(name):
         raise MlflowException(
-            f"Invalid tag name: '{name}'. {bad_path_message()}",
+            f"Invalid tag name: '{name}'. {bad_character_message()}",
             INVALID_PARAMETER_VALUE,
         )
     if path_not_unique(name):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -115,20 +115,13 @@ def validate_param_and_metric_name(name):
 
 
 def bad_character_message():
-    # In windows system valid param and metric names: may only contain slashes, alphanumerics,
-    # underscores, periods, dashes, and spaces.
-    if is_windows():
-        return (
-            "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
-            " spaces ( ) and slashes (/)."
-        )
-
-    # For other system valid param and metric names: may only contain slashes, alphanumerics,
-    # underscores, periods, dashes, colons, and spaces.
-    return (
+    # Valid param and metric names may only contain slashes, alphanumerics, underscores,
+    # periods, dashes, colons, and spaces. For windows param and metric names can not contain colon
+    msg = (
         "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
-        " spaces ( ), colon(:) and slashes (/)."
+        " spaces ( ){} and slashes (/)."
     )
+    return msg.format(", colon(:)") if is_windows() else msg.format("")
 
 
 def path_not_unique(name):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -12,13 +12,10 @@ from mlflow.environment_variables import MLFLOW_TRUNCATE_LONG_VALUES
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
+from mlflow.utils.os import is_windows
 from mlflow.utils.string_utils import is_string_type
 
 _logger = logging.getLogger(__name__)
-
-# Regex for valid param and metric names: may only contain slashes, alphanumerics,
-# underscores, periods, dashes, and spaces.
-_VALID_PARAM_AND_METRIC_NAMES = re.compile(r"^[/\w.\- ]*$")
 
 # Regex for valid run IDs: must be an alphanumeric string of length 1 to 256.
 _RUN_ID_REGEX = re.compile(r"^[a-zA-Z0-9][\w\-]{0,255}$")
@@ -33,11 +30,6 @@ _REGISTERED_MODEL_ALIAS_REGEX = re.compile(r"^[\w\-]*$")
 
 # Regex for valid registered model alias to prevent conflict with version aliases.
 _REGISTERED_MODEL_ALIAS_VERSION_REGEX = re.compile(r"^[vV]\d+$")
-
-_BAD_CHARACTERS_MESSAGE = (
-    "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
-    " spaces ( ), and slashes (/)."
-)
 
 _BAD_ALIAS_CHARACTERS_MESSAGE = (
     "Names may only contain alphanumerics, underscores (_), and dashes (-)."
@@ -111,6 +103,34 @@ def bad_path_message(name):
     ) % posixpath.normpath(name)
 
 
+def validate_param_and_metric_name(name):
+    # In windows system valid param and metric names: may only contain slashes, alphanumerics,
+    # underscores, periods, dashes, and spaces.
+    if is_windows():
+        return re.match(r"^[/\w.\- ]*$", name)
+
+    # For other system valid param and metric names: may only contain slashes, alphanumerics,
+    # underscores, periods, dashes, colons, and spaces.
+    return re.match(r"^[/\w.\- :]*$", name)
+
+
+def bad_character_message():
+    # In windows system valid param and metric names: may only contain slashes, alphanumerics,
+    # underscores, periods, dashes, and spaces.
+    if is_windows():
+        return (
+            "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
+            " spaces ( ) and slashes (/)."
+        )
+
+    # For other system valid param and metric names: may only contain slashes, alphanumerics,
+    # underscores, periods, dashes, colons, and spaces.
+    return (
+        "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
+        " spaces ( ), colon(:) and slashes (/)."
+    )
+
+
 def path_not_unique(name):
     norm = posixpath.normpath(name)
     return norm != name or norm == "." or norm.startswith("..") or norm.startswith("/")
@@ -123,9 +143,9 @@ def _validate_metric_name(name):
             f"Metric name cannot be None. {_MISSING_KEY_NAME_MESSAGE}",
             error_code=INVALID_PARAMETER_VALUE,
         )
-    if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
+    if not validate_param_and_metric_name(name):
         raise MlflowException(
-            f"Invalid metric name: '{name}'. {_BAD_CHARACTERS_MESSAGE}",
+            f"Invalid metric name: '{name}'. {bad_character_message()}",
             INVALID_PARAMETER_VALUE,
         )
     if path_not_unique(name):
@@ -252,9 +272,9 @@ def _validate_param_name(name):
             f"Parameter name cannot be None. {_MISSING_KEY_NAME_MESSAGE}",
             error_code=INVALID_PARAMETER_VALUE,
         )
-    if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
+    if not validate_param_and_metric_name(name):
         raise MlflowException(
-            f"Invalid parameter name: '{name}'. {_BAD_CHARACTERS_MESSAGE}",
+            f"Invalid parameter name: '{name}'. {bad_path_message()}",
             INVALID_PARAMETER_VALUE,
         )
     if path_not_unique(name):
@@ -272,9 +292,9 @@ def _validate_tag_name(name):
             f"Tag name cannot be None. {_MISSING_KEY_NAME_MESSAGE}",
             error_code=INVALID_PARAMETER_VALUE,
         )
-    if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
+    if not validate_param_and_metric_name(name):
         raise MlflowException(
-            f"Invalid tag name: '{name}'. {_BAD_CHARACTERS_MESSAGE}",
+            f"Invalid tag name: '{name}'. {bad_path_message()}",
             INVALID_PARAMETER_VALUE,
         )
     if path_not_unique(name):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -449,6 +449,23 @@ def test_log_params_duplicate_keys_raises():
     assert finished_run.data.params == params
 
 
+@pytest.mark.skipif(is_windows(), reason="Windows do not support colon in params and metrics")
+def test_param_metric_with_colon():
+    with start_run() as active_run:
+        run_id = active_run.info.run_id
+        mlflow.log_param("a:b", 3)
+        mlflow.log_metric("c:d", 4)
+    finished_run = tracking.MlflowClient().get_run(run_id)
+
+    # Validate param
+    assert len(finished_run.data.params) == 1
+    assert finished_run.data.params == {"a:b": "3"}
+
+    # Validate metric
+    assert len(finished_run.data.metrics) == 1
+    assert finished_run.data.metrics["c:d"] == 4
+
+
 def test_log_batch_duplicate_entries_raises():
     with start_run() as active_run:
         run_id = active_run.info.run_id


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/piyushdaftary/mlflow/pull/12943?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12943/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12943
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/issues/12940

### What changes are proposed in this pull request?

Adding Support for colon (`:`) in mlflow param and metric names. 
Updated validation unit test to support colon.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

