### PR TITLE
Support saving LlamaIndex engine directly via model-from-code

### DIFF
--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -8,6 +8,7 @@ import yaml
 import mlflow
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
+from mlflow.llama_index.pyfunc_wrapper import create_engine_wrapper
 from mlflow.models import Model, ModelInputExample, ModelSignature
 from mlflow.models.model import MLMODEL_FILE_NAME, MODEL_CODE_PATH
 from mlflow.models.signature import _infer_signature_from_input_example
@@ -93,13 +94,22 @@ def _get_llama_index_version() -> str:
         )
 
 
+def _supported_classes():
+    from llama_index.core.base.base_query_engine import BaseQueryEngine
+    from llama_index.core.chat_engine.types import BaseChatEngine
+    from llama_index.core.indices.base import BaseIndex
+    from llama_index.core.retrievers import BaseRetriever
+
+    return BaseIndex, BaseChatEngine, BaseQueryEngine, BaseRetriever
+
+
 @experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces while loading model
 def save_model(
-    index,
+    llama_model,
     path: str,
-    engine_type: str,
+    engine_type: Optional[str] = None,
     model_config: Optional[Dict[str, Any]] = None,
     code_paths=None,
     mlflow_model: Optional[Model] = None,
@@ -111,13 +121,15 @@ def save_model(
     metadata: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
-    Save a LlamaIndex index to a path on the local file system.
+    Save a LlamaIndex model to a path on the local file system.
 
     Args:
-        index: LlamaIndex index to be saved.
+        llama_model: An LlamaIndex object to be saved, or a string representing the path to
+            a script contains LlamaIndex index/engine definition.
         path: Local path where the serialized model (as YAML) is to be saved.
-        engine_type: Determine the inference interface for the index when loaded as a pyfunc
-            model. The supported types are as follows:
+        engine_type: Required when saving an index object to determine the inference interface
+            for the index when loaded as a pyfunc model. This field is **not** required when
+            saving an engine directly. The supported types are as follows:
 
             - ``"chat"``: load the index as an instance of the LlamaIndex
               `ChatEngine <https://docs.llamaindex.ai/en/stable/module_guides/deploying/chat_engines/>`_.
@@ -142,14 +154,13 @@ def save_model(
         conda_env: {{ conda_env }}
         metadata: {{ metadata }}
     """
-    from mlflow.llama_index.pyfunc_wrapper import create_engine_wrapper
-    from mlflow.llama_index.serialize_objects import serialize_settings
+    from llama_index.core.indices.base import BaseIndex
 
-    _validate_engine_type(engine_type)
+    from mlflow.llama_index.serialize_objects import serialize_settings
 
     # TODO: make this logic cleaner and maybe a util
     with tempfile.TemporaryDirectory() as temp_dir:
-        index_or_code_path = _validate_and_prepare_llama_index_model_or_path(index, temp_dir)
+        model_or_code_path = _validate_and_prepare_llama_index_model_or_path(llama_model, temp_dir)
 
         _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
@@ -157,13 +168,23 @@ def save_model(
         _validate_and_prepare_target_save_path(path)
 
         model_code_path = None
-        if isinstance(index_or_code_path, str):
-            model_code_path = index_or_code_path
-            index = _load_model_code_path(model_code_path, model_config)
+        if isinstance(model_or_code_path, str):
+            model_code_path = model_or_code_path
+            llama_model = _load_model_code_path(model_code_path, model_config)
             _validate_and_copy_file_to_directory(model_code_path, path, "code")
 
-        else:
-            index = index_or_code_path
+        elif isinstance(model_or_code_path, BaseIndex):
+            _validate_engine_type(engine_type)
+            llama_model = model_or_code_path
+
+        elif isinstance(model_or_code_path, _supported_classes()):
+            raise MlflowException.invalid_parameter_value(
+                "Saving an engine object is only supported in the 'Model-from-Code' saving mode. "
+                "The legacy serialization method is exclusively for saving index objects. Please "
+                "pass the path to the script containing the engine definition to save an engine "
+                "object. For more information, see "
+                "https://www.mlflow.org/docs/latest/model/models-from-code.html",
+            )
 
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
@@ -172,7 +193,7 @@ def save_model(
     saved_example = _save_example(mlflow_model, input_example, path)
 
     if signature is None and saved_example is not None:
-        wrapped_model = create_engine_wrapper(index, engine_type, model_config)
+        wrapped_model = create_engine_wrapper(llama_model, engine_type, model_config)
         signature = _infer_signature_from_input_example(saved_example, wrapped_model)
     elif signature is False:
         signature = None
@@ -191,9 +212,9 @@ def save_model(
     settings_path = os.path.join(path, _SETTINGS_FILE)
     serialize_settings(settings_path)
 
-    # Do not save the index object in model-from-code saving mode
-    if not isinstance(model_code_path, str):
-        _save_index(index, path)
+    # Do not save the index/engine object in model-from-code saving mode
+    if not isinstance(model_code_path, str) and isinstance(llama_model, BaseIndex):
+        _save_index(llama_model, path)
 
     pyfunc.add_to_model(
         mlflow_model,
@@ -247,9 +268,9 @@ def save_model(
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces while loading model
 def log_model(
-    index,
+    llama_model,
     artifact_path: str,
-    engine_type: str,
+    engine_type: Optional[str] = None,
     model_config: Optional[Dict[str, Any]] = None,
     code_paths: Optional[List[str]] = None,
     registered_model_name: Optional[str] = None,
@@ -263,13 +284,15 @@ def log_model(
     **kwargs,
 ):
     """
-    Log a LlamaIndex index as an MLflow artifact for the current run.
+    Log a LlamaIndex model as an MLflow artifact for the current run.
 
     Args:
-        index: LlamaIndex index to be saved.
+        llama_model: An LlamaIndex object to be saved, or a string representing the path to
+            a script contains LlamaIndex index/engine definition.
         artifact_path: Local path where the serialized model (as YAML) is to be saved.
-        engine_type: Determine the inference interface for the index when loaded as a pyfunc
-            model. The supported types are as follows:
+        engine_type: Required when saving an index object to determine the inference interface
+            for the index when loaded as a pyfunc model. This field is **not** required when
+            saving an engine directly. The supported types are as follows:
 
             - ``"chat"``: load the index as an instance of the LlamaIndex
               `ChatEngine <https://docs.llamaindex.ai/en/stable/module_guides/deploying/chat_engines/>`_.
@@ -308,7 +331,7 @@ def log_model(
         model_config=model_config,
         flavor=mlflow.llama_index,
         registered_model_name=registered_model_name,
-        index=index,
+        llama_model=llama_model,
         conda_env=conda_env,
         code_paths=code_paths,
         signature=signature,
@@ -321,19 +344,19 @@ def log_model(
     )
 
 
-def _validate_and_prepare_llama_index_model_or_path(index, temp_dir=None):
-    from llama_index.core.indices.base import BaseIndex
+def _validate_and_prepare_llama_index_model_or_path(llama_model, temp_dir=None):
+    if isinstance(llama_model, str):
+        return _validate_and_get_model_code_path(llama_model, temp_dir)
 
-    if isinstance(index, str):
-        return _validate_and_get_model_code_path(index, temp_dir)
-
-    if not isinstance(index, BaseIndex):
+    if not isinstance(llama_model, _supported_classes()):
+        supported_cls_names = [cls.__name__ for cls in _supported_classes()]
         raise MlflowException.invalid_parameter_value(
-            message=f"The provided object of type {type(index).__name__} is not a valid "
-            "index. MLflow llama-index flavor only supports saving LlamaIndex indices."
+            message=f"The provided object of type {type(llama_model).__name__} is not a valid "
+            "index. MLflow llama-index flavor only supports saving LlamaIndex objects "
+            f"subclassed from one of the following classes: {supported_cls_names}.",
         )
 
-    return index
+    return llama_model
 
 
 def _save_index(index, path):
@@ -342,8 +365,8 @@ def _save_index(index, path):
     index.storage_context.persist(persist_dir=index_path)
 
 
-def _load_index(path, flavor_conf):
-    """Deserialize the index."""
+def _load_llama_model(path, flavor_conf):
+    """Load the LlamaIndex index or engine from either model code or serialized index."""
     from llama_index.core import StorageContext, load_index_from_storage
 
     _add_code_from_conf_to_system_path(path, flavor_conf)
@@ -369,7 +392,7 @@ def _load_index(path, flavor_conf):
 @trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):
     """
-    Load a LlamaIndex index from a local file or a run.
+    Load a LlamaIndex index or engine from a local file or a run.
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
@@ -398,7 +421,7 @@ def load_model(model_uri, dst_path=None):
     settings_path = os.path.join(local_model_path, _SETTINGS_FILE)
     # NB: Settings is a singleton and can be loaded via llama_index.core.Settings
     deserialize_settings(settings_path)
-    return _load_index(local_model_path, flavor_conf)
+    return _load_llama_model(local_model_path, flavor_conf)
 
 
 def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
@@ -406,7 +429,7 @@ def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
 
     index = load_model(path)
     flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
-    engine_type = flavor_conf.pop("engine_type")
+    engine_type = flavor_conf.pop("engine_type", None)  # Not present when saving an engine object
     return create_engine_wrapper(index, engine_type, model_config)
 
 

--- a/mlflow/llama_index/pyfunc_wrapper.py
+++ b/mlflow/llama_index/pyfunc_wrapper.py
@@ -56,11 +56,15 @@ def _format_predict_input_query_engine_and_retriever(data) -> "QueryBundle":
 class _LlamaIndexModelWrapperBase:
     def __init__(
         self,
-        index,
+        engine,
         model_config: Optional[Dict[str, Any]] = None,
     ):
-        self.index = index
+        self.engine = engine
         self.model_config = model_config or {}
+
+    @property
+    def index(self):
+        return self.engine.index
 
     def get_raw_model(self):
         return self.engine
@@ -92,10 +96,9 @@ class _LlamaIndexModelWrapperBase:
 
 
 class ChatEngineWrapper(_LlamaIndexModelWrapperBase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.engine_type = CHAT_ENGINE_NAME
-        self.engine = self.index.as_chat_engine(**self.model_config)
+    @property
+    def engine_type(self):
+        return CHAT_ENGINE_NAME
 
     def _predict_single(self, *args, **kwargs) -> str:
         return self.engine.chat(*args, **kwargs).response
@@ -137,10 +140,9 @@ class ChatEngineWrapper(_LlamaIndexModelWrapperBase):
 
 
 class QueryEngineWrapper(_LlamaIndexModelWrapperBase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.engine_type = QUERY_ENGINE_NAME
-        self.engine = self.index.as_query_engine(**self.model_config)
+    @property
+    def engine_type(self):
+        return QUERY_ENGINE_NAME
 
     def _predict_single(self, *args, **kwargs) -> str:
         return self.engine.query(*args, **kwargs).response
@@ -150,10 +152,9 @@ class QueryEngineWrapper(_LlamaIndexModelWrapperBase):
 
 
 class RetrieverEngineWrapper(_LlamaIndexModelWrapperBase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.engine_type = RETRIEVER_ENGINE_NAME
-        self.engine = self.index.as_retriever(**self.model_config)
+    @property
+    def engine_type(self):
+        return RETRIEVER_ENGINE_NAME
 
     def _predict_single(self, *args, **kwargs) -> List[Dict]:
         response = self.engine.retrieve(*args, **kwargs)
@@ -163,14 +164,53 @@ class RetrieverEngineWrapper(_LlamaIndexModelWrapperBase):
         return _format_predict_input_query_engine_and_retriever(data)
 
 
-def create_engine_wrapper(index, engine_type: str, model_config: Optional[Dict[str, Any]] = None):
+def create_engine_wrapper(
+    index_or_engine: Any,
+    engine_type: Optional[str] = None,
+    model_config: Optional[Dict[str, Any]] = None,
+):
+    """
+    A factory function that creates a Pyfunc wrapper around a Llama index or engine.
+    """
+    from llama_index.core.indices.base import BaseIndex
+
+    if isinstance(index_or_engine, BaseIndex):
+        return _create_wrapper_from_index(index_or_engine, engine_type, model_config)
+    else:
+        return _create_wrapper_from_engine(index_or_engine, model_config)
+
+
+def _create_wrapper_from_index(
+    index, engine_type: str, model_config: Optional[Dict[str, Any]] = None
+):
+    model_config = model_config or {}
     if engine_type == QUERY_ENGINE_NAME:
-        return QueryEngineWrapper(index, model_config)
+        engine = index.as_query_engine(**model_config)
+        return QueryEngineWrapper(engine, model_config)
     elif engine_type == CHAT_ENGINE_NAME:
-        return ChatEngineWrapper(index, model_config)
+        engine = index.as_chat_engine(**model_config)
+        return ChatEngineWrapper(engine, model_config)
     elif engine_type == RETRIEVER_ENGINE_NAME:
-        return RetrieverEngineWrapper(index, model_config)
+        engine = index.as_retriever(**model_config)
+        return RetrieverEngineWrapper(engine, model_config)
     else:
         raise ValueError(
             f"Unsupported engine type: {engine_type}. It must be one of {SUPPORTED_ENGINES}"
+        )
+
+
+def _create_wrapper_from_engine(engine: Any, model_config: Optional[Dict[str, Any]] = None):
+    from llama_index.core.base.base_query_engine import BaseQueryEngine
+    from llama_index.core.chat_engine.types import BaseChatEngine
+    from llama_index.core.retrievers import BaseRetriever
+
+    if isinstance(engine, BaseChatEngine):
+        return ChatEngineWrapper(engine, model_config)
+    elif isinstance(engine, BaseQueryEngine):
+        return QueryEngineWrapper(engine, model_config)
+    elif isinstance(engine, BaseRetriever):
+        return RetrieverEngineWrapper(engine, model_config)
+    else:
+        raise ValueError(
+            f"Unsupported engine type: {type(engine)}. It must be one of {SUPPORTED_ENGINES}"
         )

--- a/mlflow/llama_index/pyfunc_wrapper.py
+++ b/mlflow/llama_index/pyfunc_wrapper.py
@@ -170,7 +170,7 @@ def create_engine_wrapper(
     model_config: Optional[Dict[str, Any]] = None,
 ):
     """
-    A factory function that creates a Pyfunc wrapper around a Llama index or engine.
+    A factory function that creates a Pyfunc wrapper around a LlamaIndex index or engine.
     """
     from llama_index.core.indices.base import BaseIndex
 

--- a/tests/llama_index/sample_code/basic_chat_engine.py
+++ b/tests/llama_index/sample_code/basic_chat_engine.py
@@ -1,0 +1,15 @@
+"""
+Sample code to define an chat engine and save it with model-from-code logging.
+
+Ref: https://qdrant.tech/documentation/quickstart/
+"""
+from llama_index.core import Document, VectorStoreIndex
+from llama_index.core.chat_engine.types import ChatMode
+
+import mlflow
+
+index = VectorStoreIndex.from_documents(documents=[Document.example()])
+# Setting SIMPLE chat mode will create a SimpleChatEngine instance
+chat_engine = index.as_chat_engine(chat_mode=ChatMode.SIMPLE)
+
+mlflow.models.set_model(chat_engine)

--- a/tests/llama_index/sample_code/query_engine_with_reranker.py
+++ b/tests/llama_index/sample_code/query_engine_with_reranker.py
@@ -1,0 +1,42 @@
+"""
+Sample code to define an query engine with post processors and save it with model-from-code logging.
+
+Ref: https://qdrant.tech/documentation/quickstart/
+"""
+from typing import List, Optional
+
+from llama_index.core import Document, QueryBundle, VectorStoreIndex
+from llama_index.core.postprocessor import LLMRerank
+from llama_index.core.postprocessor.types import BaseNodePostprocessor
+from llama_index.core.schema import NodeWithScore
+
+import mlflow
+
+index = VectorStoreIndex.from_documents(documents=[Document.example()])
+
+# Postprocessor 1: Reranker
+reranker = LLMRerank(
+    choice_batch_size=5,
+    top_n=2,
+)
+
+
+# Postprocessor 2: custom postprocessor
+class CustomNodePostprocessor(BaseNodePostprocessor):
+    call_count: int = 0
+
+    def _postprocess_nodes(
+        self, nodes: List[NodeWithScore], query_bundle: Optional[QueryBundle]
+    ) -> List[NodeWithScore]:
+        # subtracts 1 from the score
+        self.call_count += 1
+        return nodes
+
+
+query_engine = index.as_query_engine(
+    similarity_top_k=5,
+    node_postprocessors=[reranker, CustomNodePostprocessor()],
+)
+
+
+mlflow.models.set_model(query_engine)

--- a/tests/llama_index/test_llama_index_evaluate.py
+++ b/tests/llama_index/test_llama_index_evaluate.py
@@ -28,7 +28,7 @@ from mlflow.metrics import latency
 def test_llama_index_evaluate(data, engine_type, single_index):
     with mlflow.start_run():
         model_info = mlflow.llama_index.log_model(
-            index=single_index,
+            llama_index_model=single_index,
             engine_type=engine_type,
             artifact_path="llama_index",
         )

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 from llama_index.core import QueryBundle, Settings, VectorStoreIndex
 from llama_index.core.base.base_query_engine import BaseQueryEngine
+from llama_index.core.chat_engine import SimpleChatEngine
 from llama_index.core.llms import ChatMessage
 from llama_index.core.vector_stores.simple import SimpleVectorStore
 from llama_index.embeddings.databricks import DatabricksEmbedding
@@ -21,6 +22,8 @@ import mlflow.pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.llama_index.pyfunc_wrapper import (
     _CHAT_MESSAGE_HISTORY_PARAMETER_NAME,
+    ChatEngineWrapper,
+    QueryEngineWrapper,
     create_engine_wrapper,
 )
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -74,9 +77,15 @@ def test_llama_index_native_log_and_load_model(request, index_fixture):
     assert engine.query(_TEST_QUERY).response != ""
 
 
-def test_llama_index_save_invalid_object_raise():
+def test_llama_index_save_invalid_object_raise(single_index):
     with pytest.raises(MlflowException, match="The provided object of type "):
-        mlflow.llama_index.save_model(index=OpenAI(), path="model", engine_type="query")
+        mlflow.llama_index.save_model(llama_model=OpenAI(), path="model", engine_type="query")
+
+    with pytest.raises(MlflowException, match="Saving an engine object is only supported"):
+        mlflow.llama_index.save_model(
+            llama_model=single_index.as_query_engine(),
+            path="model",
+        )
 
 
 @pytest.mark.parametrize(
@@ -149,7 +158,7 @@ def test_format_predict_input_correct_schema_complex(single_index, engine_type):
 def test_query_engine_predict(single_index, with_input_example, payload):
     with mlflow.start_run():
         model_info = mlflow.llama_index.log_model(
-            index=single_index,
+            llama_model=single_index,
             artifact_path="model",
             input_example=payload if with_input_example else None,
             engine_type="query",
@@ -185,7 +194,7 @@ def test_query_engine_predict(single_index, with_input_example, payload):
 def test_query_engine_predict_list(single_index, with_input_example, payload):
     with mlflow.start_run():
         model_info = mlflow.llama_index.log_model(
-            index=single_index,
+            llama_model=single_index,
             artifact_path="model",
             input_example=payload if with_input_example else None,
             engine_type="query",
@@ -212,13 +221,15 @@ def test_query_engine_predict_numeric(model_path, single_index, with_input_examp
     if with_input_example:
         with pytest.raises(ValueError, match="Unsupported input type"):
             mlflow.llama_index.save_model(
-                index=single_index,
+                llama_model=single_index,
                 input_example=input_example,
                 path=model_path,
                 engine_type="query",
             )
     else:
-        mlflow.llama_index.save_model(index=single_index, path=model_path, engine_type="query")
+        mlflow.llama_index.save_model(
+            llama_model=single_index, path=model_path, engine_type="query"
+        )
         model = mlflow.pyfunc.load_model(model_path)
         with pytest.raises(ValueError, match="Unsupported input type"):
             _ = model.predict(payload)
@@ -244,7 +255,7 @@ def test_query_engine_predict_numeric(model_path, single_index, with_input_examp
 def test_chat_engine_predict(single_index, with_input_example, payload):
     with mlflow.start_run():
         model_info = mlflow.llama_index.log_model(
-            index=single_index,
+            llama_model=single_index,
             artifact_path="model",
             input_example=payload if with_input_example else None,
             engine_type="chat",
@@ -271,11 +282,17 @@ def test_chat_engine_dict_raises(model_path, single_index, with_input_example):
     if with_input_example:
         with pytest.raises(TypeError, match="got an unexpected keyword argument"):
             mlflow.llama_index.save_model(
-                index=single_index, input_example=input_example, path=model_path, engine_type="chat"
+                llama_model=single_index,
+                input_example=input_example,
+                path=model_path,
+                engine_type="chat",
             )
     else:
         mlflow.llama_index.save_model(
-            index=single_index, input_example=input_example, path=model_path, engine_type="chat"
+            llama_model=single_index,
+            input_example=input_example,
+            path=model_path,
+            engine_type="chat",
         )
 
         model = mlflow.pyfunc.load_model(model_path)
@@ -288,7 +305,7 @@ def test_retriever_engine_predict(single_index, with_input_example):
     payload = "string"
     with mlflow.start_run():
         model_info = mlflow.llama_index.log_model(
-            index=single_index,
+            llama_model=single_index,
             artifact_path="model",
             input_example=payload if with_input_example else None,
             engine_type="retriever",
@@ -314,7 +331,9 @@ def test_llama_index_databricks_integration(monkeypatch, document, model_path, m
     )
 
     index = VectorStoreIndex(nodes=[document])
-    mlflow.llama_index.save_model(index, path=model_path, input_example="hi", engine_type="query")
+    mlflow.llama_index.save_model(
+        llama_model=index, path=model_path, input_example="hi", engine_type="query"
+    )
 
     with model_path.joinpath("requirements.txt").open() as file:
         requirements = file.read()
@@ -366,10 +385,10 @@ def test_llama_index_databricks_integration(monkeypatch, document, model_path, m
         ),
     ],
 )
-def test_save_load_index_as_code_optional_code_path(index_code_path, vector_store_class):
+def test_save_load_index_as_code_index(index_code_path, vector_store_class):
     with mlflow.start_run():
         model_info = mlflow.llama_index.log_model(
-            index=index_code_path,
+            llama_model=index_code_path,
             engine_type="query",
             artifact_path="model",
             input_example="hi",
@@ -386,3 +405,46 @@ def test_save_load_index_as_code_optional_code_path(index_code_path, vector_stor
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert isinstance(pyfunc_loaded_model.get_raw_model(), BaseQueryEngine)
     assert _TEST_QUERY in pyfunc_loaded_model.predict(_TEST_QUERY)
+
+
+def test_save_load_index_as_code_query_engine():
+    index_code_path = "tests/llama_index/sample_code/query_engine_with_reranker.py"
+    with mlflow.start_run():
+        model_info = mlflow.llama_index.log_model(
+            llama_model=index_code_path,
+            artifact_path="model",
+            input_example="hi",
+        )
+
+    loaded_engine = mlflow.llama_index.load_model(model_info.model_uri)
+    assert isinstance(loaded_engine, BaseQueryEngine)
+    processors = loaded_engine._node_postprocessors
+    assert len(processors) == 2
+    assert processors[0].__class__.__name__ == "LLMRerank"
+    assert processors[1].__class__.__name__ == "CustomNodePostprocessor"
+
+    pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert isinstance(pyfunc_loaded_model._model_impl, QueryEngineWrapper)
+    assert isinstance(pyfunc_loaded_model.get_raw_model(), BaseQueryEngine)
+    assert pyfunc_loaded_model.predict(_TEST_QUERY) != ""
+    custom_processor = pyfunc_loaded_model.get_raw_model()._node_postprocessors[1]
+    assert custom_processor.call_count == 1
+
+
+def test_save_load_index_as_code_chat_engine():
+    index_code_path = "tests/llama_index/sample_code/basic_chat_engine.py"
+    with mlflow.start_run():
+        model_info = mlflow.llama_index.log_model(
+            llama_model=index_code_path,
+            artifact_path="model",
+            input_example="hi",
+        )
+
+    loaded_engine = mlflow.llama_index.load_model(model_info.model_uri)
+    # The sample code sets chat mode to SIMPLE, so it should be a SimpleChatEngine
+    assert isinstance(loaded_engine, SimpleChatEngine)
+
+    pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert isinstance(pyfunc_loaded_model._model_impl, ChatEngineWrapper)
+    assert isinstance(pyfunc_loaded_model.get_raw_model(), SimpleChatEngine)
+    assert pyfunc_loaded_model.predict(_TEST_QUERY) != ""

--- a/tests/llama_index/test_llama_index_pyfunc_wrapper.py
+++ b/tests/llama_index/test_llama_index_pyfunc_wrapper.py
@@ -238,7 +238,7 @@ def test_format_predict_input_correct_schema_complex(single_index, engine_type):
 )
 def test_spark_udf_retriever_and_query_engine(model_path, spark, single_index, engine_type, input):
     mlflow.llama_index.save_model(
-        llama_model=single_index,
+        llama_index_model=single_index,
         engine_type=engine_type,
         path=model_path,
         input_example=input,
@@ -260,7 +260,7 @@ def test_spark_udf_chat(model_path, spark, single_index):
         }
     )
     mlflow.llama_index.save_model(
-        llama_model=single_index,
+        llama_index_model=single_index,
         engine_type=engine_type,
         path=model_path,
         input_example=input,

--- a/tests/llama_index/test_llama_index_pyfunc_wrapper.py
+++ b/tests/llama_index/test_llama_index_pyfunc_wrapper.py
@@ -238,7 +238,7 @@ def test_format_predict_input_correct_schema_complex(single_index, engine_type):
 )
 def test_spark_udf_retriever_and_query_engine(model_path, spark, single_index, engine_type, input):
     mlflow.llama_index.save_model(
-        index=single_index,
+        llama_model=single_index,
         engine_type=engine_type,
         path=model_path,
         input_example=input,
@@ -260,7 +260,7 @@ def test_spark_udf_chat(model_path, spark, single_index):
         }
     )
     mlflow.llama_index.save_model(
-        index=single_index,
+        llama_model=single_index,
         engine_type=engine_type,
         path=model_path,
         input_example=input,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12978?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12978/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12978
```

</p>
</details>

### What changes are proposed in this pull request?

Currently, LlamaIndex flavor only allow saving `index` object. When loading the index as pyfunc, we convert it to respective engine type by calling `as_xxx_engine()` method with default. However, this is very limiting because many custom components e.g. [reranker](https://docs.llamaindex.ai/en/stable/examples/node_postprocessor/CohereRerank/), [graph RAG](https://docs.llamaindex.ai/en/stable/examples/query_engine/knowledge_graph_rag_query_engine/), [router](https://docs.llamaindex.ai/en/stable/examples/query_engine/RouterQueryEngine/), are configured as engine level, not an index. These advanced methods are strong reasons for users to choose LlamaIndex.
 
Therefore, this PR adds support for saving the engine objects (`QueryEngine`, `ChatEngine`, and `Retriever`) directly instead of the index objects. Engine saving is only supported in the **model-from-code** mode, because it is nearly impossible to serialize all those custom components. We will gradually make model-from-code as a primary method and deprecate default serialization based logging, because it is not quite useful in practical application due to little coverage of objects.

Fortunately, this is fairy simple extension, because our pyfunc wrapper is already a wrapper around engin instance. It is just the matter of whether we call `as_xxx_engine` or users call it inside their script.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

The engine script (`engine.py`):

```
%%writefile engine.py
from databricks.vector_search.client import VectorSearchClient
from llama_index.core import VectorStoreIndex
from llama_index.vector_stores.databricks import DatabricksVectorSearch
from llama_index.core.postprocessor import LLMRerank
import mlflow

index = VectorSearchClient().get_index(
  endpoint_name="<my-endpoint>",
  index_name="<my-index>",
)

databricks_vector_store = DatabricksVectorSearch(
    index=index,
    text_column="text",
    columns=None,
)
index = VectorStoreIndex.from_vector_store(vector_store=databricks_vector_store)

query_engine = index.as_query_engine(
    similarity_top_k=10,
    node_postprocessors=[
        LLMRerank(
            choice_batch_size=5,
            top_n=2,
        )
    ],
)

mlflow.models.set_model(query_engine)
```

Logging to MLflow:

![Screenshot 2024-08-20 at 16 17 08](https://github.com/user-attachments/assets/55b5258c-dde5-4c65-9392-7478e1a482aa)

Loading and making prediction, the postprocessor `LLMRerank` is executed properly:
![Screenshot 2024-08-20 at 16 20 21](https://github.com/user-attachments/assets/09a7230f-a655-4c8b-9b88-9675654409c8)



### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

**TODO**: I will update the documentation in a follow-up PR: (1) clearly display the difference of two saving method and their coverage (2) use model-from-code as primary examples.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support saving `engine` objects directly in the LlamaIndex flavor. This will unlock wider range of use cases including advanced RAG techniques, such as reranking, graph query, dynamic routing, etc.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
