### PR TITLE
Remove `entrypoints`

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -26,7 +26,8 @@ from mlflow.store.tracking import DEFAULT_ARTIFACTS_URI, DEFAULT_LOCAL_FILE_AND_
 from mlflow.tracking import _get_store
 from mlflow.utils import cli_args
 from mlflow.utils.logging_utils import eprint
-from mlflow.utils.os import get_entry_points, is_windows
+from mlflow.utils.os import is_windows
+from mlflow.utils.plugins import get_entry_points
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils.server_cli_utils import (
     artifacts_only_config_validation,

--- a/mlflow/data/dataset_registry.py
+++ b/mlflow/data/dataset_registry.py
@@ -3,12 +3,11 @@ import warnings
 from contextlib import suppress
 from typing import Dict, Optional
 
-import entrypoints
-
 import mlflow.data
 from mlflow.data.dataset import Dataset
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.utils.plugins import get_entry_points
 
 
 class DatasetRegistry:
@@ -48,7 +47,7 @@ class DatasetRegistry:
         Registers dataset sources defined as Python entrypoints. For reference, see
         https://mlflow.org/docs/latest/plugins.html#defining-a-plugin.
         """
-        for entrypoint in entrypoints.get_group_all("mlflow.dataset_constructor"):
+        for entrypoint in get_entry_points("mlflow.dataset_constructor"):
             try:
                 self.register_constructor(
                     constructor_fn=entrypoint.load(), constructor_name=entrypoint.name

--- a/mlflow/data/dataset_source_registry.py
+++ b/mlflow/data/dataset_source_registry.py
@@ -1,13 +1,12 @@
 import warnings
 from typing import Any, List, Optional
 
-import entrypoints
-
 from mlflow.data.artifact_dataset_sources import register_artifact_dataset_sources
 from mlflow.data.dataset_source import DatasetSource
 from mlflow.data.http_dataset_source import HTTPDatasetSource
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.utils.plugins import get_entry_points
 
 
 class DatasetSourceRegistry:
@@ -27,7 +26,7 @@ class DatasetSourceRegistry:
         Registers dataset sources defined as Python entrypoints. For reference, see
         https://mlflow.org/docs/latest/plugins.html#defining-a-plugin.
         """
-        for entrypoint in entrypoints.get_group_all("mlflow.dataset_source"):
+        for entrypoint in get_entry_points("mlflow.dataset_source"):
             try:
                 self.register(entrypoint.load())
             except (AttributeError, ImportError) as exc:

--- a/mlflow/deployments/plugin_manager.py
+++ b/mlflow/deployments/plugin_manager.py
@@ -2,6 +2,8 @@ import abc
 import importlib.metadata
 import inspect
 
+import importlib_metadata
+
 from mlflow.deployments.base import BaseDeploymentClient
 from mlflow.deployments.utils import parse_target_uri
 from mlflow.exceptions import MlflowException
@@ -97,7 +99,7 @@ class DeploymentPlugins(PluginManager):
             )
             raise MlflowException(msg, error_code=RESOURCE_DOES_NOT_EXIST)
 
-        if isinstance(plugin_like, importlib.metadata.EntryPoint):
+        if isinstance(plugin_like, (importlib_metadata.EntryPoint, importlib.metadata.EntryPoint)):
             try:
                 plugin_obj = plugin_like.load()
             except (AttributeError, ImportError) as exc:

--- a/mlflow/deployments/plugin_manager.py
+++ b/mlflow/deployments/plugin_manager.py
@@ -2,12 +2,12 @@ import abc
 import importlib.metadata
 import inspect
 
-from build.lib.mlflow.utils.os import get_entry_points
 from mlflow.deployments.base import BaseDeploymentClient
 from mlflow.deployments.utils import parse_target_uri
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.annotations import developer_stable
+from mlflow.utils.plugins import get_entry_points
 
 # TODO: refactor to have a common base class for all the plugin implementation in MLflow
 #   mlflow/tracking/context/registry.py
@@ -53,6 +53,18 @@ class PluginManager(abc.ABC):
         to register plugins
         """
         return self._has_registered
+
+    def register(self, target_name, plugin_module):
+        """Register a deployment client given its target name and module
+        Args:
+            target_name: The name of the deployment target. This name will be used by
+                `get_deploy_client()` to retrieve a deployment client from
+                the plugin store.
+            plugin_module: The module that implements the deployment plugin interface.
+        """
+        self.registry[target_name] = importlib.metadata.EntryPoint(
+            target_name, plugin_module, self.group_name
+        )
 
     def register_entrypoints(self):
         """

--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -3,7 +3,7 @@ from typing import Dict, Type, Union
 from mlflow import MlflowException
 from mlflow.gateway.config import Provider
 from mlflow.gateway.providers import BaseProvider
-from mlflow.utils.os import get_entry_points
+from mlflow.utils.plugins import get_entry_points
 
 
 class ProviderRegistry:

--- a/mlflow/models/evaluation/evaluator_registry.py
+++ b/mlflow/models/evaluation/evaluator_registry.py
@@ -1,9 +1,8 @@
 import warnings
 
-import entrypoints
-
 from mlflow.exceptions import MlflowException
 from mlflow.utils.import_hooks import register_post_import_hook
+from mlflow.utils.plugins import get_entry_points
 
 
 class ModelEvaluatorRegistry:
@@ -20,7 +19,7 @@ class ModelEvaluatorRegistry:
 
     def register_entrypoints(self):
         # Register ModelEvaluator implementation provided by other packages
-        for entrypoint in entrypoints.get_group_all("mlflow.model_evaluator"):
+        for entrypoint in get_entry_points("mlflow.model_evaluator"):
             try:
                 self.register(entrypoint.name, entrypoint.load())
             except (AttributeError, ImportError) as exc:

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -24,7 +24,8 @@ from mlflow.server.handlers import (
     search_datasets_handler,
     upload_artifact_handler,
 )
-from mlflow.utils.os import get_entry_points, is_windows
+from mlflow.utils.os import is_windows
+from mlflow.utils.plugins import get_entry_points
 from mlflow.utils.process import _exec_cmd
 from mlflow.version import VERSION
 

--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -1,8 +1,6 @@
 import warnings
 from typing import Dict
 
-import entrypoints
-
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
@@ -19,6 +17,7 @@ from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.store.artifact.sftp_artifact_repo import SFTPArtifactRepository
 from mlflow.store.artifact.uc_volume_artifact_repo import uc_volume_artifact_repo_factory
+from mlflow.utils.plugins import get_entry_points
 from mlflow.utils.uri import get_uri_scheme, is_uc_volumes_uri
 
 
@@ -44,7 +43,7 @@ class ArtifactRepositoryRegistry:
 
     def register_entrypoints(self):
         # Register artifact repositories provided by other packages
-        for entrypoint in entrypoints.get_group_all("mlflow.artifact_repository"):
+        for entrypoint in get_entry_points("mlflow.artifact_repository"):
             try:
                 self.register(entrypoint.name, entrypoint.load())
             except (AttributeError, ImportError) as exc:

--- a/mlflow/tracking/context/registry.py
+++ b/mlflow/tracking/context/registry.py
@@ -2,8 +2,6 @@ import logging
 import warnings
 from typing import List, Optional
 
-import entrypoints
-
 from mlflow.tracking.context.abstract_context import RunContextProvider
 from mlflow.tracking.context.databricks_cluster_context import DatabricksClusterRunContext
 from mlflow.tracking.context.databricks_command_context import DatabricksCommandRunContext
@@ -13,6 +11,7 @@ from mlflow.tracking.context.databricks_repo_context import DatabricksRepoRunCon
 from mlflow.tracking.context.default_context import DefaultRunContext
 from mlflow.tracking.context.git_context import GitRunContext
 from mlflow.tracking.context.system_environment_context import SystemEnvironmentContext
+from mlflow.utils.plugins import get_entry_points
 
 _logger = logging.getLogger(__name__)
 
@@ -37,7 +36,7 @@ class RunContextProviderRegistry:
 
     def register_entrypoints(self):
         """Register tracking stores provided by other packages"""
-        for entrypoint in entrypoints.get_group_all("mlflow.run_context_provider"):
+        for entrypoint in get_entry_points("mlflow.run_context_provider"):
             try:
                 self.register(entrypoint.load())
             except (AttributeError, ImportError) as exc:

--- a/mlflow/tracking/default_experiment/registry.py
+++ b/mlflow/tracking/default_experiment/registry.py
@@ -1,12 +1,11 @@
 import logging
 import warnings
 
-import entrypoints
-
 from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 from mlflow.tracking.default_experiment.databricks_notebook_experiment_provider import (
     DatabricksNotebookExperimentProvider,
 )
+from mlflow.utils.plugins import get_entry_points
 
 _logger = logging.getLogger(__name__)
 # Listed below are the list of providers, which are used to provide MLflow Experiment IDs based on
@@ -33,7 +32,7 @@ class DefaultExperimentProviderRegistry:
 
     def register_entrypoints(self):
         """Register tracking stores provided by other packages"""
-        for entrypoint in entrypoints.get_group_all("mlflow.default_experiment_provider"):
+        for entrypoint in get_entry_points("mlflow.default_experiment_provider"):
             try:
                 self.register(entrypoint.load())
             except (AttributeError, ImportError) as exc:

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -1,10 +1,9 @@
 import warnings
 from abc import ABCMeta, abstractmethod
 
-import entrypoints
-
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.utils.plugins import get_entry_points
 from mlflow.utils.uri import get_uri_scheme
 
 
@@ -50,7 +49,7 @@ class StoreRegistry:
 
     def register_entrypoints(self):
         """Register tracking stores provided by other packages"""
-        for entrypoint in entrypoints.get_group_all(self.group_name):
+        for entrypoint in get_entry_points(self.group_name):
             try:
                 self.register(entrypoint.name, entrypoint.load())
             except (AttributeError, ImportError) as exc:

--- a/mlflow/tracking/request_auth/registry.py
+++ b/mlflow/tracking/request_auth/registry.py
@@ -1,6 +1,6 @@
 import warnings
 
-import entrypoints
+from mlflow.utils.plugins import get_entry_points
 
 REQUEST_AUTH_PROVIDER_ENTRYPOINT = "mlflow.request_auth_provider"
 
@@ -13,7 +13,7 @@ class RequestAuthProviderRegistry:
         self._registry.append(request_auth_provider())
 
     def register_entrypoints(self):
-        for entrypoint in entrypoints.get_group_all(REQUEST_AUTH_PROVIDER_ENTRYPOINT):
+        for entrypoint in get_entry_points(REQUEST_AUTH_PROVIDER_ENTRYPOINT):
             try:
                 self.register(entrypoint.load())
             except (AttributeError, ImportError) as exc:

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -1,14 +1,13 @@
 import logging
 import warnings
 
-import entrypoints
-
 from mlflow.tracking.request_header.databricks_request_header_provider import (
     DatabricksRequestHeaderProvider,
 )
 from mlflow.tracking.request_header.default_request_header_provider import (
     DefaultRequestHeaderProvider,
 )
+from mlflow.utils.plugins import get_entry_points
 
 _logger = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ class RequestHeaderProviderRegistry:
 
     def register_entrypoints(self):
         """Register tracking stores provided by other packages"""
-        for entrypoint in entrypoints.get_group_all("mlflow.request_header_provider"):
+        for entrypoint in get_entry_points("mlflow.request_header_provider"):
             try:
                 self.register(entrypoint.load())
             except (AttributeError, ImportError) as exc:

--- a/mlflow/utils/os.py
+++ b/mlflow/utils/os.py
@@ -1,6 +1,4 @@
-import importlib.metadata
 import os
-import sys
 
 
 def is_windows():
@@ -12,13 +10,3 @@ def is_windows():
 
     """
     return os.name == "nt"
-
-
-def get_entry_points(namespace):
-    if sys.version_info >= (3, 10):
-        return importlib.metadata.entry_points(group=namespace)
-    else:
-        try:
-            return importlib.metadata.entry_points().get(namespace, [])
-        except AttributeError:
-            return importlib.metadata.entry_points().select(group=namespace)

--- a/mlflow/utils/plugins.py
+++ b/mlflow/utils/plugins.py
@@ -3,7 +3,7 @@ import sys
 from typing import List
 
 
-def get_entry_points(group: str) -> List[importlib.metadata.EntryPoint]:
+def _get_entry_points(group: str) -> List[importlib.metadata.EntryPoint]:
     if sys.version_info >= (3, 10):
         return importlib.metadata.entry_points(group=group)
 
@@ -11,3 +11,7 @@ def get_entry_points(group: str) -> List[importlib.metadata.EntryPoint]:
         return importlib.metadata.entry_points().get(group, [])
     except AttributeError:
         return importlib.metadata.entry_points().select(group=group)
+
+
+def get_entry_points(group: str) -> List[importlib.metadata.EntryPoint]:
+    return _get_entry_points(group)

--- a/mlflow/utils/plugins.py
+++ b/mlflow/utils/plugins.py
@@ -1,0 +1,13 @@
+import importlib.metadata
+import sys
+from typing import List
+
+
+def get_entry_points(group: str) -> List[importlib.metadata.EntryPoint]:
+    if sys.version_info >= (3, 10):
+        return importlib.metadata.entry_points(group=group)
+
+    try:
+        return importlib.metadata.entry_points().get(group, [])
+    except AttributeError:
+        return importlib.metadata.entry_points().select(group=group)

--- a/mlflow/utils/plugins.py
+++ b/mlflow/utils/plugins.py
@@ -7,10 +7,11 @@ def _get_entry_points(group: str) -> List[importlib.metadata.EntryPoint]:
     if sys.version_info >= (3, 10):
         return importlib.metadata.entry_points(group=group)
 
+    entrypoints = importlib.metadata.entry_points()
     try:
-        return importlib.metadata.entry_points().get(group, [])
+        return entrypoints.get(group, [])
     except AttributeError:
-        return importlib.metadata.entry_points().select(group=group)
+        return entrypoints.select(group=group)
 
 
 def get_entry_points(group: str) -> List[importlib.metadata.EntryPoint]:

--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -26,7 +26,6 @@ dependencies = [
   "click<9,>=7.0",
   "cloudpickle<4",
   "databricks-sdk<1,>=0.20.0",
-  "entrypoints<1",
   "gitpython<4,>=3.1.9",
   "importlib_metadata<8,>=3.7.0,!=4.7.0",
   "opentelemetry-api<3,>=1.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "cloudpickle<4",
   "databricks-sdk<1,>=0.20.0",
   "docker<8,>=4.0.0",
-  "entrypoints<1",
   "gitpython<4,>=3.1.9",
   "graphene<4",
   "gunicorn<23; platform_system != 'Windows'",
@@ -255,6 +254,7 @@ forced-separate = ["tests"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "pkg_resources".msg = "Do not use pkg_resources. Use importlib.resources or importlib.metadata instead."
+"entrypoints".msg = "Do not use entrypoints. Use importlib.metadata.entry_points instead."
 "pip".msg = "Importing pip can cause undesired side effects such as https://github.com/scikit-learn/scikit-learn/issues/26992. Consider using `subprocess.run([sys.executable, '-m', 'pip', ...])` instead."
 
 [tool.ruff.lint.pydocstyle]

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -4,7 +4,6 @@
 
 click<9,>=7.0
 cloudpickle<4
-entrypoints<1
 gitpython<4,>=3.1.9
 pyyaml<7,>=5.1
 protobuf<6,>=3.12.0

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -13,10 +13,6 @@ cloudpickle:
   pip_release: cloudpickle
   max_major_version: 3
 
-entrypoints:
-  pip_release: entrypoints
-  max_major_version: 0
-
 gitpython:
   pip_release: gitpython
   minimum: "3.1.9"

--- a/tests/projects/backend/test_loader.py
+++ b/tests/projects/backend/test_loader.py
@@ -1,25 +1,18 @@
+import importlib.metadata
 from unittest import mock
-
-import entrypoints
 
 from mlflow.projects.backend import loader
 
 
 def test_plugin_backend():
-    mock_entry_point = mock.MagicMock(spec=entrypoints.EntryPoint)
-    with mock.patch("entrypoints.get_single", return_value=mock_entry_point) as mock_get_single:
+    with mock.patch(
+        "mlflow.projects.backend.loader.get_entry_points",
+        return_value=[mock.MagicMock(spec=importlib.metadata.EntryPoint)],
+    ) as mock_get_single:
         loader.load_backend("my_plugin")
-        # Check calls to entrypoints
-        mock_get_single.assert_called_with(loader.ENTRYPOINT_GROUP_NAME, "my_plugin")
-        # Check backend has been built
-        mock_entry_point.load.assert_called_once()
+        mock_get_single.assert_called_once()
 
 
 def test_plugin_does_not_exist():
-    def raise_entrypoint_exception(group, name):
-        raise entrypoints.NoSuchEntryPoint(group, name)
-
-    with mock.patch("entrypoints.get_single") as mock_get_single:
-        mock_get_single.side_effect = raise_entrypoint_exception
-        backend = loader.load_backend("my_plugin")
-        assert backend is None
+    backend = loader.load_backend("my_plugin")
+    assert backend is None

--- a/tests/projects/backend/test_loader.py
+++ b/tests/projects/backend/test_loader.py
@@ -6,7 +6,7 @@ from mlflow.projects.backend import loader
 
 def test_plugin_backend():
     with mock.patch(
-        "mlflow.projects.backend.loader.get_entry_points",
+        "mlflow.utils.plugins._get_entry_points",
         return_value=[mock.MagicMock(spec=importlib.metadata.EntryPoint)],
     ) as mock_get_single:
         loader.load_backend("my_plugin")

--- a/tests/store/artifact/test_artifact_repository_registry.py
+++ b/tests/store/artifact/test_artifact_repository_registry.py
@@ -12,7 +12,7 @@ def test_standard_artifact_registry():
     mock_entrypoint = mock.Mock()
     mock_entrypoint.name = "mock-scheme"
 
-    with mock.patch("entrypoints.get_group_all", return_value=[mock_entrypoint]):
+    with mock.patch("mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]):
         # Entrypoints are registered at import time, so we need to reload the
         # module to register the entrypoint given by the mocked
         # entrypoints.get_group_all
@@ -80,7 +80,7 @@ def test_plugin_registration_via_entrypoints():
     mock_entrypoint.name = "mock-scheme"
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         artifact_repository_registry = ArtifactRepositoryRegistry()
         artifact_repository_registry.register_entrypoints()
@@ -102,7 +102,7 @@ def test_plugin_registration_failure_via_entrypoints(exception):
     mock_entrypoint.name = "mock-scheme"
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         repo_registry = ArtifactRepositoryRegistry()
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -233,7 +233,7 @@ def test_standard_store_registry_with_mocked_entrypoint():
     mock_entrypoint = mock.Mock()
     mock_entrypoint.name = "mock-scheme"
 
-    with mock.patch("importlib.metadata.entry_points", return_value=[mock_entrypoint]):
+    with mock.patch("mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]):
         # Entrypoints are registered at import time, so we need to reload the
         # module to register the entrypoint given by the mocked
         # entrypoints.get_group_all
@@ -291,7 +291,7 @@ def test_plugin_registration_via_entrypoints():
     mock_entrypoint.name = "mock-scheme"
 
     with mock.patch(
-        "importlib.metadata.entry_points", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         tracking_store = TrackingStoreRegistry()
         tracking_store.register_entrypoints()
@@ -309,9 +309,7 @@ def test_handle_plugin_registration_failure_via_entrypoints(exception):
     mock_entrypoint = mock.Mock(load=mock.Mock(side_effect=exception))
     mock_entrypoint.name = "mock-scheme"
 
-    with mock.patch(
-        "importlib.metadata.entry_points", return_value=[mock_entrypoint]
-    ) as mock_get_group_all:
+    with mock.patch("mlflow.plugins._", return_value=[mock_entrypoint]) as mock_get_group_all:
         tracking_store = TrackingStoreRegistry()
 
         # Check that the raised warning contains the message from the original exception

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -309,7 +309,9 @@ def test_handle_plugin_registration_failure_via_entrypoints(exception):
     mock_entrypoint = mock.Mock(load=mock.Mock(side_effect=exception))
     mock_entrypoint.name = "mock-scheme"
 
-    with mock.patch("mlflow.plugins._", return_value=[mock_entrypoint]) as mock_get_group_all:
+    with mock.patch(
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
+    ) as mock_get_group_all:
         tracking_store = TrackingStoreRegistry()
 
         # Check that the raised warning contains the message from the original exception

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -233,7 +233,7 @@ def test_standard_store_registry_with_mocked_entrypoint():
     mock_entrypoint = mock.Mock()
     mock_entrypoint.name = "mock-scheme"
 
-    with mock.patch("entrypoints.get_group_all", return_value=[mock_entrypoint]):
+    with mock.patch("importlib.metadata.entry_points", return_value=[mock_entrypoint]):
         # Entrypoints are registered at import time, so we need to reload the
         # module to register the entrypoint given by the mocked
         # entrypoints.get_group_all
@@ -291,7 +291,7 @@ def test_plugin_registration_via_entrypoints():
     mock_entrypoint.name = "mock-scheme"
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "importlib.metadata.entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         tracking_store = TrackingStoreRegistry()
         tracking_store.register_entrypoints()
@@ -310,7 +310,7 @@ def test_handle_plugin_registration_failure_via_entrypoints(exception):
     mock_entrypoint.name = "mock-scheme"
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "importlib.metadata.entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         tracking_store = TrackingStoreRegistry()
 

--- a/tests/tracking/context/test_registry.py
+++ b/tests/tracking/context/test_registry.py
@@ -27,7 +27,7 @@ def test_run_context_provider_registry_register_entrypoints():
     mock_entrypoint.load.return_value = provider_class
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         registry = RunContextProviderRegistry()
         registry.register_entrypoints()
@@ -45,7 +45,7 @@ def test_run_context_provider_registry_register_entrypoints_handles_exception(ex
     mock_entrypoint.load.side_effect = exception
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         registry = RunContextProviderRegistry()
         # Check that the raised warning contains the message from the original exception
@@ -82,7 +82,7 @@ def test_registry_instance_loads_entrypoints():
     mock_entrypoint.load.return_value = MockRunContext
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         # Entrypoints are registered at import time, so we need to reload the module to register the
         # entrypoint given by the mocked entrypoints.get_group_all

--- a/tests/tracking/default_experiment/test_registry.py
+++ b/tests/tracking/default_experiment/test_registry.py
@@ -28,7 +28,7 @@ def test_default_experiment_provider_registry_register_entrypoints():
     mock_entrypoint.load.return_value = provider_class
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         registry = DefaultExperimentProviderRegistry()
         registry.register_entrypoints()
@@ -46,7 +46,7 @@ def test_default_experiment_provider_registry_register_entrypoints_handles_excep
     mock_entrypoint.load.side_effect = exception
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         registry = DefaultExperimentProviderRegistry()
         # Check that the raised warning contains the message from the original exception
@@ -81,7 +81,7 @@ def test_registry_instance_loads_entrypoints():
     mock_entrypoint.load.return_value = MockRunContext
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         # Entrypoints are registered at import time, so we need to reload the module to register the
         # entrypoint given by the mocked entrypoints.get_group_all

--- a/tests/tracking/request_auth/test_registry.py
+++ b/tests/tracking/request_auth/test_registry.py
@@ -22,7 +22,7 @@ def test_request_auth_provider_registry_register_entrypoints():
     mock_entrypoint.load.return_value = provider_class
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         registry = RequestAuthProviderRegistry()
         registry.register_entrypoints()
@@ -40,7 +40,7 @@ def test_request_auth_provider_registry_register_entrypoints_handles_exception(e
     mock_entrypoint.load.side_effect = exception
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         registry = RequestAuthProviderRegistry()
         # Check that the raised warning contains the message from the original exception
@@ -59,7 +59,7 @@ def test_registry_instance_loads_entrypoints():
     mock_entrypoint.load.return_value = MockRequestAuthProvider
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         # Entrypoints are registered at import time, so we need to reload the module to register the
         # entrypoint given by the mocked entrypoints.get_group_all

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -34,7 +34,7 @@ def test_request_header_provider_registry_register_entrypoints():
     mock_entrypoint.load.return_value = provider_class
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         registry = RequestHeaderProviderRegistry()
         registry.register_entrypoints()
@@ -52,7 +52,7 @@ def test_request_header_provider_registry_register_entrypoints_handles_exception
     mock_entrypoint.load.side_effect = exception
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         registry = RequestHeaderProviderRegistry()
         # Check that the raised warning contains the message from the original exception
@@ -83,7 +83,7 @@ def test_registry_instance_loads_entrypoints():
     mock_entrypoint.load.return_value = MockRequestHeaderProvider
 
     with mock.patch(
-        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+        "mlflow.utils.plugins._get_entry_points", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
         # Entrypoints are registered at import time, so we need to reload the module to register the
         # entrypoint given by the mocked entrypoints.get_group_all


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/12964?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12964/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12964
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

https://github.com/takluyver/entrypoints says:

> This package is in maintenance-only mode. New code should use the [importlib.metadata module](https://docs.python.org/3/library/importlib.metadata.html) in the Python standard library to find and load entry points.

To modernize the codebase, replace `entrypoints` with `importlib.metadata`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
