### PR TITLE
Add polars dataset

### DIFF
--- a/docs/api_reference/source/python_api/mlflow.data.rst
+++ b/docs/api_reference/source/python_api/mlflow.data.rst
@@ -133,6 +133,17 @@ TensorFlow
     :undoc-members:
 
 
+polars
+~~~~~~
+
+.. autofunction:: mlflow.data.from_polars
+
+.. autoclass:: mlflow.data.polars_dataset.PolarsDataset()
+    :members:
+    :undoc-members:
+    :exclude-members: to_pyfunc, to_evaluation_dataset
+
+
 Dataset Sources 
 ~~~~~~~~~~~~~~~~
 

--- a/docs/api_reference/source/python_api/mlflow.data.rst
+++ b/docs/api_reference/source/python_api/mlflow.data.rst
@@ -12,7 +12,7 @@ following important interfaces:
   :py:class:`Datasets <mlflow.data.dataset.Dataset>` from a variety of Python data objects, including
   Pandas DataFrames (:py:func:`mlflow.data.from_pandas()`), NumPy arrays
   (:py:func:`mlflow.data.from_numpy()`), Spark DataFrames (:py:func:`mlflow.data.from_spark()`
-  / :py:func:`mlflow.data.load_delta()`), and more.
+  / :py:func:`mlflow.data.load_delta()`), Polars DataFrames (:py:func:`mlflow.data.from_polars()`), and more.
 
 * :py:func:`DatasetSource <mlflow.data.dataset_source.DatasetSource>`: Represents the source of a
   dataset. For example, this may be a directory of files stored in S3, a Delta Table, or a web URL.

--- a/docs/docs/classic-ml/dataset/index.mdx
+++ b/docs/docs/classic-ml/dataset/index.mdx
@@ -36,6 +36,7 @@ The `Dataset` abstraction is a metadata tracking object that holds comprehensive
 - <APILink fn="mlflow.data.pandas_dataset.PandasDataset">`PandasDataset`</APILink> - For Pandas DataFrames
 - <APILink fn="mlflow.data.spark_dataset.SparkDataset">`SparkDataset`</APILink> - For Apache Spark DataFrames
 - <APILink fn="mlflow.data.numpy_dataset.NumpyDataset">`NumpyDataset`</APILink> - For NumPy arrays
+- <APILink fn="mlflow.data.polars_dataset.PolarsDataset">`PolarsDataset`</APILink> - For Polars DataFrames
 - <APILink fn="mlflow.data.huggingface_dataset.HuggingFaceDataset">`HuggingFaceDataset`</APILink> - For Hugging Face datasets
 - <APILink fn="mlflow.data.tensorflow_dataset.TensorFlowDataset">`TensorFlowDataset`</APILink> - For TensorFlow datasets
 - <APILink fn="mlflow.data.meta_dataset.MetaDataset">`MetaDataset`</APILink> - For metadata-only datasets (no actual data storage)

--- a/mlflow/data/dataset_registry.py
+++ b/mlflow/data/dataset_registry.py
@@ -162,3 +162,7 @@ with suppress(ImportError):
 
     _dataset_registry.register_constructor(load_delta)
     _dataset_registry.register_constructor(from_spark)
+with suppress(ImportError):
+    from mlflow.data.polars_dataset import from_polars
+
+    _dataset_registry.register_constructor(from_polars)

--- a/mlflow/data/polars_dataset.py
+++ b/mlflow/data/polars_dataset.py
@@ -5,12 +5,8 @@ from inspect import isclass
 from typing import Any, Dict, Final, Optional, TypedDict, Union
 
 import polars as pl
-from polars.datatypes.classes import (
-    DataType as PolarsDataType,
-)
-from polars.datatypes.classes import (
-    DataTypeClass as PolarsDataTypeClass,
-)
+from polars.datatypes.classes import DataType as PolarsDataType
+from polars.datatypes.classes import DataTypeClass as PolarsDataTypeClass
 
 from mlflow.data.dataset import Dataset
 from mlflow.data.dataset_source import DatasetSource

--- a/mlflow/data/polars_dataset.py
+++ b/mlflow/data/polars_dataset.py
@@ -307,7 +307,7 @@ def from_polars(
             :py:class:`DatasetSource <mlflow.data.dataset_source.DatasetSource>`.
             If unspecified, the source is assumed to be the code location
             (e.g. notebook cell, script, etc.) where
-            :py:func:`from_polars <mlflow.data.polars_dataset.from_polars>` is being called.
+            :py:func:`from_polars <mlflow.data.from_polars>` is being called.
         targets: An optional target column name for supervised training. This column
             must be present in ``df``.
         name: Name of the dataset. If unspecified, a name is generated.

--- a/mlflow/data/polars_dataset.py
+++ b/mlflow/data/polars_dataset.py
@@ -1,0 +1,356 @@
+import json
+import logging
+from functools import cached_property
+from inspect import isclass
+from typing import Any, Dict, Final, Optional, TypedDict, Union
+
+import polars as pl
+from polars.datatypes.classes import (
+    DataType as PolarsDataType,
+)
+from polars.datatypes.classes import (
+    DataTypeClass as PolarsDataTypeClass,
+)
+
+from mlflow.data.dataset import Dataset
+from mlflow.data.dataset_source import DatasetSource
+from mlflow.data.evaluation_dataset import EvaluationDataset
+from mlflow.data.pyfunc_dataset_mixin import PyFuncConvertibleDatasetMixin, PyFuncInputsOutputs
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.types.schema import Array, ColSpec, DataType, Object, Property, Schema
+
+_logger = logging.getLogger(__name__)
+
+
+def hash_polars_df(df: pl.DataFrame) -> str:
+    # probably not the best way to hash, also see:
+    # https://github.com/pola-rs/polars/issues/9743
+    # https://stackoverflow.com/q/76678160
+    return str(df.hash_rows().sum())
+
+
+ColSpecType = Union[DataType, Array, Object, str]
+TYPE_MAP: Final[Dict[PolarsDataTypeClass, DataType]] = {
+    pl.Binary: DataType.binary,
+    pl.Boolean: DataType.boolean,
+    pl.Datetime: DataType.datetime,
+    pl.Float32: DataType.float,
+    pl.Float64: DataType.double,
+    pl.Int8: DataType.integer,
+    pl.Int16: DataType.integer,
+    pl.Int32: DataType.integer,
+    pl.Int64: DataType.long,
+    pl.String: DataType.string,
+    pl.Utf8: DataType.string,
+}
+CLOSE_MAP: Final[Dict[PolarsDataTypeClass, DataType]] = {
+    pl.Categorical: DataType.string,
+    pl.Enum: DataType.string,
+    pl.Date: DataType.datetime,
+    pl.UInt8: DataType.integer,
+    pl.UInt16: DataType.integer,
+    pl.UInt32: DataType.long,
+}
+# Remaining types:
+# pl.Decimal
+# pl.UInt64
+# pl.Duration
+# pl.Time
+# pl.Null
+# pl.Object
+# pl.Unknown
+
+
+def infer_schema(df: pl.DataFrame) -> Schema:
+    return Schema([infer_colspec(df[col]) for col in df.columns])
+
+
+def infer_colspec(col: pl.Series, *, allow_unknown: bool = True) -> ColSpec:
+    return ColSpec(
+        type=infer_dtype(col.dtype, col.name, allow_unknown=allow_unknown),
+        name=col.name,
+        required=col.count() > 0,
+    )
+
+
+def infer_dtype(
+    dtype: Union[PolarsDataType, PolarsDataTypeClass], col_name: str, *, allow_unknown: bool
+) -> ColSpecType:
+    cls: PolarsDataTypeClass = dtype if isinstance(dtype, PolarsDataTypeClass) else type(dtype)
+    mapped = TYPE_MAP.get(cls)
+    if mapped is not None:
+        return mapped
+
+    mapped = CLOSE_MAP.get(cls)
+    if mapped is not None:
+        logging.warning(
+            "Data type of Column '%s' contains dtype=%s which will be mapped to %s."
+            " This is not an exact match but is close enough",
+            col_name,
+            dtype,
+            mapped,
+        )
+        return mapped
+
+    if not isinstance(dtype, PolarsDataType):
+        return _handle_unknown_dtype(dtype=dtype, col_name=col_name, allow_unknown=allow_unknown)
+
+    if isinstance(dtype, (pl.Array, pl.List)):
+        # cannot check inner if not instantiated
+        if isclass(dtype):
+            if not allow_unknown:
+                _raise_unknown_type(dtype)
+            return Array("Unknown")
+
+        inner = (
+            "Unknown"
+            if dtype.inner is None
+            else infer_dtype(dtype.inner, f"{col_name}.[]", allow_unknown=allow_unknown)
+        )
+        return Array(inner)
+
+    if isinstance(dtype, pl.Struct):
+        # cannot check fields if not instantiated
+        if isclass(dtype):
+            if not allow_unknown:
+                _raise_unknown_type(dtype)
+            return Object([])
+
+        return Object(
+            [
+                Property(
+                    name=field.name,
+                    dtype=infer_dtype(
+                        field.dtype, f"{col_name}.{field.name}", allow_unknown=allow_unknown
+                    ),
+                )
+                for field in dtype.fields
+            ]
+        )
+
+    return _handle_unknown_dtype(dtype=dtype, col_name=col_name, allow_unknown=allow_unknown)
+
+
+def _handle_unknown_dtype(dtype: Any, col_name: str, *, allow_unknown: bool) -> str:
+    if not allow_unknown:
+        _raise_unknown_type(dtype)
+
+    logging.warning(
+        "Data type of Columns '%s' contains dtype=%s, which cannot be mapped to any DataType",
+        col_name,
+        dtype,
+    )
+    return str(dtype)
+
+
+def _raise_unknown_type(dtype: Any) -> None:
+    msg = f"Unknown type: {dtype!r}"
+    raise ValueError(msg)
+
+
+class PolarsDataset(Dataset, PyFuncConvertibleDatasetMixin):
+    """A polars DataFrame for use with MLflow Tracking."""
+
+    def __init__(
+        self,
+        df: pl.DataFrame,
+        source: DatasetSource,
+        targets: Optional[str] = None,
+        name: Optional[str] = None,
+        digest: Optional[str] = None,
+        predictions: Optional[str] = None,
+    ) -> None:
+        """
+        Args:
+            df: A polars DataFrame.
+            source: Source of the DataFrame.
+            targets: Name of the target column. Optional.
+            name: Name of the dataset. E.g. "wiki_train". If unspecified, a name is automatically
+                generated.
+            digest: Digest (hash, fingerprint) of the dataset. If unspecified, a digest is
+                automatically computed.
+            predictions: Name of the column containing model predictions, if the dataset contains
+                model predictions. Optional. If specified, this column must be present in ``df``.
+        """
+        if targets is not None and targets not in df.columns:
+            raise MlflowException(
+                f"DataFrame does not contain specified targets column: '{targets}'",
+                INVALID_PARAMETER_VALUE,
+            )
+        if predictions is not None and predictions not in df.columns:
+            raise MlflowException(
+                f"DataFrame does not contain specified predictions column: '{predictions}'",
+                INVALID_PARAMETER_VALUE,
+            )
+
+        # _df needs to be set before super init, as it is used in _compute_digest
+        # see Dataset.__init__()
+        self._df = df
+        super().__init__(source=source, name=name, digest=digest)
+        self._targets = targets
+        self._predictions = predictions
+
+    def _compute_digest(self) -> str:
+        """Compute a digest for the dataset.
+
+        Called if the user doesn't supply a digest when constructing the dataset.
+        """
+        return hash_polars_df(self._df)
+
+    class PolarsDatasetConfig(TypedDict):
+        name: str
+        digest: str
+        source: str
+        source_type: str
+        schema: str
+        profile: str
+
+    def to_dict(self) -> PolarsDatasetConfig:
+        """Create config dictionary for the dataset.
+
+        Return a string dictionary containing the following fields: name, digest, source,
+        source type, schema, and profile.
+        """
+        schema = json.dumps({"mlflow_colspec": self.schema.to_dict()} if self.schema else None)
+        return {
+            "name": self.name,
+            "digest": self.digest,
+            "source": self.source.to_json(),
+            "source_type": self.source._get_source_type(),
+            "schema": schema,
+            "profile": json.dumps(self.profile),
+        }
+
+    @property
+    def df(self) -> pl.DataFrame:
+        """Underlying DataFrame."""
+        return self._df
+
+    @property
+    def source(self) -> DatasetSource:
+        """Source of the dataset."""
+        return self._source
+
+    @property
+    def targets(self) -> Optional[str]:
+        """Name of the target column.
+
+        May be ``None`` if no target column is available.
+        """
+        return self._targets
+
+    @property
+    def predictions(self) -> Optional[str]:
+        """Name of the predictions column.
+
+        May be ``None`` if no predictions column is available.
+        """
+        return self._predictions
+
+    class PolarsDatasetProfile(TypedDict):
+        num_rows: int
+        num_elements: int
+
+    @property
+    def profile(self) -> PolarsDatasetProfile:
+        """Profile of the dataset."""
+        return {
+            "num_rows": self._df.height,
+            "num_elements": self._df.height * self._df.width,
+        }
+
+    @cached_property
+    def schema(self) -> Optional[Schema]:
+        """Instance of :py:class:`mlflow.types.Schema` representing the tabular dataset.
+
+        May be ``None`` if the schema cannot be inferred from the dataset.
+        """
+        try:
+            return infer_schema(self._df)
+        except Exception as e:
+            _logger.warning("Failed to infer schema for PolarsDataset. Exception: %s", e)
+        return None
+
+    def to_pyfunc(self) -> PyFuncInputsOutputs:
+        """Convert dataset to a collection of pyfunc inputs and outputs for model evaluation."""
+        if self._targets:
+            inputs = self._df.drop(*self._targets)
+            outputs = self._df.select(self._targets).to_series()
+            return PyFuncInputsOutputs([inputs.to_pandas()], [outputs.to_pandas()])
+        else:
+            return PyFuncInputsOutputs([self._df.to_pandas()])
+
+    def to_evaluation_dataset(self, path=None, feature_names=None) -> EvaluationDataset:
+        """Convert dataset to an EvaluationDataset for model evaluation."""
+        return EvaluationDataset(
+            data=self._df.to_pandas(),
+            targets=self._targets,
+            path=path,
+            feature_names=feature_names,
+            predictions=self._predictions,
+        )
+
+
+def from_polars(
+    df: pl.DataFrame,
+    source: Union[str, DatasetSource, None] = None,
+    targets: Optional[str] = None,
+    name: Optional[str] = None,
+    digest: Optional[str] = None,
+    predictions: Optional[str] = None,
+) -> PolarsDataset:
+    """Construct a :py:class:`PolarsDataset <mlflow.data.polars_dataset.PolarsDataset>` instance.
+
+    Args:
+        df: A polars DataFrame.
+        source: Source from which the DataFrame was derived, e.g. a filesystem
+            path, an S3 URI, an HTTPS URL, a delta table name with version, or
+            spark table etc. ``source`` may be specified as a URI, a path-like string,
+            or an instance of
+            :py:class:`DatasetSource <mlflow.data.dataset_source.DatasetSource>`.
+            If unspecified, the source is assumed to be the code location
+            (e.g. notebook cell, script, etc.) where
+            :py:func:`from_polars <mlflow.data.polars_dataset.from_polars>` is being called.
+        targets: An optional target column name for supervised training. This column
+            must be present in ``df``.
+        name: Name of the dataset. If unspecified, a name is generated.
+        digest: Dataset digest (hash). If unspecified, a digest is computed
+            automatically.
+        predictions: An optional predictions column name for model evaluation. This column
+            must be present in ``df``.
+
+    .. code-block:: python
+        :test:
+        :caption: Example
+
+        import mlflow
+        import polars as pl
+
+        x = pl.DataFrame(
+            [["tom", 10, 1, 1], ["nick", 15, 0, 1], ["juli", 14, 1, 1]],
+            schema=["Name", "Age", "Label", "ModelOutput"],
+        )
+        dataset = mlflow.data.from_polars(x, targets="Label", predictions="ModelOutput")
+    """
+
+    from mlflow.data.code_dataset_source import CodeDatasetSource
+    from mlflow.data.dataset_source_registry import resolve_dataset_source
+    from mlflow.tracking.context import registry
+
+    if source is not None:
+        if isinstance(source, DatasetSource):
+            resolved_source = source
+        else:
+            resolved_source = resolve_dataset_source(source)
+    else:
+        context_tags = registry.resolve_tags()
+        resolved_source = CodeDatasetSource(tags=context_tags)
+    return PolarsDataset(
+        df=df,
+        source=resolved_source,
+        targets=targets,
+        name=name,
+        digest=digest,
+        predictions=predictions,
+    )

--- a/mlflow/data/polars_dataset.py
+++ b/mlflow/data/polars_dataset.py
@@ -2,7 +2,7 @@ import json
 import logging
 from functools import cached_property
 from inspect import isclass
-from typing import Any, Dict, Final, Optional, TypedDict, Union
+from typing import Any, Final, Optional, TypedDict, Union
 
 import polars as pl
 from polars.datatypes.classes import DataType as PolarsDataType
@@ -27,7 +27,7 @@ def hash_polars_df(df: pl.DataFrame) -> str:
 
 
 ColSpecType = Union[DataType, Array, Object, str]
-TYPE_MAP: Final[Dict[PolarsDataTypeClass, DataType]] = {
+TYPE_MAP: Final[dict[PolarsDataTypeClass, DataType]] = {
     pl.Binary: DataType.binary,
     pl.Boolean: DataType.boolean,
     pl.Datetime: DataType.datetime,
@@ -40,7 +40,7 @@ TYPE_MAP: Final[Dict[PolarsDataTypeClass, DataType]] = {
     pl.String: DataType.string,
     pl.Utf8: DataType.string,
 }
-CLOSE_MAP: Final[Dict[PolarsDataTypeClass, DataType]] = {
+CLOSE_MAP: Final[dict[PolarsDataTypeClass, DataType]] = {
     pl.Categorical: DataType.string,
     pl.Enum: DataType.string,
     pl.Date: DataType.datetime,

--- a/mlflow/data/polars_dataset.py
+++ b/mlflow/data/polars_dataset.py
@@ -324,7 +324,7 @@ def from_polars(
         import polars as pl
 
         x = pl.DataFrame(
-            [["tom", 10, 1, 1], ["nick", 15, 0, 1], ["juli", 14, 1, 1]],
+            [["tom", 10, 1, 1], ["nick", 15, 0, 1], ["julie", 14, 1, 1]],
             schema=["Name", "Age", "Label", "ModelOutput"],
         )
         dataset = mlflow.data.from_polars(x, targets="Label", predictions="ModelOutput")

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -18,3 +18,5 @@ incremental<24.7.0
 # this is an extra dependency for the auth app which
 # is not included in the core mlflow requirements
 Flask-WTF<2
+# required for testing polars dataset integration
+polars>=1

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -44,3 +44,5 @@ opentelemetry-exporter-otlp-proto-http
 scikit-learn<1.6
 # Required for testing mlflow.server.auth
 Flask-WTF<2
+# required for testing polars dataset integration
+polars>=1

--- a/tests/data/test_polars_dataset.py
+++ b/tests/data/test_polars_dataset.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from mlflow.data.code_dataset_source import CodeDatasetSource
+from mlflow.data.evaluation_dataset import EvaluationDataset
+from mlflow.data.filesystem_dataset_source import FileSystemDatasetSource
+from mlflow.data.polars_dataset import PolarsDataset, from_polars, infer_schema
+from mlflow.data.pyfunc_dataset_mixin import PyFuncInputsOutputs
+from mlflow.exceptions import MlflowException
+from mlflow.types.schema import Schema
+
+from tests.resources.data.dataset_source import SampleDatasetSource
+
+
+@pytest.fixture(name="source", scope="module")
+def sample_source() -> SampleDatasetSource:
+    source_uri = "test:/my/test/uri"
+    return SampleDatasetSource._resolve(source_uri)
+
+
+def test_conversion_to_json(source: SampleDatasetSource) -> None:
+    dataset = PolarsDataset(
+        df=pl.DataFrame([1, 2, 3], schema=["Numbers"]), source=source, name="testname"
+    )
+
+    dataset_json = dataset.to_json()
+    parsed_json = json.loads(dataset_json)
+
+    assert parsed_json.keys() <= {"name", "digest", "source", "source_type", "schema", "profile"}
+    assert parsed_json["name"] == dataset.name
+    assert parsed_json["digest"] == dataset.digest
+    assert parsed_json["source"] == dataset.source.to_json()
+    assert parsed_json["source_type"] == dataset.source._get_source_type()
+    assert parsed_json["profile"] == json.dumps(dataset.profile)
+
+    schema_json = json.dumps(json.loads(parsed_json["schema"])["mlflow_colspec"])
+    assert Schema.from_json(schema_json) == dataset.schema
+
+
+def test_digest_property_has_expected_value(source: SampleDatasetSource) -> None:
+    dataset = PolarsDataset(df=pl.DataFrame([1, 2, 3], schema=["Numbers"]), source=source)
+    assert dataset.digest == dataset._compute_digest()
+    assert dataset.digest == "2935675642698967471"
+
+
+def test_digest_consistent(source: SampleDatasetSource) -> None:
+    """Row order does not affect digest."""
+    dataset1 = PolarsDataset(
+        df=pl.DataFrame({"numbers": [1, 2, 3], "strs": ["a", "b", "c"]}), source=source
+    )
+
+    dataset2 = PolarsDataset(
+        df=pl.DataFrame({"numbers": [2, 3, 1], "strs": ["b", "c", "a"]}), source=source
+    )
+    assert dataset1.digest == dataset2.digest
+
+
+def test_digest_change(source: SampleDatasetSource) -> None:
+    """Different rows produce different digests."""
+    dataset1 = PolarsDataset(
+        df=pl.DataFrame({"numbers": [1, 2, 3], "strs": ["a", "b", "c"]}), source=source
+    )
+
+    dataset2 = PolarsDataset(
+        df=pl.DataFrame({"numbers": [10, 20, 30], "strs": ["aa", "bb", "cc"]}), source=source
+    )
+    assert dataset1.digest != dataset2.digest
+
+
+def test_df_property(source: SampleDatasetSource) -> None:
+    df = pl.DataFrame({"numbers": [1, 2, 3]})
+    dataset = PolarsDataset(df=df, source=source)
+    assert dataset.df.equals(df)
+
+
+def test_targets_none(source: SampleDatasetSource) -> None:
+    df_no_targets = pl.DataFrame({"numbers": [1, 2, 3]})
+    dataset_no_targets = PolarsDataset(df=df_no_targets, source=source)
+    assert dataset_no_targets._targets is None
+
+
+def test_targets_not_none(source: SampleDatasetSource) -> None:
+    df_with_targets = pl.DataFrame({"a": [1, 1], "b": [2, 2], "c": [3, 3]})
+    dataset_with_targets = PolarsDataset(df=df_with_targets, source=source, targets="c")
+    assert dataset_with_targets._targets == "c"
+
+
+def test_targets_invalid(source: SampleDatasetSource) -> None:
+    df = pl.DataFrame({"a": [1, 1], "b": [2, 2], "c": [3, 3]})
+    with pytest.raises(
+        MlflowException,
+        match="DataFrame does not contain specified targets column: 'd'",
+    ):
+        PolarsDataset(df=df, source=source, targets="d")
+
+
+def test_to_pyfunc_wo_outputs(source: SampleDatasetSource) -> None:
+    df = pl.DataFrame({"numbers": [1, 2, 3]})
+    dataset = PolarsDataset(df=df, source=source)
+
+    input_outputs = dataset.to_pyfunc()
+
+    assert isinstance(input_outputs, PyFuncInputsOutputs)
+    assert len(input_outputs.inputs) == 1
+    assert isinstance(input_outputs.inputs[0], pd.DataFrame)
+    assert input_outputs.inputs[0].equals(pd.DataFrame({"numbers": [1, 2, 3]}))
+
+
+def test_to_pyfunc_with_outputs(source: SampleDatasetSource) -> None:
+    df = pl.DataFrame({"a": [1, 1], "b": [2, 2], "c": [3, 3]})
+    dataset = PolarsDataset(df=df, source=source, targets="c")
+
+    input_outputs = dataset.to_pyfunc()
+
+    assert isinstance(input_outputs, PyFuncInputsOutputs)
+    assert len(input_outputs.inputs) == 1
+    assert isinstance(input_outputs.inputs[0], pd.DataFrame)
+    assert input_outputs.inputs[0].equals(pd.DataFrame({"a": [1, 1], "b": [2, 2]}))
+    assert len(input_outputs.outputs) == 1
+    assert isinstance(input_outputs.outputs[0], pd.Series)
+    assert input_outputs.outputs[0].equals(pd.Series([3, 3], name="c"))
+
+
+def test_from_polars_with_targets(tmp_path: Path) -> None:
+    df = pl.DataFrame({"a": [1, 1], "b": [2, 2], "c": [3, 3]})
+    path = tmp_path / "temp.csv"
+    df.write_csv(path)
+
+    dataset = from_polars(df, targets="c", source=str(path))
+    input_outputs = dataset.to_pyfunc()
+
+    assert isinstance(input_outputs, PyFuncInputsOutputs)
+    assert len(input_outputs.inputs) == 1
+    assert isinstance(input_outputs.inputs[0], pd.DataFrame)
+    assert input_outputs.inputs[0].equals(pd.DataFrame({"a": [1, 1], "b": [2, 2]}))
+    assert len(input_outputs.outputs) == 1
+    assert isinstance(input_outputs.outputs[0], pd.Series)
+    assert input_outputs.outputs[0].equals(pd.Series([3, 3], name="c"))
+
+
+def test_from_polars_file_system_datasource(tmp_path: Path) -> None:
+    df = pl.DataFrame({"a": [1, 1], "b": [2, 2], "c": [3, 3]})
+    path = tmp_path / "temp.csv"
+    df.write_csv(path)
+
+    mlflow_df = from_polars(df, source=str(path))
+
+    assert isinstance(mlflow_df, PolarsDataset)
+    assert mlflow_df.df.equals(df)
+    assert mlflow_df.schema == infer_schema(df)
+    assert mlflow_df.profile == {"num_rows": 2, "num_elements": 6}
+    assert isinstance(mlflow_df.source, FileSystemDatasetSource)
+
+
+def test_from_polars_no_source_specified() -> None:
+    df = pl.DataFrame({"a": [1, 1], "b": [2, 2], "c": [3, 3]})
+
+    mlflow_df = from_polars(df)
+
+    assert isinstance(mlflow_df, PolarsDataset)
+    assert isinstance(mlflow_df.source, CodeDatasetSource)
+    assert "mlflow.source.name" in mlflow_df.source.to_json()
+
+
+def test_to_evaluation_dataset(source: SampleDatasetSource) -> None:
+    import numpy as np
+
+    df = pl.DataFrame({"a": [1, 1], "b": [2, 2], "c": [3, 3]})
+    dataset = PolarsDataset(df=df, source=source, targets="c", name="testname")
+    evaluation_dataset = dataset.to_evaluation_dataset()
+
+    assert isinstance(evaluation_dataset, EvaluationDataset)
+    assert isinstance(evaluation_dataset.features_data, pd.DataFrame)
+    assert evaluation_dataset.features_data.equals(df.drop("c").to_pandas())
+    assert isinstance(evaluation_dataset.labels_data, np.ndarray)
+    assert np.array_equal(evaluation_dataset.labels_data, df["c"].to_numpy())

--- a/tests/data/test_polars_dataset.py
+++ b/tests/data/test_polars_dataset.py
@@ -122,7 +122,7 @@ def test_conversion_to_json(source: SampleDatasetSource) -> None:
 def test_digest_property_has_expected_value(source: SampleDatasetSource) -> None:
     dataset = PolarsDataset(df=pl.DataFrame([1, 2, 3], schema=["Numbers"]), source=source)
     assert dataset.digest == dataset._compute_digest()
-    assert dataset.digest == "2935675642698967471"
+    assert dataset.digest == "2485371048825281677"
 
 
 def test_digest_consistent(source: SampleDatasetSource) -> None:

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -14,6 +14,7 @@ from itertools import zip_longest
 from unittest import mock
 
 import pandas as pd
+import polars as pl
 import pytest
 
 import mlflow
@@ -1369,6 +1370,23 @@ def test_log_inputs(tmp_path):
     assert json.loads(dataset_inputs[2].dataset.source) == {"uri": str(path3)}
     assert dataset_inputs[2].tags[0].key == mlflow_tags.MLFLOW_DATASET_CONTEXT
     assert dataset_inputs[2].tags[0].value == "train3"
+
+
+def test_log_input_polars(tmp_path):
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+    path = tmp_path / "temp.csv"
+    df.write_csv(path)
+    dataset = mlflow.data.from_polars(df, source=path)
+    with start_run() as run:
+        mlflow.log_input(dataset, "train")
+
+    logged_inputs = MlflowClient().get_run(run.info.run_id).inputs
+    dataset_inputs = logged_inputs.dataset_inputs
+
+    assert len(dataset_inputs) == 1
+    assert dataset_inputs[0].dataset.name == "dataset"
+    assert dataset_inputs[0].dataset.digest == "17158191685003305501"
+    assert dataset_inputs[0].dataset.source_type == "local"
 
 
 def test_log_input_metadata_only():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AlpAribal/mlflow/pull/13006?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13006/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13006
```

</p>
</details>

### Related Issues/PRs

Resolve #10292

### What changes are proposed in this pull request?

PR implements PolarsDataset, which provides the most basic support for polars dataframes.

Note that no changes were made in `mlflow.types` or `PyFuncInputsOutputs` and the dataframe is converted to pandas at evaluation time. Further work is required to bring in deeper support and perhaps even performance improvements.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support Polars dataframe in MLflow Dataset Tracking

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
