### PR TITLE
Unpin `mlserver`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -73,6 +73,8 @@ jobs:
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/setup-python
+        with:
+          python-version: 3.9
       - uses: ./.github/actions/setup-pyenv
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/cache-pip

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -131,10 +131,8 @@ def build(package_type: PackageType) -> None:
                     # a remote Kubernetes cluster
                     "kubernetes",
                     # Required to serve models through MLServer
-                    # NOTE: remove the upper version pin once protobuf is no longer pinned in
-                    # mlserver. Reference issue: https://github.com/SeldonIO/MLServer/issues/1089
-                    "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-                    "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
+                    "mlserver>=1.2.0,!=1.3.1",
+                    "mlserver-mlflow>=1.2.0,!=1.3.1",
                     "virtualenv",
                     # Required for exporting metrics from the MLflow server to Prometheus
                     # as part of the MLflow server monitoring add-on

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -57,8 +57,8 @@ extras = [
   "azureml-core>=1.2.0",
   "pysftp",
   "kubernetes",
-  "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-  "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
+  "mlserver>=1.2.0,!=1.3.1",
+  "mlserver-mlflow>=1.2.0,!=1.3.1",
   "virtualenv",
   "prometheus-flask-exporter",
 ]

--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -53,8 +53,8 @@ extras = [
   "azureml-core>=1.2.0",
   "pysftp",
   "kubernetes",
-  "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-  "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
+  "mlserver>=1.2.0,!=1.3.1",
+  "mlserver-mlflow>=1.2.0,!=1.3.1",
   "virtualenv",
   "prometheus-flask-exporter",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ extras = [
   "azureml-core>=1.2.0",
   "pysftp",
   "kubernetes",
-  "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-  "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
+  "mlserver>=1.2.0,!=1.3.1",
+  "mlserver-mlflow>=1.2.0,!=1.3.1",
   "virtualenv",
   "prometheus-flask-exporter",
 ]

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -25,10 +25,8 @@ flaml[automl]
 # this is pinned because huggingface_hub >= 0.24.0 causes setfit to be unimportable, see
 # https://github.com/huggingface/setfit/issues/544
 huggingface_hub<0.24.0
-# Pinned due to protobuf requirement pinning in 1.3.0 of ml-server that is incompatible
-# 1.4.0 does not support pydantic v2 https://github.com/SeldonIO/MLServer/pull/1595
-mlserver>=1.2.0,!=1.3.1,<1.4.0
-mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0
+mlserver>=1.2.0,!=1.3.1
+mlserver-mlflow>=1.2.0,!=1.3.1
 # Required by evaluator tests
 shap
 # Required to evaluate language models in `mlflow.evaluate`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -466,8 +466,8 @@ def test_mlflow_models_serve(enable_mlserver):
                 artifact_path="model",
                 python_model=model,
                 extra_pip_requirements=[
-                    "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-                    "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
+                    "mlserver>=1.2.0,!=1.3.1",
+                    "mlserver-mlflow>=1.2.0,!=1.3.1",
                     PROTOBUF_REQUIREMENT,
                 ],
             )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13039?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13039/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13039
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix the following error in `mlserver`:

https://github.com/mlflow/mlflow/actions/runs/10629451325/job/29466321282

```
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/.venv/bin/mlserver", line 5, in <module>
    from mlserver.cli import main
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.8/site-packages/mlserver/__init__.py", line 2, in <module>
    from .server import MLServer
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.8/site-packages/mlserver/server.py", line 7, in <module>
    from .model import MLModel
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.8/site-packages/mlserver/model.py", line 3, in <module>
    from .codecs import (
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.8/site-packages/mlserver/codecs/__init__.py", line 1, in <module>
    from .numpy import NumpyCodec, NumpyRequestCodec
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.8/site-packages/mlserver/codecs/numpy.py", line 5, in <module>
    from ..types import RequestInput, ResponseOutput, Parameters
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.8/site-packages/mlserver/types/__init__.py", line 1, in <module>
    from .dataplane import (
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.8/site-packages/mlserver/types/dataplane.py", line 33, in <module>
    class TensorData(BaseModel):
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.8/site-packages/pydantic/_internal/_model_construction.py", line 96, in __new__
    private_attributes = inspect_namespace(
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.8/site-packages/pydantic/_internal/_model_construction.py", line 344, in inspect_namespace
    raise TypeError("To define root models, use `pydantic.RootModel` rather than a field called '__root__'")
TypeError: To define root models, use `pydantic.RootModel` rather than a field called '__root__'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
