### PR TITLE
Fix llama-index dev

### DIFF
--- a/mlflow/llama_index/serialize_objects.py
+++ b/mlflow/llama_index/serialize_objects.py
@@ -42,8 +42,6 @@ def object_to_dict(o: object):
             field_val = getattr(o, k, None)
             if field_val != v.default and callable(field_val):
                 callable_fields.add(k)
-                # exclude the callable field from serialization
-                v.exclude = True
         if callable_fields:
             _logger.warning(
                 f"Object {o} contains callable fields that are not serializable: {callable_fields},"
@@ -51,7 +49,7 @@ def object_to_dict(o: object):
             )
         # exclude default values from serialization to avoid
         # unnecessary clutter in the serialized object
-        o_state_as_dict = o.to_dict(exclude_defaults=True)
+        o_state_as_dict = o.to_dict(exclude=callable_fields)
 
         if o_state_as_dict != {}:
             o_state_as_dict = _sanitize_api_key(o_state_as_dict)

--- a/mlflow/llama_index/serialize_objects.py
+++ b/mlflow/llama_index/serialize_objects.py
@@ -38,7 +38,8 @@ def object_to_dict(o: object):
     if isinstance(o, BaseComponent):
         # we can't serialize callables in the model fields
         callable_fields = set()
-        for k, v in o.model_fields.items():
+        fields = o.model_fields if hasattr(o, "model_fields") else o.__fields__
+        for k, v in fields.items():
             field_val = getattr(o, k, None)
             if field_val != v.default and callable(field_val):
                 callable_fields.add(k)

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -715,6 +715,7 @@ llama_index:
     install_dev: |
       pip install git+https://github.com/run-llama/llama_index.git
       pip install git+https://github.com/run-llama/llama_index.git#egg=llama-index-llms-openai-like\&subdirectory=llama-index-integrations/llms/llama-index-llms-openai-like
+      pip install git+https://github.com/run-llama/llama_index.git#egg=llama-index-vector-stores-qdrant\&subdirectory=llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant
   models:
     # New event/span framework is fully implemented in 0.10.44
     minimum: "0.10.44"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -728,12 +728,14 @@ llama_index:
           # Required to test external vector stores
           "llama-index-vector-stores-qdrant",
         ]
+      ">= 0.11.0": ["fastapi>=0.100.0"]
     run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
   autologging:
     minimum: "0.10.44"
     maximum: "0.10.58"
     requirements:
       ">= 0.0.0": ["openai"]
+      ">= 0.11.0": ["fastapi>=0.100.0"]
     run: pytest tests/llama_index/test_llama_index_autolog.py tests/llama_index/test_llama_index_tracer.py
 
 autogen:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -714,6 +714,7 @@ llama_index:
     module_name: "llama_index.core"
     install_dev: |
       pip install git+https://github.com/run-llama/llama_index.git
+      pip install git+https://github.com/run-llama/llama_index.git#egg=llama-index-llms-openai-like\&subdirectory=llama-index-integrations/llms/llama-index-llms-openai-like
   models:
     # New event/span framework is fully implemented in 0.10.44
     minimum: "0.10.44"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -715,7 +715,6 @@ llama_index:
     install_dev: |
       pip install git+https://github.com/run-llama/llama_index.git
       pip install git+https://github.com/run-llama/llama_index.git#egg=llama-index-llms-openai-like\&subdirectory=llama-index-integrations/llms/llama-index-llms-openai-like
-      pip install git+https://github.com/run-llama/llama_index.git#egg=llama-index-vector-stores-qdrant\&subdirectory=llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant
   models:
     # New event/span framework is fully implemented in 0.10.44
     minimum: "0.10.44"

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 from unittest import mock
 
+import llama_index.core
 import numpy as np
 import pandas as pd
 import pytest
@@ -16,6 +17,7 @@ from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.databricks import Databricks
 from llama_index.llms.openai import OpenAI
 from llama_index.vector_stores.qdrant import QdrantVectorStore
+from packaging.version import Version
 
 import mlflow
 import mlflow.llama_index
@@ -113,9 +115,15 @@ def test_format_predict_input_correct(single_index, engine_type):
 def test_format_predict_input_incorrect_schema(single_index, engine_type):
     wrapped_model = create_engine_wrapper(single_index, engine_type)
 
-    with pytest.raises(TypeError, match="missing 1 required positional argument"):
+    exception_error = (
+        r"__init__\(\) got an unexpected keyword argument 'incorrect'"
+        if Version(llama_index.core.__version__) >= Version("0.10.68")
+        else "missing 1 required positional argument"
+    )
+
+    with pytest.raises(TypeError, match=exception_error):
         wrapped_model._format_predict_input(pd.DataFrame({"incorrect": ["hi"]}))
-    with pytest.raises(TypeError, match="missing 1 required positional argument"):
+    with pytest.raises(TypeError, match=exception_error):
         wrapped_model._format_predict_input({"incorrect": ["hi"]})
 
 

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -118,7 +118,7 @@ def test_format_predict_input_incorrect_schema(single_index, engine_type):
     exception_error = (
         r"__init__\(\) got an unexpected keyword argument 'incorrect'"
         if Version(llama_index.core.__version__) > Version("0.10.68")
-        else "missing 1 required positional argument"
+        else r"missing 1 required positional argument"
     )
 
     with pytest.raises(TypeError, match=exception_error):

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -117,7 +117,7 @@ def test_format_predict_input_incorrect_schema(single_index, engine_type):
 
     exception_error = (
         r"__init__\(\) got an unexpected keyword argument 'incorrect'"
-        if Version(llama_index.core.__version__) >= Version("0.10.68")
+        if Version(llama_index.core.__version__) > Version("0.10.68")
         else "missing 1 required positional argument"
     )
 

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any
 from unittest import mock
 
-import llama_index
+import llama_index.core
 import numpy as np
 import pandas as pd
 import pytest
@@ -117,7 +117,7 @@ def test_format_predict_input_incorrect_schema(single_index, engine_type):
 
     exception_error = (
         r"__init__\(\) got an unexpected keyword argument 'incorrect'"
-        if Version(llama_index.__version__) >= Version("0.11.0")
+        if Version(llama_index.core.__version__) >= Version("0.11.0")
         else r"missing 1 required positional argument"
     )
 

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any
 from unittest import mock
 
-import llama_index.core
+import llama_index
 import numpy as np
 import pandas as pd
 import pytest
@@ -117,7 +117,7 @@ def test_format_predict_input_incorrect_schema(single_index, engine_type):
 
     exception_error = (
         r"__init__\(\) got an unexpected keyword argument 'incorrect'"
-        if Version(llama_index.core.__version__) > Version("0.10.68")
+        if Version(llama_index.__version__) >= Version("0.11.0")
         else r"missing 1 required positional argument"
     )
 

--- a/tests/llama_index/test_llama_index_pyfunc_wrapper.py
+++ b/tests/llama_index/test_llama_index_pyfunc_wrapper.py
@@ -197,19 +197,6 @@ def test_format_predict_input_correct(single_index, engine_type):
     "engine_type",
     ["query", "retriever"],
 )
-def test_format_predict_input_incorrect_schema(single_index, engine_type):
-    wrapped_model = create_engine_wrapper(single_index, engine_type)
-
-    with pytest.raises(TypeError, match="missing 1 required positional argument"):
-        wrapped_model._format_predict_input(pd.DataFrame({"incorrect": ["hi"]}))
-    with pytest.raises(TypeError, match="missing 1 required positional argument"):
-        wrapped_model._format_predict_input({"incorrect": ["hi"]})
-
-
-@pytest.mark.parametrize(
-    "engine_type",
-    ["query", "retriever"],
-)
 def test_format_predict_input_correct_schema_complex(single_index, engine_type):
     wrapped_model = create_engine_wrapper(single_index, engine_type)
 

--- a/tests/llama_index/test_llama_index_serialization.py
+++ b/tests/llama_index/test_llama_index_serialization.py
@@ -104,6 +104,19 @@ def test_settings_serialization_full_object(tmp_path, settings):
     assert len(set(objects.keys()) - set(settings.__dict__.keys())) == 0
 
 
+def _assert_equal(settings_obj, deserialized_obj):
+    if isinstance(settings_obj, list):
+        assert len(settings_obj) == len(deserialized_obj)
+        for i in range(len(settings_obj)):
+            _assert_equal(settings_obj[i], deserialized_obj[i])
+    else:
+        for k, v in settings_obj.__dict__.items():
+            if k != "callback_manager":
+                assert getattr(deserialized_obj, k) == v
+            else:
+                assert getattr(deserialized_obj, k) is not None
+
+
 def test_settings_serde(tmp_path, settings, mock_logger):
     path = tmp_path / "serialized_settings.json"
     _llm = settings.llm
@@ -127,10 +140,11 @@ def test_settings_serde(tmp_path, settings, mock_logger):
     deserialize_settings(path)
 
     assert Settings is not None
-    assert Settings.llm == _llm  # Token is automatically applied from environment vars
-    assert Settings.embed_model == _embed_model
+    # Token is automatically applied from environment vars
+    _assert_equal(Settings.llm, _llm)
+    _assert_equal(Settings.embed_model, _embed_model)
     assert Settings.callback_manager is not None  # Auto-generated from defaults
     assert Settings.tokenizer is not None  # Auto-generated from defaults
-    assert Settings.node_parser == _node_parser
-    assert Settings.prompt_helper == _prompt_helper
-    assert Settings.transformations == _transformations
+    _assert_equal(Settings.node_parser, _node_parser)
+    _assert_equal(Settings.prompt_helper, _prompt_helper)
+    _assert_equal(Settings.transformations, _transformations)

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -5,6 +5,7 @@ from typing import List
 from unittest.mock import ANY
 
 import importlib_metadata
+import llama_index.core
 import openai
 import pytest
 from llama_index.agent.openai import OpenAIAgent
@@ -287,6 +288,8 @@ def test_trace_query_engine(multi_index, is_stream, is_async):
         response = asyncio.run(engine.aquery("Hello")) if is_async else engine.query("Hello")
         assert response.response.startswith('[{"role": "system", "content": "You are an')
         response = asdict(response)
+        if Version(llama_index.core.__version__) > Version("0.10.68"):
+            response["source_nodes"] = [n.dict() for n in response["source_nodes"]]
 
     traces = _get_all_traces()
     assert len(traces) == 1

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -73,7 +73,7 @@ def test_trace_llm_complete(is_async):
 
 
 def test_trace_llm_complete_stream():
-    model_name = "gpt-3.5-turbo-instruct"
+    model_name = "gpt-3.5-turbo"
     llm = OpenAI(model=model_name)
 
     response_gen = llm.stream_complete("Hello")
@@ -96,7 +96,7 @@ def test_trace_llm_complete_stream():
     assert spans[0].outputs["text"] == "Hello world"
 
     attr = spans[0].attributes
-    assert attr["usage"] == {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
+    assert attr["usage"] == {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21}
     assert attr["prompt"] == "Hello"
     assert attr["invocation_params"]["model_name"] == model_name
     assert attr["model_dict"]["model"] == model_name


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13029?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13029/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13029
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix https://github.com/mlflow-automation/mlflow/actions/runs/10615908169/job/29438941806

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
