### PR TITLE
Improve error message of _validate_max_results_param

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -78,7 +78,11 @@ from mlflow.utils.mlflow_tags import (
     _get_run_name_from_tags,
 )
 from mlflow.utils.name_utils import _generate_random_name, _generate_unique_integer_id
-from mlflow.utils.search_utils import SearchExperimentsUtils, SearchTraceUtils, SearchUtils
+from mlflow.utils.search_utils import (
+    SearchExperimentsUtils,
+    SearchTraceUtils,
+    SearchUtils,
+)
 from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.uri import (
@@ -234,14 +238,18 @@ class FileStore(AbstractStore):
         _validate_run_id(run_uuid)
         _validate_metric_name(metric_key)
         return os.path.join(
-            self._get_run_dir(experiment_id, run_uuid), FileStore.METRICS_FOLDER_NAME, metric_key
+            self._get_run_dir(experiment_id, run_uuid),
+            FileStore.METRICS_FOLDER_NAME,
+            metric_key,
         )
 
     def _get_param_path(self, experiment_id, run_uuid, param_name):
         _validate_run_id(run_uuid)
         _validate_param_name(param_name)
         return os.path.join(
-            self._get_run_dir(experiment_id, run_uuid), FileStore.PARAMS_FOLDER_NAME, param_name
+            self._get_run_dir(experiment_id, run_uuid),
+            FileStore.PARAMS_FOLDER_NAME,
+            param_name,
         )
 
     def _get_experiment_tag_path(self, experiment_id, tag_name):
@@ -259,7 +267,9 @@ class FileStore(AbstractStore):
         _validate_run_id(run_uuid)
         _validate_tag_name(tag_name)
         return os.path.join(
-            self._get_run_dir(experiment_id, run_uuid), FileStore.TAGS_FOLDER_NAME, tag_name
+            self._get_run_dir(experiment_id, run_uuid),
+            FileStore.TAGS_FOLDER_NAME,
+            tag_name,
         )
 
     def _get_artifact_dir(self, experiment_id, run_uuid):
@@ -292,14 +302,14 @@ class FileStore(AbstractStore):
     ):
         if not isinstance(max_results, int) or max_results < 1:
             raise MlflowException(
-                "Invalid value for max_results. It must be a positive integer,"
-                f" but got {max_results}",
+                f"Invalid value {max_results} for parameter 'max_results' supplied. It must be "
+                f"a positive integer",
                 INVALID_PARAMETER_VALUE,
             )
         if max_results > SEARCH_MAX_RESULTS_THRESHOLD:
             raise MlflowException(
-                f"Invalid value for max_results. It must be at most {SEARCH_MAX_RESULTS_THRESHOLD},"
-                f" but got {max_results}",
+                f"Invalid value {max_results} for parameter 'max_results' supplied. It must be at "
+                f"most {SEARCH_MAX_RESULTS_THRESHOLD}",
                 INVALID_PARAMETER_VALUE,
             )
 
@@ -319,7 +329,8 @@ class FileStore(AbstractStore):
                     experiments.append(exp)
             except MissingConfigException as e:
                 logging.warning(
-                    f"Malformed experiment '{exp_id}'. Detailed error {e}", exc_info=True
+                    f"Malformed experiment '{exp_id}'. Detailed error {e}",
+                    exc_info=True,
                 )
         filtered = SearchExperimentsUtils.filter(experiments, filter_string)
         sorted_experiments = SearchExperimentsUtils.sort(
@@ -541,7 +552,8 @@ class FileStore(AbstractStore):
         run_info = self._get_run_info(run_id)
         if run_info is None:
             raise MlflowException(
-                f"Run '{run_id}' metadata is in invalid state.", databricks_pb2.INVALID_STATE
+                f"Run '{run_id}' metadata is in invalid state.",
+                databricks_pb2.INVALID_STATE,
             )
         new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.DELETED)
         self._overwrite_run_info(new_info, deleted_time=get_current_time_millis())
@@ -565,7 +577,9 @@ class FileStore(AbstractStore):
         current_time = get_current_time_millis()
         experiment_ids = self._get_active_experiments() + self._get_deleted_experiments()
         deleted_runs = self.search_runs(
-            experiment_ids=experiment_ids, filter_string="", run_view_type=ViewType.DELETED_ONLY
+            experiment_ids=experiment_ids,
+            filter_string="",
+            run_view_type=ViewType.DELETED_ONLY,
         )
         deleted_run_ids = []
         for deleted_run in deleted_runs:
@@ -580,7 +594,8 @@ class FileStore(AbstractStore):
         run_info = self._get_run_info(run_id)
         if run_info is None:
             raise MlflowException(
-                f"Run '{run_id}' metadata is in invalid state.", databricks_pb2.INVALID_STATE
+                f"Run '{run_id}' metadata is in invalid state.",
+                databricks_pb2.INVALID_STATE,
             )
         new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.ACTIVE)
         self._overwrite_run_info(new_info, deleted_time=None)
@@ -678,7 +693,8 @@ class FileStore(AbstractStore):
         run_info = self._get_run_info(run_id)
         if run_info is None:
             raise MlflowException(
-                f"Run '{run_id}' metadata is in invalid state.", databricks_pb2.INVALID_STATE
+                f"Run '{run_id}' metadata is in invalid state.",
+                databricks_pb2.INVALID_STATE,
             )
         return self._get_run_from_info(run_info)
 
@@ -705,7 +721,8 @@ class FileStore(AbstractStore):
         run_info = self._get_run_info_from_dir(run_dir)
         if run_info.experiment_id != exp_id:
             raise MlflowException(
-                f"Run '{run_uuid}' metadata is in invalid state.", databricks_pb2.INVALID_STATE
+                f"Run '{run_uuid}' metadata is in invalid state.",
+                databricks_pb2.INVALID_STATE,
             )
         return run_info
 
@@ -923,12 +940,21 @@ class FileStore(AbstractStore):
                 # artifact storage, it's common the folder is not a run folder
                 r_id = os.path.basename(r_dir)
                 logging.debug(
-                    "Malformed run '%s'. Detailed error %s", r_id, str(rnfe), exc_info=True
+                    "Malformed run '%s'. Detailed error %s",
+                    r_id,
+                    str(rnfe),
+                    exc_info=True,
                 )
         return run_infos
 
     def _search_runs(
-        self, experiment_ids, filter_string, run_view_type, max_results, order_by, page_token
+        self,
+        experiment_ids,
+        filter_string,
+        run_view_type,
+        max_results,
+        order_by,
+        page_token,
     ):
         if max_results > SEARCH_MAX_RESULTS_THRESHOLD:
             raise MlflowException(
@@ -1411,7 +1437,12 @@ class FileStore(AbstractStore):
         """
         # Save basic trace info to TRACE_INFO_FILE_NAME
         trace_info_dict = self._convert_trace_info_to_dict(trace_info)
-        write_yaml(trace_dir, FileStore.TRACE_INFO_FILE_NAME, trace_info_dict, overwrite=overwrite)
+        write_yaml(
+            trace_dir,
+            FileStore.TRACE_INFO_FILE_NAME,
+            trace_info_dict,
+            overwrite=overwrite,
+        )
         # Save request_metadata to its own folder
         self._write_dict_to_trace_sub_folder(
             trace_dir,

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -334,11 +334,23 @@ def test_search_experiments_max_results(store):
 
 
 def test_search_experiments_max_results_validation(store):
-    with pytest.raises(MlflowException, match=r"It must be a positive integer, but got None"):
+    with pytest.raises(
+        MlflowException,
+        match=r"Invalid value None for parameter 'max_results' supplied. "
+        r"It must be a positive integer",
+    ):
         store.search_experiments(max_results=None)
-    with pytest.raises(MlflowException, match=r"It must be a positive integer, but got 0"):
+    with pytest.raises(
+        MlflowException,
+        match=r"Invalid value 0 for parameter 'max_results' supplied. "
+        r"It must be a positive integer",
+    ):
         store.search_experiments(max_results=0)
-    with pytest.raises(MlflowException, match=r"It must be at most \d+, but got 1000000"):
+    with pytest.raises(
+        MlflowException,
+        match=r"Invalid value 1000000 for parameter 'max_results' supplied. "
+        r"It must be at most 50000",
+    ):
         store.search_experiments(max_results=1_000_000)
 
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4334,10 +4334,15 @@ def test_search_traces_with_invalid_filter(store_with_traces, filter_string, err
 
 
 def test_search_traces_raise_if_max_results_arg_is_invalid(store):
-    with pytest.raises(MlflowException, match="Invalid value for request parameter"):
+    with pytest.raises(
+        MlflowException,
+        match="Invalid value 50001 for parameter 'max_results' supplied.",
+    ):
         store.search_traces(experiment_ids=[], max_results=50001)
 
-    with pytest.raises(MlflowException, match="Invalid value for request parameter"):
+    with pytest.raises(
+        MlflowException, match="Invalid value -1 for parameter 'max_results' supplied."
+    ):
         store.search_traces(experiment_ids=[], max_results=-1)
 
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -629,11 +629,23 @@ def test_search_experiments_max_results(store: SqlAlchemyStore):
 
 
 def test_search_experiments_max_results_validation(store: SqlAlchemyStore):
-    with pytest.raises(MlflowException, match=r"It must be a positive integer, but got None"):
+    with pytest.raises(
+        MlflowException,
+        match=r"Invalid value None for parameter 'max_results' supplied. "
+        r"It must be a positive integer",
+    ):
         store.search_experiments(max_results=None)
-    with pytest.raises(MlflowException, match=r"It must be a positive integer, but got 0"):
+    with pytest.raises(
+        MlflowException,
+        match=r"Invalid value 0 for parameter 'max_results' supplied. "
+        r"It must be a positive integer",
+    ):
         store.search_experiments(max_results=0)
-    with pytest.raises(MlflowException, match=r"It must be at most \d+, but got 1000000"):
+    with pytest.raises(
+        MlflowException,
+        match=r"Invalid value 1000000 for parameter 'max_results' supplied. "
+        r"It must be at most 50000",
+    ):
         store.search_experiments(max_results=1_000_000)
 
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -48,7 +48,10 @@ from mlflow.store.db.utils import (
     _get_latest_schema_revision,
     _get_schema_version,
 )
-from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
+from mlflow.store.tracking import (
+    SEARCH_MAX_RESULTS_DEFAULT,
+    SEARCH_MAX_RESULTS_THRESHOLD,
+)
 from mlflow.store.tracking.dbmodels import models
 from mlflow.store.tracking.dbmodels.models import (
     SqlDataset,
@@ -474,13 +477,19 @@ def test_search_experiments_filter_by_time_attribute(store: SqlAlchemyStore):
     assert [e.experiment_id for e in experiments] == [exp_id1]
 
     experiments = store.search_experiments(filter_string=f"creation_time != {exp1.creation_time}")
-    assert [e.experiment_id for e in experiments] == [exp_id2, store.DEFAULT_EXPERIMENT_ID]
+    assert [e.experiment_id for e in experiments] == [
+        exp_id2,
+        store.DEFAULT_EXPERIMENT_ID,
+    ]
 
     experiments = store.search_experiments(filter_string=f"creation_time >= {time_before_create1}")
     assert [e.experiment_id for e in experiments] == [exp_id2, exp_id1]
 
     experiments = store.search_experiments(filter_string=f"creation_time < {time_before_create2}")
-    assert [e.experiment_id for e in experiments] == [exp_id1, store.DEFAULT_EXPERIMENT_ID]
+    assert [e.experiment_id for e in experiments] == [
+        exp_id1,
+        store.DEFAULT_EXPERIMENT_ID,
+    ]
 
     now = get_current_time_millis()
     experiments = store.search_experiments(filter_string=f"creation_time >= {now}")
@@ -792,7 +801,13 @@ def test_run_info(store: SqlAlchemyStore):
 
     for k, v in config.items():
         # These keys were removed from RunInfo.
-        if k in ["source_name", "source_type", "source_version", "name", "entry_point_name"]:
+        if k in [
+            "source_name",
+            "source_type",
+            "source_version",
+            "name",
+            "entry_point_name",
+        ]:
             continue
 
         v2 = getattr(run.info, k)
@@ -887,7 +902,8 @@ def test_to_mlflow_entity_and_proto(store: SqlAlchemyStore):
     created_run = _run_factory(store)
     run_id = created_run.info.run_id
     store.log_metric(
-        run_id=run_id, metric=entities.Metric(key="my-metric", value=3.4, timestamp=0, step=0)
+        run_id=run_id,
+        metric=entities.Metric(key="my-metric", value=3.4, timestamp=0, step=0),
     )
     store.log_param(run_id=run_id, param=Param(key="my-param", value="param-val"))
     store.set_tag(run_id=run_id, tag=RunTag(key="my-tag", value="tag-val"))
@@ -1003,7 +1019,8 @@ def test_log_metric_concurrent_logging_succeeds(store: SqlAlchemyStore):
     def log_metrics(run):
         for metric_val in range(100):
             store.log_metric(
-                run.info.run_id, Metric("metric_key", metric_val, get_current_time_millis(), 0)
+                run.info.run_id,
+                Metric("metric_key", metric_val, get_current_time_millis(), 0),
             )
         for batch_idx in range(5):
             store.log_batch(
@@ -1022,7 +1039,8 @@ def test_log_metric_concurrent_logging_succeeds(store: SqlAlchemyStore):
             )
         for metric_val in range(100):
             store.log_metric(
-                run.info.run_id, Metric("metric_key", metric_val, get_current_time_millis(), 0)
+                run.info.run_id,
+                Metric("metric_key", metric_val, get_current_time_millis(), 0),
             )
         return "success"
 
@@ -2057,8 +2075,13 @@ def test_search_with_max_results(store: SqlAlchemyStore):
     for n in [1, 2, 4, 8, 10, 20, 50, 100, 500, 1000, 1200, 2000]:
         assert runs[: min(1200, n)] == _search_runs(store, exp, max_results=n)
 
-    with pytest.raises(MlflowException, match=r"Invalid value for request parameter max_results"):
-        _search_runs(store, exp, max_results=int(1e10))
+    maxPlusOne = SEARCH_MAX_RESULTS_THRESHOLD + 1
+
+    with pytest.raises(
+        MlflowException,
+        match=rf"Invalid value {maxPlusOne} for parameter 'max_results'",
+    ):
+        _search_runs(store, exp, max_results=maxPlusOne)
 
 
 def test_search_with_deterministic_max_results(store: SqlAlchemyStore):
@@ -2611,7 +2634,11 @@ def test_log_batch_with_unchanged_and_new_params(store: SqlAlchemyStore):
         store,
         run.info.run_id,
         metrics=[],
-        params=[entities.Param("a", "0"), entities.Param("b", "1"), entities.Param("c", "2")],
+        params=[
+            entities.Param("a", "0"),
+            entities.Param("b", "1"),
+            entities.Param("c", "2"),
+        ],
         tags=[],
     )
 
@@ -2714,7 +2741,15 @@ def test_log_batch_metrics(store: SqlAlchemyStore):
     neg_inf_metric = entities.Metric("NegInf", -float("inf"), 0, 0)
 
     # duplicate metric and metric2 values should be eliminated
-    metrics = [metric, metric2, nan_metric, pos_inf_metric, neg_inf_metric, metric, metric2]
+    metrics = [
+        metric,
+        metric2,
+        nan_metric,
+        pos_inf_metric,
+        neg_inf_metric,
+        metric,
+        metric2,
+    ]
     store._log_metrics(run.info.run_id, metrics)
 
     run = store.get_run(run.info.run_id)
@@ -2784,7 +2819,10 @@ def test_log_batch_null_metrics(store: SqlAlchemyStore):
 def test_log_batch_params_max_length_value(store: SqlAlchemyStore, monkeypatch):
     run = _run_factory(store)
     param_entities = [Param("long param", "x" * 6000), Param("short param", "xyz")]
-    expected_param_entities = [Param("long param", "x" * 6000), Param("short param", "xyz")]
+    expected_param_entities = [
+        Param("long param", "x" * 6000),
+        Param("short param", "xyz"),
+    ]
     store.log_batch(run.info.run_id, [], param_entities, [])
     _verify_logged(store, run.info.run_id, [], expected_param_entities, [])
     param_entities = [Param("long param", "x" * 6001)]
@@ -2951,7 +2989,9 @@ def _generate_large_data(store, nb_runs=1000):
     return experiment_id, run_ids
 
 
-def test_search_runs_returns_expected_results_with_large_experiment(store: SqlAlchemyStore):
+def test_search_runs_returns_expected_results_with_large_experiment(
+    store: SqlAlchemyStore,
+):
     """
     This case tests the SQLAlchemyStore implementation of the SearchRuns API to ensure
     that search queries over an experiment containing many runs, each with a large number
@@ -2999,10 +3039,18 @@ def test_search_runs_keep_all_runs_when_sorting(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("test_experiment1")
 
     r1 = store.create_run(
-        experiment_id=experiment_id, start_time=0, tags=[], user_id="Me", run_name="name"
+        experiment_id=experiment_id,
+        start_time=0,
+        tags=[],
+        user_id="Me",
+        run_name="name",
     ).info.run_uuid
     r2 = store.create_run(
-        experiment_id=experiment_id, start_time=0, tags=[], user_id="Me", run_name="name"
+        experiment_id=experiment_id,
+        start_time=0,
+        tags=[],
+        user_id="Me",
+        run_name="name",
     ).info.run_uuid
     store.set_tag(r1, RunTag(key="t1", value="1"))
     store.set_tag(r1, RunTag(key="t2", value="1"))
@@ -3035,7 +3083,11 @@ def test_try_get_run_tag(store: SqlAlchemyStore):
 def test_get_metric_history_on_non_existent_metric_key(store: SqlAlchemyStore):
     experiment_id = _create_experiments(store, "test_exp")[0]
     run = store.create_run(
-        experiment_id=experiment_id, user_id="user", start_time=0, tags=[], run_name="name"
+        experiment_id=experiment_id,
+        user_id="user",
+        start_time=0,
+        tags=[],
+        run_name="name",
     )
     run_id = run.info.run_id
     metrics = store.get_metric_history(run_id, "test_metric")
@@ -3169,7 +3221,9 @@ def test_log_inputs_and_retrieve_runs_behaves_as_expected(store: SqlAlchemyStore
     assert_dataset_inputs_equal(run3.inputs.dataset_inputs, inputs_run3)
 
 
-def test_log_input_multiple_times_does_not_overwrite_tags_or_dataset(store: SqlAlchemyStore):
+def test_log_input_multiple_times_does_not_overwrite_tags_or_dataset(
+    store: SqlAlchemyStore,
+):
     experiment_id = _create_experiments(store, "test exp")
     run = _run_factory(store, config=_get_run_configs(experiment_id))
     dataset = entities.Dataset(
@@ -3222,7 +3276,8 @@ def test_log_input_multiple_times_does_not_overwrite_tags_or_dataset(store: SqlA
     )
     other_name_input_tags = [entities.InputTag(key="k1", value="v1")]
     store.log_inputs(
-        run.info.run_id, [entities.DatasetInput(other_name_dataset, other_name_input_tags)]
+        run.info.run_id,
+        [entities.DatasetInput(other_name_dataset, other_name_input_tags)],
     )
 
     other_digest_dataset = entities.Dataset(
@@ -3235,7 +3290,8 @@ def test_log_input_multiple_times_does_not_overwrite_tags_or_dataset(store: SqlA
     )
     other_digest_input_tags = [entities.InputTag(key="k2", value="v2")]
     store.log_inputs(
-        run.info.run_id, [entities.DatasetInput(other_digest_dataset, other_digest_input_tags)]
+        run.info.run_id,
+        [entities.DatasetInput(other_digest_dataset, other_digest_input_tags)],
     )
 
     run = store.get_run(run.info.run_id)
@@ -3637,7 +3693,11 @@ def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db(monkeypatc
     store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
     experiment_id = store.create_experiment(name="exp1")
     run = store.create_run(
-        experiment_id=experiment_id, user_id="user", start_time=0, tags=[], run_name="name"
+        experiment_id=experiment_id,
+        user_id="user",
+        start_time=0,
+        tags=[],
+        run_name="name",
     )
     run_id = run.info.run_id
     metric = entities.Metric("mymetric", 1, 0, 0)
@@ -3768,7 +3828,8 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
         with TempDir() as tmp:
             dbfile_path = tmp.path("db")
             store = SqlAlchemyStore(
-                db_uri="sqlite:///" + dbfile_path, default_artifact_root=artifact_root_uri
+                db_uri="sqlite:///" + dbfile_path,
+                default_artifact_root=artifact_root_uri,
             )
             exp_id = store.create_experiment(name="exp")
             exp = store.get_experiment(exp_id)
@@ -3786,7 +3847,10 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
-        ("\\my_server/my_path/my_sub_path", "file:///{drive}my_server/my_path/my_sub_path/{e}"),
+        (
+            "\\my_server/my_path/my_sub_path",
+            "file:///{drive}my_server/my_path/my_sub_path/{e}",
+        ),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}"),
         ("#path/to/local/folder?", "file://{cwd}/{e}#path/to/local/folder?"),
@@ -3868,11 +3932,16 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
         with TempDir() as tmp:
             dbfile_path = tmp.path("db")
             store = SqlAlchemyStore(
-                db_uri="sqlite:///" + dbfile_path, default_artifact_root=artifact_root_uri
+                db_uri="sqlite:///" + dbfile_path,
+                default_artifact_root=artifact_root_uri,
             )
             exp_id = store.create_experiment(name="exp")
             run = store.create_run(
-                experiment_id=exp_id, user_id="user", start_time=0, tags=[], run_name="name"
+                experiment_id=exp_id,
+                user_id="user",
+                start_time=0,
+                tags=[],
+                run_name="name",
             )
             cwd = Path.cwd().as_posix()
             drive = Path.cwd().drive
@@ -3893,9 +3962,18 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
             "file:///{drive}my_server/my_path/my_sub_path/{e}/{r}/artifacts",
         ),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
-        ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}/{r}/artifacts"),
-        ("#path/to/local/folder?", "file://{cwd}/{e}/{r}/artifacts#path/to/local/folder?"),
-        ("file:path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
+        (
+            "/path/to/local/folder",
+            "file:///{drive}path/to/local/folder/{e}/{r}/artifacts",
+        ),
+        (
+            "#path/to/local/folder?",
+            "file://{cwd}/{e}/{r}/artifacts#path/to/local/folder?",
+        ),
+        (
+            "file:path/to/local/folder",
+            "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts",
+        ),
         (
             "file:///path/to/local/folder",
             "file:///{drive}path/to/local/folder/{e}/{r}/artifacts",
@@ -3923,7 +4001,10 @@ def test_create_run_appends_to_artifact_local_path_file_uri_correctly_on_windows
         ("path/to/local/folder", "{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
         ("/path/to/local/folder", "/path/to/local/folder/{e}/{r}/artifacts"),
         ("#path/to/local/folder?", "{cwd}/#path/to/local/folder?/{e}/{r}/artifacts"),
-        ("file:path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
+        (
+            "file:path/to/local/folder",
+            "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts",
+        ),
         (
             "file:///path/to/local/folder",
             "file:///path/to/local/folder/{e}/{r}/artifacts",
@@ -4050,7 +4131,8 @@ def _create_trace(
         store.create_experiment(store, experiment_id)
 
     with mock.patch(
-        "mlflow.store.tracking.sqlalchemy_store.generate_request_id", side_effect=lambda: request_id
+        "mlflow.store.tracking.sqlalchemy_store.generate_request_id",
+        side_effect=lambda: request_id,
     ):
         trace_info = store.start_trace(
             experiment_id=experiment_id,
@@ -4136,7 +4218,10 @@ def store_with_traces(tmp_path):
         (["timestamp"], ["tr-0", "tr-1", "tr-2", "tr-3", "tr-4"]),
         (["timestamp DESC"], ["tr-4", "tr-3", "tr-2", "tr-1", "tr-0"]),
         # Order by execution_time and timestamp
-        (["execution_time DESC", "timestamp ASC"], ["tr-3", "tr-4", "tr-0", "tr-2", "tr-1"]),
+        (
+            ["execution_time DESC", "timestamp ASC"],
+            ["tr-3", "tr-4", "tr-0", "tr-2", "tr-1"],
+        ),
         # Order by experiment ID
         (["experiment_id"], ["tr-4", "tr-3", "tr-2", "tr-1", "tr-0"]),
         # Order by status
@@ -4349,10 +4434,18 @@ def test_delete_traces(store):
 
     for i in range(10):
         _create_trace(
-            store, f"tr-exp1-{i}", exp1, tags={"tag": "apple"}, request_metadata={"rq": "foo"}
+            store,
+            f"tr-exp1-{i}",
+            exp1,
+            tags={"tag": "apple"},
+            request_metadata={"rq": "foo"},
         )
         _create_trace(
-            store, f"tr-exp2-{i}", exp2, tags={"tag": "orange"}, request_metadata={"rq": "bar"}
+            store,
+            f"tr-exp2-{i}",
+            exp2,
+            tags={"tag": "orange"},
+            request_metadata={"rq": "bar"},
         )
 
     traces, _ = store.search_traces([exp1, exp2])
@@ -4427,7 +4520,8 @@ def test_delete_traces_raises_error(store):
     exp_id = store.create_experiment("test")
 
     with pytest.raises(
-        MlflowException, match=r"Either `max_timestamp_millis` or `request_ids` must be specified."
+        MlflowException,
+        match=r"Either `max_timestamp_millis` or `request_ids` must be specified.",
     ):
         store.delete_traces(exp_id)
     with pytest.raises(
@@ -4436,7 +4530,8 @@ def test_delete_traces_raises_error(store):
     ):
         store.delete_traces(exp_id, max_timestamp_millis=100, request_ids=["request_id"])
     with pytest.raises(
-        MlflowException, match=r"`max_traces` can't be specified if `request_ids` is specified."
+        MlflowException,
+        match=r"`max_traces` can't be specified if `request_ids` is specified.",
     ):
         store.delete_traces(exp_id, max_traces=2, request_ids=["request_id"])
     with pytest.raises(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nojaf/mlflow/pull/12965?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12965/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12965
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx
Related to https://github.com/mlflow/mlflow/issues/12550

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
The test `test_search_with_max_results` in `tests/store/tracking/test_sqlalchemy_store.py` is currently failing for our Go implementation because the input value `int(1e10)` does not fit into a `int32`. Due to the nature of Python this is not a problem, but we receive a deserialization in Go because that input just does not fit into the Proto spec.

In this PR I propose to update the test so that input fits into an int32. And I've updated the error messages inside the `mlflow/store/tracking/sqlalchemy_store.py` to be more consistent with the other validation messages.

After running `pre-commit`, I did notice more changes due to formatting. Is this to be expected?

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
