### PR TITLE
Change uc_function to function

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -3,9 +3,9 @@ import logging
 from typing import Generator, List, Optional, Set
 
 from mlflow.models.resources import (
+    DatabricksFunction,
     DatabricksServingEndpoint,
     DatabricksSQLWarehouse,
-    DatabricksUCFunction,
     DatabricksVectorSearchIndex,
     Resource,
 )
@@ -114,7 +114,7 @@ def _extract_databricks_dependencies_from_tools(tools) -> Generator[Resource, No
                         ]
                         # This should always have the length 1
                         for tool_name in filtered_tool_names:
-                            yield DatabricksUCFunction(function_name=tool_name)
+                            yield DatabricksFunction(function_name=tool_name)
         # Add the deduped warehouse ids
         for warehouse_id in warehouse_ids:
             yield DatabricksSQLWarehouse(warehouse_id=warehouse_id)

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -17,7 +17,7 @@ class ResourceType(Enum):
     VECTOR_SEARCH_INDEX = "vector_search_index"
     SERVING_ENDPOINT = "serving_endpoint"
     SQL_WAREHOUSE = "sql_warehouse"
-    UC_FUNCTION = "uc_function"
+    FUNCTION = "function"
 
 
 @dataclass
@@ -119,7 +119,7 @@ class DatabricksSQLWarehouse(DatabricksResource):
 
 
 @dataclass
-class DatabricksUCFunction(DatabricksResource):
+class DatabricksFunction(DatabricksResource):
     """
     Define Databricks UC Function to serve a model.
 
@@ -127,7 +127,7 @@ class DatabricksUCFunction(DatabricksResource):
         function_name (str): The name of the function used by the model
     """
 
-    type: ResourceType = ResourceType.UC_FUNCTION
+    type: ResourceType = ResourceType.FUNCTION
     function_name: str = None
 
     def to_dict(self):
@@ -144,7 +144,7 @@ def _get_resource_class_by_type(target_uri: str, resource_type: ResourceType):
             ResourceType.SERVING_ENDPOINT.value: DatabricksServingEndpoint,
             ResourceType.VECTOR_SEARCH_INDEX.value: DatabricksVectorSearchIndex,
             ResourceType.SQL_WAREHOUSE.value: DatabricksSQLWarehouse,
-            ResourceType.UC_FUNCTION.value: DatabricksUCFunction,
+            ResourceType.FUNCTION.value: DatabricksFunction,
         }
     }
     resource = resource_classes.get(target_uri)

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -200,7 +200,7 @@ def get_model_version_dependencies(model_dir):
         )
         dependencies.extend(
             _fetch_langchain_dependency_from_model_resources(
-                databricks_dependencies, ResourceType.UC_FUNCTION.value, "DATABRICKS_UC_FUNCTION"
+                databricks_dependencies, ResourceType.FUNCTION.value, "DATABRICKS_UC_FUNCTION"
             )
         )
     else:

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -16,9 +16,9 @@ from mlflow.langchain.databricks_dependencies import (
 )
 from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
 from mlflow.models.resources import (
+    DatabricksFunction,
     DatabricksServingEndpoint,
     DatabricksSQLWarehouse,
-    DatabricksUCFunction,
     DatabricksVectorSearchIndex,
 )
 
@@ -296,7 +296,7 @@ def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
 
     resources = list(_extract_dependency_list_from_lc_model(agent))
     assert resources == [
-        DatabricksUCFunction(function_name="rag.test.test_function"),
+        DatabricksFunction(function_name="rag.test.test_function"),
         DatabricksSQLWarehouse(warehouse_id="testId1"),
     ]
 
@@ -401,9 +401,9 @@ def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch)
     if include_uc_function_tools:
         expected = [
             DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat"),
-            DatabricksUCFunction(function_name="rag.test.test_function"),
-            DatabricksUCFunction(function_name="rag.test.test_function_2"),
-            DatabricksUCFunction(function_name="rag.test.test_function_3"),
+            DatabricksFunction(function_name="rag.test.test_function"),
+            DatabricksFunction(function_name="rag.test.test_function_2"),
+            DatabricksFunction(function_name="rag.test.test_function_3"),
             DatabricksVectorSearchIndex(index_name="mlflow.rag.vs_index"),
             DatabricksServingEndpoint(endpoint_name="embedding-model"),
             DatabricksSQLWarehouse(warehouse_id="testId1"),

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2034,7 +2034,7 @@ def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
         "serving_endpoint": [{"name": "databricks-llama-2-70b-chat"}, {"name": "embedding-model"}],
         "vector_search_index": [{"name": "mlflow.rag.vs_index"}],
         "sql_warehouse": [{"name": "test_id_1"}],
-        "uc_function": [{"name": function} for function in uc_functions],
+        "function": [{"name": function} for function in uc_functions],
     }
 
     assert all(item in actual["serving_endpoint"] for item in expected["serving_endpoint"])
@@ -2042,8 +2042,8 @@ def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
     assert actual["vector_search_index"] == expected["vector_search_index"]
     if uc_function_tools:
         assert actual["sql_warehouse"] == expected["sql_warehouse"]
-        assert all(item in actual["uc_function"] for item in expected["uc_function"])
-        assert all(item in expected["uc_function"] for item in actual["uc_function"])
+        assert all(item in actual["function"] for item in expected["function"])
+        assert all(item in expected["function"] for item in actual["function"])
 
 
 @pytest.mark.skipif(
@@ -2092,7 +2092,7 @@ def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
     if len(uc_function_tools) > 0:
         uc_expected = {
             "sql_warehouse": [{"name": "test_id_1"}],
-            "uc_function": [{"name": function} for function in uc_functions],
+            "function": [{"name": function} for function in uc_functions],
         }
         expected.update(uc_expected)
 
@@ -2101,8 +2101,8 @@ def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
     assert actual["vector_search_index"] == expected["vector_search_index"]
     if uc_function_tools:
         assert actual["sql_warehouse"] == expected["sql_warehouse"]
-        assert all(item in actual["uc_function"] for item in expected["uc_function"])
-        assert all(item in expected["uc_function"] for item in actual["uc_function"])
+        assert all(item in actual["function"] for item in expected["function"])
+        assert all(item in expected["function"] for item in actual["function"])
 
 
 def _error_func(*args, **kwargs):

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -2,9 +2,9 @@ import pytest
 
 from mlflow.models.resources import (
     DEFAULT_API_VERSION,
+    DatabricksFunction,
     DatabricksServingEndpoint,
     DatabricksSQLWarehouse,
-    DatabricksUCFunction,
     DatabricksVectorSearchIndex,
     _ResourceBuilder,
 )
@@ -41,8 +41,8 @@ def test_sql_warehouse():
 
 
 def test_uc_function():
-    uc_function = DatabricksUCFunction(function_name="function")
-    expected = {"uc_function": [{"name": "function"}]}
+    uc_function = DatabricksFunction(function_name="function")
+    expected = {"function": [{"name": "function"}]}
     assert uc_function.to_dict() == expected
     assert _ResourceBuilder.from_resources([uc_function]) == {
         "api_version": DEFAULT_API_VERSION,
@@ -56,8 +56,8 @@ def test_resources():
         DatabricksServingEndpoint(endpoint_name="databricks-mixtral-8x7b-instruct"),
         DatabricksServingEndpoint(endpoint_name="databricks-llama-8x7b-instruct"),
         DatabricksSQLWarehouse(warehouse_id="id123"),
-        DatabricksUCFunction(function_name="rag.studio.test_function_1"),
-        DatabricksUCFunction(function_name="rag.studio.test_function_2"),
+        DatabricksFunction(function_name="rag.studio.test_function_1"),
+        DatabricksFunction(function_name="rag.studio.test_function_2"),
     ]
     expected = {
         "api_version": DEFAULT_API_VERSION,
@@ -68,7 +68,7 @@ def test_resources():
                 {"name": "databricks-llama-8x7b-instruct"},
             ],
             "sql_warehouse": [{"name": "id123"}],
-            "uc_function": [
+            "function": [
                 {"name": "rag.studio.test_function_1"},
                 {"name": "rag.studio.test_function_2"},
             ],
@@ -92,7 +92,7 @@ def test_resources_from_yaml(tmp_path):
                 - name: databricks-llama-8x7b-instruct
                 sql_warehouse:
                 - name: id123
-                uc_function:
+                function:
                 - name: rag.studio.test_function_1
                 - name: rag.studio.test_function_2
             """
@@ -107,7 +107,7 @@ def test_resources_from_yaml(tmp_path):
                 {"name": "databricks-llama-8x7b-instruct"},
             ],
             "sql_warehouse": [{"name": "id123"}],
-            "uc_function": [
+            "function": [
                 {"name": "rag.studio.test_function_1"},
                 {"name": "rag.studio.test_function_2"},
             ],

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -32,9 +32,9 @@ from mlflow.models import Model, infer_signature
 from mlflow.models.dependencies_schemas import DependenciesSchemasType
 from mlflow.models.model import _DATABRICKS_FS_LOADER_MODULE
 from mlflow.models.resources import (
+    DatabricksFunction,
     DatabricksServingEndpoint,
     DatabricksSQLWarehouse,
-    DatabricksUCFunction,
     DatabricksVectorSearchIndex,
 )
 from mlflow.models.utils import _read_example
@@ -1618,7 +1618,7 @@ def test_model_save_load_with_resources(tmp_path):
             ],
             "vector_search_index": [{"name": "rag.studio_bugbash.databricks_docs_index"}],
             "sql_warehouse": [{"name": "testid"}],
-            "uc_function": [
+            "function": [
                 {"name": "rag.studio.test_function_a"},
                 {"name": "rag.studio.test_function_b"},
             ],
@@ -1634,8 +1634,8 @@ def test_model_save_load_with_resources(tmp_path):
             DatabricksServingEndpoint(endpoint_name="azure-eastus-model-serving-2_vs_endpoint"),
             DatabricksVectorSearchIndex(index_name="rag.studio_bugbash.databricks_docs_index"),
             DatabricksSQLWarehouse(warehouse_id="testid"),
-            DatabricksUCFunction(function_name="rag.studio.test_function_a"),
-            DatabricksUCFunction(function_name="rag.studio.test_function_b"),
+            DatabricksFunction(function_name="rag.studio.test_function_a"),
+            DatabricksFunction(function_name="rag.studio.test_function_b"),
         ],
     )
 
@@ -1656,7 +1656,7 @@ def test_model_save_load_with_resources(tmp_path):
                 - name: azure-eastus-model-serving-2_vs_endpoint
                 sql_warehouse:
                 - name: testid
-                uc_function:
+                function:
                 - name: rag.studio.test_function_a
                 - name: rag.studio.test_function_b
             """
@@ -1686,7 +1686,7 @@ def test_model_log_with_resources(tmp_path):
             ],
             "vector_search_index": [{"name": "rag.studio_bugbash.databricks_docs_index"}],
             "sql_warehouse": [{"name": "testid"}],
-            "uc_function": [
+            "function": [
                 {"name": "rag.studio.test_function_a"},
                 {"name": "rag.studio.test_function_b"},
             ],
@@ -1702,8 +1702,8 @@ def test_model_log_with_resources(tmp_path):
                 DatabricksServingEndpoint(endpoint_name="azure-eastus-model-serving-2_vs_endpoint"),
                 DatabricksVectorSearchIndex(index_name="rag.studio_bugbash.databricks_docs_index"),
                 DatabricksSQLWarehouse(warehouse_id="testid"),
-                DatabricksUCFunction(function_name="rag.studio.test_function_a"),
-                DatabricksUCFunction(function_name="rag.studio.test_function_b"),
+                DatabricksFunction(function_name="rag.studio.test_function_a"),
+                DatabricksFunction(function_name="rag.studio.test_function_b"),
             ],
         )
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
@@ -1725,7 +1725,7 @@ def test_model_log_with_resources(tmp_path):
                 - name: azure-eastus-model-serving-2_vs_endpoint
                 sql_warehouse:
                 - name: testid
-                uc_function:
+                function:
                 - name: rag.studio.test_function_a
                 - name: rag.studio.test_function_b
             """

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -243,7 +243,7 @@ def langchain_local_model_dir_with_resources(tmp_path):
                     {"name": "chat_endpoint"},
                 ],
                 "vector_search_index": [{"name": "index1"}, {"name": "index2"}],
-                "uc_function": [
+                "function": [
                     {"name": "test.schema.test_function"},
                     {"name": "test.schema.test_function_2"},
                 ],


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aravind-segu/mlflow/pull/13019?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13019/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13019
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
In resources, change the naming of functions for uc_function to function. This helps with extending this to other types of functions in the future.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
