### PR TITLE
Support model-from-code in LlamaIndex flavor

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -58,7 +58,7 @@ black[jupyter]==23.7.0
     # via
     #   -r lint-requirements.txt
     #   blacken-docs
-blacken-docs==1.16.0
+blacken-docs==1.18.0
     # via -r lint-requirements.txt
 boto3==1.34.133
     # via moto

--- a/docs/source/llms/llama-index/index.rst
+++ b/docs/source/llms/llama-index/index.rst
@@ -279,6 +279,11 @@ The logged index can be loaded back using the :py:func:`mlflow.llama_index.load_
     index = mlflow.llama_index.load_model(model_info.model_uri)
     index.as_query_engine().query("What is MLflow?")
 
+.. note::
+
+    The object that is passed to the ``set_model()`` method must be a LlamaIndex index that is compatible with the engine type specified during logging. More
+    objects support will be added in the future releases.
+
 
 I have an index logged with ``query`` engine type. Can I load it back a ``chat`` engine?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/llms/llama-index/index.rst
+++ b/docs/source/llms/llama-index/index.rst
@@ -111,10 +111,6 @@ The ``index`` object is the centerpiece of the LlamaIndex and MLflow integration
     documents = SimpleDirectoryReader("data").load_data()
     index = VectorStoreIndex.from_documents(documents)
 
-.. note::
-
-    Currently, MLflow LlamaIndex flavor only support logging and loading the index with the default in-memory vector store. The support for external vector stores such as ``FaissVectorStore`` and ``DatabricksVectorSearch`` will be added in future releases.
-
 Logging the Index to MLflow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -143,6 +139,13 @@ The following code is an example of logging an index to MLflow with the ``chat``
             engine_type="chat",
             input_example="What did the author do growing up?",
         )
+
+.. note::
+
+    The above code snippet passes the index object directly to the ``log_model`` function.
+    This method only works with the default ``SimpleVectorStore`` vector store, which
+    simply keeps the embedded documents in memory. If your index uses **external vector stores** such as ``QdrantVectorStore`` or ``DatabricksVectorSearch``, you can use the Model-from-Code
+    logging method. See the `How to log an index with external vector stores <#how-to-log-an-index-with-external-vector-stores>`_ for more details.
 
 .. figure:: ../../_static/images/llms/llama-index/llama-index-artifacts.png
     :alt: MLflow artifacts for the LlamaIndex index
@@ -220,6 +223,58 @@ You can disable tracing by running the same function with the ``disable`` parame
 
 FAQ
 ---
+
+
+How to log and load an index with external vector stores?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your index uses the default ``SimpleVectorStore``, you can log the index directly to MLflow using the :py:func:`mlflow.llama_index.log_model` function. MLflow persists the in-memory index data (embedded documents) to MLflow artifact store, which allows loading the index back with the same data without re-indexing the documents.
+
+However, when the index uses external vector stores like ``DatabricksVectorSearch`` and ``QdrantVectorStore``, the index data is stored remotely and they do not support local serialization. Thereby, you cannot log the index with these stores directly. For such cases, you can use the `Model-from-Code <../../../models.html#models-from-code>`_ logging that provides more control over the index saving process and allow you to use the external vector store.
+
+To use model-from-code logging, you first need to create a separate Python file that defines the index. If you are on Jupyter notebook, you can use the ``%%writefile`` magic command to save the cell code to a Python file.
+
+.. code-block:: python
+
+    %%writefile index.py
+
+    # Create Qdrant client with your own settings.
+    client = qdrant_client.QdrantClient(
+        host="localhost",
+        port=6333,
+    )
+
+    # Here we simply load vector store from the existing collection to avoid
+    # re-indexing documents, because this Python file is executed every time
+    # when the model is loaded. If you don't have an existing collection, create
+    # a new one by following the official tutorial:
+    # https://docs.llamaindex.ai/en/stable/examples/vector_stores/QdrantIndexDemo/
+    vector_store = QdrantVectorStore(client=client, collection_name="my_collection")
+    index = VectorStoreIndex.from_vector_store(vector_store=vector_store)
+
+    # IMPORTANT: call set_model() method to tell MLflow to log this index
+    mlflow.models.set_model(index)
+
+Then you can log the index by passing the Python file path to the :py:func:`mlflow.llama_index.log_model` function. The global `Settings <https://docs.llamaindex.ai/en/stable/module_guides/supporting_modules/settings/>`_ object is saved normally as part of the model.
+
+.. code-block:: python
+
+    import mlflow
+
+    with mlflow.start_run():
+        model_info = mlflow.llama_index.log_model(
+            "index.py",
+            artifact_path="index",
+            engine_type="query",
+        )
+
+The logged index can be loaded back using the :py:func:`mlflow.llama_index.load_model` or :py:func:`mlflow.pyfunc.load_model` function, in the same way as with the local index.
+
+.. code-block:: python
+
+    index = mlflow.llama_index.load_model(model_info.model_uri)
+    index.as_query_engine().query("What is MLflow?")
+
 
 I have an index logged with ``query`` engine type. Can I load it back a ``chat`` engine?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/llms/llama-index/index.rst
+++ b/docs/source/llms/llama-index/index.rst
@@ -234,6 +234,8 @@ However, when the index uses external vector stores like ``DatabricksVectorSearc
 
 To use model-from-code logging, you first need to create a separate Python file that defines the index. If you are on Jupyter notebook, you can use the ``%%writefile`` magic command to save the cell code to a Python file.
 
+.. blacken-docs:off
+
 .. code-block:: python
 
     %%writefile index.py
@@ -254,6 +256,8 @@ To use model-from-code logging, you first need to create a separate Python file 
 
     # IMPORTANT: call set_model() method to tell MLflow to log this index
     mlflow.models.set_model(index)
+
+.. blacken-docs:on
 
 Then you can log the index by passing the Python file path to the :py:func:`mlflow.llama_index.log_model` function. The global `Settings <https://docs.llamaindex.ai/en/stable/module_guides/supporting_modules/settings/>`_ object is saved normally as part of the model.
 

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -421,7 +421,7 @@ def autolog(
     only supports autologging for tracing.
 
     Args:
-        log_traces: If ``True``, traces are logged for LlamIndex models by using. If ``False``,
+        log_traces: If ``True``, traces are logged for LlamaIndex models by using. If ``False``,
             no traces are collected during inference. Default to ``True``.
         disable: If ``True``, disables the LlamaIndex autologging integration. If ``False``,
             enables the LlamaIndex autologging integration.

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import tempfile
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
@@ -8,9 +9,13 @@ import mlflow
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature
-from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.models.model import MLMODEL_FILE_NAME, MODEL_CODE_PATH
 from mlflow.models.signature import _infer_signature_from_input_example
-from mlflow.models.utils import _save_example
+from mlflow.models.utils import (
+    _load_model_code_path,
+    _save_example,
+    _validate_and_get_model_code_path,
+)
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -33,6 +38,7 @@ from mlflow.utils.model_utils import (
     _add_code_from_conf_to_system_path,
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
+    _validate_and_copy_file_to_directory,
     _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
@@ -140,11 +146,25 @@ def save_model(
     from mlflow.llama_index.serialize_objects import serialize_settings
 
     _validate_engine_type(engine_type)
-    _validate_index(index)
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
-    path = os.path.abspath(path)
-    _validate_and_prepare_target_save_path(path)
+    # TODO: make this logic cleaner and maybe a util
+    with tempfile.TemporaryDirectory() as temp_dir:
+        index_or_code_path = _validate_and_prepare_llama_index_model_or_path(index, temp_dir)
+
+        _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+
+        path = os.path.abspath(path)
+        _validate_and_prepare_target_save_path(path)
+
+        model_code_path = None
+        if isinstance(index_or_code_path, str):
+            model_code_path = index_or_code_path
+            index = _load_model_code_path(model_code_path, model_config)
+            _validate_and_copy_file_to_directory(model_code_path, path, "code")
+
+        else:
+            index = index_or_code_path
+
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:
@@ -171,7 +191,9 @@ def save_model(
     settings_path = os.path.join(path, _SETTINGS_FILE)
     serialize_settings(settings_path)
 
-    _save_index(index, path)
+    # Do not save the index object in model-from-code saving mode
+    if not isinstance(model_code_path, str):
+        _save_index(index, path)
 
     pyfunc.add_to_model(
         mlflow_model,
@@ -179,6 +201,7 @@ def save_model(
         conda_env=_CONDA_ENV_FILE_NAME,
         python_env=_PYTHON_ENV_FILE_NAME,
         code=code_dir_subpath,
+        model_code_path=model_code_path,
         model_config=model_config,
     )
     mlflow_model.add_flavor(
@@ -298,14 +321,19 @@ def log_model(
     )
 
 
-def _validate_index(index):
+def _validate_and_prepare_llama_index_model_or_path(index, temp_dir=None):
     from llama_index.core.indices.base import BaseIndex
+
+    if isinstance(index, str):
+        return _validate_and_get_model_code_path(index, temp_dir)
 
     if not isinstance(index, BaseIndex):
         raise MlflowException.invalid_parameter_value(
             message=f"The provided object of type {type(index).__name__} is not a valid "
             "index. MLflow llama-index flavor only supports saving LlamaIndex indices."
         )
+
+    return index
 
 
 def _save_index(index, path):
@@ -320,9 +348,21 @@ def _load_index(path, flavor_conf):
 
     _add_code_from_conf_to_system_path(path, flavor_conf)
 
-    index_path = os.path.join(path, _INDEX_PERSIST_FOLDER)
-    storage_context = StorageContext.from_defaults(persist_dir=index_path)
-    return load_index_from_storage(storage_context)
+    # Handle model-from-code
+    pyfunc_flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=pyfunc.FLAVOR_NAME)
+    if model_code_path := pyfunc_flavor_conf.get(MODEL_CODE_PATH):
+        # TODO: The code path saved in the MLModel file is the local absolute path to the code
+        # file when it is saved. We should update the relative path in artifact directory.
+        model_code_path = os.path.join(
+            path,
+            os.path.basename(model_code_path),
+        )
+        return _load_model_code_path(model_code_path, flavor_conf)
+    else:
+        # Use default vector store when loading from the serialized index
+        index_path = os.path.join(path, _INDEX_PERSIST_FOLDER)
+        storage_context = StorageContext.from_defaults(persist_dir=index_path)
+        return load_index_from_storage(storage_context)
 
 
 @experimental
@@ -381,9 +421,8 @@ def autolog(
     only supports autologging for tracing.
 
     Args:
-        log_traces: If ``True``, traces are logged for Langchain models by using
-            MlflowLangchainTracer as a callback during inference. If ``False``, no traces are
-            collected during inference. Default to ``True``.
+        log_traces: If ``True``, traces are logged for LlamIndex models by using. If ``False``,
+            no traces are collected during inference. Default to ``True``.
         disable: If ``True``, disables the LlamaIndex autologging integration. If ``False``,
             enables the LlamaIndex autologging integration.
         silent: If ``True``, suppress all event logs and warnings from MLflow during LlamaIndex

--- a/mlflow/llama_index/pyfunc_wrapper.py
+++ b/mlflow/llama_index/pyfunc_wrapper.py
@@ -43,6 +43,9 @@ class _LlamaIndexModelWrapperBase:
         self.index = index
         self.model_config = model_config or {}
 
+    def get_raw_model(self):
+        return self.engine
+
     def _predict_single(self, *args, **kwargs) -> Any:
         raise NotImplementedError
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -723,6 +723,8 @@ llama_index:
           # Required to test Databricks integration
           "llama-index-llms-databricks",
           "llama-index-embeddings-databricks",
+          # Required to test external vector stores
+          "llama-index-vector-stores-faiss",
         ]
     run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
   autologging:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -724,7 +724,7 @@ llama_index:
           "llama-index-llms-databricks",
           "llama-index-embeddings-databricks",
           # Required to test external vector stores
-          "llama-index-vector-stores-faiss",
+          "llama-index-vector-stores-qdrant",
         ]
     run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
   autologging:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -67,6 +67,9 @@ METADATA_FILES = [
 ]
 MODEL_CONFIG = "config"
 MODEL_CODE_PATH = "model_code_path"
+SET_MODEL_ERROR = (
+    "Model should either be an instance of PyFuncModel, Langchain type, or LlamaIndex type."
+)
 
 
 class ModelInfo:
@@ -1001,6 +1004,18 @@ def update_model_requirements(
 __mlflow_model__ = None
 
 
+def _validate_langchain_model(model):
+    from mlflow.langchain import _validate_and_prepare_lc_model_or_path
+
+    return _validate_and_prepare_lc_model_or_path(model, None)
+
+
+def _validate_llama_index_model(model):
+    from mlflow.llama_index import _validate_and_prepare_llama_index_model_or_path
+
+    return _validate_and_prepare_llama_index_model_or_path(model, None)
+
+
 @experimental
 def set_model(model):
     """
@@ -1012,20 +1027,17 @@ def set_model(model):
     """
     from mlflow.pyfunc import PythonModel
 
-    if not (isinstance(model, PythonModel) or callable(model)):
-        try:
-            from mlflow.langchain import _validate_and_prepare_lc_model_or_path
+    if isinstance(model, str):
+        raise mlflow.MlflowException(SET_MODEL_ERROR)
 
-            # If its not a PyFuncModel, then it should be a Langchain model (not a path)
-            # Check this since the validation function does not
-            if isinstance(model, str):
-                raise mlflow.MlflowException(
-                    "Model should either be an instance of PyFuncModel or Langchain type."
-                )
-            model = _validate_and_prepare_lc_model_or_path(model, None)
-        except Exception as e:
-            raise mlflow.MlflowException(
-                "Model should either be an instance of PyFuncModel or Langchain type."
-            ) from e
+    if not (isinstance(model, PythonModel) or callable(model)):
+        for validate_function in [_validate_langchain_model, _validate_llama_index_model]:
+            try:
+                globals()["__mlflow_model__"] = validate_function(model)
+                return
+            except Exception:
+                pass
+        else:
+            raise mlflow.MlflowException(SET_MODEL_ERROR)
 
     globals()["__mlflow_model__"] = model

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -68,7 +68,7 @@ METADATA_FILES = [
 MODEL_CONFIG = "config"
 MODEL_CODE_PATH = "model_code_path"
 SET_MODEL_ERROR = (
-    "Model should either be an instance of PyFuncModel, Langchain type, or LlamaIndex type."
+    "Model should either be an instance of PyFuncModel, Langchain type, or LlamaIndex index."
 )
 
 

--- a/requirements/lint-requirements.txt
+++ b/requirements/lint-requirements.txt
@@ -1,7 +1,7 @@
 ruff==0.2.1
 rstcheck==6.1.1
 black[jupyter]==23.7.0
-blacken-docs==1.16.0
+blacken-docs==1.18.0
 pre-commit==2.20.0
 toml==0.10.2
 -e ./dev/clint

--- a/tests/llama_index/sample_code/basic_vector_store.py
+++ b/tests/llama_index/sample_code/basic_vector_store.py
@@ -1,0 +1,7 @@
+from llama_index.core import Document, VectorStoreIndex
+
+import mlflow
+
+index = VectorStoreIndex.from_documents(documents=[Document.example()])
+
+mlflow.models.set_model(index)

--- a/tests/llama_index/sample_code/external_vector_store.py
+++ b/tests/llama_index/sample_code/external_vector_store.py
@@ -1,41 +1,25 @@
 """
 Sample code to define an index using an external vector store (Faiss) for model-from-code logging.
 
-Ref: https://docs.llamaindex.ai/en/stable/examples/vector_stores/FaissIndexDemo/
+Ref: https://qdrant.tech/documentation/quickstart/
 """
-import os
-
-import faiss
-from llama_index.core import (
-    Document,
-    StorageContext,
-    VectorStoreIndex,
-    load_index_from_storage,
-)
-from llama_index.vector_stores.faiss import FaissVectorStore
+from llama_index.core import VectorStoreIndex
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams
 
 import mlflow
 
-FAISS_EMBEDDING_DIM = 1536
-FAISS_PERSIST_DIR = "./faiss_persist_dir"
+# Run Qdrant with in-memory mode for testing purpose
+client = QdrantClient(location=":memory:")
+client.create_collection(
+    collection_name="test",
+    # 1536 is the size of OpenAI embeddings
+    vectors_config=VectorParams(size=1536, distance=Distance.DOT),
+)
 
-# Only create the index once
-if os.path.exists(FAISS_PERSIST_DIR):
-    vector_store = FaissVectorStore.from_persist_dir(FAISS_PERSIST_DIR)
-    storage_context = StorageContext.from_defaults(
-        vector_store=vector_store,
-        persist_dir=FAISS_PERSIST_DIR,
-    )
-    index = load_index_from_storage(storage_context=storage_context)
-else:
-    faiss_index = faiss.IndexFlatL2(FAISS_EMBEDDING_DIM)
-    vector_store = FaissVectorStore(faiss_index=faiss_index)
-    storage_context = StorageContext.from_defaults(vector_store=vector_store)
-    index = VectorStoreIndex.from_documents(
-        documents=[Document.example(), Document.example()],
-        storage_context=storage_context,
-    )
-    index.storage_context.persist(FAISS_PERSIST_DIR)
+vector_store = QdrantVectorStore(client=client, collection_name="test")
+index = VectorStoreIndex.from_vector_store(vector_store=vector_store)
 
 
 mlflow.models.set_model(index)

--- a/tests/llama_index/sample_code/external_vector_store.py
+++ b/tests/llama_index/sample_code/external_vector_store.py
@@ -1,0 +1,41 @@
+"""
+Sample code to define an index using an external vector store (Faiss) for model-from-code logging.
+
+Ref: https://docs.llamaindex.ai/en/stable/examples/vector_stores/FaissIndexDemo/
+"""
+import os
+
+import faiss
+from llama_index.core import (
+    Document,
+    StorageContext,
+    VectorStoreIndex,
+    load_index_from_storage,
+)
+from llama_index.vector_stores.faiss import FaissVectorStore
+
+import mlflow
+
+FAISS_EMBEDDING_DIM = 1536
+FAISS_PERSIST_DIR = "./faiss_persist_dir"
+
+# Only create the index once
+if os.path.exists(FAISS_PERSIST_DIR):
+    vector_store = FaissVectorStore.from_persist_dir(FAISS_PERSIST_DIR)
+    storage_context = StorageContext.from_defaults(
+        vector_store=vector_store,
+        persist_dir=FAISS_PERSIST_DIR,
+    )
+    index = load_index_from_storage(storage_context=storage_context)
+else:
+    faiss_index = faiss.IndexFlatL2(FAISS_EMBEDDING_DIM)
+    vector_store = FaissVectorStore(faiss_index=faiss_index)
+    storage_context = StorageContext.from_defaults(vector_store=vector_store)
+    index = VectorStoreIndex.from_documents(
+        documents=[Document.example(), Document.example()],
+        storage_context=storage_context,
+    )
+    index.storage_context.persist(FAISS_PERSIST_DIR)
+
+
+mlflow.models.set_model(index)

--- a/tests/llama_index/sample_code/external_vector_store.py
+++ b/tests/llama_index/sample_code/external_vector_store.py
@@ -6,7 +6,7 @@ Ref: https://qdrant.tech/documentation/quickstart/
 from llama_index.core import VectorStoreIndex
 from llama_index.vector_stores.qdrant import QdrantVectorStore
 from qdrant_client import QdrantClient
-from qdrant_client.models import Distance, VectorParams
+from qdrant_client.models import Distance, PointStruct, VectorParams
 
 import mlflow
 
@@ -16,6 +16,16 @@ client.create_collection(
     collection_name="test",
     # 1536 is the size of OpenAI embeddings
     vectors_config=VectorParams(size=1536, distance=Distance.DOT),
+)
+# dummy embeddings
+vec = [0.1] * 1536
+client.upsert(
+    collection_name="test",
+    wait=True,
+    points=[
+        PointStruct(id=1, vector=vec, payload={"text": "hi"}),
+        PointStruct(id=1, vector=vec, payload={"text": "hola"}),
+    ],
 )
 
 vector_store = QdrantVectorStore(client=client, collection_name="test")

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -27,6 +27,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import ColSpec, DataType, Schema
 
 _EMBEDDING_DIM = 1536
+_TEST_QUERY = "Spell llamaindex"
 
 
 @pytest.fixture
@@ -48,7 +49,7 @@ def test_llama_index_native_save_and_load_model(request, index_fixture, model_pa
     loaded_model = mlflow.llama_index.load_model(model_path)
 
     assert type(loaded_model) == type(index)
-    assert loaded_model.as_query_engine().query("Spell llamaindex").response != ""
+    assert loaded_model.as_query_engine().query(_TEST_QUERY).response != ""
 
 
 @pytest.mark.parametrize(
@@ -70,7 +71,7 @@ def test_llama_index_native_log_and_load_model(request, index_fixture):
     assert type(loaded_model) == type(index)
     engine = loaded_model.as_query_engine()
     assert engine is not None
-    assert engine.query("Spell llamaindex").response != ""
+    assert engine.query(_TEST_QUERY).response != ""
 
 
 def test_llama_index_save_invalid_object_raise():
@@ -343,13 +344,13 @@ def test_llama_index_databricks_integration(monkeypatch, document, model_path, m
 
     # validate if the mocking works
     with pytest.raises(Exception, match="Should not be called"):
-        index.as_query_engine().query("Spell llamaindex")
+        index.as_query_engine().query(_TEST_QUERY)
 
     loaded_model = mlflow.pyfunc.load_model(model_path)
 
-    response = loaded_model.predict("Spell llamaindex")
+    response = loaded_model.predict(_TEST_QUERY)
     assert isinstance(response, str)
-    assert response != ""
+    assert _TEST_QUERY in response
 
 
 @pytest.mark.parametrize(
@@ -384,4 +385,4 @@ def test_save_load_index_as_code_optional_code_path(index_code_path, vector_stor
 
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert isinstance(pyfunc_loaded_model.get_raw_model(), BaseQueryEngine)
-    assert pyfunc_loaded_model.predict("Spell llamaindex") != ""
+    assert _TEST_QUERY in pyfunc_loaded_model.predict(_TEST_QUERY)

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -1,14 +1,19 @@
+import os
+from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pandas as pd
 import pytest
 from llama_index.core import QueryBundle, Settings, VectorStoreIndex
+from llama_index.core.base.base_query_engine import BaseQueryEngine
 from llama_index.core.llms import ChatMessage
+from llama_index.core.vector_stores.simple import SimpleVectorStore
 from llama_index.embeddings.databricks import DatabricksEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.databricks import Databricks
 from llama_index.llms.openai import OpenAI
+from llama_index.vector_stores.faiss import FaissVectorStore
 
 import mlflow
 import mlflow.llama_index
@@ -18,6 +23,7 @@ from mlflow.llama_index.pyfunc_wrapper import (
     _CHAT_MESSAGE_HISTORY_PARAMETER_NAME,
     create_engine_wrapper,
 )
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import ColSpec, DataType, Schema
 
 _EMBEDDING_DIM = 1536
@@ -344,3 +350,38 @@ def test_llama_index_databricks_integration(monkeypatch, document, model_path, m
     response = loaded_model.predict("Spell llamaindex")
     assert isinstance(response, str)
     assert response != ""
+
+
+@pytest.mark.parametrize(
+    ("index_code_path", "vector_store_class"),
+    [
+        (
+            "tests/llama_index/sample_code/basic_vector_store.py",
+            SimpleVectorStore,
+        ),
+        (
+            "tests/llama_index/sample_code/external_vector_store.py",
+            FaissVectorStore,
+        ),
+    ],
+)
+def test_save_load_index_as_code_optional_code_path(index_code_path, vector_store_class):
+    with mlflow.start_run():
+        model_info = mlflow.llama_index.log_model(
+            index=index_code_path,
+            engine_type="query",
+            artifact_path="model",
+            input_example="hi",
+        )
+
+    artifact_path = Path(_download_artifact_from_uri(model_info.model_uri))
+    assert os.path.exists(artifact_path / os.path.basename(index_code_path))
+    assert not os.path.exists(artifact_path / "index")
+    assert os.path.exists(artifact_path / "settings.json")
+
+    loaded_index = mlflow.llama_index.load_model(model_info.model_uri)
+    assert isinstance(loaded_index.vector_store, vector_store_class)
+
+    pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert isinstance(pyfunc_loaded_model.get_raw_model(), BaseQueryEngine)
+    assert pyfunc_loaded_model.predict("Spell llamaindex") != ""

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -13,7 +13,7 @@ from llama_index.embeddings.databricks import DatabricksEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.databricks import Databricks
 from llama_index.llms.openai import OpenAI
-from llama_index.vector_stores.faiss import FaissVectorStore
+from llama_index.vector_stores.qdrant import QdrantVectorStore
 
 import mlflow
 import mlflow.llama_index
@@ -361,7 +361,7 @@ def test_llama_index_databricks_integration(monkeypatch, document, model_path, m
         ),
         (
             "tests/llama_index/sample_code/external_vector_store.py",
-            FaissVectorStore,
+            QdrantVectorStore,
         ),
     ],
 )

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -14,7 +14,7 @@ from scipy.sparse import csc_matrix
 
 import mlflow
 from mlflow.models import Model, ModelSignature, infer_signature, set_model, validate_schema
-from mlflow.models.model import METADATA_FILES
+from mlflow.models.model import METADATA_FILES, SET_MODEL_ERROR
 from mlflow.models.resources import DatabricksServingEndpoint, DatabricksVectorSearchIndex
 from mlflow.models.utils import _read_example, _save_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
@@ -581,7 +581,7 @@ def test_langchain_set_model():
 def test_error_set_model(sklearn_knn_model):
     with pytest.raises(
         mlflow.MlflowException,
-        match="Model should either be an instance of PyFuncModel or Langchain type.",
+        match=SET_MODEL_ERROR,
     ):
         set_model(sklearn_knn_model)
 

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -579,10 +579,7 @@ def test_langchain_set_model():
 
 
 def test_error_set_model(sklearn_knn_model):
-    with pytest.raises(
-        mlflow.MlflowException,
-        match=SET_MODEL_ERROR,
-    ):
+    with pytest.raises(mlflow.MlflowException, match=SET_MODEL_ERROR):
         set_model(sklearn_knn_model)
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12944?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12944/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12944
```

</p>
</details>

### What changes are proposed in this pull request?

(Taking over https://github.com/mlflow/mlflow/pull/12912 for timeline reason)

Support model-from-code logging in the LlamaIndex flavor, so that users can log an index with external vector stores such as `QdrantVectorStore` and `DatabricksVectorStore` (Requested in https://github.com/mlflow/mlflow/issues/12856).

The decision of using model-from-code is because of the lack of a standard way to serialize different vector store implementations. It is also extendable to non-index objects in the future.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with Databricks Vector Search.

1. Create VS endpoint and index following https://docs.llamaindex.ai/en/stable/examples/vector_stores/DatabricksVectorSearchDemo/
2. Try saving and loading with normal logging (object-based). Confirmed that loading fails.
3. Saving with model-from-code. The following is the model code:
```
%%writefile index.py

from databricks.vector_search.client import VectorSearchClient
from llama_index.core import VectorStoreIndex, StorageContext
from llama_index.vector_stores.databricks import DatabricksVectorSearch
import mlflow

# Get Databricks VectorSearch index object
client = VectorSearchClient()
databricks_index = client.get_index(
    endpoint_name="<ENDPOINT_NAME>",
    index_name="<INDEX_NAME>",
)

# Create LlamaIndex VectorSearch instance
databricks_vector_store = DatabricksVectorSearch(
    index=databricks_index,
    text_column="text",
    columns=None,
)
storage_context = StorageContext.from_defaults(
    vector_store=databricks_vector_store
)

# Create LlamaIndex index from existing vector store
index = VectorStoreIndex.from_vector_store(databricks_vector_store)


mlflow.models.set_model(index)
```

```
with mlflow.start_run(run_name="model-from-code"):
    model_info = mlflow.llama_index.log_model(
        "index.py",
        artifact_path="index",
        input_example="Why did the author choose to work on AI?",
        engine_type="query",
    )
```
4. Load the model and confirm that it loads DatabricksVectorSearch correctly.
```
loaded_index = mlflow.llama_index.load_model(model_info.model_uri)
print(loaded_index.vector_store)
# > DatabricksVectorSearch(...)

loaded_pyfunc = mlflow.pyfunc.load_model(model_info.model_uri)
loaded_pyfunc.predict("Why did the author choose to work on AI?")
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

LlamaIndex flavor support model-from-code logging, which allows saving indices with non-default vector stores such as `QdrantVectorStore` and `DatabricksVectorStore`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
