### PR TITLE
Add `/rerun` command to rerun failed jobs on PR

### DIFF
--- a/.github/workflows/rerun.js
+++ b/.github/workflows/rerun.js
@@ -1,0 +1,51 @@
+module.exports = async ({ github, context }) => {
+  const {
+    repo: { owner, repo },
+  } = context;
+
+  await github.rest.reactions.createForIssueComment({
+    owner,
+    repo,
+    comment_id: context.payload.comment.id,
+    content: "rocket",
+  });
+
+  const { data: pr } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: context.issue.number,
+  });
+
+  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref: pr.head.sha,
+  });
+  const runIdsToRerun = checkRuns
+    // Select failed/cancelled github action runs
+    .filter(
+      ({ name, status, conclusion, app: { slug } }) =>
+        slug === "github-actions" &&
+        status === "completed" &&
+        (conclusion === "failure" || conclusion === "cancelled") &&
+        name !== "rerun"
+    )
+    .map(
+      ({
+        // Example: https://github.com/mlflow/mlflow/actions/runs/10675586265/job/29587793829
+        //                                                        ^^^^^^^^^^^ run_id
+        html_url,
+      }) => html_url.match(/\/actions\/runs\/(\d+)/)[1]
+    );
+
+  const uniqueRunIds = [...new Set(runIdsToRerun)];
+  const promises = uniqueRunIds.map(async (run_id) => {
+    console.log(`Rerunning https://github.com/${owner}/${repo}/actions/runs/${run_id}`);
+    await github.rest.actions.reRunWorkflowFailedJobs({
+      repo,
+      owner,
+      run_id,
+    });
+  });
+  await Promise.all(promises);
+};

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           script: |
             const rerun = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/rerun.js`);
-            await rerun({ context, github, workflow_id: "cross-version-tests.yml" });
+            await rerun({ context, github });

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       pull-requests: write # to create a reaction to the comment
       actions: write # to rerun github action workflows
-    if: ${{ github.event.issue.pull_request }} && (github.event.comment.body == '/rerun' || github.event.comment.body == '/rr')
+    if: github.event.issue.pull_request && (github.event.comment.body == '/rerun' || github.event.comment.body == '/rr')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,31 @@
+name: rerun
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write # to create a reaction to the comment
+      actions: write # to rerun github action workflows
+    if: ${{ github.event.issue.pull_request }} && (github.event.comment.body == '/rerun' || github.event.comment.body == '/rr')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const rerun = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/rerun.js`);
+            await rerun({ context, github, workflow_id: "cross-version-tests.yml" });


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13057?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13057/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13057
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Add `/rerun` command to run failed jobs on the PR for convenience.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
