### PR TITLE
[BUG] add support for file removal for local artifact repo

### DIFF
--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -122,7 +122,10 @@ class LocalArtifactRepository(ArtifactRepository):
         )
 
         if os.path.exists(artifact_path):
-            shutil.rmtree(artifact_path)
+            if os.path.isfile(artifact_path):
+                os.remove(artifact_path)
+            else:
+                shutil.rmtree(artifact_path)
 
     def download_trace_data(self) -> Dict[str, Any]:
         """

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -211,7 +211,7 @@ def test_delete_artifacts_files(local_artifact_repo, tmp_path):
     (nested / "c.txt").write_text("C")
 
     local_artifact_repo.log_artifacts(str(subdir))
-    artifact_dir = pathlib.PosixPath(local_artifact_repo._artifact_dir)
+    artifact_dir = pathlib.Path(local_artifact_repo._artifact_dir)
     assert (artifact_dir / "nested").exists()
     assert (artifact_dir / "a.txt").exists()
     assert (artifact_dir / "b.txt").exists()

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -181,7 +181,7 @@ def test_hidden_files_are_logged_correctly(local_artifact_repo):
             assert f.read() == "42"
 
 
-def test_delete_artifacts(local_artifact_repo):
+def test_delete_artifacts_folder(local_artifact_repo):
     with TempDir() as local_dir:
         os.mkdir(local_dir.path("subdir"))
         os.mkdir(local_dir.path("subdir", "nested"))
@@ -197,6 +197,31 @@ def test_delete_artifacts(local_artifact_repo):
         assert os.path.exists(os.path.join(local_artifact_repo._artifact_dir, "b.txt"))
         local_artifact_repo.delete_artifacts()
         assert not os.path.exists(os.path.join(local_artifact_repo._artifact_dir))
+
+
+def test_delete_artifacts_files(local_artifact_repo):
+    with TempDir() as local_dir:
+        os.mkdir(local_dir.path("subdir"))
+        os.mkdir(local_dir.path("subdir", "nested"))
+        with open(local_dir.path("subdir", "a.txt"), "w") as f:
+            f.write("A")
+        with open(local_dir.path("subdir", "b.txt"), "w") as f:
+            f.write("B")
+        with open(local_dir.path("subdir", "nested", "c.txt"), "w") as f:
+            f.write("C")
+        local_artifact_repo.log_artifacts(local_dir.path("subdir"))
+        assert os.path.exists(os.path.join(local_artifact_repo._artifact_dir, "nested"))
+        assert os.path.exists(os.path.join(local_artifact_repo._artifact_dir, "a.txt"))
+        assert os.path.exists(os.path.join(local_artifact_repo._artifact_dir, "b.txt"))
+        local_artifact_repo.delete_artifacts(artifact_path="nested/c.txt")
+        local_artifact_repo.delete_artifacts(artifact_path="b.txt")
+        assert not os.path.exists(
+            os.path.join(local_artifact_repo._artifact_dir, "nested", "c.txt")
+        )
+        assert not os.path.exists(
+            os.path.join(local_artifact_repo._artifact_dir, "b.txt")
+        )
+        assert os.path.exists(os.path.join(local_artifact_repo._artifact_dir, "a.txt"))
 
 
 def test_delete_artifacts_with_nonexistent_path_succeeds(local_artifact_repo):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rzalawad/mlflow/pull/13005?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13005/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13005
```

</p>
</details>

### Related Issues/PRs
Resolve https://github.com/mlflow/mlflow/issues/4185
<!-- Uncomment 'Resolve' if this PR can close the linked items. -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/5313083a-4aa8-4491-9335-f5b48150fc13">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes
* Update local artifact repo to handle file deletions.

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?
This PR affects the delete_artifacts feature of Local artifact repository. The user can now delete artifacts rather than just folders.

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
