### PR TITLE
[WIP] Support logging Transformers model without loading it into memory.

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -788,7 +788,7 @@ class Model:
                 model_info.registered_model_version = registered_model.version
 
             # validate input example works for serving when logging the model
-            if serving_input:
+            if serving_input and kwargs.get("validate_serving_input", True):
                 from mlflow.models import validate_serving_input
 
                 try:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -982,6 +982,10 @@ def log_model(
         code_paths=code_paths,
         signature=signature,
         input_example=input_example,
+        # NB: We don't validate the serving input for Transformers flavor because
+        # it requires loading the model into memory and make prediction, which is
+        # expensive and can cause OOM errors.
+        validate_serving_input=False,
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
         model_config=model_config,

--- a/mlflow/transformers/flavor_config.py
+++ b/mlflow/transformers/flavor_config.py
@@ -167,7 +167,8 @@ def build_flavor_config_from_repo_info(
     hf_repo_info: Dict, processor=None, torch_dtype=None
 ) -> Dict[str, Any]:
     """
-    Generates the flavor metadata from a Hugging Face model repository ID e.g. "meta-llama/Meta-Llama-3.1-405B, instead of the pipeline instance in-memory.
+    Generates the flavor metadata from a Hugging Face model repository ID
+    e.g. "meta-llama/Meta-Llama-3.1-405B, instead of the pipeline instance in-memory.
     """
     from transformers import AutoTokenizer, pipelines
 
@@ -210,7 +211,7 @@ def _infer_framework(hf_repo_info: Dict) -> str:
     """
     from transformers.utils import is_torch_available
 
-    if not is_torch_available:
+    if not is_torch_available():
         return "tf"
 
     # Check repo tag

--- a/mlflow/transformers/hub_utils.py
+++ b/mlflow/transformers/hub_utils.py
@@ -1,7 +1,8 @@
 import functools
 import logging
 import os
-from typing import Optional
+import shutil
+from typing import Dict, Optional
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
@@ -53,3 +54,96 @@ def is_valid_hf_repo_id(maybe_repo_id: Optional[str]) -> bool:
     except HFValidationError as e:
         _logger.warning(f"The repository identified {maybe_repo_id} is invalid: {e}")
         return False
+
+
+def download_model_weights_from_hub(flavor_conf: Dict, dst_path: str):
+    """
+    Download the model weights from the HuggingFace model hub.
+
+    The model repository can store multiple weight files for different frameworks. This function
+    determines which files to download based on the framework specified in the flavor configuration
+    and the availability of the weight files in the repository.
+    """
+    from huggingface_hub import hf_hub_download
+    from transformers.utils import (
+        CONFIG_NAME,
+        SAFE_WEIGHTS_INDEX_NAME,
+        SAFE_WEIGHTS_NAME,
+        TF2_WEIGHTS_INDEX_NAME,
+        TF2_WEIGHTS_NAME,
+        TF_WEIGHTS_NAME,
+        WEIGHTS_INDEX_NAME,
+        WEIGHTS_NAME,
+    )
+    from transformers.utils.hub import get_checkpoint_shard_files, has_file
+
+    from mlflow.transformers.flavor_config import FlavorKey
+
+    framework = flavor_conf.get(FlavorKey.FRAMEWORK)
+    repo_id = flavor_conf[FlavorKey.MODEL_NAME]
+    revision = flavor_conf[FlavorKey.MODEL_REVISION]
+
+    def _try_download(index_filename: str, weight_filename: str) -> bool:
+        """
+        Try to download the weight files with the specific framework e.g. Pytorch.
+
+        For each framework, the weight files can be stored in either a single file or multiple
+        shards. For the single file case, the weight file is directly downloaded. For the multiple
+        shards case, the index file is first downloaded to get the list of shard files, and then
+        each shard file is downloaded.
+
+        Returns:
+            Whether the download is successful.
+        """
+        try:
+            if has_file(repo_id, index_filename, revision=revision):
+                index_local_file = hf_hub_download(
+                    repo_id,
+                    index_filename,
+                    revision=revision,
+                    local_dir=dst_path,
+                )
+                cached_files, _ = get_checkpoint_shard_files(
+                    repo_id,
+                    index_local_file,
+                    revision=revision,
+                )
+                for file in cached_files:
+                    # Copy files to the destination directory
+                    shutil.copy(file, os.path.join(dst_path, os.path.basename(file)))
+            else:
+                hf_hub_download(repo_id, weight_filename, revision=revision, local_dir=dst_path)
+            return True
+        except Exception:
+            return False
+
+    # Load the config.json file
+    hf_hub_download(repo_id, CONFIG_NAME, revision=revision, local_dir=dst_path)
+
+    # Cascade through the possible weight files to download with the priority:
+    #    Safetensor -> Pytorch -> TF 2 -> TF 1
+    #
+    # The index and file names are fixed for each framework, for example, for Pytorch
+    # the index file is "pytorch_model.bin.index.json" and the weight file is
+    # "pytorch_model.bin". Therefore, we can use the existence of those files to determine
+    # which framework the weight file is for.
+    if _try_download(SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME):
+        pass
+    elif framework == "pt":
+        if _try_download(WEIGHTS_INDEX_NAME, WEIGHTS_NAME):
+            pass
+        else:
+            raise MlflowException(
+                "Framework is set to Pytorch, but the weight file is not found "
+                f"in the HuggingFace Hub repository {repo_id}.",
+            )
+    else:
+        if _try_download(TF2_WEIGHTS_INDEX_NAME, TF2_WEIGHTS_NAME) or _try_download(
+            None, TF_WEIGHTS_NAME
+        ):
+            pass
+        else:
+            raise MlflowException(
+                "Framework is set to Tensorflow, but the weight file is not found "
+                f"in the HuggingFace Hub repository {repo_id}.",
+            )

--- a/mlflow/transformers/hub_utils.py
+++ b/mlflow/transformers/hub_utils.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import os
-import shutil
+from pathlib import Path
 from typing import Dict, Optional
 
 from mlflow.exceptions import MlflowException
@@ -108,9 +108,11 @@ def download_model_weights_from_hub(flavor_conf: Dict, dst_path: str):
                     index_local_file,
                     revision=revision,
                 )
+                # Move the weight files in the HF cache directory to the destination.
+                # The filepath returned by above is a symlink, so we need to resolve it first.
                 for file in cached_files:
-                    # Copy files to the destination directory
-                    shutil.copy(file, os.path.join(dst_path, os.path.basename(file)))
+                    resolved_file = Path(file).resolve()
+                    os.rename(resolved_file, os.path.join(dst_path, os.path.basename(file)))
             else:
                 hf_hub_download(repo_id, weight_filename, revision=revision, local_dir=dst_path)
             return True

--- a/mlflow/transformers/hub_utils.py
+++ b/mlflow/transformers/hub_utils.py
@@ -147,3 +147,25 @@ def download_model_weights_from_hub(flavor_conf: Dict, dst_path: str):
                 "Framework is set to Tensorflow, but the weight file is not found "
                 f"in the HuggingFace Hub repository {repo_id}.",
             )
+
+
+def infer_framework_from_repo(repo_id: str) -> str:
+    """
+    Infer framework mimicing Transformers implementation, but without loading
+    the model into memory
+    https://github.com/huggingface/transformers/blob/44f6fdd74f84744b159fa919474fd3108311a906/src/transformers/pipelines/base.py#L215C28-L215C37
+    """
+    import huggingface_hub
+    from transformers.utils import is_torch_available
+
+    if not is_torch_available():
+        return "tf"
+
+    # Check repo tag
+    repo_tag = huggingface_hub.model_info(repo_id).tags
+    is_torch_supported = "pytorch" in repo_tag
+    if not is_torch_supported:
+        return "tf"
+
+    # Default to Pytorch if both are available, probably we should do a better check
+    return "pt"

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -96,7 +96,15 @@ def load_model_and_components_from_huggingface_hub(flavor_conf, accelerate_conf,
     loaded[FlavorKey.MODEL] = _load_model(
         model_repo, flavor_conf, accelerate_conf, device, revision=model_revision
     )
+    loaded.update(load_components(flavor_conf))
+    return loaded
 
+
+def load_components(flavor_conf):
+    """
+    Load the auxiliary components of a Transformer pipeline from HuggingFace Hub, such as tokenizer,
+    """
+    loaded = {}
     components = flavor_conf.get(FlavorKey.COMPONENTS, [])
     if FlavorKey.PROCESSOR_TYPE in flavor_conf:
         components.append("processor")

--- a/mlflow/transformers/peft.py
+++ b/mlflow/transformers/peft.py
@@ -8,13 +8,13 @@ as from_pretrained(), save_pretrained().
 _PEFT_ADAPTOR_DIR_NAME = "peft"
 
 
-def is_peft_model(model) -> bool:
+def is_peft_model(pipeline) -> bool:
     try:
         from peft import PeftModel
     except ImportError:
         return False
 
-    return isinstance(model, PeftModel)
+    return isinstance(pipeline.model, PeftModel)
 
 
 def get_peft_base_model(model):

--- a/tests/transformers/test_hub_utils.py
+++ b/tests/transformers/test_hub_utils.py
@@ -1,16 +1,19 @@
-from mlflow.transformers.flavor_config import FlavorKey
 import pytest
+
+from mlflow.transformers.flavor_config import FlavorKey
 
 
 @pytest.mark.parametrize(
     ("repo_id", "framework", "expected_files"),
     [
         (
-            "distilgpt2", "pt",
+            "distilgpt2",
+            "pt",
             ["model.safetensors", "config.json"],
         ),
         (
-            "hf-internal-testing/tiny-random-bert-sharded-safetensors", "pt",
+            "hf-internal-testing/tiny-random-bert-sharded-safetensors",
+            "pt",
             [
                 "config.json",
                 "model.safetensors.index.json",
@@ -22,14 +25,16 @@ import pytest
             ],
         ),
         (
-            "google/tapas-small-finetuned-wtq", "pt",
+            "google/tapas-small-finetuned-wtq",
+            "pt",
             ["pytorch_model.bin", "config.json"],
         ),
         (
-            "google/tapas-small-finetuned-wtq", "tf",
+            "google/tapas-small-finetuned-wtq",
+            "tf",
             ["tf_model.h5", "config.json"],
         ),
-    ]
+    ],
 )
 def test_download_model_weights_from_hub(tmp_path, repo_id, framework, expected_files):
     from mlflow.transformers.hub_utils import download_model_weights_from_hub
@@ -43,4 +48,3 @@ def test_download_model_weights_from_hub(tmp_path, repo_id, framework, expected_
 
     for file in expected_files:
         assert (tmp_path / file).exists()
-

--- a/tests/transformers/test_hub_utils.py
+++ b/tests/transformers/test_hub_utils.py
@@ -1,0 +1,46 @@
+from mlflow.transformers.flavor_config import FlavorKey
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("repo_id", "framework", "expected_files"),
+    [
+        (
+            "distilgpt2", "pt",
+            ["model.safetensors", "config.json"],
+        ),
+        (
+            "hf-internal-testing/tiny-random-bert-sharded-safetensors", "pt",
+            [
+                "config.json",
+                "model.safetensors.index.json",
+                "model-00001-of-00005.safetensors",
+                "model-00002-of-00005.safetensors",
+                "model-00003-of-00005.safetensors",
+                "model-00004-of-00005.safetensors",
+                "model-00005-of-00005.safetensors",
+            ],
+        ),
+        (
+            "google/tapas-small-finetuned-wtq", "pt",
+            ["pytorch_model.bin", "config.json"],
+        ),
+        (
+            "google/tapas-small-finetuned-wtq", "tf",
+            ["tf_model.h5", "config.json"],
+        ),
+    ]
+)
+def test_download_model_weights_from_hub(tmp_path, repo_id, framework, expected_files):
+    from mlflow.transformers.hub_utils import download_model_weights_from_hub
+
+    flavor_conf = {
+        FlavorKey.MODEL_NAME: repo_id,
+        FlavorKey.FRAMEWORK: framework,
+        FlavorKey.MODEL_REVISION: None,
+    }
+    download_model_weights_from_hub(flavor_conf, tmp_path)
+
+    for file in expected_files:
+        assert (tmp_path / file).exists()
+


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13059?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13059/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13059
```

</p>
</details>

### What changes are proposed in this pull request?

#### Problem

The `mlflow.transformers.log_model()` API requires pipeline or model instance to be specified for `transformer_model` argument. This blocks users from logging a huge foundation models like llama-3.1-70B because loading those models into memory highly likely cause OOM in the typical notebook environment. Consequently, users need to spin up an expensive cluster just to log a model even though they don't run the model there at all.

```
# Instantiating pipeline is an expensive operation as it requires loading the model onto memory.
pipeline = transformers.pipeline(model="meta-llama/Meta-Llama-3.1-70B-Instruct")

with mlflow.start_run():
     mlflow.transformers.log_model(pipeline, ...)
```

#### Solution

This PR resolves the pain point by allowing users to log Transformer models with HuggingFace repository ID.

```
with mlflow.start_run():
     mlflow.transformers.log_model("meta-llama/Meta-Llama-3.1-70B-Instruct", ...)
```

During the logging operation or registration, MLflow does not load the model into memory at all. What happens under the hood is similar to the `save_pretrained=False` mode introduced a while ago ([doc](https://mlflow.org/docs/latest/llms/transformers/guide/index.html#storage-efficient-model-logging-with-save-pretrained-option)). Basically, MLflow stores the repository ID and commit sha instead of the actual model weights. Other metadata such as framework, components, are directly retrieved from the HuggingFace Hub as well, instead of creating a pipeline instance. The main logging logic change mostly reside in `build_flavor_config_from_repo_info()` function.

#### UC Registration

Since we already had `save_pretrained=False` support, updating the logging logic itself is not that hard. However, the major complexity in this PR is in another part, which is UC model registration.

One of the requirement for UC registration is that the model weight must exist in the artifact store, so it can be copied into the model serving container without downloading from the HF hub. The model saved with `save_pretrained=False` does not meet this requirement, because the logged model only contains the reference to the HF repo (id and commit sha). Therefore, when we introduced the `save_pretrained` flag, we also added the [mlflow.transformers.persist_pretrained_model()](https://github.com/mlflow/mlflow/blob/582461a133995f27f48daf7dfd0007b661b4b9d0/mlflow/transformers/__init__.py#L1033) API. This API downloads the model weights from the HF repo into artifact. When users try to register a model logged with `save_pretrained=False`, MLflow automatically invokes this API ([code](https://github.com/mlflow/mlflow/blob/582461a133995f27f48daf7dfd0007b661b4b9d0/mlflow/store/_unity_catalog/registry/rest_store.py#L670)), so it can be registered to UC.

However, this API cannot be reused as it is for repo_id based logging. The reason is that it persists the model weight by instantiating the pipeline and call `pipeline.save_pretained()` ([code](https://github.com/mlflow/mlflow/blob/582461a133995f27f48daf7dfd0007b661b4b9d0/mlflow/transformers/__init__.py#L1087)). For large models, this step causes OOM after all even when logging itself is unblocked.

Therefore, this PR also updates this `persist_pretrained_model()` not to rely on pipeline instantiation. Instead, the new implementation directly downloads the model weight files from the hub and upload them to the artifact store.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Documentation is updated in a separate PR to reduce the PR size.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow Transformer flavor supports logging model with HuggingFace repository name. Now it does not require loading the model/pipeline into memory, allowing logging LLMs without expensive compute resources.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
