### PR TITLE
Silence autologging supported version warning for LangChain/LlamaIndex/OpenAI

### DIFF
--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -381,9 +381,9 @@ def _check_and_log_warning_for_unsupported_package_versions(integration_name):
         module = importlib.import_module(FLAVOR_TO_MODULE_NAME[integration_name])
         _logger.warning(
             f"MLflow {integration_name} autologging is known to be compatible with "
-            f"{min_var} <= {pip_release} <= {max_var}, but your current version is "
+            f"{min_var} <= {pip_release} <= {max_var}, but the installed version is "
             f"{module.__version__}. If you encounter errors during autologging, try upgrading "
-            f"/ downgrading {pip_release} to a supported version, or try upgrading MLflow.",
+            f"/ downgrading {pip_release} to a compatible version, or try upgrading MLflow.",
         )
 
 

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -1,4 +1,5 @@
 import contextlib
+import importlib
 import inspect
 import logging
 import sys
@@ -80,6 +81,17 @@ MLFLOW_EVALUATE_RESTRICT_LANGCHAIN_AUTOLOG_TO_TRACES_CONFIG = {
     "extra_model_classes": None,
     "log_traces": True,
 }
+
+# When the library version installed in the user's environment is outside of the supported
+# version range declared in `ml-package-versions.yml`, a warning message is issued to the user.
+# However, some libraries releases versions very frequently, and our configuration (updated on
+# MLflow release) cannot keep up with the pace, resulting in false alarms. Therefore, we
+# suppress warnings for certain libraries that are known to have frequent releases.
+_AUTOLOGGING_SUPPORTED_VERSION_WARNING_SUPPRESS_LIST = [
+    "langchain",
+    "llama-index",
+    "openai",
+]
 
 _logger = logging.getLogger(__name__)
 
@@ -363,13 +375,15 @@ def _check_and_log_warning_for_unsupported_package_versions(integration_name):
         and not get_autologging_config(integration_name, "disable", True)
         and not get_autologging_config(integration_name, "disable_for_unsupported_versions", False)
         and not is_flavor_supported_for_associated_package_versions(integration_name)
+        and integration_name not in _AUTOLOGGING_SUPPORTED_VERSION_WARNING_SUPPRESS_LIST
     ):
+        min_var, max_var, pip_release = get_min_max_version_and_pip_release(integration_name)
+        module = importlib.import_module(FLAVOR_TO_MODULE_NAME[integration_name])
         _logger.warning(
-            "You are using an unsupported version of %s. If you encounter errors during "
-            "autologging, try upgrading / downgrading %s to a supported version, or try "
-            "upgrading MLflow.",
-            integration_name,
-            integration_name,
+            f"MLflow {integration_name} autologging is known to be compatible with "
+            f"{min_var} <= {pip_release} <= {max_var}, but your current version is "
+            f"{module.__version__}. If you encounter errors during autologging, try upgrading "
+            f"/ downgrading {pip_release} to a supported version, or try upgrading MLflow.",
         )
 
 

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -827,7 +827,7 @@ def test_unsupported_versions_warning_should_not_shown_for_excluded_packages():
         AUTOLOGGING_INTEGRATIONS.clear()
         with mock.patch("mlflow.utils.autologging_utils._logger.warning") as log_warn_fn:
             mlflow.langchain.autolog()
-            assert (
+            assert len(log_warn_fn.call_args_list) == 0 or (
                 "MLflow langchain autologging is known to be compatible"
                 not in log_warn_fn.call_args_list[0][0]
             )

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -760,10 +760,7 @@ def test_disable_for_unsupported_versions_warning_sklearn_integration():
     log_info_fn_name = "mlflow.tracking.fluent._logger.info"
 
     def is_sklearn_warning_fired(log_warn_fn_args):
-        return (
-            "You are using an unsupported version of" in log_warn_fn_args[0][0]
-            and log_warn_fn_args[0][1] == "sklearn"
-        )
+        return "MLflow sklearn autologging is known to be compatible" in log_warn_fn_args[0][0]
 
     def is_sklearn_autolog_enabled_info_fired(log_info_fn_args):
         return (
@@ -823,6 +820,17 @@ def test_disable_for_unsupported_versions_warning_sklearn_integration():
             mlflow.sklearn.autolog(disable_for_unsupported_versions=False)
             assert log_warn_fn.call_count == 1
             assert is_sklearn_warning_fired(log_warn_fn.call_args)
+
+
+def test_unsupported_versions_warning_should_not_shown_for_excluded_packages():
+    with mock.patch("langchain.__version__", "100.200.300"):
+        AUTOLOGGING_INTEGRATIONS.clear()
+        with mock.patch("mlflow.utils.autologging_utils._logger.warning") as log_warn_fn:
+            mlflow.langchain.autolog()
+            assert (
+                "MLflow langchain autologging is known to be compatible"
+                not in log_warn_fn.call_args_list[0][0]
+            )
 
 
 def test_get_instance_method_first_arg_value():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12950?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12950/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12950
```

</p>
</details>

### What changes are proposed in this pull request?

MLflow issues a warning when the version of the autologging integrated library is not in the range defined in `ml-package-version.py`. The range is updated per every MLflow release, but some packages have faster release cycle and leads to false alarm (because we test autologging new version). 

<img width="744" alt="Screenshot 2024-08-15 at 12 51 27" src="https://github.com/user-attachments/assets/3b5ff826-35ed-4698-8747-d495b2d74acf">

This PR suppresses warnings for frequently updated libraryes - LangChain / LlamaIndex / OpenAI and also rephrase the warning message to be less scary.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

No warning with the latest LangChain:

<img width="500" alt="Screenshot 2024-08-15 at 15 02 13" src="https://github.com/user-attachments/assets/17baf75e-1cdf-404b-b4d1-f1c6ca2b0566">

The updated message is shown for other libraries:
<img width="500" alt="Screenshot 2024-08-15 at 15 02 15" src="https://github.com/user-attachments/assets/b7518bf1-8e59-4535-ad76-1850cd86afd1">


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
