### PR TITLE
Support long conversion to float for 0 and 1

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -821,7 +821,7 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
     if is_upcast:
         return values.astype(numpy_type, errors="raise")
     else:
-        # support converting long -> float/double for 0 values
+        # support converting long -> float/double for 0 and 1 values
         def all_zero_or_ones(xs):
             return all(pd.isnull(x) or x in [0, 1] for x in xs)
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -822,13 +822,13 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
         return values.astype(numpy_type, errors="raise")
     else:
         # support converting long -> float/double for 0 values
-        def all_zeros(xs):
-            return all(pd.isnull(x) or x == 0 for x in xs)
+        def all_zero_or_ones(xs):
+            return all(pd.isnull(x) or x in [0, 1] for x in xs)
 
         if (
             values.dtype == np.int64
             and numpy_type in (np.float32, np.float64)
-            and all_zeros(values)
+            and all_zero_or_ones(values)
         ):
             return values.astype(numpy_type, errors="raise")
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -821,6 +821,17 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
     if is_upcast:
         return values.astype(numpy_type, errors="raise")
     else:
+        # support converting long -> float/double for 0 values
+        def all_zeros(xs):
+            return all(pd.isnull(x) or x == 0 for x in xs)
+
+        if (
+            values.dtype == np.int64
+            and numpy_type in (np.float32, np.float64)
+            and all_zeros(values)
+        ):
+            return values.astype(numpy_type, errors="raise")
+
         # NB: conversion between incompatible types (e.g. floats -> ints or
         # double -> float) are not allowed. While supported by pandas and numpy,
         # these conversions alter the values significantly.

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -2973,3 +2973,10 @@ def test_pyfunc_model_schema_enforcement_complex(data, schema, format_key):
     result = json.loads(response.content.decode("utf-8"))["predictions"]
     expected_result = df.to_dict(orient="records")
     np.testing.assert_equal(result, expected_result)
+
+
+def test_zero_longs_convert_to_floats():
+    zeros = pd.Series([0, 0, 0])
+    schema = Schema([ColSpec(DataType.long)])
+    data = _enforce_schema(zeros, schema)
+    assert all(x == 0.0 for x in data)

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -2976,7 +2976,9 @@ def test_pyfunc_model_schema_enforcement_complex(data, schema, format_key):
 
 
 def test_zero_longs_convert_to_floats():
-    zeros = pd.Series([0, 0, 0])
-    schema = Schema([ColSpec(DataType.long)])
+    zeros = pd.DataFrame([{"temperature": 0}, {"temperature": 0.9}, {}])
+    schema = Schema([ColSpec(DataType.double, name="temperature", required=False)])
     data = _enforce_schema(zeros, schema)
-    assert all(x == 0.0 for x in data)
+    pd.testing.assert_series_equal(
+        data["temperature"], pd.Series([0.0, 0.9, np.nan], dtype=np.float64), check_names=False
+    )

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -2975,10 +2975,10 @@ def test_pyfunc_model_schema_enforcement_complex(data, schema, format_key):
     np.testing.assert_equal(result, expected_result)
 
 
-def test_zero_longs_convert_to_floats():
-    zeros = pd.DataFrame([{"temperature": 0}, {"temperature": 0.9}, {}])
+def test_zero_or_one_longs_convert_to_floats():
+    zeros = pd.DataFrame([{"temperature": 0}, {"temperature": 0.9}, {"temperature": 1}, {}])
     schema = Schema([ColSpec(DataType.double, name="temperature", required=False)])
     data = _enforce_schema(zeros, schema)
     pd.testing.assert_series_equal(
-        data["temperature"], pd.Series([0.0, 0.9, np.nan], dtype=np.float64), check_names=False
+        data["temperature"], pd.Series([0.0, 0.9, 1.0, np.nan], dtype=np.float64), check_names=False
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13036?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13036/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13036
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
0 should be able to convert from long type to float/double type

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
