### PR TITLE
Fix device when loading transformers model

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -273,9 +273,9 @@ MLFLOW_HUGGINGFACE_DISABLE_ACCELERATE_FEATURES = _BooleanEnvironmentVariable(
 
 #: Specifies to Huggingface whether to use the automatic device placement logic of
 # HuggingFace accelerate. If it's set to false, the low_cpu_mem_usage flag will not be
-# set to True and device_map will not be set to "auto".
+# set to True and device_map will not be set to "auto". Default to False.
 MLFLOW_HUGGINGFACE_USE_DEVICE_MAP = _BooleanEnvironmentVariable(
-    "MLFLOW_HUGGINGFACE_USE_DEVICE_MAP", True
+    "MLFLOW_HUGGINGFACE_USE_DEVICE_MAP", False
 )
 
 #: Specifies to Huggingface to use the automatic device placement logic of HuggingFace accelerate.

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1167,14 +1167,6 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
     if framework := flavor_config.get(FlavorKey.FRAMEWORK):
         conf["framework"] = framework
 
-    if device is None:
-        if MLFLOW_DEFAULT_PREDICTION_DEVICE.get():
-            try:
-                device = int(MLFLOW_DEFAULT_PREDICTION_DEVICE.get())
-            except ValueError:
-                device = _TRANSFORMERS_DEFAULT_CPU_DEVICE_ID
-        elif is_gpu_available():
-            device = _TRANSFORMERS_DEFAULT_GPU_DEVICE_ID
     # Note that we don't set the device in the conf yet because device is
     # incompatible with device_map.
     accelerate_model_conf = {}
@@ -1183,7 +1175,21 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
         conf["device_map"] = device_map_strategy
         accelerate_model_conf["device_map"] = device_map_strategy
         # Cannot use device with device_map
+        if device is not None:
+            _logger.warning(
+                "MLFLOW_HUGGINGFACE_USE_DEVICE_MAP is set to True, device "
+                f"is incompatible with device_map, ignoring device param `{device}` passed."
+            )
         device = None
+
+    if device is None:
+        if MLFLOW_DEFAULT_PREDICTION_DEVICE.get():
+            try:
+                device = int(MLFLOW_DEFAULT_PREDICTION_DEVICE.get())
+            except ValueError:
+                device = _TRANSFORMERS_DEFAULT_CPU_DEVICE_ID
+        elif is_gpu_available():
+            device = _TRANSFORMERS_DEFAULT_GPU_DEVICE_ID
 
     if device is not None:
         conf["device"] = device

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1181,8 +1181,7 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
                 f"is incompatible with device_map, ignoring device param `{device}` passed."
             )
         device = None
-
-    if device is None:
+    elif device is None:
         if MLFLOW_DEFAULT_PREDICTION_DEVICE.get():
             try:
                 device = int(MLFLOW_DEFAULT_PREDICTION_DEVICE.get())

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1177,10 +1177,11 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
         # Cannot use device with device_map
         if device is not None:
             raise MlflowException.invalid_parameter_value(
-                f"MLFLOW_HUGGINGFACE_USE_DEVICE_MAP is True, but device is set to {device}, "
-                f"device_map and device cannot be used together. Set "
-                "MLFLOW_HUGGINGFACE_USE_DEVICE_MAP to False to use device, or set "
-                "device to None to use device_map."
+                "The environment variable MLFLOW_HUGGINGFACE_USE_DEVICE_MAP is set to True, but "
+                f"the `device` argument is provided with value {device}. The device_map and "
+                "`device` argument cannot be used together. Set MLFLOW_HUGGINGFACE_USE_DEVICE_MAP "
+                "to False to specify a particular device ID, or pass None for the `device` "
+                "argument to use device_map."
             )
         device = None
     elif device is None:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1176,9 +1176,11 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
         accelerate_model_conf["device_map"] = device_map_strategy
         # Cannot use device with device_map
         if device is not None:
-            _logger.warning(
-                "MLFLOW_HUGGINGFACE_USE_DEVICE_MAP is set to True, device "
-                f"is incompatible with device_map, ignoring device param `{device}` passed."
+            raise MlflowException.invalid_parameter_value(
+                f"MLFLOW_HUGGINGFACE_USE_DEVICE_MAP is True, but device is set to {device}, "
+                f"device_map and device cannot be used together. Set "
+                "MLFLOW_HUGGINGFACE_USE_DEVICE_MAP to False to use device, or set "
+                "device to None to use device_map."
             )
         device = None
     elif device is None:

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3633,3 +3633,14 @@ def test_peft_pipeline_copy_metadata_in_databricks(mock_is_in_databricks, peft_p
     else:
         assert not os.path.exists(metadata_path)
     mock_is_in_databricks.assert_called_once()
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda", 0, -1, None])
+def test_device_param_on_load_model(device, small_qa_pipeline, model_path, monkeypatch):
+    mlflow.transformers.save_model(small_qa_pipeline, path=model_path)
+    conf = mlflow.transformers.load_model(model_path, return_type="components", device=device)
+    assert conf.get("device") == device
+
+    monkeypatch.setenv("MLFLOW_HUGGINGFACE_USE_DEVICE_MAP", "true")
+    conf = mlflow.transformers.load_model(model_path, return_type="components", device=device)
+    assert conf.get("device") is None

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3648,6 +3648,7 @@ def test_device_param_on_load_model(device, small_qa_pipeline, model_path, monke
     else:
         with pytest.raises(
             MlflowException,
-            match=rf"MLFLOW_HUGGINGFACE_USE_DEVICE_MAP is True, but device is set to {device}",
+            match=r"The environment variable MLFLOW_HUGGINGFACE_USE_DEVICE_MAP is set to True, "
+            rf"but the `device` argument is provided with value {device}.",
         ):
             mlflow.transformers.load_model(model_path, return_type="components", device=device)

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3642,5 +3642,12 @@ def test_device_param_on_load_model(device, small_qa_pipeline, model_path, monke
     assert conf.get("device") == device
 
     monkeypatch.setenv("MLFLOW_HUGGINGFACE_USE_DEVICE_MAP", "true")
-    conf = mlflow.transformers.load_model(model_path, return_type="components", device=device)
-    assert conf.get("device") is None
+    if device is None:
+        conf = mlflow.transformers.load_model(model_path, return_type="components", device=device)
+        assert conf.get("device") is None
+    else:
+        with pytest.raises(
+            MlflowException,
+            match=rf"MLFLOW_HUGGINGFACE_USE_DEVICE_MAP is True, but device is set to {device}",
+        ):
+            mlflow.transformers.load_model(model_path, return_type="components", device=device)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/12977?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12977/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12977
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #12871

### What changes are proposed in this pull request?
Set default value of MLFLOW_HUGGINGFACE_USE_DEVICE_MAP to False. Emit warning if device is set but MLFLOW_HUGGINGFACE_USE_DEVICE_MAP is set to True.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
