### PR TITLE
Support Langgraph agents in Auto Auth

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -58,49 +58,50 @@ def _get_vectorstore_from_retriever(retriever) -> Generator[Resource, None, None
 
 
 def _extract_databricks_dependencies_from_tools(tools) -> Generator[Resource, None, None]:
-    from langchain_community.tools import BaseTool
+    if isinstance(tools, list):
+        from langchain_community.tools import BaseTool
 
-    warehouse_ids = set()
-    for tool in tools:
-        if isinstance(tool, BaseTool):
-            # Handle Retriever tools
-            if hasattr(tool.func, "keywords") and "retriever" in tool.func.keywords:
-                retriever = tool.func.keywords.get("retriever")
-                yield from _get_vectorstore_from_retriever(retriever)
-            else:
-                try:
-                    from langchain_community.tools.databricks import UCFunctionToolkit
-                except Exception:
-                    continue
-                # Tools here are a part of the BaseTool and have no attribute of a
-                # WarehouseID Extract the global variables of the function defined
-                # in the tool to get the UCFunctionToolkit Constants
-                nonlocal_vars = inspect.getclosurevars(tool.func).nonlocals
-                if "self" in nonlocal_vars and isinstance(
-                    nonlocal_vars.get("self"), UCFunctionToolkit
-                ):
-                    uc_function_toolkit = nonlocal_vars.get("self")
-                    # As we are iterating through each tool, adding a warehouse id everytime
-                    # is a duplicative resouce. Use a set to dedup warehouse ids and add
-                    # them in the end
-                    warehouse_ids.add(uc_function_toolkit.warehouse_id)
+        warehouse_ids = set()
+        for tool in tools:
+            if isinstance(tool, BaseTool):
+                # Handle Retriever tools
+                if hasattr(tool.func, "keywords") and "retriever" in tool.func.keywords:
+                    retriever = tool.func.keywords.get("retriever")
+                    yield from _get_vectorstore_from_retriever(retriever)
+                else:
+                    try:
+                        from langchain_community.tools.databricks import UCFunctionToolkit
+                    except Exception:
+                        continue
+                    # Tools here are a part of the BaseTool and have no attribute of a
+                    # WarehouseID Extract the global variables of the function defined
+                    # in the tool to get the UCFunctionToolkit Constants
+                    nonlocal_vars = inspect.getclosurevars(tool.func).nonlocals
+                    if "self" in nonlocal_vars and isinstance(
+                        nonlocal_vars.get("self"), UCFunctionToolkit
+                    ):
+                        uc_function_toolkit = nonlocal_vars.get("self")
+                        # As we are iterating through each tool, adding a warehouse id everytime
+                        # is a duplicative resouce. Use a set to dedup warehouse ids and add
+                        # them in the end
+                        warehouse_ids.add(uc_function_toolkit.warehouse_id)
 
-                    # In langchain the names of the tools are modified to have underscores:
-                    # main.catalog.test_func -> main_catalog_test_func
-                    # The original name of the tool is stored as the key in the tools
-                    # dictionary. This code finds the correct tool and extract the key
-                    langchain_tool_name = tool.name
-                    filtered_tool_names = [
-                        tool_name
-                        for tool_name, uc_tool in uc_function_toolkit.tools.items()
-                        if uc_tool.name == langchain_tool_name
-                    ]
-                    # This should always have the length 1
-                    for tool_name in filtered_tool_names:
-                        yield DatabricksUCFunction(function_name=tool_name)
-    # Add the deduped warehouse ids
-    for warehouse_id in warehouse_ids:
-        yield DatabricksSQLWarehouse(warehouse_id=warehouse_id)
+                        # In langchain the names of the tools are modified to have underscores:
+                        # main.catalog.test_func -> main_catalog_test_func
+                        # The original name of the tool is stored as the key in the tools
+                        # dictionary. This code finds the correct tool and extract the key
+                        langchain_tool_name = tool.name
+                        filtered_tool_names = [
+                            tool_name
+                            for tool_name, uc_tool in uc_function_toolkit.tools.items()
+                            if uc_tool.name == langchain_tool_name
+                        ]
+                        # This should always have the length 1
+                        for tool_name in filtered_tool_names:
+                            yield DatabricksUCFunction(function_name=tool_name)
+        # Add the deduped warehouse ids
+        for warehouse_id in warehouse_ids:
+            yield DatabricksSQLWarehouse(warehouse_id=warehouse_id)
 
 
 def _extract_databricks_dependencies_from_retriever(retriever) -> Generator[Resource, None, None]:
@@ -159,27 +160,6 @@ def _extract_databricks_dependencies_from_tool_nodes(tool_node) -> Generator[Res
         )
 
 
-def _extract_databricks_dependencies_from_agent(
-    agent_executor,
-) -> Generator[Resource, None, None]:
-    # Tools are passed into a Langchain as Seq[BaseTool] part of an AgentExecutor
-    # This function looks for an AgentExecutor, extracts all the tools generated from
-    # UC Function Toolkit. From each of these tools it then extracts the Databricks
-    # SQL Warehouse ID and UC Function Names and adds them to resources.
-    from langchain.agents import AgentExecutor
-
-    if isinstance(agent_executor, AgentExecutor):
-        agent = agent_executor.agent
-
-        # Get the Dependencies for the LLM
-        if agent.llm_chain is not None:
-            yield from _extract_databricks_dependencies_from_chat_model(agent.llm_chain.llm)
-            yield from _extract_databricks_dependencies_from_llm(agent.llm_chain.llm)
-
-            tools = agent_executor.tools
-            yield from _extract_databricks_dependencies_from_tools(tools)
-
-
 _LEGACY_MODEL_ATTR_SET = {
     "llm",  # LLMChain
     "retriever",  # RetrievalQA
@@ -189,7 +169,9 @@ _LEGACY_MODEL_ATTR_SET = {
     "refine_llm_chain",  # RefineDocumentsChain
     "combine_documents_chain",  # RetrievalQA, ReduceDocumentsChain
     "combine_docs_chain",  # BaseConversationalRetrievalChain
-    "collapse_documents_chain",  # ReduceDocumentsChain
+    "collapse_documents_chain",  # ReduceDocumentsChain,
+    "agent",  # Agent,
+    "tools",  # Tools
 }
 
 
@@ -208,7 +190,11 @@ def _extract_dependency_list_from_lc_model(lc_model) -> Generator[Resource, None
     yield from _extract_databricks_dependencies_from_chat_model(lc_model)
     yield from _extract_databricks_dependencies_from_retriever(lc_model)
     yield from _extract_databricks_dependencies_from_llm(lc_model)
+
     if Version(langchain.__version__) >= Version("0.1.0"):
+        yield from _extract_databricks_dependencies_from_tools(lc_model)
+    # Langgraph needs langcahin version 0.2.0 or higher
+    if Version(langchain.__version__) >= Version("0.2.0"):
         yield from _extract_databricks_dependencies_from_tool_nodes(lc_model)
 
     # recursively inspect legacy chain
@@ -233,6 +219,7 @@ def _traverse_runnable(
     current_object_id = id(lc_model)
     if current_object_id in visited:
         return
+
     # Visit the current object
     visited.add(current_object_id)
     yield from _extract_dependency_list_from_lc_model(lc_model)
@@ -247,9 +234,6 @@ def _traverse_runnable(
 
 
 def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> List[Resource]:
-    import langchain
-    from langchain.agents import AgentExecutor
-
     """
     Detects the databricks dependencies of a langchain model and returns a list of
     detected endpoint names and index names.
@@ -271,12 +255,7 @@ def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> Li
     If a chat_model is found, it will be used to extract the databricks chat dependencies.
     """
     try:
-        if isinstance(lc_model, AgentExecutor) and Version(langchain.__version__) >= Version(
-            "0.1.0"
-        ):
-            dependency_list = list(_extract_databricks_dependencies_from_agent(lc_model))
-        else:
-            dependency_list = list(_traverse_runnable(lc_model))
+        dependency_list = list(_traverse_runnable(lc_model))
         # Filter out duplicate dependencies so same dependencies are not added multiple times
         # We can't use set here as the object is not hashable so we need to filter it out manually.
         unique_dependencies = []

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -667,6 +667,7 @@ langchain:
           "numexpr",
           "hf_transfer",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
+          "langgraph",
         ]
       ">= 0.2": ["langchain-huggingface"]
       # We cannot use install langchain-openai with langchain >= 0.2.0, while pinning openai to <1.8.0

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -8,10 +8,10 @@ from packaging.version import Version
 
 from mlflow.langchain.databricks_dependencies import (
     _detect_databricks_dependencies,
-    _extract_databricks_dependencies_from_agent,
     _extract_databricks_dependencies_from_chat_model,
     _extract_databricks_dependencies_from_llm,
     _extract_databricks_dependencies_from_retriever,
+    _extract_dependency_list_from_lc_model,
 )
 from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
 from mlflow.models.resources import (
@@ -293,7 +293,7 @@ def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
         verbose=True,
     )
 
-    resources = list(_extract_databricks_dependencies_from_agent(agent))
+    resources = list(_extract_dependency_list_from_lc_model(agent))
     assert resources == [
         DatabricksUCFunction(function_name="rag.test.test_function"),
         DatabricksSQLWarehouse(warehouse_id="testId1"),
@@ -390,7 +390,7 @@ def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch)
         chat_model,
         verbose=True,
     )
-    resources = list(_extract_databricks_dependencies_from_agent(agent))
+    resources = list(_extract_dependency_list_from_lc_model(agent))
     # Ensure all resources are added in
     expected = [
         DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat"),

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -174,6 +174,81 @@ def create_openai_llmagent(return_intermediate_steps=False):
     )
 
 
+def create_uc_tools(
+    monkeypatch, warehouse_id, expected_catalog_name, expected_schema_name, functions
+):
+    try:
+        from langchain_community.tools.databricks import UCFunctionToolkit
+    except Exception:
+        return []
+
+    from databricks.sdk.service.catalog import FunctionInfo
+
+    # Return 2 functions from the function lis
+    def mock_function_list(self, catalog_name, schema_name):
+        assert catalog_name == expected_catalog_name
+        assert schema_name == expected_schema_name
+        return [FunctionInfo(full_name=function) for function in functions]
+
+    # For each function ensure that it returns a tool which takes one input
+    def mock_function_get(self, function_name):
+        components = function_name.split(".")
+        param_dict = {
+            "parameters": [
+                {
+                    "name": "param",
+                    "parameter_type": "PARAM",
+                    "position": 0,
+                    "type_json": '{"name":"param","type":"string","nullable":true,"metadata":{}}',
+                    "type_name": "STRING",
+                    "type_precision": 0,
+                    "type_scale": 0,
+                    "type_text": "string",
+                }
+            ]
+        }
+        return FunctionInfo.from_dict(
+            {
+                "catalog_name": components[0],
+                "schema_name": components[1],
+                "name": components[2],
+                "input_params": param_dict,
+            }
+        )
+
+    monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
+    monkeypatch.setattr("databricks.sdk.service.catalog.FunctionsAPI.list", mock_function_list)
+    monkeypatch.setattr("databricks.sdk.service.catalog.FunctionsAPI.get", mock_function_get)
+
+    # Create an toolkit with the '*' syntax
+    return (
+        UCFunctionToolkit(warehouse_id=warehouse_id)
+        .include(f"{expected_catalog_name}.{expected_schema_name}.*")
+        .get_tools()
+    )
+
+
+def create_retriever_tool(monkeypatch):
+    from langchain.tools.retriever import create_retriever_tool
+    from langchain_community.vectorstores import DatabricksVectorSearch
+
+    vsc = MockVectorSearchClient()
+    vs_index = vsc.get_index(
+        endpoint_name="dbdemos_vs_endpoint",
+        index_name="mlflow.rag.vs_index",
+        has_embedding_endpoint=True,
+    )
+
+    mock_module = mock.MagicMock()
+    mock_module.VectorSearchIndex = MockVectorSearchIndex
+    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
+
+    vectorstore = DatabricksVectorSearch(vs_index, text_column="content")
+    retriever = vectorstore.as_retriever()
+    return create_retriever_tool(retriever, "vs_index_name", "vs_index_desc")
+
+
 class FakeLLM(LLM):
     """Fake LLM wrapper for testing purposes."""
 
@@ -1919,87 +1994,84 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
     Version(langchain.__version__) < Version("0.1.0"),
     reason="Tools are not supported the way we want in earlier versions",
 )
-def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
-    from databricks.sdk.service.catalog import FunctionInfo
-    from langchain.tools.retriever import create_retriever_tool
+def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
     from langchain_community.chat_models import ChatDatabricks
-    from langchain_community.vectorstores import DatabricksVectorSearch
+    from langchain_core.runnables import RunnableLambda
+    from langgraph.prebuilt import create_react_agent
 
-    # Return 2 functions from the function lis
-    def mock_function_list(self, catalog_name, schema_name):
-        assert catalog_name == "rag"
-        assert schema_name == "studio"
-        return [
-            FunctionInfo(full_name="rag.studio.test_function_a"),
-            FunctionInfo(full_name="rag.studio.test_function_b"),
-        ]
-
-    # For each function ensure that it returns a tool which takes one input
-    def mock_function_get(self, function_name):
-        components = function_name.split(".")
-        param_dict = {
-            "parameters": [
-                {
-                    "name": "param",
-                    "parameter_type": "PARAM",
-                    "position": 0,
-                    "type_json": '{"name":"param","type":"string","nullable":true,"metadata":{}}',
-                    "type_name": "STRING",
-                    "type_precision": 0,
-                    "type_scale": 0,
-                    "type_text": "string",
-                }
-            ]
-        }
-        return FunctionInfo.from_dict(
-            {
-                "catalog_name": components[0],
-                "schema_name": components[1],
-                "name": components[2],
-                "input_params": param_dict,
-            }
-        )
-
-    vsc = MockVectorSearchClient()
-    vs_index = vsc.get_index(
-        endpoint_name="dbdemos_vs_endpoint",
-        index_name="mlflow.rag.vs_index",
-        has_embedding_endpoint=True,
-    )
-
-    mock_module = mock.MagicMock()
-    mock_module.VectorSearchIndex = MockVectorSearchIndex
-    mock_get_deploy_client = mock.MagicMock()
-
-    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
-    monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
-    monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
-    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
-    monkeypatch.setattr("databricks.sdk.service.catalog.FunctionsAPI.list", mock_function_list)
-    monkeypatch.setattr("databricks.sdk.service.catalog.FunctionsAPI.get", mock_function_get)
     # Mocking Cloudpickle because serialization in this setup is failing
     monkeypatch.setattr("cloudpickle.dump", mock.MagicMock())
 
-    # Create an toolkit with the '*' syntax
-    include_uc_function_tools = False
-    try:
-        from langchain_community.tools.databricks import UCFunctionToolkit
-
-        include_uc_function_tools = True
-    except Exception:
-        include_uc_function_tools = False
-
-    uc_function_tools = (
-        (UCFunctionToolkit(warehouse_id="test_id_1").include("rag.studio.*").get_tools())
-        if include_uc_function_tools
-        else []
+    uc_functions = ["rag.studio.test_function_a", "rag.studio.test_function_b"]
+    uc_function_tools = create_uc_tools(
+        monkeypatch,
+        warehouse_id="test_id_1",
+        expected_catalog_name="rag",
+        expected_schema_name="studio",
+        functions=uc_functions,
     )
-
+    retriever_tool = create_retriever_tool(monkeypatch)
     chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
 
-    vectorstore = DatabricksVectorSearch(vs_index, text_column="content")
-    retriever = vectorstore.as_retriever()
-    retriever_tool = create_retriever_tool(retriever, "vs_index_name", "vs_index_desc")
+    agent = create_react_agent(chat_model, uc_function_tools + [retriever_tool])
+
+    def wrap_agent(input):
+        return agent.invoke(input)
+
+    pyfunc_artifact_path = "retrieval_qa_chain"
+    with mlflow.start_run() as run:
+        mlflow.langchain.log_model(
+            RunnableLambda(wrap_agent),
+            pyfunc_artifact_path,
+        )
+    pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
+    pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
+    reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
+    actual = reloaded_model.resources["databricks"]
+
+    # Ensure both functions are outputted
+    expected = {
+        "serving_endpoint": [{"name": "databricks-llama-2-70b-chat"}, {"name": "embedding-model"}],
+        "vector_search_index": [{"name": "mlflow.rag.vs_index"}],
+    }
+
+    if len(uc_function_tools) > 0:
+        uc_expected = {
+            "sql_warehouse": [{"name": "test_id_1"}],
+            "uc_function": [{"name": function} for function in uc_functions],
+        }
+        expected.update(uc_expected)
+
+    assert all(item in actual["serving_endpoint"] for item in expected["serving_endpoint"])
+    assert all(item in expected["serving_endpoint"] for item in actual["serving_endpoint"])
+    assert actual["vector_search_index"] == expected["vector_search_index"]
+    if uc_function_tools:
+        assert actual["sql_warehouse"] == expected["sql_warehouse"]
+        assert all(item in actual["uc_function"] for item in expected["uc_function"])
+        assert all(item in expected["uc_function"] for item in actual["uc_function"])
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.1.0"),
+    reason="Tools are not supported the way we want in earlier versions",
+)
+def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
+    from langchain_community.chat_models import ChatDatabricks
+
+    # Mocking Cloudpickle because serialization in this setup is failing
+    monkeypatch.setattr("cloudpickle.dump", mock.MagicMock())
+
+    uc_functions = ["rag.studio.test_function_a", "rag.studio.test_function_b"]
+    uc_function_tools = create_uc_tools(
+        monkeypatch,
+        warehouse_id="test_id_1",
+        expected_catalog_name="rag",
+        expected_schema_name="studio",
+        functions=uc_functions,
+    )
+    retriever_tool = create_retriever_tool(monkeypatch)
+    chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
+
     agent = initialize_agent(
         uc_function_tools + [retriever_tool],
         chat_model,
@@ -2022,13 +2094,10 @@ def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
         "vector_search_index": [{"name": "mlflow.rag.vs_index"}],
     }
 
-    if uc_function_tools:
+    if len(uc_function_tools) > 0:
         uc_expected = {
             "sql_warehouse": [{"name": "test_id_1"}],
-            "uc_function": [
-                {"name": "rag.studio.test_function_a"},
-                {"name": "rag.studio.test_function_b"},
-            ],
+            "uc_function": [{"name": function} for function in uc_functions],
         }
         expected.update(uc_expected)
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1991,8 +1991,8 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
 
 
 @pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.1.0"),
-    reason="Tools are not supported the way we want in earlier versions",
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="Langgraph are not supported the way we want in earlier versions",
 )
 def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
     from langchain_community.chat_models import ChatDatabricks

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2033,14 +2033,9 @@ def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
     expected = {
         "serving_endpoint": [{"name": "databricks-llama-2-70b-chat"}, {"name": "embedding-model"}],
         "vector_search_index": [{"name": "mlflow.rag.vs_index"}],
+        "sql_warehouse": [{"name": "test_id_1"}],
+        "uc_function": [{"name": function} for function in uc_functions],
     }
-
-    if len(uc_function_tools) > 0:
-        uc_expected = {
-            "sql_warehouse": [{"name": "test_id_1"}],
-            "uc_function": [{"name": function} for function in uc_functions],
-        }
-        expected.update(uc_expected)
 
     assert all(item in actual["serving_endpoint"] for item in expected["serving_endpoint"])
     assert all(item in expected["serving_endpoint"] for item in actual["serving_endpoint"])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aravind-segu/mlflow/pull/13001?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13001/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13001
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Extends auto auth to now support Langgraph agents. The current test case only tests langgraph agents wrapped in a RunnableLambda. When native agents are supported will add a test case for them as well. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x]  New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Support Extracting Dependencies for Langgraph Agents

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?
Yes
`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
