### PR TITLE
map ints to longs in `convert_dataclass_to_schema`

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -1385,7 +1385,7 @@ class ParamSchema:
 def _map_field_type(field):
     field_type_mapping = {
         bool: "boolean",
-        int: "integer",
+        int: "long",  # int is mapped to long to support 64-bit integers
         builtins.float: "float",
         str: "string",
         bytes: "binary",

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -1,6 +1,8 @@
 import json
 
+from dataclasses import asdict
 import numpy as np
+from openai import ChatCompletion
 import pandas as pd
 import pyspark
 import pytest
@@ -18,6 +20,7 @@ from mlflow.types.schema import (
     ParamSpec,
     Schema,
     TensorSpec,
+    convert_dataclass_to_schema,
 )
 
 
@@ -313,3 +316,14 @@ def test_signature_for_rag():
         ),
         "params": None,
     }
+
+
+def test_infer_signature_and_convert_dataclass_to_schema_for_rag():
+    inferred_signature = infer_signature(
+        asdict(rag_signatures.ChatCompletionRequest()),
+        asdict(rag_signatures.ChatCompletionResponse()),
+    )
+    input_schema = convert_dataclass_to_schema(rag_signatures.ChatCompletionRequest())
+    output_schema = convert_dataclass_to_schema(rag_signatures.ChatCompletionResponse())
+    assert inferred_signature.inputs == input_schema
+    assert inferred_signature.outputs == output_schema

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -305,7 +305,7 @@ def test_signature_for_rag():
         "outputs": (
             '[{"type": "array", "items": {"type": "object", "properties": '
             '{"finish_reason": {"type": "string", "required": true}, '
-            '"index": {"type": "integer", "required": true}, '
+            '"index": {"type": "long", "required": true}, '
             '"message": {"type": "object", "properties": '
             '{"content": {"type": "string", "required": true}, '
             '"role": {"type": "string", "required": true}}, '

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -1,8 +1,7 @@
 import json
-
 from dataclasses import asdict
+
 import numpy as np
-from openai import ChatCompletion
 import pandas as pd
 import pyspark
 import pytest

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1767,7 +1767,7 @@ def test_convert_dataclass_to_schema_for_rag():
                 "type": "object",
                 "properties": {
                     "finish_reason": {"type": "string", "required": True},
-                    "index": {"type": "integer", "required": True},
+                    "index": {"type": "long", "required": True},
                     "message": {
                         "type": "object",
                         "properties": {
@@ -1808,7 +1808,7 @@ def test_convert_dataclass_to_schema_complex():
             "items": {
                 "type": "object",
                 "properties": {
-                    "bar": {"type": "integer", "required": True},
+                    "bar": {"type": "long", "required": True},
                     "config_settings": {
                         "type": "object",
                         "properties": {"baz": {"type": "boolean", "required": False}},


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bbqiu/mlflow/pull/12968?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12968/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12968
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- map ints to longs in `convert_dataclass_to_schema` to match the behavior from `infer_signature`
- add tests

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
