### PR TITLE
Replace `querystring_parser.parse` with `flask.Request.args` in artifact handlers

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1877,10 +1877,9 @@ def _create_model_version():
 @catch_mlflow_exception
 @_disable_if_artifacts_only
 def get_model_version_artifact_handler():
-    request_dict = request.args.to_dict()
-    name = request_dict.get("name")
-    version = request_dict.get("version")
-    path = request_dict["path"]
+    name = request.args.get("name")
+    version = request.args.get("version")
+    path = request.args["path"]
     path = validate_path_is_safe(path)
     artifact_uri = _get_model_registry_store().get_model_version_download_uri(name, version)
     if _is_servable_proxied_run_artifact_root(artifact_uri):

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -611,12 +611,8 @@ def _disable_if_artifacts_only(func):
 
 @catch_mlflow_exception
 def get_artifact_handler():
-    from querystring_parser import parser
-
-    query_string = request.query_string.decode("utf-8")
-    request_dict = parser.parse(query_string, normalized=True)
-    run_id = request_dict.get("run_id") or request_dict.get("run_uuid")
-    path = request_dict["path"]
+    run_id = request.args.get("run_id") or request.args.get("run_uuid")
+    path = request.args["path"]
     path = validate_path_is_safe(path)
     run = _get_tracking_store().get_run(run_id)
 
@@ -1881,10 +1877,7 @@ def _create_model_version():
 @catch_mlflow_exception
 @_disable_if_artifacts_only
 def get_model_version_artifact_handler():
-    from querystring_parser import parser
-
-    query_string = request.query_string.decode("utf-8")
-    request_dict = parser.parse(query_string, normalized=True)
+    request_dict = request.args.to_dict()
     name = request_dict.get("name")
     version = request_dict.get("version")
     path = request_dict["path"]
@@ -2502,11 +2495,7 @@ def _delete_trace_tag(request_id):
 @catch_mlflow_exception
 @_disable_if_artifacts_only
 def get_trace_artifact_handler():
-    from querystring_parser import parser
-
-    query_string = request.query_string.decode("utf-8")
-    request_dict = parser.parse(query_string, normalized=True)
-    request_id = request_dict.get("request_id")
+    request_id = request.args.get("request_id")
 
     if not request_id:
         raise MlflowException(


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

In https://github.com/conda-forge/mlflow-feedstock/pull/187, `querystring_parser` was blocking us from uploading mlflow 2.15.0 to conda-forge. This package hasn't been updated for 3 years (https://github.com/bernii/querystring-parser). I think we should remove it before it bites us again. This PR replaces `querystring_parser.parse` calls in the artifact handlers.

There is one more `querystring_parser.parse` here, I think this is also replaceable but needs more verification. I'll fix this in another PR.

https://github.com/mlflow/mlflow/blob/72ba50b265e05e5c64d9b08f5277732993918fdf/mlflow/server/handlers.py#L479-L485

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Checked the pages on MLflow UI that use the updated artifact handlers, work fine.

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
