### PR TITLE
Support saving LangGraph object via model-from-code

### DIFF
--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -149,7 +149,7 @@ class APIRequest:
     def single_call_api(self, callback_handlers: Optional[List[BaseCallbackHandler]]):
         from langchain.schema import BaseRetriever
 
-        from mlflow.langchain.utils import lc_runnables_types
+        from mlflow.langchain.utils import langgraph_types, lc_runnables_types
 
         if isinstance(self.lc_model, BaseRetriever):
             # Retrievers are invoked differently than Chains
@@ -159,7 +159,7 @@ class APIRequest:
             response = [
                 {"page_content": doc.page_content, "metadata": doc.metadata} for doc in docs
             ]
-        elif isinstance(self.lc_model, lc_runnables_types()):
+        elif isinstance(self.lc_model, lc_runnables_types() + langgraph_types()):
             if isinstance(self.request_json, dict):
                 # This is a temporary fix for the case when spark_udf converts
                 # input into pandas dataframe with column name, while the model

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -35,6 +35,7 @@ from mlflow.langchain.utils.chat import (
     try_transform_response_iter_to_chat_format,
     try_transform_response_to_chat_format,
 )
+from mlflow.langchain.utils.serialization import convert_to_serializable
 from mlflow.pyfunc.context import (
     Context,
     get_prediction_context,
@@ -105,28 +106,6 @@ class APIRequest:
     stream: bool
     prediction_context: Optional[Context] = None
 
-    def _prepare_to_serialize(self, response: dict):
-        """
-        Converts LangChain objects to JSON-serializable formats.
-        """
-        from langchain.load.dump import dumps
-
-        if "intermediate_steps" in response:
-            steps = response["intermediate_steps"]
-            try:
-                # `AgentAction` objects are not JSON serializable
-                # https://github.com/langchain-ai/langchain/issues/8815#issuecomment-1666763710
-                response["intermediate_steps"] = dumps(steps)
-            except Exception as e:
-                _logger.warning(f"Failed to serialize intermediate steps: {e!r}")
-
-        # The `dumps` format for `Document` objects is noisy, so we will still have custom logic
-        if "source_documents" in response:
-            response["source_documents"] = [
-                {"page_content": doc.page_content, "metadata": doc.metadata}
-                for doc in response["source_documents"]
-            ]
-
     def _predict_single_input(self, single_input, callback_handlers, **kwargs):
         if self.stream:
             return self.lc_model.stream(
@@ -153,12 +132,9 @@ class APIRequest:
 
         if isinstance(self.lc_model, BaseRetriever):
             # Retrievers are invoked differently than Chains
-            docs = self.lc_model.get_relevant_documents(
+            response = self.lc_model.get_relevant_documents(
                 **self.request_json, callbacks=callback_handlers
             )
-            response = [
-                {"page_content": doc.page_content, "metadata": doc.metadata} for doc in docs
-            ]
         elif isinstance(self.lc_model, lc_runnables_types() + langgraph_types()):
             if isinstance(self.request_json, dict):
                 # This is a temporary fix for the case when spark_udf converts
@@ -202,12 +178,8 @@ class APIRequest:
                 # to maintain existing code, single output chains will still return
                 # only the result
                 response = response.popitem()[1]
-            elif not self.stream:
-                # DO NOT call _prepare_to_serialize for stream output. It will consume the generator
-                # until the end and the iterator will be empty when the user tries to consume it.
-                self._prepare_to_serialize(response)
 
-        return response
+        return convert_to_serializable(response)
 
     def call_api(
         self, status_tracker: StatusTracker, callback_handlers: Optional[List[BaseCallbackHandler]]

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -21,7 +21,6 @@ from mlflow.langchain.utils import (
     _MODEL_TYPE_KEY,
     _PICKLE_LOAD_KEY,
     _RUNNABLE_LOAD_KEY,
-    _UNSUPPORTED_MODEL_ERROR_MESSAGE,
     _load_base_lcs,
     _load_from_json,
     _load_from_pickle,
@@ -31,6 +30,7 @@ from mlflow.langchain.utils import (
     _validate_and_prepare_lc_model_or_path,
     base_lc_types,
     custom_type_to_loader_dict,
+    get_unsupported_model_message,
     lc_runnable_assign_types,
     lc_runnable_binding_types,
     lc_runnable_branch_types,
@@ -493,7 +493,7 @@ def _save_runnables(model, path, loader_fn=None, persist_dir=None):
         _save_runnable_binding(model, os.path.join(path, model_data_path), loader_fn, persist_dir)
     else:
         raise MlflowException.invalid_parameter_value(
-            _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=type(model).__name__)
+            get_unsupported_model_message(type(model).__name__)
         )
     model_data_kwargs[_MODEL_DATA_KEY] = model_data_path
     return model_data_kwargs
@@ -515,9 +515,7 @@ def _load_runnables(path, conf):
         return _load_runnable_assign(os.path.join(path, model_data))
     if model_type in (x.__name__ for x in lc_runnable_binding_types()):
         return _load_runnable_binding(os.path.join(path, model_data))
-    raise MlflowException.invalid_parameter_value(
-        _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=model_type)
-    )
+    raise MlflowException.invalid_parameter_value(get_unsupported_model_message(model_type))
 
 
 def get_runnable_steps(model: Runnable):

--- a/mlflow/langchain/utils/__init__.py
+++ b/mlflow/langchain/utils/__init__.py
@@ -45,16 +45,6 @@ _BASE_LOAD_KEY = "base_load"
 _CONFIG_LOAD_KEY = "config_load"
 _PICKLE_LOAD_KEY = "pickle_load"
 _MODEL_LOAD_KEY = "model_load"
-_UNSUPPORTED_MODEL_ERROR_MESSAGE = (
-    "MLflow langchain flavor only supports subclasses of "
-    "langchain.chains.base.Chain, langchain.agents.agent.AgentExecutor, "
-    "langchain.schema.BaseRetriever, langchain.schema.runnable.RunnableSequence, "
-    "langchain.schema.runnable.RunnableLambda, "
-    "langchain.schema.runnable.RunnableParallel, "
-    "langchain.schema.runnable.RunnablePassthrough, "
-    "langchain.schema.runnable.passthrough.RunnableAssign instances, "
-    "found {instance_type}"
-)
 _UNSUPPORTED_MODEL_WARNING_MESSAGE = (
     "MLflow does not guarantee support for Chains outside of the subclasses of LLMChain, found %s"
 )
@@ -145,8 +135,23 @@ def lc_runnables_types():
     )
 
 
+def langgraph_types():
+    try:
+        from langgraph.graph.graph import CompiledGraph
+
+        return (CompiledGraph,)
+    except ImportError:
+        return ()
+
+
 def supported_lc_types():
-    return base_lc_types() + lc_runnables_types()
+    return base_lc_types() + lc_runnables_types() + langgraph_types()
+
+
+_UNSUPPORTED_MODEL_ERROR_MESSAGE = (
+    f"MLflow langchain flavor only supports subclasses of {supported_lc_types()}, "
+    "found {instance_type}."
+)
 
 
 @lru_cache

--- a/mlflow/langchain/utils/serialization.py
+++ b/mlflow/langchain/utils/serialization.py
@@ -1,0 +1,24 @@
+import inspect
+
+
+def convert_to_serializable(response):
+    """
+    Convert the response to a JSON serializable format.
+
+    LangChain response objects often contains Pydantic objects, which causes an serialization
+    error when the model is served behind REST endpoint.
+    """
+    from langchain_core.pydantic_v1 import BaseModel
+
+    if isinstance(response, BaseModel):
+        return response.dict()
+    elif inspect.isgenerator(response):
+        return (convert_to_serializable(chunk) for chunk in response)
+    elif isinstance(response, dict):
+        return {k: convert_to_serializable(v) for k, v in response.items()}
+    elif isinstance(response, list):
+        return [convert_to_serializable(v) for v in response]
+    elif isinstance(response, tuple):
+        return tuple(convert_to_serializable(v) for v in response)
+
+    return response

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -655,11 +655,7 @@ langchain:
           "transformers",
           "torch",
           "torchvision",
-          # TODO: The LLM saving/loading logic does not handle partner packages such as langchain-openai
-          # and always load llms from the legacy community package. Particularly for OpenAI LLM,
-          # the legacy version is not comptible with OpenAI SDK >= 1.8.0, so we need to pin the
-          # version here until resolving the loading issue.
-          "openai<1.8.0",
+          "openai",
           "google-search-results",
           "psutil",
           "faiss-cpu",
@@ -667,12 +663,13 @@ langchain:
           "numexpr",
           "hf_transfer",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
-          "langchain_openai",
+          "langchain-openai",
           "langgraph",
         ]
-      ">= 0.2": ["langchain-huggingface"]
-      # We cannot use install langchain-openai with langchain >= 0.2.0, while pinning openai to <1.8.0
-      "< 0.2.0": ["langchain-openai"]
+      # langchain-openai 0.1.22 is imcomptible with earlier langchain-core due to
+      # https://github.com/langchain-ai/langchain/commit/b83f1eb0d56dbf99605a1fce93953ee09d77aabf
+      "< 0.2": ["langchain-openai<=0.1.22"]
+      ">= 0.2": ["langchain-openai", "langchain-huggingface"]
     run: |
       # Run all langchain tests except autologging
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -667,6 +667,7 @@ langchain:
           "numexpr",
           "hf_transfer",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
+          "langchain_openai",
           "langgraph",
         ]
       ">= 0.2": ["langchain-huggingface"]

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1798,7 +1798,7 @@ def _load_model_code_path(code_path: str, config: Optional[Union[str, Dict[str, 
         except Exception as e:
             raise MlflowException(
                 f"Failed to run user code from {code_path}. "
-                f"Error: {e!s}."
+                f"Error: {e!s}. "
                 "Review the stack trace for more information."
             ) from e
 

--- a/tests/langchain/sample_code/langgraph.py
+++ b/tests/langchain/sample_code/langgraph.py
@@ -1,0 +1,26 @@
+from typing import Literal
+
+from langchain.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+import mlflow
+
+llm = ChatOpenAI()
+
+
+@tool
+def get_weather(city: Literal["nyc", "sf"]):
+    """Use this to get weather information."""
+    if city == "nyc":
+        return "It might be cloudy in nyc"
+    elif city == "sf":
+        return "It's always sunny in sf"
+    else:
+        raise AssertionError("Unknown city")
+
+
+tools = [get_weather]
+graph = create_react_agent(llm, tools)
+
+mlflow.models.set_model(graph)

--- a/tests/langchain/sample_code/langgraph.py
+++ b/tests/langchain/sample_code/langgraph.py
@@ -1,12 +1,30 @@
 from typing import Literal
 
-from langchain.tools import tool
+from langchain_core.messages import AIMessage, ToolCall
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 import mlflow
 
-llm = ChatOpenAI()
+
+class FakeOpenAI(ChatOpenAI, extra="allow"):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._responses = iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[ToolCall(name="get_weather", args={"city": "sf"}, id="123")],
+                ),
+                AIMessage(content="The weather in San Francisco is always sunny!"),
+            ]
+        )
+
+    def _generate(self, *args, **kwargs):
+        return ChatResult(generations=[ChatGeneration(message=next(self._responses))])
 
 
 @tool
@@ -16,10 +34,9 @@ def get_weather(city: Literal["nyc", "sf"]):
         return "It might be cloudy in nyc"
     elif city == "sf":
         return "It's always sunny in sf"
-    else:
-        raise AssertionError("Unknown city")
 
 
+llm = FakeOpenAI()
 tools = [get_weather]
 graph = create_react_agent(llm, tools)
 

--- a/tests/langchain/sample_code/openai_agent.py
+++ b/tests/langchain/sample_code/openai_agent.py
@@ -1,0 +1,69 @@
+import os
+
+from langchain.agents import AgentExecutor, create_openai_tools_agent
+from langchain.tools import tool
+from langchain_core.messages import AIMessageChunk, ToolCall
+from langchain_core.outputs import ChatGenerationChunk
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_openai import ChatOpenAI
+
+import mlflow
+
+
+class FakeOpenAI(ChatOpenAI, extra="allow"):
+    # In normal LangChain tests, we use the fake OpenAI server to mock the OpenAI REST API.
+    # The fake server returns the input payload as it is. However, for agent tests, the
+    # response should be a specific format so that the agent can parse it correctly.
+    # Also, mocking with mock.patch does not work for testing model serving (as the server
+    # will run in a separate process).
+    # Therefore, we mock the OpenAI client in the model definition here.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._responses = iter(
+            [
+                # First response is tool call
+                AIMessageChunk(
+                    content="",
+                    tool_calls=[ToolCall(name="multiply", args={"a": 2, "b": 3}, id="123")],
+                ),
+                # Second response is the final answer
+                AIMessageChunk(content="The result of 2 * 3 is 6."),
+            ]
+        )
+
+    def _stream(self, *args, **kwargs):
+        yield ChatGenerationChunk(message=next(self._responses))
+
+
+@tool
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+@tool
+def multiply(a: int, b: int) -> int:
+    """Multiply two numbers."""
+    return a * b
+
+
+llm = FakeOpenAI()
+tools = [add, multiply]
+prompt = ChatPromptTemplate(
+    [
+        ("system", "You are a helpful assistant"),
+        MessagesPlaceholder("chat_history", optional=True),
+        ("human", "{input}"),
+        MessagesPlaceholder("agent_scratchpad"),
+    ]
+)
+agent = create_openai_tools_agent(llm, tools, prompt)
+agent_executor = AgentExecutor(
+    agent=agent,
+    tools=tools,
+    # Use env var to switch model configuration during testing
+    return_intermediate_steps=os.environ.get("RETURN_INTERMEDIATE_STEPS", False),
+)
+
+mlflow.models.set_model(agent_executor)

--- a/tests/langchain/sample_code/openai_agent.py
+++ b/tests/langchain/sample_code/openai_agent.py
@@ -50,7 +50,7 @@ def multiply(a: int, b: int) -> int:
 
 llm = FakeOpenAI()
 tools = [add, multiply]
-prompt = ChatPromptTemplate(
+prompt = ChatPromptTemplate.from_messages(
     [
         ("system", "You are a helpful assistant"),
         MessagesPlaceholder("chat_history", optional=True),

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1083,7 +1083,7 @@ def test_unsupported_class():
     with pytest.raises(
         MlflowException,
         match="MLflow langchain flavor only supports subclasses of "
-        + "langchain.chains.base.Chain",
+        + "\\(<class 'langchain.chains.base.Chain'>",
     ):
         with mlflow.start_run():
             mlflow.langchain.log_model(llm, "fake_llm")

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -12,7 +12,6 @@ from unittest import mock
 
 import langchain
 import numpy as np
-import openai
 import pytest
 import yaml
 from langchain import SQLDatabase
@@ -155,23 +154,6 @@ def create_qa_eval_chain():
 def create_qa_with_sources_chain():
     # StuffDocumentsChain
     return load_qa_with_sources_chain(OpenAI(temperature=0), chain_type="stuff")
-
-
-def create_openai_llmagent(return_intermediate_steps=False):
-    from langchain.agents import AgentType, initialize_agent, load_tools
-
-    # TODO: The new OpenAI LLM from langchain-openai package does not support pickle
-    # serialization and make AgentExecutor saving to fail. We need to fix this issue
-    # and update this test to use the new OpenAI LLM.
-    llm = OpenAI(temperature=0)
-    tools = load_tools(["serpapi", "llm-math"], llm=llm)
-    return initialize_agent(
-        tools,
-        llm,
-        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
-        verbose=True,
-        return_intermediate_steps=return_intermediate_steps,
-    )
 
 
 def create_uc_tools(
@@ -586,108 +568,121 @@ def test_langchain_log_huggingface_hub_model_metadata(model_path):
     assert loaded_model.prompt.template == "What is a good name for a company that makes {product}?"
 
 
-# TODO: Fix the AgentExecutor saving issue and remove the skip
-@pytest.mark.skipif(
-    Version(openai.__version__) >= Version("1.0"),
-    reason="OpenAI Client since 1.0 contains thread lock object that cannot be pickled.",
-)
 @pytest.mark.parametrize("return_intermediate_steps", [False, True])
-def test_langchain_agent_model_predict(return_intermediate_steps):
-    langchain_agent_output = {
-        "id": "chatcmpl-123",
-        "object": "chat.completion",
-        "created": 1677652288,
-        "choices": [
-            {
-                "index": 0,
-                "finish_reason": "stop",
-                "text": "Final Answer: test",
-            }
-        ],
-        "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
-    }
-    model = create_openai_llmagent(return_intermediate_steps=return_intermediate_steps)
-    langchain_input = {
-        "input": "What was the high temperature in SF yesterday in Fahrenheit?"
-        "What is that number raised to the .023 power?"
-    }
+def test_langchain_agent_model_predict(return_intermediate_steps, monkeypatch):
+    input_example = {"input": "What is 2 * 3?"}
+
+    # Use env var to control the return_intermediate_steps without modifying the code
+    monkeypatch.setenv("RETURN_INTERMEDIATE_STEPS", str(return_intermediate_steps))
+
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(
-            model, "langchain_model", input_example=langchain_input
+            # OpenAI Client since 1.0 contains thread lock object that cannot be
+            # pickled. Therefore, AgentExecutor cannot be saved with the legacy
+            # object-based logging and we need to use Model-from-Code logging.
+            lc_model="tests/langchain/sample_code/openai_agent.py",
+            artifact_path="langchain_model",
+            input_example=input_example,
         )
+
     loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
+    response = loaded_model.predict([input_example])
 
     if return_intermediate_steps:
-        langchain_output = [
+        expected_output = [
             {
-                "output": "test",
-                "intermediate_steps": {
-                    "tool": "Search",
-                    "tool_input": "High temperature in SF yesterday",
-                    "log": " I need to find the temperature first...",
-                    "result": "San Francisco...",
-                },
+                "output": "The result of 2 * 3 is 6.",
+                "intermediate_steps": [
+                    # tuple of (action, observation)
+                    (
+                        {
+                            "log": mock.ANY,
+                            "message_log": [mock.ANY],
+                            "tool": "multiply",
+                            "tool_call_id": "123",
+                            "tool_input": {"a": 2, "b": 3},
+                            "type": "AgentActionMessageLog",
+                        },
+                        6,
+                    )
+                ],
             }
         ]
         # hardcoded output key because that is the default for an agent
         # but it is not an attribute of the agent or anything that we log
     else:
-        langchain_output = ["test"]
+        expected_output = ["The result of 2 * 3 is 6."]
 
-    with mock.patch("openai.OpenAI.completions.create", return_value=langchain_agent_output):
-        result = loaded_model.predict([langchain_input])
-        assert result == langchain_output
+    assert response == expected_output
 
     inference_payload = load_serving_example(logged_model.model_uri)
-    langchain_agent_output_serving = {"predictions": langchain_agent_output}
-    with mock.patch("openai.OpenAI.completions.create", return_value=langchain_agent_output):
-        response = pyfunc_serve_and_score_model(
-            logged_model.model_uri,
-            data=inference_payload,
-            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-            extra_args=["--env-manager", "local"],
-        )
+    response = pyfunc_serve_and_score_model(
+        logged_model.model_uri,
+        data=inference_payload,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    # TODO: The response is not wrapped by the "predictions" key. This is a bug in
+    # output handling. Often the user input contains a key "input" because it is
+    # used in popular agent prompts in the hub. However, this confuses the scoring
+    # server to treat it as a llm/v1/completion request.
+    response = json.loads(response.content.decode("utf-8"))
+    if return_intermediate_steps:
+        # Tuples are converted to lists during JSON serialization
+        response[0]["intermediate_steps"] = [tuple(r) for r in response[0]["intermediate_steps"]]
+    assert response == expected_output
 
-        assert (
-            PredictionsResponse.from_json(response.content.decode("utf-8"))
-            == langchain_agent_output_serving
-        )
 
-
-# TODO: Fix the AgentExecutor saving issue and remove the skip
-@pytest.mark.skipif(
-    Version(openai.__version__) >= Version("1.0"),
-    reason="OpenAI Client since 1.0 contains thread lock object that cannot be pickled.",
-)
 def test_langchain_agent_model_predict_stream():
-    langchain_agent_output = {
-        "id": "chatcmpl-123",
-        "object": "chat.completion",
-        "created": 1677652288,
-        "choices": [
-            {
-                "index": 0,
-                "finish_reason": "stop",
-                "text": "Final Answer: test",
-            }
-        ],
-        "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
-    }
-    model = create_openai_llmagent()
-
+    input_example = {"input": "What is 2 * 3?"}
     with mlflow.start_run():
-        logged_model = mlflow.langchain.log_model(model, "langchain_model")
+        logged_model = mlflow.langchain.log_model(
+            # OpenAI Client since 1.0 contains thread lock object that cannot be
+            # pickled. Therefore, AgentExecutor cannot be saved with the legacy
+            # object-based logging and we need to use Model-from-Code logging.
+            lc_model="tests/langchain/sample_code/openai_agent.py",
+            artifact_path="langchain_model",
+            input_example=input_example,
+        )
+
     loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
-    langchain_input = {"input": "foo"}
-    with mock.patch("openai.OpenAI.completions.create", return_value=langchain_agent_output):
-        response = loaded_model.predict_stream([langchain_input])
-        assert inspect.isgenerator(response)
-        assert list(response) == [
-            {
-                "output": "test",
-                "messages": [AIMessage(content="Final Answer: test")],
-            }
-        ]
+    response = loaded_model.predict_stream([input_example])
+    assert inspect.isgenerator(response)
+    assert list(response) == [
+        {
+            "actions": [
+                {
+                    "log": mock.ANY,
+                    "message_log": [mock.ANY],
+                    "tool": "multiply",
+                    "tool_call_id": "123",
+                    "tool_input": {"a": 2, "b": 3},
+                    "type": "AgentActionMessageLog",
+                }
+            ],
+            "messages": [mock.ANY],
+        },
+        {
+            "steps": [
+                {
+                    "action": {
+                        "log": mock.ANY,
+                        "message_log": [mock.ANY],
+                        "tool": "multiply",
+                        "tool_call_id": "123",
+                        "tool_input": {"a": 2, "b": 3},
+                        "type": mock.ANY,
+                    },
+                    "observation": 6,
+                }
+            ],
+            "messages": [mock.ANY],
+        },
+        {
+            "output": "The result of 2 * 3 is 6.",
+            "messages": [mock.ANY],
+        },
+    ]
 
 
 def test_langchain_native_log_and_load_qaevalchain():
@@ -862,7 +857,7 @@ def test_log_and_load_retriever_chain(tmp_path):
     # Create the vector db, persist the db to a local fs folder
     loader = TextLoader("tests/langchain/state_of_the_union.txt")
     documents = loader.load()
-    text_splitter = CharacterTextSplitter(chunk_size=10, chunk_overlap=0)
+    text_splitter = CharacterTextSplitter(chunk_size=256, chunk_overlap=0)
     docs = text_splitter.split_documents(documents)
     embeddings = DeterministicDummyEmbeddings(size=5)
     db = FAISS.from_documents(docs, embeddings)
@@ -923,7 +918,12 @@ def test_log_and_load_retriever_chain(tmp_path):
     loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model.model_uri)
     result = loaded_pyfunc_model.predict([langchain_input])
     expected_result = [
-        {"page_content": doc.page_content, "metadata": doc.metadata}
+        {
+            "page_content": doc.page_content,
+            "metadata": doc.metadata,
+            "id": None,
+            "type": "Document",
+        }
         for doc in db.as_retriever().get_relevant_documents(query)
     ]
     assert result == [expected_result]

--- a/tests/langchain/test_langgraph.py
+++ b/tests/langchain/test_langgraph.py
@@ -1,0 +1,36 @@
+from langgraph.graph.graph import CompiledGraph
+
+import mlflow
+
+
+def test_langgraph_save_as_code():
+    input_example = {"messages": [{"role": "user", "content": "what is the weather in sf?"}]}
+
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            lc_model="tests/langchain/sample_code/langgraph.py",
+            artifact_path="langgraph",
+            input_example=input_example,
+        )
+
+    loaded_graph = mlflow.langchain.load_model(model_info.model_uri)
+    assert isinstance(loaded_graph, CompiledGraph)
+    response = loaded_graph.invoke(input_example)
+    # The OpenAI mock should return the same response as input
+    assert response["messages"][0].content == "what is the weather in sf?"
+
+    for chunk in loaded_graph.stream(input_example):
+        assert (
+            chunk["agent"]["messages"][0].content
+            == '[{"role": "user", "content": "what is the weather in sf?"}]'
+        )
+
+    loaded_pyfunc = mlflow.pyfunc.load_model(model_info.model_uri)
+    response = loaded_pyfunc.predict(input_example)[0]
+    assert response["messages"][0].content == "what is the weather in sf?"
+
+    for chunk in loaded_pyfunc.predict_stream(input_example, params={"stream_mode": "values"}):
+        assert (
+            chunk["agent"]["messages"][0].content
+            == '[{"role": "user", "content": "what is the weather in sf?"}]'
+        )

--- a/tests/langchain/test_langgraph.py
+++ b/tests/langchain/test_langgraph.py
@@ -1,8 +1,16 @@
 import json
 
+import langchain
+import pytest
+from packaging.version import Version
+
 import mlflow
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="Agent behavior is not stable across minor versions",
+)
 def test_langgraph_save_as_code():
     input_example = {"messages": [{"role": "user", "content": "what is the weather in sf?"}]}
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/12996?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/12996/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 12996
```

</p>
</details>

### What changes are proposed in this pull request?

Support saving LangGraph models. We only support it in model-from-code method, because they don't have native serialization support.

One key change in this PR is the output handling. Pydantic models are not JSON serializable, which is problematic when deploying the model in Model Serving. We had some ad-hoc processing like [this](https://github.com/mlflow/mlflow/blob/tracing/mlflow/langchain/api_request_parallel_processor.py#L160-L195), but it doesn't cover general LangGraph and Agent use cases. Therefore, this PR adds a general transformation that converts the pydantic models into dictionary.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

![Screenshot 2024-08-22 at 12 36 45](https://github.com/user-attachments/assets/531bc5b4-6030-411d-84a8-8b4acd662dc1)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support saving LangGraph models via model-from-code.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
