### PR TITLE
Fix evaluate for LlamaIndex flavor

### DIFF
--- a/mlflow/llama_index/pyfunc_wrapper.py
+++ b/mlflow/llama_index/pyfunc_wrapper.py
@@ -13,11 +13,30 @@ SUPPORTED_ENGINES = {CHAT_ENGINE_NAME, QUERY_ENGINE_NAME, RETRIEVER_ENGINE_NAME}
 _CHAT_MESSAGE_HISTORY_PARAMETER_NAME = "chat_history"
 
 
+def _convert_llm_input_data_with_unwrapping(data):
+    """
+    Transforms the input data to the format expected by the LlamaIndex engine.
+
+    TODO: Migrate the unwrapping logic to mlflow.evaluate() function or _convert_llm_input_data,
+    # because it is not specific to LlamaIndex.
+    """
+    data = _convert_llm_input_data(data)
+
+    # For mlflow.evaluate() call, the input dataset will be a pandas DataFrame. The DF should have
+    # a column named "inputs" which contains the actual query data. After the preprocessing, the
+    # each row will be passed here as a dictionary with the key "inputs". Therefore, we need to
+    # extract the actual query data from the dictionary.
+    if isinstance(data, dict) and ("inputs" in data):
+        data = data["inputs"]
+
+    return data
+
+
 def _format_predict_input_query_engine_and_retriever(data) -> "QueryBundle":
     """Convert pyfunc input to a QueryBundle."""
     from llama_index.core import QueryBundle
 
-    data = _convert_llm_input_data(data)
+    data = _convert_llm_input_data_with_unwrapping(data)
 
     if isinstance(data, str):
         return QueryBundle(query_str=data)
@@ -100,7 +119,7 @@ class ChatEngineWrapper(_LlamaIndexModelWrapperBase):
         return data
 
     def _format_predict_input(self, data) -> Union[str, Dict, List]:
-        data = _convert_llm_input_data(data)
+        data = _convert_llm_input_data_with_unwrapping(data)
 
         if isinstance(data, str):
             return data

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1477,6 +1477,8 @@ class DefaultEvaluator(ModelEvaluator):
                 return sum(y_pred_list, [])
             elif isinstance(sample_pred, pd.Series):
                 return pd.concat(y_pred_list, ignore_index=True)
+            elif isinstance(sample_pred, str):
+                return y_pred_list
             else:
                 raise MlflowException(
                     message=f"Unsupported prediction type {type(sample_pred)} for model type "

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1640,12 +1640,10 @@ def _validate_model_code_from_notebook(code):
     return output_code.encode("utf-8")
 
 
-# Convert llm input data:
-# numpy array is not json serializable, so we convert it to list
-# then send it to the model
 def _convert_llm_ndarray_to_list(data):
-    import numpy as np
-
+    """
+    Convert numpy array in the input data to list, because numpy array is not json serializable.
+    """
     if isinstance(data, np.ndarray):
         return data.tolist()
     if isinstance(data, list):
@@ -1655,10 +1653,18 @@ def _convert_llm_ndarray_to_list(data):
     return data
 
 
-def _convert_llm_input_data(data):
-    import pandas as pd
+def _convert_llm_input_data(data: Any) -> Union[List, Dict]:
+    """
+    Convert input data to a format that can be passed to the model with GenAI flavors such as
+    LangChain and LLamaIndex.
 
-    # This handles spark_udf inputs and input_example inputs
+    Args
+        data: Input data to be converted. We assume it is a single request payload, but it can be
+            in any format such as a single scalar value, a dictionary, list (with one element),
+            Pandas DataFrame, etc.
+    """
+    # This handles pyfunc / spark_udf inputs with model signature. Schema enforcement convert
+    # the input data to pandas DataFrame, so we convert it back.
     if isinstance(data, pd.DataFrame):
         # if the data only contains a single key as 0, we assume the input
         # is either a string or list of strings

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -89,7 +89,7 @@ MLFLOW_EVALUATE_RESTRICT_LANGCHAIN_AUTOLOG_TO_TRACES_CONFIG = {
 # suppress warnings for certain libraries that are known to have frequent releases.
 _AUTOLOGGING_SUPPORTED_VERSION_WARNING_SUPPRESS_LIST = [
     "langchain",
-    "llama-index",
+    "llama_index",
     "openai",
 ]
 

--- a/tests/llama_index/test_llama_index_evaluate.py
+++ b/tests/llama_index/test_llama_index_evaluate.py
@@ -5,8 +5,27 @@ import mlflow
 from mlflow.metrics import latency
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        # Single row
+        pd.DataFrame(
+            {
+                "inputs": ["What is MLflow?"],
+                "ground_truth": ["What is MLflow?"],
+            }
+        ),
+        # Multiple rows
+        pd.DataFrame(
+            {
+                "inputs": ["What is MLflow?", "What is Spark?"],
+                "ground_truth": ["What is MLflow?", "Not what is Spark?"],
+            }
+        ),
+    ],
+)
 @pytest.mark.parametrize("engine_type", ["query", "chat"])
-def test_llama_index_evaluate(engine_type, single_index):
+def test_llama_index_evaluate(data, engine_type, single_index):
     with mlflow.start_run():
         model_info = mlflow.llama_index.log_model(
             index=single_index,
@@ -15,16 +34,6 @@ def test_llama_index_evaluate(engine_type, single_index):
         )
 
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
-
-    data = pd.DataFrame(
-        {
-            "inputs": [
-                "What is MLflow?",
-                "What is Spark?",
-            ],
-            "ground_truth": ["What is MLflow?", "Not what is Spark?"],
-        }
-    )
     eval_dataset = mlflow.data.from_pandas(data, targets="ground_truth")
 
     with mlflow.start_run():

--- a/tests/llama_index/test_llama_index_evaluate.py
+++ b/tests/llama_index/test_llama_index_evaluate.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import pytest
+
+import mlflow
+from mlflow.metrics import latency
+
+
+@pytest.mark.parametrize("engine_type", ["query", "chat"])
+def test_llama_index_evaluate(engine_type, single_index):
+    with mlflow.start_run():
+        model_info = mlflow.llama_index.log_model(
+            index=single_index,
+            engine_type=engine_type,
+            artifact_path="llama_index",
+        )
+
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+
+    data = pd.DataFrame(
+        {
+            "inputs": [
+                "What is MLflow?",
+                "What is Spark?",
+            ],
+            "ground_truth": ["What is MLflow?", "Not what is Spark?"],
+        }
+    )
+    eval_dataset = mlflow.data.from_pandas(data, targets="ground_truth")
+
+    with mlflow.start_run():
+        eval_result = mlflow.evaluate(
+            pyfunc_model,
+            data=eval_dataset,
+            extra_metrics=[latency()],
+        )
+    assert eval_result.metrics["latency/mean"] > 0

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -4,6 +4,7 @@ from dataclasses import asdict
 from typing import List
 from unittest.mock import ANY
 
+import importlib_metadata
 import openai
 import pytest
 from llama_index.agent.openai import OpenAIAgent
@@ -14,6 +15,7 @@ from llama_index.core.retrievers import VectorIndexRetriever
 from llama_index.core.tools import FunctionTool
 from llama_index.llms.openai import OpenAI
 from openai.types.chat import ChatCompletionMessageToolCall
+from packaging.version import Version
 
 import mlflow
 import mlflow.tracking._tracking_service
@@ -23,6 +25,8 @@ from mlflow.entities.trace_status import TraceStatus
 from mlflow.llama_index.tracer import remove_llama_index_tracer, set_llama_index_tracer
 from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
+
+llama_oai_version = Version(importlib_metadata.version("llama-index-llms-openai"))
 
 
 @pytest.fixture(autouse=True)
@@ -117,6 +121,12 @@ def test_trace_llm_chat(is_async):
     assert spans[0].inputs == {
         "messages": [{"role": "system", "content": "Hello", "additional_kwargs": {}}]
     }
+    # `addtional_kwargs` was broken until 0.1.30 release of llama-index-llms-openai
+    expected_kwargs = (
+        {"completion_tokens": 12, "prompt_tokens": 9, "total_tokens": 21}
+        if llama_oai_version >= Version("0.1.30")
+        else {}
+    )
     assert spans[0].outputs == {
         "message": {
             "role": "assistant",
@@ -126,7 +136,7 @@ def test_trace_llm_chat(is_async):
         "raw": ANY,
         "delta": None,
         "logprobs": None,
-        "additional_kwargs": {"completion_tokens": 12, "prompt_tokens": 9, "total_tokens": 21},
+        "additional_kwargs": expected_kwargs,
     }
 
     attr = spans[0].attributes
@@ -160,6 +170,12 @@ def test_trace_llm_chat_stream():
     assert spans[0].inputs == {
         "messages": [{"role": "system", "content": "Hello", "additional_kwargs": {}}]
     }
+    # `addtional_kwargs` was broken until 0.1.30 release of llama-index-llms-openai
+    expected_kwargs = (
+        {"completion_tokens": 12, "prompt_tokens": 9, "total_tokens": 21}
+        if llama_oai_version >= Version("0.1.30")
+        else {}
+    )
     assert spans[0].outputs == {
         "message": {
             "role": "assistant",
@@ -169,7 +185,7 @@ def test_trace_llm_chat_stream():
         "raw": ANY,
         "delta": " world",
         "logprobs": None,
-        "additional_kwargs": {"completion_tokens": 12, "prompt_tokens": 9, "total_tokens": 21},
+        "additional_kwargs": expected_kwargs,
     }
 
     attr = spans[0].attributes

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -126,7 +126,7 @@ def test_trace_llm_chat(is_async):
         "raw": ANY,
         "delta": None,
         "logprobs": None,
-        "additional_kwargs": {},
+        "additional_kwargs": {"completion_tokens": 12, "prompt_tokens": 9, "total_tokens": 21},
     }
 
     attr = spans[0].attributes
@@ -169,7 +169,7 @@ def test_trace_llm_chat_stream():
         "raw": ANY,
         "delta": " world",
         "logprobs": None,
-        "additional_kwargs": {},
+        "additional_kwargs": {"completion_tokens": 12, "prompt_tokens": 9, "total_tokens": 21},
     }
 
     attr = spans[0].attributes


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12976?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12976/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12976
```

</p>
</details>

### What changes are proposed in this pull request?

Solve two issues in evaluation with LLamaIndex models.

1. The input data is wrapped in `inputs` column, which caused an error when creating `QueryBundle` object for input.
2. The output from the pyfunc model of LlamaIndex flavor is a single string. However, `mlflow.evaluate()` does not handle that output type ([code](https://github.com/mlflow/mlflow/blob/master/mlflow/models/evaluation/default_evaluator.py#L1472-L1479)) during aggregation.

This PR fixes these two issues to unblock the journey. The first fix is temporary limited to LlamaIndex flavor to reduce regression risk, but should be generalized to other flavors as well. The second fix is less risky so directly applied to the evaluation logic.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

![Screenshot 2024-08-20 at 13 39 22](https://github.com/user-attachments/assets/58dda3b1-e42c-4e20-8314-85011f775bab)

![Screenshot 2024-08-20 at 13 39 14](https://github.com/user-attachments/assets/8c85c639-c971-43f1-8fea-a2530b25876e)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix input/output format bugs in `mlflow.evaluate()` with the LlamaIndex flavor.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
