### PR TITLE
[1] Support logging Transformers model without loading it into memory

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -788,7 +788,7 @@ class Model:
                 model_info.registered_model_version = registered_model.version
 
             # validate input example works for serving when logging the model
-            if serving_input:
+            if serving_input and kwargs.get("validate_serving_input", True):
                 from mlflow.models import validate_serving_input
 
                 try:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -981,6 +981,10 @@ def log_model(
         code_paths=code_paths,
         signature=signature,
         input_example=input_example,
+        # NB: We don't validate the serving input for Transformers flavor because
+        # it requires loading the model into memory and make prediction, which is
+        # expensive and can cause OOM errors.
+        validate_serving_input=False,
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
         model_config=model_config,

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -584,7 +584,7 @@ def save_model(
         else:
             mlflow_model.metadata = {FlavorKey.PROMPT_TEMPLATE: prompt_template}
 
-    if is_peft_model(built_pipeline):
+    if (built_pipeline is not None) and is_peft_model(built_pipeline.model):
         _logger.info(
             "Overriding save_pretrained to False for PEFT models, following the Transformers "
             "behavior. The PEFT adaptor and config will be saved, but the base model weights "

--- a/mlflow/transformers/peft.py
+++ b/mlflow/transformers/peft.py
@@ -8,13 +8,13 @@ as from_pretrained(), save_pretrained().
 _PEFT_ADAPTOR_DIR_NAME = "peft"
 
 
-def is_peft_model(pipeline) -> bool:
+def is_peft_model(model) -> bool:
     try:
         from peft import PeftModel
     except ImportError:
         return False
 
-    return isinstance(pipeline.model, PeftModel)
+    return isinstance(model, PeftModel)
 
 
 def get_peft_base_model(model):

--- a/mlflow/transformers/peft.py
+++ b/mlflow/transformers/peft.py
@@ -8,13 +8,13 @@ as from_pretrained(), save_pretrained().
 _PEFT_ADAPTOR_DIR_NAME = "peft"
 
 
-def is_peft_model(model) -> bool:
+def is_peft_model(pipeline) -> bool:
     try:
         from peft import PeftModel
     except ImportError:
         return False
 
-    return isinstance(model, PeftModel)
+    return isinstance(pipeline.model, PeftModel)
 
 
 def get_peft_base_model(model):

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -29,7 +29,11 @@ _DEFAULT_SIGNATURE_FOR_TASK = {
     "token-classification": _TEXT2TEXT_SIGNATURE,
     "translation": _TEXT2TEXT_SIGNATURE,
     "text-generation": _TEXT2TEXT_SIGNATURE,
+    "text2text-generation": _TEXT2TEXT_SIGNATURE,
     "text-classification": _CLASSIFICATION_SIGNATURE,
+    "conversational": _TEXT2TEXT_SIGNATURE,
+    "fill-mask": _TEXT2TEXT_SIGNATURE,
+    "summarization": _TEXT2TEXT_SIGNATURE,
     "image-classification": _CLASSIFICATION_SIGNATURE,
     "zero-shot-classification": ModelSignature(
         inputs=Schema(
@@ -78,7 +82,7 @@ _DEFAULT_SIGNATURE_FOR_TASK = {
 
 def infer_or_get_default_signature(
     pipeline: Optional[Any],
-    task: Optional[str],
+    task: Optional[str] = None,
     example=None,
     model_config=None,
     flavor_config=None,
@@ -118,6 +122,9 @@ def infer_or_get_default_signature(
                 )
             _logger.warning(msg)
 
+    task = task or getattr(pipeline, "task", None)
+    if task.startswith("translation_"):
+        task = "translation"
     if signature := _DEFAULT_SIGNATURE_FOR_TASK.get(task):
         return signature
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -840,6 +840,7 @@ def test_huggingface_hub_not_installed(small_seq2seq_pipeline, model_path):
 
         assert result is None
 
+        # Normal model saving should pass (without model card)
         mlflow.transformers.save_model(transformers_model=small_seq2seq_pipeline, path=model_path)
 
         contents = {item.name for item in model_path.iterdir()}
@@ -847,6 +848,14 @@ def test_huggingface_hub_not_installed(small_seq2seq_pipeline, model_path):
 
         license_data = model_path.joinpath("LICENSE.txt").read_text()
         assert license_data.rstrip().endswith("mobilebert")
+
+        # Repo ID saving requires huggingface_hub
+        shutil.rmtree(model_path)
+        with pytest.raises(MlflowException, match="Saving a model with a HuggingFace Hub"):
+            mlflow.transformers.save_model(
+                transformers_model="lordtt13/emo-mobilebert",
+                path=model_path,
+            )
 
 
 @pytest.mark.skipif(

--- a/tests/transformers/test_transformers_signature.py
+++ b/tests/transformers/test_transformers_signature.py
@@ -145,7 +145,7 @@ def test_signature_inference(pipeline_name, example, expected_signature, request
     default_signature = infer_or_get_default_signature(pipeline)
     assert default_signature == expected_signature
 
-    signature_from_input_example = infer_or_get_default_signature(pipeline, example)
+    signature_from_input_example = infer_or_get_default_signature(pipeline, example=example)
     assert signature_from_input_example == expected_signature
 
 


### PR DESCRIPTION
### Related Issues/PRs

This PR is the first one of the 3 stacked PRs:
1. Extend `mlflow.transformers.log_model()` to accept HF repo id as a model **<- HERE!**
2. Update `mlflow.transformers.persist_pretrained_model()` not to load the model into memory (required for UC registration)
3. Add docs

### What changes are proposed in this pull request?

#### Problem

The `mlflow.transformers.log_model()` API requires pipeline or model instance to be specified for `transformer_model` argument. This blocks users from logging a huge foundation models like llama-3.1-70B because loading those models into memory highly likely cause OOM in the typical notebook environment. Consequently, users need to spin up an expensive cluster just to log a model even though they don't run the model there at all.

```
# Instantiating pipeline is an expensive operation as it requires loading the model onto memory.
pipeline = transformers.pipeline(model="meta-llama/Meta-Llama-3.1-70B-Instruct")

with mlflow.start_run():
     mlflow.transformers.log_model(pipeline, ...)
```

#### Solution

This PR resolves the pain point by allowing users to log Transformer models with HuggingFace repository ID.

```
with mlflow.start_run():
     mlflow.transformers.log_model("meta-llama/Meta-Llama-3.1-70B-Instruct", ...)
```

During the logging operation or registration, MLflow does not load the model into memory at all. What happens under the hood is similar to the `save_pretrained=False` mode introduced a while ago ([doc](https://mlflow.org/docs/latest/llms/transformers/guide/index.html#storage-efficient-model-logging-with-save-pretrained-option)). Basically, MLflow stores the repository ID and commit sha instead of the actual model weights. Other metadata such as framework, components, are directly retrieved from the HuggingFace Hub as well, instead of creating a pipeline instance. The main logging logic change mostly reside in `build_flavor_config_from_repo_info()` function.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Doc will be updated in a follow-up PR.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow Transformer flavor supports logging model with HuggingFace repository name. Now it does not require loading the model/pipeline into memory, allowing logging LLMs without expensive compute resources.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
