### PR TITLE
Fix data conversion for serving in langchain

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1652,6 +1652,10 @@ def _convert_llm_ndarray_to_list(data):
         return [_convert_llm_ndarray_to_list(d) for d in data]
     if isinstance(data, dict):
         return {k: _convert_llm_ndarray_to_list(v) for k, v in data.items()}
+    # scalar values are also converted to numpy types, but they are
+    # not acceptable by the model
+    if np.isscalar(data) and isinstance(data, np.generic):
+        return data.item()
     return data
 
 

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -575,16 +575,17 @@ def test_flatten_nested_params():
 
 
 @pytest.mark.parametrize(
-    ("data", "target"),
+    ("data", "target", "target_type"),
     [
-        (pd.DataFrame([{"a": [1, 2, 3]}]), [{"a": [1, 2, 3]}]),
-        (pd.DataFrame([{"a": np.array([1, 2, 3])}]), [{"a": [1, 2, 3]}]),
-        (pd.DataFrame([{0: np.array(["abc"])[0]}]), ["abc"]),
-        (np.array([1, 2, 3]), [1, 2, 3]),
-        (np.array([123])[0], 123),
+        (pd.DataFrame([{"a": [1, 2, 3]}]), [{"a": [1, 2, 3]}], list),
+        (pd.DataFrame([{"a": np.array([1, 2, 3])}]), [{"a": [1, 2, 3]}], list),
+        (pd.DataFrame([{0: np.array(["abc"])[0]}]), ["abc"], list),
+        (np.array([1, 2, 3]), [1, 2, 3], list),
+        (np.array([123])[0], 123, int),
+        (np.array(["abc"])[0], "abc", str),
     ],
 )
-def test_convert_llm_input_data(data, target):
+def test_convert_llm_input_data(data, target, target_type):
     result = _convert_llm_input_data(data)
     assert result == target
-    assert not isinstance(result, np.generic)
+    assert type(result) == target_type

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from unittest import mock
 
 import numpy as np
+import pandas as pd
 import pytest
 import sklearn.neighbors as knn
 from sklearn import datasets
@@ -14,6 +15,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import add_libraries_to_model
 from mlflow.models.utils import (
     _config_context,
+    _convert_llm_input_data,
     _enforce_array,
     _enforce_datatype,
     _enforce_object,
@@ -570,3 +572,19 @@ def test_flatten_nested_params():
     }
 
     assert _flatten_nested_params(rag_params) == expected_rag_flattened_params
+
+
+@pytest.mark.parametrize(
+    ("data", "target"),
+    [
+        (pd.DataFrame([{"a": [1, 2, 3]}]), [{"a": [1, 2, 3]}]),
+        (pd.DataFrame([{"a": np.array([1, 2, 3])}]), [{"a": [1, 2, 3]}]),
+        (pd.DataFrame([{0: np.array(["abc"])[0]}]), ["abc"]),
+        (np.array([1, 2, 3]), [1, 2, 3]),
+        (np.array([123])[0], 123),
+    ],
+)
+def test_convert_llm_input_data(data, target):
+    result = _convert_llm_input_data(data)
+    assert result == target
+    assert not isinstance(result, np.generic)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Convert numpy generic data back to normal python types as they're not acceptable by the model; this is due to the conversion happened inside serving.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
