### PR TITLE
Remove `querystring_parser`

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -477,7 +477,7 @@ def _get_request_json(flask_request=request):
 
 
 def _get_request_message(request_message, flask_request=request, schema=None):
-    if flask_request.method == "GET" and len(flask_request.query_string) > 0:
+    if flask_request.method == "GET" and flask_request.args:
         # Convert atomic values of repeated fields to lists before calling protobuf deserialization.
         # Context: We parse the parameter string into a dictionary outside of protobuf since
         # protobuf does not know how to read the query parameters directly. The query parser above

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -477,31 +477,22 @@ def _get_request_json(flask_request=request):
 
 
 def _get_request_message(request_message, flask_request=request, schema=None):
-    from querystring_parser import parser
-
     if flask_request.method == "GET" and len(flask_request.query_string) > 0:
-        # This is a hack to make arrays of length 1 work with the parser.
-        # for example experiment_ids%5B%5D=0 should be parsed to {experiment_ids: [0]}
-        # but it gets parsed to {experiment_ids: 0}
-        # but it doesn't. However, experiment_ids%5B0%5D=0 will get parsed to the right
-        # result.
-        query_string = re.sub("%5B%5D", "%5B0%5D", flask_request.query_string.decode("utf-8"))
-        request_dict = parser.parse(query_string, normalized=True)
         # Convert atomic values of repeated fields to lists before calling protobuf deserialization.
         # Context: We parse the parameter string into a dictionary outside of protobuf since
         # protobuf does not know how to read the query parameters directly. The query parser above
         # has no type information and hence any parameter that occurs exactly once is parsed as an
         # atomic value. Since protobuf requires that the values of repeated fields are lists,
         # deserialization will fail unless we do the fix below.
+        request_json = {}
         for field in request_message.DESCRIPTOR.fields:
-            if (
-                field.label == descriptor.FieldDescriptor.LABEL_REPEATED
-                and field.name in request_dict
-            ):
-                if not isinstance(request_dict[field.name], list):
-                    request_dict[field.name] = [request_dict[field.name]]
-        request_json = request_dict
+            if field.name not in flask_request.args:
+                continue
 
+            if field.label == descriptor.FieldDescriptor.LABEL_REPEATED:
+                request_json[field.name] = flask_request.args.getlist(field.name)
+            else:
+                request_json[field.name] = flask_request.args.get(field.name)
     else:
         request_json = _get_request_json(flask_request)
 

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -35,7 +35,6 @@ dependencies = [
   "numpy<2",
   "pandas<3",
   "pyarrow<16,>=4.0.0",
-  "querystring_parser<2",
   "scikit-learn<2",
   "scipy<2",
   "sqlalchemy<3,>=1.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
   "pyarrow<16,>=4.0.0",
   "pytz<2025",
   "pyyaml<7,>=5.1",
-  "querystring_parser<2",
   "requests<3,>=2.17.3",
   "scikit-learn<2",
   "scipy<2",

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -8,7 +8,6 @@ Flask<4
 numpy<2
 scipy<2
 pandas<3
-querystring_parser<2
 sqlalchemy<3,>=1.4.0
 gunicorn<23; platform_system != 'Windows'
 waitress<4; platform_system == 'Windows'

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -31,10 +31,6 @@ pandas:
   pip_release: pandas
   max_major_version: 2
 
-querystring_parser:
-  pip_release: querystring_parser
-  max_major_version: 1
-
 sqlalchemy:
   pip_release: sqlalchemy
   minimum: "1.4.0"

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -216,7 +216,7 @@ def test_can_parse_post_json_with_content_type_params():
 def test_can_parse_get_json_with_unknown_fields():
     request = mock.MagicMock()
     request.method = "GET"
-    request.query_string = b"name=hello&superDuperUnknown=field"
+    request.args = {"name": "hello", "superDuperUnknown": "field"}
     msg = _get_request_message(CreateExperiment(), flask_request=request)
     assert msg.name == "hello"
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12960?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12960/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12960
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

See #12953 for context. This PR removes `querystring_parser`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
