### PR TITLE
Filter invalid params for xgboost model predict

### DIFF
--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -368,6 +368,9 @@ class _XGBModelWrapper:
         params = params or {}
         # filter is applied inside predict_fn wrapper for xgb.Booster
         if not isinstance(self.xgb_model, xgb.Booster):
+            # Exclude unrecognized parameters as feature store team has
+            # dependency on this behavior. They might pass additional parameters
+            # that cannot be passed to the model.
             params = _exclude_unrecognized_kwargs(predict_fn, params)
         return predict_fn(dataframe, **params)
 

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -376,7 +376,7 @@ def _exclude_unrecognized_kwargs(predict_fn, kwargs):
     filtered_kwargs = {}
     allowed_params = inspect.signature(predict_fn).parameters
     # avoid excluding kwargs when predict function uses args or kwargs
-    if not allowed_params.keys().isdisjoint({"args", "kwargs"}):
+    if any(p.kind == p.VAR_POSITIONAL or p.kind == p.VAR_KEYWORD for p in allowed_params.values()):
         return kwargs
     invalid_params = set()
     for key, value in kwargs.items():

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -16,7 +16,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.utils
 import mlflow.xgboost
 from mlflow import pyfunc
-from mlflow.models import Model, ModelSignature
+from mlflow.models import Model, ModelSignature, infer_signature
 from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -627,3 +627,23 @@ def test_get_raw_model(xgb_model):
         raw_model.predict(xgb_model.inference_dmatrix),
         xgb_model.model.predict(xgb_model.inference_dmatrix),
     )
+
+
+def test_predict_filter_invalid_params(xgb_model):
+    signature = infer_signature(
+        xgb_model.inference_dataframe.head(3), params={"invalid_param": 1, "approx_contribs": True}
+    )
+    with mlflow.start_run():
+        model_info = mlflow.xgboost.log_model(xgb_model.model, "model", signature=signature)
+    pyfunc_model = pyfunc.load_model(model_info.model_uri)
+    with mock.patch("mlflow.xgboost._logger.warning") as mock_warning:
+        np.testing.assert_array_almost_equal(
+            pyfunc_model.predict(
+                xgb_model.inference_dataframe, params={"invalid_param": 2, "approx_contribs": True}
+            ),
+            xgb_model.model.predict(xgb_model.inference_dmatrix, approx_contribs=True),
+        )
+        mock_warning.assert_called_once_with(
+            "Params {'invalid_param'} are not accepted by the xgboost model, "
+            "ignoring them during predict."
+        )

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -26,6 +26,7 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.proto_json_utils import dataframe_from_parsed_json
+from mlflow.xgboost import _exclude_unrecognized_kwargs
 
 from tests.helper_functions import (
     _assert_pip_requirements,
@@ -671,3 +672,19 @@ def test_xgbmodel_predict_exclude_invalid_params(xgb_sklearn_model):
             "Params {'invalid_param'} are not accepted by the xgboost model, "
             "ignoring them during predict."
         )
+
+
+def test_exclude_unrecognized_kwargs():
+    def custom_func(*args, **kwargs):
+        return [1, 2, 3]
+
+    def custom_func2(data, **kwargs):
+        return [2, 3, 4]
+
+    def custom_func3(x, y):
+        return x + y
+
+    params = {"data": 1, "x": 1, "y": 2, "z": 3}
+    assert _exclude_unrecognized_kwargs(custom_func, params) == params
+    assert _exclude_unrecognized_kwargs(custom_func2, params) == params
+    assert _exclude_unrecognized_kwargs(custom_func3, params) == {"x": 1, "y": 2}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12974?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12974/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12974
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
For params defined in the model signature, if the underlying xgboost model doesn't accept them we will ignore them and print a warning.


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
