### PR TITLE
Fix timezone issue with autogen tracing

### DIFF
--- a/tests/autogen/test_autogen_autolog.py
+++ b/tests/autogen/test_autogen_autolog.py
@@ -251,6 +251,33 @@ def test_tracing_agent_with_function_calling(llm_config):
     assert tool_span.end_time_ns - tool_span.start_time_ns >= 1e9  # 1 second
 
 
+def test_tracing_llm_completion_duration_timezone(llm_config, monkeypatch):
+    # Test if the duration calculation for LLM completion is robust to timezone changes.
+    monkeypatch.setenv("TZ", "Asia/Tokyo")
+    time.tzset()
+
+    mlflow.autogen.autolog()
+
+    with mock_user_input(
+        ["What is the capital of Tokyo?", "How long is it take from San Francisco?", "exit"]
+    ):
+        assistant, user_proxy = get_simple_agent(llm_config)
+        assistant.initiate_chat(user_proxy, message="How can I help you today?")
+
+    # Check if the initiate_chat method is patched
+    traces = get_traces()
+    span_name_to_dict = {span.name: span for span in traces[0].data.spans}
+    llm_span = span_name_to_dict["chat_completion_1"]
+
+    # We mock OpenAI LLM call so it should not take too long e.g. > 10 seconds. If it does,
+    # it most likely a bug such as incorrect timezone handling.
+    assert 0 < llm_span.end_time_ns - llm_span.start_time_ns <= 10e9
+
+    # Check if the start time is in reasonable range
+    root_span = span_name_to_dict["initiate_chat"]
+    assert 0 < llm_span.start_time_ns - root_span.start_time_ns <= 1e9
+
+
 def test_tracing_composite_agent(llm_config):
     # Composite agent can call initiate_chat() or generate_reply() method of its sub-agents.
     # This test is to ensure that won't create a new trace for the sub-agent's method call.

--- a/tests/autogen/test_autogen_autolog.py
+++ b/tests/autogen/test_autogen_autolog.py
@@ -251,11 +251,21 @@ def test_tracing_agent_with_function_calling(llm_config):
     assert tool_span.end_time_ns - tool_span.start_time_ns >= 1e9  # 1 second
 
 
-def test_tracing_llm_completion_duration_timezone(llm_config, monkeypatch):
-    # Test if the duration calculation for LLM completion is robust to timezone changes.
+@pytest.fixture
+def tokyo_timezone(monkeypatch):
+    # Set the timezone to Tokyo
     monkeypatch.setenv("TZ", "Asia/Tokyo")
     time.tzset()
 
+    yield
+
+    # Reset the timezone
+    monkeypatch.delenv("TZ")
+    time.tzset()
+
+
+def test_tracing_llm_completion_duration_timezone(llm_config, tokyo_timezone):
+    # Test if the duration calculation for LLM completion is robust to timezone changes.
     mlflow.autogen.autolog()
 
     with mock_user_input(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13047?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13047/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13047
```

</p>
</details>

### What changes are proposed in this pull request?

During running autogen tracing in my own laptop, I found that the span duration for LLM call is not correct (about 32400s). The root cause was that the timestamp obtained [here](https://github.com/mlflow/mlflow/blob/f810d03ec4188c06c61219650b97e64df7748aa1/mlflow/autogen/autogen_logger.py#L236-L238) does not handle the local timezone correctly and added 9 hours offset in my case. This was not caught in manual testing before because our staging account is based on UTC timezone.

<img width="1219" alt="Screenshot 2024-09-02 at 19 16 02" src="https://github.com/user-attachments/assets/e7b2a192-e0f6-41ac-8a9c-413bbc904c60">

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1227" alt="Screenshot 2024-09-02 at 19 15 34" src="https://github.com/user-attachments/assets/763af648-483b-4605-9b9d-7a94af650da9">


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix timezone handling in the AutoGen tracing integration.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
