### PR TITLE
Remove `pytz`

### DIFF
--- a/mlflow/utils/time.py
+++ b/mlflow/utils/time.py
@@ -1,8 +1,6 @@
 import datetime
 import time
 
-from pytz import reference
-
 
 def get_current_time_millis():
     """
@@ -15,7 +13,9 @@ def conv_longdate_to_str(longdate, local_tz=True):
     date_time = datetime.datetime.fromtimestamp(longdate / 1000.0)
     str_long_date = date_time.strftime("%Y-%m-%d %H:%M:%S")
     if local_tz:
-        str_long_date += " " + reference.LocalTimezone().tzname(date_time)
+        tzinfo = datetime.datetime.now().astimezone().tzinfo
+        if tzinfo:
+            str_long_date += " " + tzinfo.tzname(date_time)
 
     return str_long_date
 

--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -33,7 +33,6 @@ dependencies = [
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<25",
   "protobuf<6,>=3.12.0",
-  "pytz<2025",
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",
   "sqlparse<1,>=0.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
   "pandas<3",
   "protobuf<6,>=3.12.0",
   "pyarrow<16,>=4.0.0",
-  "pytz<2025",
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",
   "scikit-learn<2",

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -8,7 +8,6 @@ entrypoints<1
 gitpython<4,>=3.1.9
 pyyaml<7,>=5.1
 protobuf<6,>=3.12.0
-pytz<2025
 requests<3,>=2.17.3
 packaging<25
 importlib_metadata<8,>=3.7.0,!=4.7.0

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -32,10 +32,6 @@ protobuf:
   minimum: "3.12.0"
   max_major_version: 5
 
-pytz:
-  pip_release: pytz
-  max_major_version: 2024
-
 requests:
   pip_release: requests
   minimum: "2.17.3"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12962?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12962/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12962
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`pytz` is used to infer the local time zone. We can do the same thing using the built-in `datetime` module. No need to depend on `pytz`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Checked `mlflow runs list` behavior is the same as master:

```
# master
> mlflow runs list --experiment-id 0
Date                     Name               ID                              
-----------------------  -----------------  --------------------------------
2024-08-15 18:51:04 JST  welcoming-steed-2  60549ecdac2d4b1391001fc15faede47
2024-08-15 18:47:31 JST  loud-crow-701      a96a4f8cea9545779aa45a34a9a09077

# this PR
> mlflow runs list --experiment-id 0
Date                     Name               ID                              
-----------------------  -----------------  --------------------------------
2024-08-15 18:51:04 JST  welcoming-steed-2  60549ecdac2d4b1391001fc15faede47
2024-08-15 18:47:31 JST  loud-crow-701      a96a4f8cea9545779aa45a34a9a09077
```

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
