### PR TITLE
Add UCFunctionToolkit Langchain dependency

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -64,7 +64,6 @@ def _extract_databricks_dependencies_from_agent(
     # SQL Warehouse ID and UC Function Names and adds them to resources.
     from langchain.agents import AgentExecutor
     from langchain_community.tools import BaseTool
-    from langchain_community.tools.databricks import UCFunctionToolkit
 
     if isinstance(agent_executor, AgentExecutor):
         agent = agent_executor.agent
@@ -83,6 +82,10 @@ def _extract_databricks_dependencies_from_agent(
                         retriever = tool.func.keywords.get("retriever")
                         yield from _get_vectorstore_from_retriever(retriever)
                     else:
+                        try:
+                            from langchain_community.tools.databricks import UCFunctionToolkit
+                        except:
+                            continue
                         # Tools here are a part of the BaseTool and have no attribute of a
                         # WarehouseID Extract the global variables of the function defined
                         # in the tool to get the UCFunctionToolkit Constants

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -79,10 +79,9 @@ def _extract_databricks_dependencies_from_agent(
             for tool in tools:
                 if isinstance(tool, BaseTool):
                     # Handle Retriever tools
-                    if hasattr(tool.func, 'keywords') and 'retriever' in tool.func.keywords:
-                        retriever = tool.func.keywords.get('retriever')
-                        for dep in _get_vectorstore_from_retriever(retriever):
-                            yield dep
+                    if hasattr(tool.func, "keywords") and "retriever" in tool.func.keywords:
+                        retriever = tool.func.keywords.get("retriever")
+                        yield from _get_vectorstore_from_retriever(retriever)
                     else:
                         # Tools here are a part of the BaseTool and have no attribute of a
                         # WarehouseID Extract the global variables of the function defined
@@ -227,6 +226,7 @@ def _traverse_runnable(
 
 def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> List[Resource]:
     from langchain.agents import AgentExecutor
+
     """
     Detects the databricks dependencies of a langchain model and returns a list of
     detected endpoint names and index names.
@@ -248,8 +248,8 @@ def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> Li
     If a chat_model is found, it will be used to extract the databricks chat dependencies.
     """
     try:
-        if (isinstance(lc_model, AgentExecutor)):
-            dependency_list = _extract_databricks_dependencies_from_agent(lc_model)
+        if isinstance(lc_model, AgentExecutor):
+            dependency_list = list(_extract_databricks_dependencies_from_agent(lc_model))
         else:
             dependency_list = list(_traverse_runnable(lc_model))
         # Filter out duplicate dependencies so same dependencies are not added multiple times

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -84,7 +84,7 @@ def _extract_databricks_dependencies_from_agent(
                     else:
                         try:
                             from langchain_community.tools.databricks import UCFunctionToolkit
-                        except:
+                        except Exception:
                             continue
                         # Tools here are a part of the BaseTool and have no attribute of a
                         # WarehouseID Extract the global variables of the function defined

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -2,6 +2,8 @@ import inspect
 import logging
 from typing import Generator, List, Optional, Set
 
+from packaging.version import Version
+
 from mlflow.models.resources import (
     DatabricksServingEndpoint,
     DatabricksSQLWarehouse,
@@ -228,6 +230,7 @@ def _traverse_runnable(
 
 
 def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> List[Resource]:
+    import langchain
     from langchain.agents import AgentExecutor
 
     """
@@ -251,7 +254,9 @@ def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> Li
     If a chat_model is found, it will be used to extract the databricks chat dependencies.
     """
     try:
-        if isinstance(lc_model, AgentExecutor):
+        if isinstance(lc_model, AgentExecutor) and Version(langchain.__version__) >= Version(
+            "0.1.0"
+        ):
             dependency_list = list(_extract_databricks_dependencies_from_agent(lc_model))
         else:
             dependency_list = list(_traverse_runnable(lc_model))

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from typing import Generator, List, Optional, Set
 
@@ -54,15 +55,13 @@ def _get_vectorstore_from_retriever(retriever) -> Generator[Resource, None, None
             yield DatabricksServingEndpoint(endpoint_name=embeddings.endpoint)
 
 
-def _extract_databricks_dependencies_from_uc_function_toolkit(
+def _extract_databricks_dependencies_from_agent_tools(
     agent,
 ) -> Generator[Resource, None, None]:
     # Tools are passed into a Langchain as Seq[BaseTool] part of an AgentExecutor
     # This function looks for an AgentExecutor, extracts all the tools generated from
     # UC Function Toolkit. From each of these tools it then extracts the Databricks
     # SQL Warehouse ID and UC Function Names and adds them to resources.
-    import inspect
-
     from langchain.agents import AgentExecutor
     from langchain_community.tools import BaseTool
     from langchain_community.tools.databricks import UCFunctionToolkit
@@ -175,7 +174,7 @@ def _extract_dependency_list_from_lc_model(lc_model) -> Generator[Resource, None
     yield from _extract_databricks_dependencies_from_chat_model(lc_model)
     yield from _extract_databricks_dependencies_from_retriever(lc_model)
     yield from _extract_databricks_dependencies_from_llm(lc_model)
-    yield from _extract_databricks_dependencies_from_uc_function_toolkit(lc_model)
+    yield from _extract_databricks_dependencies_from_agent_tools(lc_model)
 
     # recursively inspect legacy chain
     for attr_name in _LEGACY_MODEL_ATTR_SET:

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -96,7 +96,8 @@ class DatabricksVectorSearchIndex(DatabricksResource):
     @classmethod
     def from_dict(cls, data: Dict[str, str]):
         return cls(index_name=data["name"])
-    
+
+
 @dataclass
 class DatabricksSQLWarehouse(DatabricksResource):
     """
@@ -115,7 +116,8 @@ class DatabricksSQLWarehouse(DatabricksResource):
     @classmethod
     def from_dict(cls, data: Dict[str, str]):
         return cls(warehouse_id=data["name"])
-    
+
+
 @dataclass
 class DatabricksUCFunction(DatabricksResource):
     """
@@ -142,7 +144,7 @@ def _get_resource_class_by_type(target_uri: str, resource_type: ResourceType):
             ResourceType.SERVING_ENDPOINT.value: DatabricksServingEndpoint,
             ResourceType.VECTOR_SEARCH_INDEX.value: DatabricksVectorSearchIndex,
             ResourceType.SQL_WAREHOUSE.value: DatabricksSQLWarehouse,
-            ResourceType.UC_FUNCTION.value: DatabricksUCFunction
+            ResourceType.UC_FUNCTION.value: DatabricksUCFunction,
         }
     }
     resource = resource_classes.get(target_uri)

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -16,6 +16,8 @@ class ResourceType(Enum):
 
     VECTOR_SEARCH_INDEX = "vector_search_index"
     SERVING_ENDPOINT = "serving_endpoint"
+    SQL_WAREHOUSE = "sql_warehouse"
+    UC_FUNCTION = "uc_function"
 
 
 @dataclass
@@ -94,6 +96,44 @@ class DatabricksVectorSearchIndex(DatabricksResource):
     @classmethod
     def from_dict(cls, data: Dict[str, str]):
         return cls(index_name=data["name"])
+    
+@dataclass
+class DatabricksSQLWarehouse(DatabricksResource):
+    """
+    Define Databricks sql warehouse resource to serve a model.
+
+    Args:
+        warehouse_id (str): The id of the sql warehouse used by the model
+    """
+
+    type: ResourceType = ResourceType.SQL_WAREHOUSE
+    warehouse_id: str = None
+
+    def to_dict(self):
+        return {self.type.value: [{"name": self.warehouse_id}]} if self.warehouse_id else {}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, str]):
+        return cls(warehouse_id=data["name"])
+    
+@dataclass
+class DatabricksUCFunction(DatabricksResource):
+    """
+    Define Databricks UC Function to serve a model.
+
+    Args:
+        function_name (str): The name of the function used by the model
+    """
+
+    type: ResourceType = ResourceType.UC_FUNCTION
+    function_name: str = None
+
+    def to_dict(self):
+        return {self.type.value: [{"name": self.function_name}]} if self.function_name else {}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, str]):
+        return cls(function_name=data["name"])
 
 
 def _get_resource_class_by_type(target_uri: str, resource_type: ResourceType):
@@ -101,6 +141,8 @@ def _get_resource_class_by_type(target_uri: str, resource_type: ResourceType):
         "databricks": {
             ResourceType.SERVING_ENDPOINT.value: DatabricksServingEndpoint,
             ResourceType.VECTOR_SEARCH_INDEX.value: DatabricksVectorSearchIndex,
+            ResourceType.SQL_WAREHOUSE.value: DatabricksSQLWarehouse,
+            ResourceType.UC_FUNCTION.value: DatabricksUCFunction
         }
     }
     resource = resource_classes.get(target_uri)

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -250,7 +250,7 @@ def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
 
     try:
         from langchain_community.tools.databricks import UCFunctionToolkit
-    except:
+    except Exception:
         return
 
     # When get is called return a function
@@ -366,7 +366,7 @@ def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch)
         from langchain_community.tools.databricks import UCFunctionToolkit
 
         include_uc_function_tools = True
-    except:
+    except Exception:
         include_uc_function_tools = False
 
     uc_function_tools = (

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -297,10 +297,10 @@ def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
 def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain.agents import initialize_agent
-    from langchain_community.tools.databricks import UCFunctionToolkit
-    from langchain_community.chat_models import ChatDatabricks
-    from langchain_community.vectorstores import DatabricksVectorSearch
     from langchain.tools.retriever import create_retriever_tool
+    from langchain_community.chat_models import ChatDatabricks
+    from langchain_community.tools.databricks import UCFunctionToolkit
+    from langchain_community.vectorstores import DatabricksVectorSearch
 
     mock_get_deploy_client = MagicMock()
     mock_workspace_client = MagicMock()
@@ -375,8 +375,6 @@ def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch)
         verbose=True,
     )
     resources = list(_extract_databricks_dependencies_from_agent(agent))
-    for resource in resources:
-        print(resource)
     # Ensure all resources are added in
     assert resources == [
         DatabricksServingEndpoint(endpoint_name='databricks-llama-2-70b-chat'),

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -299,7 +299,10 @@ def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
         DatabricksSQLWarehouse(warehouse_id="testId1"),
     ]
 
-
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.1.0"),
+    reason="Tools are not supported the way we want in earlier versions",
+)
 def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain.agents import initialize_agent
@@ -395,10 +398,13 @@ def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch)
     ]
 
     if include_uc_function_tools:
-        expected = expected + [
+        expected = [
+            DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat"),
             DatabricksUCFunction(function_name="rag.test.test_function"),
             DatabricksUCFunction(function_name="rag.test.test_function_2"),
             DatabricksUCFunction(function_name="rag.test.test_function_3"),
+            DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
+            DatabricksServingEndpoint(endpoint_name="embedding-model"),
             DatabricksSQLWarehouse(warehouse_id="testId1"),
         ]
     assert resources == expected

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -299,6 +299,7 @@ def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
         DatabricksSQLWarehouse(warehouse_id="testId1"),
     ]
 
+
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.1.0"),
     reason="Tools are not supported the way we want in earlier versions",

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -8,10 +8,10 @@ from packaging.version import Version
 
 from mlflow.langchain.databricks_dependencies import (
     _detect_databricks_dependencies,
+    _extract_databricks_dependencies_from_agent_tools,
     _extract_databricks_dependencies_from_chat_model,
     _extract_databricks_dependencies_from_llm,
     _extract_databricks_dependencies_from_retriever,
-    _extract_databricks_dependencies_from_uc_function_toolkit,
 )
 from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
 from mlflow.models.resources import (
@@ -256,10 +256,10 @@ def test_parsing_dependency_from_uc_function_toolkit(monkeypatch: pytest.MonkeyP
         param_dict = {
             "parameters": [
                 {
-                    "name": "request_id",
+                    "name": "param",
                     "parameter_type": "PARAM",
                     "position": 0,
-                    "type_json": '{"name":"request_id","type":"string","nullable":true,"metadata":{}}',
+                    "type_json": '{"name":"param","type":"string","nullable":true,"metadata":{}}',
                     "type_name": "STRING",
                     "type_precision": 0,
                     "type_scale": 0,
@@ -287,7 +287,7 @@ def test_parsing_dependency_from_uc_function_toolkit(monkeypatch: pytest.MonkeyP
         verbose=True,
     )
 
-    resources = list(_extract_databricks_dependencies_from_uc_function_toolkit(agent))
+    resources = list(_extract_databricks_dependencies_from_agent_tools(agent))
     assert resources == [
         DatabricksUCFunction(function_name="rag.test.test_function"),
         DatabricksSQLWarehouse(warehouse_id="testId1"),
@@ -307,10 +307,10 @@ def test_parsing_multiple_dependency_from_uc_function_toolkit(monkeypatch: pytes
         param_dict = {
             "parameters": [
                 {
-                    "name": "request_id",
+                    "name": "param",
                     "parameter_type": "PARAM",
                     "position": 0,
-                    "type_json": '{"name":"request_id","type":"string","nullable":true,"metadata":{}}',
+                    "type_json": '{"name":"param","type":"string","nullable":true,"metadata":{}}',
                     "type_name": "STRING",
                     "type_precision": 0,
                     "type_scale": 0,
@@ -348,7 +348,7 @@ def test_parsing_multiple_dependency_from_uc_function_toolkit(monkeypatch: pytes
         llm,
         verbose=True,
     )
-    resources = list(_extract_databricks_dependencies_from_uc_function_toolkit(agent))
+    resources = list(_extract_databricks_dependencies_from_agent_tools(agent))
 
     # Ensure all resources are added in
     assert resources == [

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1914,6 +1914,7 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
     assert all(item in expected["serving_endpoint"] for item in actual["serving_endpoint"])
     assert actual["vector_search_index"] == expected["vector_search_index"]
 
+
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.1.0"),
     reason="Tools are not supported the way we want in earlier versions",

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 import sqlite3
+import sys
 import warnings
 from operator import itemgetter
 from typing import Any, Dict, Iterator, List, Mapping, Optional
@@ -1855,8 +1856,6 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
 
 
 def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
-    import sys
-
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain_community.tools.databricks import UCFunctionToolkit
 
@@ -1875,10 +1874,10 @@ def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
         param_dict = {
             "parameters": [
                 {
-                    "name": "request_id",
+                    "name": "param",
                     "parameter_type": "PARAM",
                     "position": 0,
-                    "type_json": '{"name":"request_id","type":"string","nullable":true,"metadata":{}}',
+                    "type_json": '{"name":"param","type":"string","nullable":true,"metadata":{}}',
                     "type_name": "STRING",
                     "type_precision": 0,
                     "type_scale": 0,

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1981,7 +1981,7 @@ def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
         from langchain_community.tools.databricks import UCFunctionToolkit
 
         include_uc_function_tools = True
-    except:
+    except Exception:
         include_uc_function_tools = False
 
     uc_function_tools = (

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -5,6 +5,7 @@ import shutil
 import sqlite3
 import sys
 import warnings
+from importlib.metadata import version
 from operator import itemgetter
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 from unittest import mock
@@ -1913,7 +1914,10 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
     assert all(item in expected["serving_endpoint"] for item in actual["serving_endpoint"])
     assert actual["vector_search_index"] == expected["vector_search_index"]
 
-
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.1.0"),
+    reason="Tools are not supported the way we want in earlier versions",
+)
 def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain.tools.retriever import create_retriever_tool

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -29,6 +29,7 @@ def test_index_name():
         "databricks": expected,
     }
 
+
 def test_sql_warehouse():
     sql_warehouse = DatabricksSQLWarehouse(warehouse_id="id1")
     expected = {"sql_warehouse": [{"name": "id1"}]}
@@ -37,6 +38,7 @@ def test_sql_warehouse():
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
+
 
 def test_uc_function():
     uc_function = DatabricksUCFunction(function_name="function")
@@ -55,7 +57,7 @@ def test_resources():
         DatabricksServingEndpoint(endpoint_name="databricks-llama-8x7b-instruct"),
         DatabricksSQLWarehouse(warehouse_id="id123"),
         DatabricksUCFunction(function_name="rag.studio.test_function_1"),
-        DatabricksUCFunction(function_name="rag.studio.test_function_2")
+        DatabricksUCFunction(function_name="rag.studio.test_function_2"),
     ]
     expected = {
         "api_version": DEFAULT_API_VERSION,

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -4,6 +4,8 @@ from mlflow.models.resources import (
     DEFAULT_API_VERSION,
     DatabricksServingEndpoint,
     DatabricksVectorSearchIndex,
+    DatabricksSQLWarehouse,
+    DatabricksUCFunction,
     _ResourceBuilder,
 )
 
@@ -27,12 +29,33 @@ def test_index_name():
         "databricks": expected,
     }
 
+def test_sql_warehouse():
+    sql_warehouse = DatabricksSQLWarehouse(warehouse_id="id1")
+    expected = {"sql_warehouse": [{"name": "id1"}]}
+    assert sql_warehouse.to_dict() == expected
+    assert _ResourceBuilder.from_resources([sql_warehouse]) == {
+        "api_version": DEFAULT_API_VERSION,
+        "databricks": expected,
+    }
+
+def test_uc_function():
+    uc_function = DatabricksUCFunction(function_name="function")
+    expected = {"uc_function": [{"name": "function"}]}
+    assert uc_function.to_dict() == expected
+    assert _ResourceBuilder.from_resources([uc_function]) == {
+        "api_version": DEFAULT_API_VERSION,
+        "databricks": expected,
+    }
+
 
 def test_resources():
     resources = [
         DatabricksVectorSearchIndex(index_name="rag.studio_bugbash.databricks_docs_index"),
         DatabricksServingEndpoint(endpoint_name="databricks-mixtral-8x7b-instruct"),
         DatabricksServingEndpoint(endpoint_name="databricks-llama-8x7b-instruct"),
+        DatabricksSQLWarehouse(warehouse_id="id123"),
+        DatabricksUCFunction(function_name="rag.studio.test_function_1"),
+        DatabricksUCFunction(function_name="rag.studio.test_function_2")
     ]
     expected = {
         "api_version": DEFAULT_API_VERSION,
@@ -41,6 +64,11 @@ def test_resources():
             "serving_endpoint": [
                 {"name": "databricks-mixtral-8x7b-instruct"},
                 {"name": "databricks-llama-8x7b-instruct"},
+            ],
+            "sql_warehouse": [{"name": "id123"}],
+            "uc_function": [
+                {"name": "rag.studio.test_function_1"},
+                {"name": "rag.studio.test_function_2"},
             ],
         },
     }
@@ -60,6 +88,11 @@ def test_resources_from_yaml(tmp_path):
                 serving_endpoint:
                 - name: databricks-mixtral-8x7b-instruct
                 - name: databricks-llama-8x7b-instruct
+                sql_warehouse:
+                - name: id123
+                uc_function:
+                - name: rag.studio.test_function_1
+                - name: rag.studio.test_function_2
             """
         )
 
@@ -70,6 +103,11 @@ def test_resources_from_yaml(tmp_path):
             "serving_endpoint": [
                 {"name": "databricks-mixtral-8x7b-instruct"},
                 {"name": "databricks-llama-8x7b-instruct"},
+            ],
+            "sql_warehouse": [{"name": "id123"}],
+            "uc_function": [
+                {"name": "rag.studio.test_function_1"},
+                {"name": "rag.studio.test_function_2"},
             ],
         },
     }

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -3,9 +3,9 @@ import pytest
 from mlflow.models.resources import (
     DEFAULT_API_VERSION,
     DatabricksServingEndpoint,
-    DatabricksVectorSearchIndex,
     DatabricksSQLWarehouse,
     DatabricksUCFunction,
+    DatabricksVectorSearchIndex,
     _ResourceBuilder,
 )
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -34,6 +34,8 @@ from mlflow.models.model import _DATABRICKS_FS_LOADER_MODULE
 from mlflow.models.resources import (
     DatabricksServingEndpoint,
     DatabricksVectorSearchIndex,
+    DatabricksSQLWarehouse,
+    DatabricksUCFunction,
 )
 from mlflow.models.utils import _read_example
 from mlflow.pyfunc.context import Context, set_prediction_context
@@ -1615,6 +1617,11 @@ def test_model_save_load_with_resources(tmp_path):
                 {"name": "azure-eastus-model-serving-2_vs_endpoint"},
             ],
             "vector_search_index": [{"name": "rag.studio_bugbash.databricks_docs_index"}],
+            "sql_warehouse": [{"name": "testid"}],
+            "uc_function": [
+                {"name": "rag.studio.test_function_a"},
+                {"name": "rag.studio.test_function_b"},
+            ],
         },
     }
     mlflow.pyfunc.save_model(
@@ -1626,6 +1633,9 @@ def test_model_save_load_with_resources(tmp_path):
             DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
             DatabricksServingEndpoint(endpoint_name="azure-eastus-model-serving-2_vs_endpoint"),
             DatabricksVectorSearchIndex(index_name="rag.studio_bugbash.databricks_docs_index"),
+            DatabricksSQLWarehouse(warehouse_id="testid"),
+            DatabricksUCFunction(function_name="rag.studio.test_function_a"),
+            DatabricksUCFunction(function_name="rag.studio.test_function_b"),
         ],
     )
 
@@ -1644,6 +1654,11 @@ def test_model_save_load_with_resources(tmp_path):
                 - name: databricks-mixtral-8x7b-instruct
                 - name: databricks-bge-large-en
                 - name: azure-eastus-model-serving-2_vs_endpoint
+                sql_warehouse:
+                - name: testid
+                uc_function:
+                - name: rag.studio.test_function_a
+                - name: rag.studio.test_function_b
             """
         )
 
@@ -1670,6 +1685,11 @@ def test_model_log_with_resources(tmp_path):
                 {"name": "azure-eastus-model-serving-2_vs_endpoint"},
             ],
             "vector_search_index": [{"name": "rag.studio_bugbash.databricks_docs_index"}],
+            "sql_warehouse": [{"name": "testid"}],
+            "uc_function": [
+                {"name": "rag.studio.test_function_a"},
+                {"name": "rag.studio.test_function_b"},
+            ],
         },
     }
     with mlflow.start_run() as run:
@@ -1681,6 +1701,9 @@ def test_model_log_with_resources(tmp_path):
                 DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
                 DatabricksServingEndpoint(endpoint_name="azure-eastus-model-serving-2_vs_endpoint"),
                 DatabricksVectorSearchIndex(index_name="rag.studio_bugbash.databricks_docs_index"),
+                DatabricksSQLWarehouse(warehouse_id="testid"),
+                DatabricksUCFunction(function_name="rag.studio.test_function_a"),
+                DatabricksUCFunction(function_name="rag.studio.test_function_b"),
             ],
         )
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
@@ -1700,6 +1723,11 @@ def test_model_log_with_resources(tmp_path):
                 - name: databricks-mixtral-8x7b-instruct
                 - name: databricks-bge-large-en
                 - name: azure-eastus-model-serving-2_vs_endpoint
+                sql_warehouse:
+                - name: testid
+                uc_function:
+                - name: rag.studio.test_function_a
+                - name: rag.studio.test_function_b
             """
         )
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -33,9 +33,9 @@ from mlflow.models.dependencies_schemas import DependenciesSchemasType
 from mlflow.models.model import _DATABRICKS_FS_LOADER_MODULE
 from mlflow.models.resources import (
     DatabricksServingEndpoint,
-    DatabricksVectorSearchIndex,
     DatabricksSQLWarehouse,
     DatabricksUCFunction,
+    DatabricksVectorSearchIndex,
 )
 from mlflow.models.utils import _read_example
 from mlflow.pyfunc.context import Context, set_prediction_context


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aravind-segu/mlflow/pull/12966?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12966/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12966
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add support for UCFunctionToolkit in Resources
- Introduces two new resources for SQL Warehouse and UC Functions
- Updates Llangchain dependency code to now also inject UCFunctionToolkit

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="912" alt="image" src="https://github.com/user-attachments/assets/12f62217-035e-454f-9f7b-cc42b420b671">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support UCFunctionToolkit in Mlflow

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
