### PR TITLE
Add audio support to artifact viewer UI

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -91,7 +91,8 @@
     "stylis": "^4.0.10",
     "url": "^0.11.0",
     "use-debounce": "^9.0.3",
-    "use-sync-external-store": "^1.2.0"
+    "use-sync-external-store": "^1.2.0",
+    "wavesurfer.js": "^7.8.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/mlflow/server/js/src/common/utils/FileUtils.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.ts
@@ -62,3 +62,6 @@ export const HTML_EXTENSIONS = new Set(['html']);
 export const MAP_EXTENSIONS = new Set(['geojson']);
 export const PDF_EXTENSIONS = new Set(['pdf']);
 export const DATA_EXTENSIONS = new Set(['csv', 'tsv']);
+// Audio extensions supported by wavesurfer.js
+// Source https://github.com/katspaugh/wavesurfer.js/discussions/2703#discussioncomment-5259526
+export const AUDIO_EXTENSIONS = new Set(['m4a', 'mp3', 'mp4', 'wav', 'aac', 'wma', 'flac', 'opus', 'ogg']);

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/LazyShowArtifactAudioView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/LazyShowArtifactAudioView.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { LegacySkeleton } from '@databricks/design-system';
 import { SectionErrorBoundary } from '../../../common/components/error-boundaries/SectionErrorBoundary';
+import { ShowArtifactAudioViewProps } from './ShowArtifactAudioView';
 
 const ShowArtifactAudioView = React.lazy(() => import('./ShowArtifactAudioView'));
 
-export const LazyShowArtifactAudioView = (props: any) => (
+export const LazyShowArtifactAudioView = (props: ShowArtifactAudioViewProps) => (
   <SectionErrorBoundary>
     <React.Suspense fallback={<LegacySkeleton active />}>
       <ShowArtifactAudioView {...props} />

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/LazyShowArtifactAudioView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/LazyShowArtifactAudioView.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { LegacySkeleton } from '@databricks/design-system';
+import { SectionErrorBoundary } from '../../../common/components/error-boundaries/SectionErrorBoundary';
+
+const ShowArtifactAudioView = React.lazy(() => import('./ShowArtifactAudioView'));
+
+export const LazyShowArtifactAudioView = (props: any) => (
+  <SectionErrorBoundary>
+    <React.Suspense fallback={<LegacySkeleton active />}>
+      <ShowArtifactAudioView {...props} />
+    </React.Suspense>
+  </SectionErrorBoundary>
+);

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.css
@@ -1,0 +1,3 @@
+.artifact-view-audio-outer-container {
+  padding: 20px;
+}

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.css
@@ -1,3 +1,0 @@
-.artifact-view-audio-outer-container {
-  padding: 20px;
-}

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.enzyme.test.tsx
@@ -1,0 +1,135 @@
+import { mount, shallow } from 'enzyme';
+import ShowArtifactAudioView from './ShowArtifactAudioView';
+
+import { act } from 'react-dom/test-utils';
+import { IntlProvider } from 'react-intl';
+import { ArtifactViewErrorState } from './ArtifactViewErrorState';
+import { ArtifactViewSkeleton } from './ArtifactViewSkeleton';
+import WaveSurfer, { WaveSurferOptions } from 'wavesurfer.js';
+
+
+jest.mock('wavesurfer.js', () => {
+  const mWaveSurfer = {
+    loadBlob: jest.fn(),
+    destroy: jest.fn(),
+    on: jest.fn((event, callback) => {
+      if (event === 'ready') {
+        setTimeout(callback, 0); // Simulate async event
+      }
+    }),
+  };
+  return {
+    create: jest.fn().mockReturnValue(mWaveSurfer),
+  };
+});
+
+
+describe('ShowArtifactAudioView tests', () => {
+  let wrapper: any;
+  let minimalProps: any;
+  let commonProps;
+  let getArtifact: any;
+
+  beforeEach(() => {
+    minimalProps = {
+      path: 'fakepath',
+      runUuid: 'fakeUuid',
+    };
+    // Mock the `getArtifact` function to avoid spurious network errors
+    // during testing
+    getArtifact = jest.fn().mockResolvedValue(new Blob(['audio content'], { type: 'audio/mpeg' }));
+    commonProps = { ...minimalProps, getArtifact };
+    wrapper = shallow(<ShowArtifactAudioView {...commonProps} />);
+  });
+
+  test('should render with minimal props without exploding', () => {
+    wrapper = shallow(<ShowArtifactAudioView {...minimalProps} />);
+    expect(wrapper.length).toBe(1);
+  });
+
+  test('should render loading skeleton when view is loading', () => {
+    expect(wrapper.find('.artifact-audio-view-loading').length).toBe(1);
+  });
+
+  test('should render error message when error occurs', async () => {
+    const getArtifactError = jest.fn().mockRejectedValue(new Error('my error text'));
+    const propsWithError = { ...minimalProps, getArtifact: getArtifactError };
+    // Use mount instead of shallow to trigger useEffect
+    await act(async () => {
+      wrapper = mount(
+        <IntlProvider locale="en">
+          <ShowArtifactAudioView {...propsWithError} />
+        </IntlProvider>,
+      );
+    });
+    wrapper.update();
+    expect(wrapper.find(ArtifactViewErrorState).length).toBe(1);
+    expect(wrapper.find(ArtifactViewSkeleton).length).toBe(0);
+
+    const audioContainerResult = wrapper.find('.artifact-view-audio-outer-container');
+    expect(audioContainerResult.length).toBe(1);
+    expect(audioContainerResult.getDOMNode()).toHaveStyle({ display: 'none' });
+  });
+
+  test('should display audio container when data is loaded', async () => {
+    const getArtifact = jest.fn().mockResolvedValue(new Blob(['audio content'], { type: 'audio/mpeg' }));
+    commonProps = { ...minimalProps, getArtifact };
+    const propsWithError = { ...minimalProps, getArtifact: getArtifact };
+    // Use mount instead of shallow to trigger useEffect
+    await act(async () => {
+      wrapper = mount(
+        <IntlProvider locale="en">
+          <ShowArtifactAudioView {...propsWithError} />
+        </IntlProvider>,
+      );
+    });
+    wrapper.update();
+
+
+    expect(wrapper.find(ArtifactViewErrorState).length).toBe(0);
+    expect(wrapper.find(ArtifactViewSkeleton).length).toBe(0);
+    
+    const audioContainerResult = wrapper.find('.artifact-view-audio-outer-container');
+    
+    expect(audioContainerResult.length).toBe(1);
+    expect(audioContainerResult.getDOMNode()).toHaveStyle({ display: 'block' });
+  });
+
+  test('initializes WaveSurfer with correct parameters and calls loadBlob', async () => {
+    const props = { ...minimalProps, getArtifact };
+    await act(async () => {
+      mount(
+        <IntlProvider locale="en">
+          <ShowArtifactAudioView {...props} />
+        </IntlProvider>,
+      );
+    });
+
+    expect(WaveSurfer.create).toHaveBeenCalledWith(expect.objectContaining({
+      container: expect.anything(),
+      waveColor: '#1890ff',
+      progressColor: '#0b3574',
+      height: 500,
+    }));
+
+    // Since loadBlob is called asynchronously, we need to wait for it to be called
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(WaveSurfer.create({} as WaveSurferOptions).loadBlob).toHaveBeenCalledWith(expect.any(Blob));
+  });
+
+  test('destroys WaveSurfer on component unmount', async () => {
+    const props = { ...minimalProps, getArtifact };
+    const wrapper = mount(
+      <IntlProvider locale="en">
+        <ShowArtifactAudioView {...props} />
+      </IntlProvider>,
+    );
+
+    wrapper.unmount();
+
+    expect(WaveSurfer.create({} as WaveSurferOptions).destroy).toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.enzyme.test.tsx
@@ -7,7 +7,6 @@ import { ArtifactViewErrorState } from './ArtifactViewErrorState';
 import { ArtifactViewSkeleton } from './ArtifactViewSkeleton';
 import WaveSurfer, { WaveSurferOptions } from 'wavesurfer.js';
 
-
 jest.mock('wavesurfer.js', () => {
   const mWaveSurfer = {
     loadBlob: jest.fn(),
@@ -22,7 +21,6 @@ jest.mock('wavesurfer.js', () => {
     create: jest.fn().mockReturnValue(mWaveSurfer),
   };
 });
-
 
 describe('ShowArtifactAudioView tests', () => {
   let wrapper: any;
@@ -48,7 +46,7 @@ describe('ShowArtifactAudioView tests', () => {
   });
 
   test('should render loading skeleton when view is loading', () => {
-    expect(wrapper.find('.artifact-audio-view-loading').length).toBe(1);
+    expect(wrapper.find(ArtifactViewSkeleton).length).toBe(1);
   });
 
   test('should render error message when error occurs', async () => {
@@ -65,10 +63,6 @@ describe('ShowArtifactAudioView tests', () => {
     wrapper.update();
     expect(wrapper.find(ArtifactViewErrorState).length).toBe(1);
     expect(wrapper.find(ArtifactViewSkeleton).length).toBe(0);
-
-    const audioContainerResult = wrapper.find('.artifact-view-audio-outer-container');
-    expect(audioContainerResult.length).toBe(1);
-    expect(audioContainerResult.getDOMNode()).toHaveStyle({ display: 'none' });
   });
 
   test('should display audio container when data is loaded', async () => {
@@ -85,14 +79,12 @@ describe('ShowArtifactAudioView tests', () => {
     });
     wrapper.update();
 
-
     expect(wrapper.find(ArtifactViewErrorState).length).toBe(0);
     expect(wrapper.find(ArtifactViewSkeleton).length).toBe(0);
-    
-    const audioContainerResult = wrapper.find('.artifact-view-audio-outer-container');
-    
-    expect(audioContainerResult.length).toBe(1);
-    expect(audioContainerResult.getDOMNode()).toHaveStyle({ display: 'block' });
+
+    const audioContainerDiv = wrapper.find(ShowArtifactAudioView).find('div').first();
+    expect(audioContainerDiv.length).toBe(1);
+    expect(audioContainerDiv.getDOMNode()).toHaveStyle({ display: 'block' });
   });
 
   test('initializes WaveSurfer with correct parameters and calls loadBlob', async () => {
@@ -105,16 +97,18 @@ describe('ShowArtifactAudioView tests', () => {
       );
     });
 
-    expect(WaveSurfer.create).toHaveBeenCalledWith(expect.objectContaining({
-      container: expect.anything(),
-      waveColor: '#1890ff',
-      progressColor: '#0b3574',
-      height: 500,
-    }));
+    expect(WaveSurfer.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        container: expect.anything(),
+        waveColor: '#1890ff',
+        progressColor: '#0b3574',
+        height: 500,
+      }),
+    );
 
     // Since loadBlob is called asynchronously, we need to wait for it to be called
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
     expect(WaveSurfer.create({} as WaveSurferOptions).loadBlob).toHaveBeenCalledWith(expect.any(Blob));

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.tsx
@@ -3,7 +3,6 @@ import WaveSurfer from 'wavesurfer.js';
 import { getArtifactBlob, getArtifactLocationUrl } from '../../../common/utils/ArtifactUtils';
 import { ArtifactViewErrorState } from './ArtifactViewErrorState';
 import { ArtifactViewSkeleton } from './ArtifactViewSkeleton';
-import './ShowArtifactAudioView.css';
 
 const waveSurferStyling = {
   waveColor: '#1890ff',
@@ -11,15 +10,13 @@ const waveSurferStyling = {
   height: 500,
 };
 
-const ShowArtifactAudioView = ({
-  runUuid,
-  path,
-  getArtifact = getArtifactBlob,
-}: {
+export type ShowArtifactAudioViewProps = {
   runUuid: string;
   path: string;
   getArtifact?: (...args: any[]) => any;
-}) => {
+};
+
+const ShowArtifactAudioView = ({ runUuid, path, getArtifact = getArtifactBlob }: ShowArtifactAudioViewProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [waveSurfer, setWaveSurfer] = useState<WaveSurfer | null>(null);
 
@@ -67,10 +64,15 @@ const ShowArtifactAudioView = ({
   const showLoading = loading && !error;
   return (
     <>
-      {showLoading && <ArtifactViewSkeleton className="artifact-audio-view-loading" />}
-      {error && <ArtifactViewErrorState className="artifact-audio-view-error" />}
+      {showLoading && <ArtifactViewSkeleton />}
+      {error && <ArtifactViewErrorState />}
       {/* This div is always rendered, but its visibility is controlled by the loading and error states */}
-      <div className="artifact-view-audio-outer-container" style={{ display: loading || error ? 'none' : 'block' }}>
+      <div
+        css={{
+          display: loading || error ? 'none' : 'block',
+          padding: 20,
+        }}
+      >
         <div ref={containerRef} />
       </div>
     </>

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactAudioView.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'react';
+import WaveSurfer from 'wavesurfer.js';
+import { getArtifactBlob, getArtifactLocationUrl } from '../../../common/utils/ArtifactUtils';
+import { ArtifactViewErrorState } from './ArtifactViewErrorState';
+import { ArtifactViewSkeleton } from './ArtifactViewSkeleton';
+import './ShowArtifactAudioView.css';
+
+const waveSurferStyling = {
+  waveColor: '#1890ff',
+  progressColor: '#0b3574',
+  height: 500,
+};
+
+const ShowArtifactAudioView = ({
+  runUuid,
+  path,
+  getArtifact = getArtifactBlob,
+}: {
+  runUuid: string;
+  path: string;
+  getArtifact?: (...args: any[]) => any;
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [waveSurfer, setWaveSurfer] = useState<WaveSurfer | null>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [audioData, setAudioData] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchAudio = async () => {
+      setLoading(true);
+      try {
+        const artifactLocation = getArtifactLocationUrl(path, runUuid);
+        const artifactAudioData = await getArtifact(artifactLocation);
+        setAudioData({ data: artifactAudioData });
+      } catch (error) {
+        setError(error as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAudio();
+  }, [runUuid, path, getArtifact]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const ws = WaveSurfer.create({
+      mediaControls: true,
+      container: containerRef.current,
+      ...waveSurferStyling,
+    });
+    setWaveSurfer(ws);
+
+    return () => {
+      ws.destroy();
+    };
+  }, [containerRef]);
+
+  useEffect(() => {
+    if (audioData && waveSurfer) {
+      waveSurfer.loadBlob(audioData.data);
+    }
+  }, [audioData, waveSurfer]);
+
+  const showLoading = loading && !error;
+  return (
+    <>
+      {showLoading && <ArtifactViewSkeleton className="artifact-audio-view-loading" />}
+      {error && <ArtifactViewErrorState className="artifact-audio-view-error" />}
+      {/* This div is always rendered, but its visibility is controlled by the loading and error states */}
+      <div className="artifact-view-audio-outer-container" style={{ display: loading || error ? 'none' : 'block' }}>
+        <div ref={containerRef} />
+      </div>
+    </>
+  );
+};
+
+export default ShowArtifactAudioView;

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.enzyme.test.tsx
@@ -20,8 +20,10 @@ import {
   MAP_EXTENSIONS,
   HTML_EXTENSIONS,
   DATA_EXTENSIONS,
+  AUDIO_EXTENSIONS,
 } from '../../../common/utils/FileUtils';
 import { RunTag } from '../../sdk/MlflowMessages';
+import { LazyShowArtifactAudioView } from './LazyShowArtifactAudioView';
 
 // Mock these methods because js-dom doesn't implement window.Request
 jest.mock('../../../common/utils/ArtifactUtils', () => ({
@@ -142,6 +144,12 @@ describe('ShowArtifactPage', () => {
     DATA_EXTENSIONS.forEach((ext) => {
       wrapper.setProps({ path: `image.${ext}`, runUuid: 'runId' });
       expect(wrapper.find(LazyShowArtifactTableView).length).toBe(1);
+    });
+  });
+  test('should render audio view for common audio data extensions', () => {
+    AUDIO_EXTENSIONS.forEach((ext) => {
+      wrapper.setProps({ path: `image.${ext}`, runUuid: 'runId' });
+      expect(wrapper.find(LazyShowArtifactAudioView).length).toBe(1);
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
@@ -94,7 +94,7 @@ class ShowArtifactPage extends Component<ShowArtifactPageProps> {
         } else if (PDF_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <LazyShowArtifactPdfView runUuid={this.props.runUuid} path={this.props.path} />;
         } else if (AUDIO_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
-          return <LazyShowArtifactAudioView runUuid={this.props.runUuid} path={this.props.path}/>;
+          return <LazyShowArtifactAudioView runUuid={this.props.runUuid} path={this.props.path} />;
         }
       }
     }

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
@@ -14,6 +14,7 @@ import {
   HTML_EXTENSIONS,
   PDF_EXTENSIONS,
   DATA_EXTENSIONS,
+  AUDIO_EXTENSIONS,
 } from '../../../common/utils/FileUtils';
 import { getLoggedModelPathsFromTags, getLoggedTablesFromTags } from '../../../common/utils/TagUtils';
 import { ONE_MB } from '../../constants';
@@ -31,6 +32,7 @@ import Utils from '../../../common/utils/Utils';
 import { FormattedMessage } from 'react-intl';
 import { ShowArtifactLoggedTableView } from './ShowArtifactLoggedTableView';
 import { Empty, Spacer, useDesignSystemTheme } from '@databricks/design-system';
+import { LazyShowArtifactAudioView } from './LazyShowArtifactAudioView';
 
 const MAX_PREVIEW_ARTIFACT_SIZE_MB = 50;
 
@@ -91,6 +93,8 @@ class ShowArtifactPage extends Component<ShowArtifactPageProps> {
           return <ShowArtifactHtmlView runUuid={this.props.runUuid} path={this.props.path} />;
         } else if (PDF_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <LazyShowArtifactPdfView runUuid={this.props.runUuid} path={this.props.path} />;
+        } else if (AUDIO_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
+          return <LazyShowArtifactAudioView runUuid={this.props.runUuid} path={this.props.path}/>;
         }
       }
     }
@@ -116,7 +120,7 @@ const getSelectFileView = () => {
         }
         description={
           <FormattedMessage
-            defaultMessage="Supported formats: image, text, html, pdf, geojson files"
+            defaultMessage="Supported formats: image, text, html, pdf, audio, geojson files"
             description="Text to explain users which formats are supported to display the artifacts"
           />
         }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -179,10 +179,6 @@
     "defaultMessage": "Aliases allow you to assign a mutable, named reference to a particular model version. <link>Learn more</link>",
     "description": "Explanation of registered model aliases"
   },
-  "2Exf7S": {
-    "defaultMessage": "Supported formats: image, text, html, pdf, geojson files",
-    "description": "Text to explain users which formats are supported to display the artifacts"
-  },
   "2Hf+yU": {
     "defaultMessage": "Time (wall)",
     "description": "Label for a radio button that configures the x-axis on a line chart. This option is for the absolute time that the metrics were logged."
@@ -1574,6 +1570,10 @@
   "Vvn8Cb": {
     "defaultMessage": "Open dataset",
     "description": "Text for the HTTP/HF location link in the experiment run dataset drawer"
+  },
+  "VzuUre": {
+    "defaultMessage": "Supported formats: image, text, html, pdf, audio, geojson files",
+    "description": "Text to explain users which formats are supported to display the artifacts"
   },
   "W8bOkn": {
     "defaultMessage": "250",

--- a/mlflow/server/js/yarn.lock
+++ b/mlflow/server/js/yarn.lock
@@ -4441,6 +4441,7 @@ __metadata:
     url: "npm:^0.11.0"
     use-debounce: "npm:^9.0.3"
     use-sync-external-store: "npm:^1.2.0"
+    wavesurfer.js: "npm:^7.8.4"
     webpack: "npm:^5.69.0"
     whatwg-fetch: "npm:^3.6.17"
   languageName: unknown
@@ -32792,6 +32793,13 @@ __metadata:
     glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.1.2"
   checksum: 10c0/c694de0a61004e587a8a0fdc9cfec20ee692c52032d9ab2c2e99969a37fdab9e6e1bd3164ed506f9a13f7c83e65563d563e0d6b87358470cdb7309b83db78683
+  languageName: node
+  linkType: hard
+
+"wavesurfer.js@npm:^7.8.4":
+  version: 7.8.4
+  resolution: "wavesurfer.js@npm:7.8.4"
+  checksum: 10c0/15e1dce15afd290bdd22e051f46a92bc5f1d6b673d273d997ed60a3fc2dd4041a18f0ad3ced4d46caf52a43fa58a42acdb1f31b2d472ecff2ff904d73dc1dab3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sydneyw-spotify/mlflow/pull/13017?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13017/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13017
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #6446 

### What changes are proposed in this pull request?

Add audio support to artifacts viewer UI.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/5de3a622-9a55-4da0-ac7b-ca5e6b4afe25

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/fb6e84d8-36bd-4dda-811b-fd7b2d82995f">
<img width="963" alt="image" src="https://github.com/user-attachments/assets/c7840d4e-0ade-483d-8c33-fb6c2705e584">


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Add audio support to the Artifacts section of the run UI. This includes basic audio playback and display of the audio waveform.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
