### PR TITLE
Support loading `ChatDatabricks` from the partner package

### DIFF
--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -36,6 +36,7 @@ from mlflow.langchain.utils import (
     lc_runnable_branch_types,
     lc_runnable_with_steps_types,
     lc_runnables_types,
+    patch_langchain_type_to_cls_dict,
     picklable_runnable_types,
 )
 
@@ -51,6 +52,7 @@ _DEFAULT_BRANCH_NAME = "default"
 _RUNNABLE_BINDING_CONF_FILE_NAME = "binding_conf.yaml"
 
 
+@patch_langchain_type_to_cls_dict
 def _load_model_from_config(path, model_config):
     from langchain.chains.loading import type_to_loader_dict as chains_type_to_loader_dict
     from langchain.llms import get_type_to_cls_dict as llms_get_type_to_cls_dict

--- a/mlflow/langchain/utils/__init__.py
+++ b/mlflow/langchain/utils/__init__.py
@@ -1,6 +1,7 @@
 """Utility functions for mlflow.langchain."""
 
 import contextlib
+import functools
 import importlib
 import json
 import logging
@@ -542,79 +543,64 @@ def _load_base_lcs(
     return model
 
 
-@contextlib.contextmanager
-def patch_langchain_type_to_cls_dict():
-    """Patch LangChain's type_to_cls_dict config to handle unsupported types like ChatOpenAI.
+def patch_langchain_type_to_cls_dict(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        def _load_chat_openai():
+            from langchain_community.chat_models import ChatOpenAI
 
-    The type_to_cls_dict is a hard-coded dictionary in LangChain code base that defines the mapping
-    between the LLM type e.g. "openai" to the loader function for the corresponding LLM class.
-    However, this dictionary doesn't contain some chat models like ChatOpenAI, AzureChatOpenAI,
-    which makes it unable to save and load chains with these models. Ideally, the config should
-    be updated in the LangChain code base, but similar requests have been rejected multiple times
-    in the past, because they consider this serde method to be deprecated, and instead prompt
-    users to use their new serde method https://github.com/langchain-ai/langchain/pull/8164#issuecomment-1659723157.
-    However, we can't simply migrate to the new method because it doesn't support common chains
-    like RetrievalQA, AgentExecutor, etc.
-    Therefore, we apply a hacky solution to patch the type_to_cls_dict from our side to support
-    these models, until a better solution is provided by LangChain.
-    """
+            return ChatOpenAI
 
-    def _load_chat_openai():
-        from langchain_community.chat_models import ChatOpenAI
+        def _load_azure_chat_openai():
+            from langchain_community.chat_models import AzureChatOpenAI
 
-        return ChatOpenAI
+            return AzureChatOpenAI
 
-    def _load_azure_chat_openai():
-        from langchain_community.chat_models import AzureChatOpenAI
+        def _load_chat_databricks():
+            from langchain_databricks import ChatDatabricks
 
-        return AzureChatOpenAI
+            return ChatDatabricks
 
-    def _load_chat_databricks():
-        from langchain_databricks import ChatDatabricks
+        def _patched_get_type_to_cls_dict(original):
+            def _wrapped():
+                return {
+                    **original(),
+                    "openai-chat": _load_chat_openai,
+                    "azure-openai-chat": _load_azure_chat_openai,
+                    "chat-databricks": _load_chat_databricks,
+                }
 
-        return ChatDatabricks
+            return _wrapped
 
-    def _patched_get_type_to_cls_dict(original):
-        def _wrapped():
-            return {
-                **original(),
-                "openai-chat": _load_chat_openai,
-                "azure-openai-chat": _load_azure_chat_openai,
-                "chat-databricks": _load_chat_databricks,
-            }
+        modules_to_patch = ["langchain.llms", "langchain_community.llms.loading"]
+        originals = {}
+        for name in modules_to_patch:
+            try:
+                module = importlib.import_module(name)
+                originals[name] = module.get_type_to_cls_dict  # Record original impl for cleanup
+            except (ImportError, AttributeError):
+                continue
+            module.get_type_to_cls_dict = _patched_get_type_to_cls_dict(originals[name])
 
-        return _wrapped
-
-    # NB: get_type_to_cls_dict() method is defined in the following two modules with the same
-    # name but with slight different elements. This is most likely just a mistake in the
-    # LangChain codebase, but we patch them separately to avoid any potential issues.
-    modules_to_patch = ["langchain.llms", "langchain_community.llms.loading"]
-    originals = {}
-    for module_name in modules_to_patch:
         try:
-            module = importlib.import_module(module_name)
-            originals[module_name] = module.get_type_to_cls_dict  # Record original impl for cleanup
-        except (ImportError, AttributeError):
-            continue
-        module.get_type_to_cls_dict = _patched_get_type_to_cls_dict(originals[module_name])
+            return func(*args, **kwargs)
+        except ValueError as e:
+            if m := _CHAT_MODELS_ERROR_MSG.search(str(e)):
+                model_name = "ChatOpenAI" if m.group(1) == "openai-chat" else "AzureChatOpenAI"
+                raise mlflow.MlflowException(
+                    f"Loading {model_name} chat model is not supported in MLflow with the "
+                    "current version of LangChain. Please upgrade LangChain to 0.0.307 or above "
+                    "by running `pip install langchain>=0.0.307`."
+                ) from e
+            else:
+                raise
+        finally:
+            # Clean up the patch
+            for module_name, original_impl in originals.items():
+                module = importlib.import_module(module_name)
+                module.get_type_to_cls_dict = original_impl
 
-    try:
-        yield
-    except ValueError as e:
-        if m := _CHAT_MODELS_ERROR_MSG.search(str(e)):
-            model_name = "ChatOpenAI" if m.group(1) == "openai-chat" else "AzureChatOpenAI"
-            raise mlflow.MlflowException(
-                f"Loading {model_name} chat model is not supported in MLflow with the "
-                "current version of LangChain. Please upgrade LangChain to 0.0.307 or above "
-                "by running `pip install langchain>=0.0.307`."
-            ) from e
-        else:
-            raise
-    finally:
-        # Clean up the patch
-        for module_name, original_impl in originals.items():
-            module = importlib.import_module(module_name)
-            module.get_type_to_cls_dict = original_impl
+    return wrapper
 
 
 def register_pydantic_serializer():

--- a/mlflow/langchain/utils/__init__.py
+++ b/mlflow/langchain/utils/__init__.py
@@ -569,12 +569,18 @@ def patch_langchain_type_to_cls_dict():
 
         return AzureChatOpenAI
 
+    def _load_chat_databricks():
+        from langchain_databricks import ChatDatabricks
+
+        return ChatDatabricks
+
     def _patched_get_type_to_cls_dict(original):
         def _wrapped():
             return {
                 **original(),
                 "openai-chat": _load_chat_openai,
                 "azure-openai-chat": _load_azure_chat_openai,
+                "chat-databricks": _load_chat_databricks,
             }
 
         return _wrapped

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -679,11 +679,6 @@ langchain:
           "git+https://github.com/langchain-ai/langchain-databricks.git@main#egg=langchain-databricks&subdirectory=libs/databricks",
         ]
     run: |
-      # Langchain-databricks include databricks-vectorsearch as a dependency,
-      # which falsely installs mlflow-skinny and cause weird behavior in the tests.
-      pip uninstall mlflow-skinny -y
-      # Re-install MLflow to avoid weird side effect from uninstall skinny
-      pip install . -e .
       # Run all langchain tests except autologging
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -679,9 +679,11 @@ langchain:
           "git+https://github.com/langchain-ai/langchain-databricks.git@main#egg=langchain-databricks&subdirectory=libs/databricks",
         ]
     run: |
-      # Langchain-databricks include databricks-vectorsearch as a dependency, which falsely
-      # installs mlflow-skinny and cause weird behavior in the tests.
+      # Langchain-databricks include databricks-vectorsearch as a dependency,
+      # which falsely installs mlflow-skinny and cause weird behavior in the tests.
       pip uninstall mlflow-skinny -y
+      # Re-install MLflow to avoid weird side effect from uninstall skinny
+      pip install . -e .
       # Run all langchain tests except autologging
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -667,6 +667,7 @@ langchain:
           "numexpr",
           "hf_transfer",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
+          "langchain-databricks",
           "langchain-openai",
           "langgraph",
         ]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -667,7 +667,6 @@ langchain:
           "numexpr",
           "hf_transfer",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
-          "langchain-databricks",
           "langchain-openai",
           "langgraph",
         ]
@@ -675,7 +674,6 @@ langchain:
       # https://github.com/langchain-ai/langchain/commit/b83f1eb0d56dbf99605a1fce93953ee09d77aabf
       "< 0.2": ["langchain-openai<=0.1.22"]
       ">= 0.2": [
-          "langchain-openai",
           "langchain-huggingface",
           # Install langchain-databricks from the main branch
           "git+https://github.com/langchain-ai/langchain-databricks.git@main#egg=langchain-databricks&subdirectory=libs/databricks",

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -673,7 +673,12 @@ langchain:
       # langchain-openai 0.1.22 is imcomptible with earlier langchain-core due to
       # https://github.com/langchain-ai/langchain/commit/b83f1eb0d56dbf99605a1fce93953ee09d77aabf
       "< 0.2": ["langchain-openai<=0.1.22"]
-      ">= 0.2": ["langchain-openai", "langchain-huggingface"]
+      ">= 0.2": [
+          "langchain-openai",
+          "langchain-huggingface",
+          # Install langchain-databricks from the main branch
+          "git+https://github.com/langchain-ai/langchain-databricks.git@main#egg=langchain-databricks&subdirectory=libs/databricks",
+        ]
     run: |
       # Run all langchain tests except autologging
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -679,6 +679,9 @@ langchain:
           "git+https://github.com/langchain-ai/langchain-databricks.git@main#egg=langchain-databricks&subdirectory=libs/databricks",
         ]
     run: |
+      # Langchain-databricks include databricks-vectorsearch as a dependency, which falsely
+      # installs mlflow-skinny and cause weird behavior in the tests.
+      pip uninstall mlflow-skinny -y
       # Run all langchain tests except autologging
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -416,7 +416,6 @@ def infer_pip_requirements(model_uri, flavor, fallback=None, timeout=None):
         else:
             return _infer_requirements(model_uri, flavor, raise_on_error=raise_on_error)
     except Exception as e:
-        raise e
         if raise_on_error or (fallback is None):
             raise
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -416,6 +416,7 @@ def infer_pip_requirements(model_uri, flavor, fallback=None, timeout=None):
         else:
             return _infer_requirements(model_uri, flavor, raise_on_error=raise_on_error)
     except Exception as e:
+        raise e
         if raise_on_error or (fallback is None):
             raise
 

--- a/tests/langchain/test_langchain_databricks_integration.py
+++ b/tests/langchain/test_langchain_databricks_integration.py
@@ -1,0 +1,80 @@
+# Test integration with the `langchain-databricks` package.
+from typing import Generator
+from unittest import mock
+
+import pytest
+from langchain.prompts import PromptTemplate
+from langchain.schema.output_parser import StrOutputParser
+
+import mlflow
+
+_MOCK_CHAT_RESPONSE = {
+    "id": "chatcmpl_id",
+    "object": "chat.completion",
+    "created": 1721875529,
+    "model": "meta-llama-3.1-70b-instruct-072424",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "user",
+                "content": "What is MLflow?",
+            },
+            "finish_reason": "stop",
+            "logprobs": None,
+        }
+    ],
+    "usage": {"prompt_tokens": 30, "completion_tokens": 36, "total_tokens": 66},
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_client() -> Generator:
+    client = mock.MagicMock()
+    client.predict.return_value = _MOCK_CHAT_RESPONSE
+    with mock.patch("mlflow.deployments.get_deploy_client", return_value=client):
+        yield
+
+
+@pytest.fixture
+def model_path(tmp_path):
+    return tmp_path / "model"
+
+
+def test_save_and_load_chat_databricks(model_path):
+    from langchain_databricks import ChatDatabricks
+
+    llm = ChatDatabricks(endpoint="databricks-meta-llama-3-70b-instruct")
+    prompt = PromptTemplate.from_template("What is {product}?")
+    chain = prompt | llm | StrOutputParser()
+
+    mlflow.langchain.save_model(chain, path=model_path)
+
+    with model_path.joinpath("requirements.txt").open() as f:
+        reqs = {req.split("==")[0] for req in f.read().split("\n")}
+    assert "langchain-databricks" in reqs
+
+    loaded_model = mlflow.langchain.load_model(model_path)
+    assert loaded_model == chain
+
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
+    prediction = loaded_pyfunc_model.predict([{"product": "MLflow"}])
+    assert prediction == ["What is MLflow?"]
+
+
+def test_save_and_load_chat_databricks_legacy(model_path):
+    # Test saving and loading the community version of ChatDatabricks
+    from langchain.chat_models import ChatDatabricks
+
+    llm = ChatDatabricks(endpoint="databricks-meta-llama-3-70b-instruct")
+    prompt = PromptTemplate.from_template("What is {product}?")
+    chain = prompt | llm | StrOutputParser()
+
+    mlflow.langchain.save_model(chain, path=model_path)
+
+    loaded_model = mlflow.langchain.load_model(model_path)
+    assert loaded_model == chain
+
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
+    prediction = loaded_pyfunc_model.predict([{"product": "MLflow"}])
+    assert prediction == ["What is MLflow?"]

--- a/tests/langchain/test_langchain_databricks_integration.py
+++ b/tests/langchain/test_langchain_databricks_integration.py
@@ -1,12 +1,12 @@
 # Test integration with the `langchain-databricks` package.
-from packaging.version import Version
 from typing import Generator
 from unittest import mock
 
-import pytest
 import langchain
+import pytest
 from langchain.prompts import PromptTemplate
 from langchain.schema.output_parser import StrOutputParser
+from packaging.version import Version
 
 import mlflow
 

--- a/tests/langchain/test_langchain_databricks_integration.py
+++ b/tests/langchain/test_langchain_databricks_integration.py
@@ -1,8 +1,10 @@
 # Test integration with the `langchain-databricks` package.
+from packaging.version import Version
 from typing import Generator
 from unittest import mock
 
 import pytest
+import langchain
 from langchain.prompts import PromptTemplate
 from langchain.schema.output_parser import StrOutputParser
 
@@ -41,6 +43,10 @@ def model_path(tmp_path):
     return tmp_path / "model"
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="langchain-databricks requires langchain >= 0.2.0",
+)
 def test_save_and_load_chat_databricks(model_path):
     from langchain_databricks import ChatDatabricks
 
@@ -62,6 +68,10 @@ def test_save_and_load_chat_databricks(model_path):
     assert prediction == ["What is MLflow?"]
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="langchain-databricks requires langchain >= 0.2.0",
+)
 def test_save_and_load_chat_databricks_legacy(model_path):
     # Test saving and loading the community version of ChatDatabricks
     from langchain.chat_models import ChatDatabricks

--- a/tests/langchain/test_langchain_databricks_integration.py
+++ b/tests/langchain/test_langchain_databricks_integration.py
@@ -47,7 +47,8 @@ def model_path(tmp_path):
     Version(langchain.__version__) < Version("0.2.0"),
     reason="langchain-databricks requires langchain >= 0.2.0",
 )
-def test_save_and_load_chat_databricks(model_path):
+def test_save_and_load_chat_databricks(model_path, monkeypatch):
+    monkeypatch.setenv("MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS", "true")
     from langchain_databricks import ChatDatabricks
 
     llm = ChatDatabricks(endpoint="databricks-meta-llama-3-70b-instruct")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13045?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13045/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13045
```

</p>
</details>

### What changes are proposed in this pull request?

MLflow LangChain flavor does not handle loading modules from the partner packages e.g. `langchain-openai`, instead, it can only load from the `langchain-community` package. As a workaround, we suggest users to use the "model-from-code" to log models depend on partner packages.

Recently, we've created a new `langchain-databricks` partner package and migrate classes like `ChatDatabricks` from the community package to the new one. We no longer maintain the legacy community version and strongly recommend to use the new one, but the requirement of "model-from-code" might be an obstacle for users to do the migration. Therefore, this PR adds a patch to allow save and load `ChatDatabricks` in the same manner (not model-from-code) to promote the migration.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
