### PR TITLE
Support evaluation on an endpoint URI with the `databricks-agent` model type

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -865,6 +865,9 @@ def _get_model_from_deployment_endpoint_uri(
                     - A dictionary: If the model_type is "databricks-agents" and the
                         Databricks RAG evaluator is used, this PythonModel can be invoked
                         with a single dict corresponding to the ChatCompletionsRequest schema.
+                    - A list of dictionaries: Currently we don't have any evaluator that
+                        gives this input format, but we keep this for future use cases and
+                        compatibility with normal pyfunc models.
 
             Return:
                 The prediction result. The return type will be consistent with the model input type,
@@ -872,6 +875,10 @@ def _get_model_from_deployment_endpoint_uri(
             """
             if isinstance(model_input, dict):
                 return self._predict_single(model_input)
+            elif isinstance(model_input, list) and all(
+                isinstance(data, dict) for data in model_input
+            ):
+                return [self._predict_single(data) for data in model_input]
             elif isinstance(model_input, pd.DataFrame):
                 if len(model_input.columns) != 1:
                     raise MlflowException(

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -47,6 +47,7 @@ from mlflow.models.evaluation import (
 )
 from mlflow.models.evaluation.artifacts import ImageEvaluationArtifact
 from mlflow.models.evaluation.base import (
+    _get_model_from_deployment_endpoint_uri,
     _is_model_deployment_endpoint_uri,
     _start_run_or_reuse_active_run,
 )
@@ -2125,7 +2126,7 @@ def test_evaluate_on_completion_model_endpoint(mock_deploy_client, input_data, f
         # Input column not str or dict
         (
             pd.DataFrame({"inputs": [1, 2], "ground_truth": _TEST_GT_LIST}),
-            "Invalid input column type",
+            "Invalid input data type",
         ),
     ],
 )
@@ -2139,6 +2140,55 @@ def test_evaluate_on_model_endpoint_invalid_input_data(input_data, error_message
                 targets="ground_truth",
                 inference_params={"max_tokens": 10, "temperature": 0.5},
             )
+
+
+@pytest.mark.parametrize(
+    "model_input",
+    [
+        # Case 1: Single dictionary.
+        # This is an expected input format from the Databricks RAG Evaluator.
+        {
+            "messages": [{"content": "What is MLflow?", "role": "user"}],
+            "max_tokens": 10,
+        },
+        # Case 2: DataFrame with a column of dictionaries
+        pd.DataFrame(
+            {
+                "inputs": [
+                    {
+                        "messages": [{"content": "What is MLflow?", "role": "user"}],
+                        "max_tokens": 10,
+                    },
+                    {
+                        "messages": [{"content": "What is Spark?", "role": "user"}],
+                    },
+                ]
+            }
+        ),
+        # Case 3: DataFrame with a column of strings
+        pd.DataFrame(
+            {
+                "inputs": ["What is MLflow?", "What is Spark?"],
+            }
+        ),
+    ],
+)
+@mock.patch("mlflow.deployments.get_deploy_client")
+def test_model_from_deployment_endpoint(mock_deploy_client, model_input):
+    mock_deploy_client.return_value.predict.return_value = _DUMMY_CHAT_RESPONSE
+    mock_deploy_client.return_value.get_endpoint.return_value = {"task": "llm/v1/chat"}
+
+    model = _get_model_from_deployment_endpoint_uri("endpoints:/chat")
+
+    response = model.predict(model_input)
+
+    if isinstance(model_input, dict):
+        assert mock_deploy_client.return_value.predict.call_count == 1
+        # Chat response should be unwrapped
+        assert response == "This is a response"
+    else:
+        assert mock_deploy_client.return_value.predict.call_count == 2
+        assert response.equals(pd.Series(["This is a response"] * 2))
 
 
 def test_import_evaluation_dataset():

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -2145,13 +2145,20 @@ def test_evaluate_on_model_endpoint_invalid_input_data(input_data, error_message
 @pytest.mark.parametrize(
     "model_input",
     [
-        # Case 1: Single dictionary.
+        # Case 1: Single chat dictionary.
         # This is an expected input format from the Databricks RAG Evaluator.
         {
             "messages": [{"content": "What is MLflow?", "role": "user"}],
             "max_tokens": 10,
         },
-        # Case 2: DataFrame with a column of dictionaries
+        # Case 2: List of chat dictionaries.
+        # This is not a typical input format from either default or Databricks RAG evaluators,
+        # but we support it for compatibility with the normal Pyfunc models.
+        [
+            {"messages": [{"content": "What is MLflow?", "role": "user"}]},
+            {"messages": [{"content": "What is Spark?", "role": "user"}]},
+        ],
+        # Case 3: DataFrame with a column of dictionaries
         pd.DataFrame(
             {
                 "inputs": [
@@ -2165,7 +2172,7 @@ def test_evaluate_on_model_endpoint_invalid_input_data(input_data, error_message
                 ]
             }
         ),
-        # Case 3: DataFrame with a column of strings
+        # Case 4: DataFrame with a column of strings
         pd.DataFrame(
             {
                 "inputs": ["What is MLflow?", "What is Spark?"],
@@ -2188,7 +2195,7 @@ def test_model_from_deployment_endpoint(mock_deploy_client, model_input):
         assert response == "This is a response"
     else:
         assert mock_deploy_client.return_value.predict.call_count == 2
-        assert response.equals(pd.Series(["This is a response"] * 2))
+        assert pd.Series(response).equals(pd.Series(["This is a response"] * 2))
 
 
 def test_import_evaluation_dataset():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13044?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13044/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13044
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.evaluate()` API support passing the deployment URI as the model to evaluate:
```
mlflow.evaluate(model="endpoints:/my-chat-endpoint", ...) 
```
Internally, the endpoint is wrapped by a Python Model class [ModelFromDeploymentEndpoint](https://github.com/mlflow/mlflow/blob/f810d03ec4188c06c61219650b97e64df7748aa1/mlflow/models/evaluation/base.py#L852). This wrapper is responsible for converting the input Pandas Dataframe into the correct payload for sending an HTTP request to the endpoint.

However, when the model type is set to `databricks-agent`, the input format is not PandasDataframe but a dictionary that corresponds to the chat request format. For that model type, the special `DatabricksRagEvaluator` implementation (resides in Databricks side) is used as an evaluator and it extracts the dictionary from the input dataset before making prediction call.

To workaround this issue, this PR updates the wrapper class to handle dictionary input.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="1213" alt="Screenshot 2024-09-02 at 13 14 43" src="https://github.com/user-attachments/assets/a29cd051-65d9-4d52-8666-f4e60566e1d9">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
