### PR TITLE
Support logging Transformer models with a path to local model checkpoints to reduce memory footprint

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -788,7 +788,7 @@ class Model:
                 model_info.registered_model_version = registered_model.version
 
             # validate input example works for serving when logging the model
-            if serving_input:
+            if serving_input and kwargs.get("validate_serving_input", True):
                 from mlflow.models import validate_serving_input
 
                 try:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -313,7 +313,7 @@ def save_model(
                     for loading the transformers model. This is particularly useful when logging
                     a model that cannot be loaded into memory for serialization.
 
-            An example of submitting a `Pipeline` from a default pipeline instantiation:
+            An example of specifying a `Pipeline` from a default pipeline instantiation:
 
             .. code-block:: python
 
@@ -327,7 +327,7 @@ def save_model(
                         path="path/to/save/model",
                     )
 
-            An example of supplying component-level parts of a transformers model is shown below:
+            An example of specifying component-level parts of a transformers model is shown below:
 
             .. code-block:: python
 
@@ -668,8 +668,8 @@ def save_model(
     else:
         repo = built_pipeline.model.name_or_path
         _logger.info(
-            "Skipping saving pretrained model weights to disk as the save_pretrained "
-            f"is set to False. The reference to HuggingFace Hub repository {repo} "
+            "Skipping saving pretrained model weights to disk as the save_pretrained argument"
+            f"is set to False. The reference to the HuggingFace Hub repository {repo} "
             "will be logged instead."
         )
 
@@ -832,7 +832,7 @@ def log_model(
                     for loading the transformers model. This is particularly useful when logging
                     a model that cannot be loaded into memory for serialization.
 
-            An example of submitting a `Pipeline` from a default pipeline instantiation:
+            An example of specifying a `Pipeline` from a default pipeline instantiation:
 
             .. code-block:: python
 
@@ -841,12 +841,12 @@ def log_model(
                 qa_pipe = pipeline("question-answering", "csarron/mobilebert-uncased-squad-v2")
 
                 with mlflow.start_run():
-                    mlflow.transformers.save_model(
+                    mlflow.transformers.log_model(
                         transformers_model=qa_pipe,
-                        path="path/to/save/model",
+                        artifact_path="model",
                     )
 
-            An example of supplying component-level parts of a transformers model is shown below:
+            An example of specifying component-level parts of a transformers model is shown below:
 
             .. code-block:: python
 
@@ -861,9 +861,9 @@ def log_model(
                         "model": model,
                         "tokenizer": tokenizer,
                     }
-                    mlflow.transformers.save_model(
+                    mlflow.transformers.log_model(
                         transformers_model=components,
-                        path="path/to/save/model",
+                        artifact_path="model",
                     )
 
             An example of specifying a local checkpoint path is shown below:
@@ -871,9 +871,9 @@ def log_model(
             .. code-block:: python
 
                 with mlflow.start_run():
-                    mlflow.transformers.save_model(
+                    mlflow.transformers.log_model(
                         transformers_model="path/to/local/checkpoint",
-                        path="path/to/save/model",
+                        artifact_path="model",
                     )
 
         artifact_path: Local path destination for the serialized model to be saved.
@@ -1031,10 +1031,12 @@ def log_model(
         code_paths=code_paths,
         signature=signature,
         input_example=input_example,
-        # NB: We don't validate the serving input for Transformers flavor because
-        # it requires loading the model into memory and make prediction, which is
+        # NB: We don't validate the serving input if the provided model is a path
+        # to a local checkpoint. This is because the purpose of supporting that
+        # input format is to avoid loading large model into memory. Serving input
+        # validation loads the model into memory and make prediction, which is
         # expensive and can cause OOM errors.
-        validate_serving_input=False,
+        validate_serving_input=not isinstance(transformers_model, str),
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
         model_config=model_config,

--- a/mlflow/transformers/flavor_config.py
+++ b/mlflow/transformers/flavor_config.py
@@ -183,7 +183,7 @@ def build_flavor_config_from_local_checkpoint(
     config_path = os.path.join(local_checkpoint_dir, "config.json")
     if not os.path.exists(config_path):
         raise MlflowException(
-            f"The provided directory {local_checkpoint_dir} does not contain the config.json file."
+            f"The provided directory {local_checkpoint_dir} does not contain a config.json file."
             "Please ensure that the directory contains a valid transformers model checkpoint.",
             error_code=INVALID_PARAMETER_VALUE,
         )

--- a/mlflow/transformers/flavor_config.py
+++ b/mlflow/transformers/flavor_config.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
+import os
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import ALREADY_EXISTS
-from mlflow.transformers.hub_utils import get_latest_commit_for_repo, infer_framework_from_repo
+from mlflow.protos.databricks_pb2 import ALREADY_EXISTS, INVALID_PARAMETER_VALUE
+from mlflow.transformers.hub_utils import get_latest_commit_for_repo
 from mlflow.transformers.peft import _PEFT_ADAPTOR_DIR_NAME, get_peft_base_model, is_peft_model
 from mlflow.transformers.torch_utils import _extract_torch_dtype_if_set
 
@@ -163,56 +165,60 @@ def _get_instance_type(obj):
     return obj.__class__.__name__
 
 
-def build_flavor_config_from_repo_id(
-    repo_id: str,
+def build_flavor_config_from_local_checkpoint(
+    local_checkpoint_dir: str,
+    task: str,
     processor=None,
     torch_dtype=None,
-    save_pretrained=True,
 ) -> Dict[str, Any]:
     """
     Generates the flavor metadata from a Hugging Face model repository ID
     e.g. "meta-llama/Meta-Llama-3.1-405B, instead of the pipeline instance in-memory.
     """
-    import huggingface_hub
     from transformers import AutoTokenizer, pipelines
+    from transformers.utils import is_torch_available
 
     from mlflow.transformers.model_io import _MODEL_BINARY_FILE_NAME
 
-    hf_repo_info = huggingface_hub.model_info(repo_id)
+    config_path = os.path.join(local_checkpoint_dir, "config.json")
+    if not os.path.exists(config_path):
+        raise MlflowException(
+            f"The provided directory {local_checkpoint_dir} does not contain the config.json file."
+            "Please ensure that the directory contains a valid transformers model checkpoint.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
 
-    task = hf_repo_info.pipeline_tag
+    with open(config_path) as f:
+        config = json.load(f)
+
     task_metadata = pipelines.check_task(task)
     pipeline_class = task_metadata[1]["impl"].__name__
     flavor_conf = {
         FlavorKey.TASK: task,
         FlavorKey.INSTANCE_TYPE: pipeline_class,
-        FlavorKey.FRAMEWORK: infer_framework_from_repo(repo_id),
+        FlavorKey.FRAMEWORK: "pt" if is_torch_available() else "tf",
         FlavorKey.TORCH_DTYPE: str(torch_dtype) if torch_dtype else None,
-        FlavorKey.MODEL_TYPE: hf_repo_info.config["architectures"][0],
-        FlavorKey.MODEL_NAME: hf_repo_info.id,
+        FlavorKey.MODEL_TYPE: config["architectures"][0],
+        FlavorKey.MODEL_NAME: local_checkpoint_dir,
+        FlavorKey.MODEL_BINARY: _MODEL_BINARY_FILE_NAME,
     }
 
-    if save_pretrained:
-        flavor_conf[FlavorKey.MODEL_BINARY] = _MODEL_BINARY_FILE_NAME
-    else:
-        flavor_conf[FlavorKey.MODEL_REVISION] = hf_repo_info.sha
-
     components = {FlavorKey.TOKENIZER}
-    tokenizer = AutoTokenizer.from_pretrained(repo_id)
-    tokenizer_conf = _get_component_config(
-        tokenizer, FlavorKey.TOKENIZER, save_pretrained=save_pretrained, commit_sha=hf_repo_info.sha
-    )
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(local_checkpoint_dir)
+    except OSError as e:
+        raise MlflowException(
+            f"Error loading tokenizer from {local_checkpoint_dir}. When logging a "
+            "Transformers model from a local checkpoint, please make sure that the "
+            "checkpoint directory contains a valid tokenizer configuration as well.",
+            error_code=INVALID_PARAMETER_VALUE,
+        ) from e
+
+    tokenizer_conf = _get_component_config(tokenizer, FlavorKey.TOKENIZER)
     flavor_conf.update(tokenizer_conf)
 
     if processor:
-        flavor_conf.update(
-            _get_component_config(
-                processor,
-                FlavorKey.PROCESSOR,
-                save_pretrained=save_pretrained,
-                commit_sha=hf_repo_info.sha,
-            )
-        )
+        flavor_conf.update(_get_component_config(processor, FlavorKey.PROCESSOR))
 
     flavor_conf[FlavorKey.COMPONENTS] = list(components)
     return flavor_conf

--- a/mlflow/transformers/hub_utils.py
+++ b/mlflow/transformers/hub_utils.py
@@ -1,11 +1,10 @@
 import functools
-import json
 import logging
 import os
 from typing import Optional
 
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 
 _logger = logging.getLogger(__name__)
 
@@ -54,58 +53,3 @@ def is_valid_hf_repo_id(maybe_repo_id: Optional[str]) -> bool:
     except HFValidationError as e:
         _logger.warning(f"The repository identified {maybe_repo_id} is invalid: {e}")
         return False
-
-
-def get_hf_model_info_from_local_checkpoint(path):
-    if not os.path.isdir(path):
-        raise MlflowException(
-            f"The provided path {path} is not a directory. Please provide a valid path to "
-            "the directory containing the local Transformers model checkpoint.",
-            error_code=INVALID_PARAMETER_VALUE,
-        )
-
-    config_path = os.path.join(path, "config.json")
-    if not os.path.exists(config_path):
-        raise MlflowException(
-            f"The provided directory {path} does not contain the config.json file. "
-            "Please ensure that the directory contains a valid transformers model checkpoint.",
-            error_code=INVALID_PARAMETER_VALUE,
-        )
-
-    with open(config_path) as f:
-        config = json.load(f)
-    repo_id = config.get("_name_or_path")
-
-    try:
-        import huggingface_hub
-    except ImportError:
-        raise MlflowException(
-            "Unable to fetch the model information from the HuggingFace model hub because "
-            "the huggingface-hub package to be installed. Please install the package by "
-            "running `pip install huggingface-hub`.",
-            error_code=RESOURCE_DOES_NOT_EXIST,
-        )
-
-    return huggingface_hub.model_info(repo_id)
-
-
-def infer_framework_from_repo(repo_id: str) -> str:
-    """
-    Infer framework mimicing Transformers implementation, but without loading
-    the model into memory
-    https://github.com/huggingface/transformers/blob/44f6fdd74f84744b159fa919474fd3108311a906/src/transformers/pipelines/base.py#L215C28-L215C37
-    """
-    import huggingface_hub
-    from transformers.utils import is_torch_available
-
-    if not is_torch_available():
-        return "tf"
-
-    # Check repo tag
-    repo_tag = huggingface_hub.model_info(repo_id).tags
-    is_torch_supported = "pytorch" in repo_tag
-    if not is_torch_supported:
-        return "tf"
-
-    # Default to Pytorch if both are available, probably we should do a better check
-    return "pt"

--- a/mlflow/transformers/hub_utils.py
+++ b/mlflow/transformers/hub_utils.py
@@ -1,10 +1,11 @@
 import functools
+import json
 import logging
 import os
 from typing import Optional
 
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
 
 _logger = logging.getLogger(__name__)
 
@@ -53,3 +54,58 @@ def is_valid_hf_repo_id(maybe_repo_id: Optional[str]) -> bool:
     except HFValidationError as e:
         _logger.warning(f"The repository identified {maybe_repo_id} is invalid: {e}")
         return False
+
+
+def get_hf_model_info_from_local_checkpoint(path):
+    if not os.path.isdir(path):
+        raise MlflowException(
+            f"The provided path {path} is not a directory. Please provide a valid path to "
+            "the directory containing the local Transformers model checkpoint.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    config_path = os.path.join(path, "config.json")
+    if not os.path.exists(config_path):
+        raise MlflowException(
+            f"The provided directory {path} does not contain the config.json file. "
+            "Please ensure that the directory contains a valid transformers model checkpoint.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    with open(config_path) as f:
+        config = json.load(f)
+    repo_id = config.get("_name_or_path")
+
+    try:
+        import huggingface_hub
+    except ImportError:
+        raise MlflowException(
+            "Unable to fetch the model information from the HuggingFace model hub because "
+            "the huggingface-hub package to be installed. Please install the package by "
+            "running `pip install huggingface-hub`.",
+            error_code=RESOURCE_DOES_NOT_EXIST,
+        )
+
+    return huggingface_hub.model_info(repo_id)
+
+
+def infer_framework_from_repo(repo_id: str) -> str:
+    """
+    Infer framework mimicing Transformers implementation, but without loading
+    the model into memory
+    https://github.com/huggingface/transformers/blob/44f6fdd74f84744b159fa919474fd3108311a906/src/transformers/pipelines/base.py#L215C28-L215C37
+    """
+    import huggingface_hub
+    from transformers.utils import is_torch_available
+
+    if not is_torch_available():
+        return "tf"
+
+    # Check repo tag
+    repo_tag = huggingface_hub.model_info(repo_id).tags
+    is_torch_supported = "pytorch" in repo_tag
+    if not is_torch_supported:
+        return "tf"
+
+    # Default to Pytorch if both are available, probably we should do a better check
+    return "pt"

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 
 from mlflow.environment_variables import (
     MLFLOW_HUGGINGFACE_DISABLE_ACCELERATE_FEATURES,
@@ -41,6 +42,41 @@ def save_pipeline_pretrained_weights(path, pipeline, flavor_conf, processor=None
         processor.save_pretrained(component_dir.joinpath(_PROCESSOR_BINARY_DIR_NAME))
 
 
+def save_local_checkpoint(path, checkpoint_dir, flavor_conf, processor=None):
+    """
+    Save the local checkpoint of the model and other components to the specified local path.
+
+    Args:
+        path: The local path to save the pipeline
+        checkpoint_dir: The local path to the checkpoint directory
+        flavor_config: The flavor configuration constructed for the pipeline
+        processor: Optional processor instance to save alongside the pipeline
+    """
+    # Copy files within checkpoint dir to the model path
+    shutil.copytree(checkpoint_dir, path.joinpath(_MODEL_BINARY_FILE_NAME))
+
+    for name in flavor_conf.get(FlavorKey.COMPONENTS, []):
+        # Other pipeline components such as tokenizer may not saved in the checkpoint.
+        # We first try to load the component instance from the checkpoint directory,
+        # if it fails, we load the component from the HuggingFace Hub.
+        try:
+            component = _load_component(flavor_conf, name, local_path=checkpoint_dir)
+        except Exception:
+            repo_id = flavor_conf[FlavorKey.MODEL_NAME]
+            _logger.info(
+                f"The {name} state file is not found ins the local checkpoint directory. MLflow "
+                f"will use the default component state from the base HF repository {repo_id}."
+            )
+            component = _load_component(flavor_conf, name, repo_id=repo_id)
+
+        component.save_pretrained(path.joinpath(_COMPONENTS_BINARY_DIR_NAME, name))
+
+    if processor:
+        processor.save_pretrained(
+            path.joinpath(_COMPONENTS_BINARY_DIR_NAME, _PROCESSOR_BINARY_DIR_NAME)
+        )
+
+
 def load_model_and_components_from_local(path, flavor_conf, accelerate_conf, device=None):
     """
     Load the model and components of a Transformer pipeline from the specified local path.
@@ -66,7 +102,10 @@ def load_model_and_components_from_local(path, flavor_conf, accelerate_conf, dev
         components.append("processor")
 
     for component_key in components:
-        loaded[component_key] = _load_component(flavor_conf, component_key, local_path=path)
+        component_path = path.joinpath(_COMPONENTS_BINARY_DIR_NAME, component_key)
+        loaded[component_key] = _load_component(
+            flavor_conf, component_key, local_path=component_path
+        )
 
     return loaded
 
@@ -107,7 +146,7 @@ def load_model_and_components_from_huggingface_hub(flavor_conf, accelerate_conf,
     return loaded
 
 
-def _load_component(flavor_conf, name, local_path=None):
+def _load_component(flavor_conf, name, local_path=None, repo_id=None):
     import transformers
 
     _COMPONENT_TO_AUTOCLASS_MAP = {
@@ -134,11 +173,10 @@ def _load_component(flavor_conf, name, local_path=None):
 
     if local_path is not None:
         # Load component from local file
-        path = local_path.joinpath(_COMPONENTS_BINARY_DIR_NAME, name)
-        return cls.from_pretrained(str(path), trust_remote_code=trust_remote)
+        return cls.from_pretrained(str(local_path), trust_remote_code=trust_remote)
     else:
         # Load component from HuggingFace Hub
-        repo = flavor_conf[FlavorKey.COMPONENT_NAME.format(name)]
+        repo = repo_id or flavor_conf[FlavorKey.COMPONENT_NAME.format(name)]
         revision = flavor_conf.get(FlavorKey.COMPONENT_REVISION.format(name))
         return cls.from_pretrained(repo, revision=revision, trust_remote_code=trust_remote)
 

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Optional
 
 import numpy as np
 
@@ -22,20 +23,18 @@ _CLASSIFICATION_SIGNATURE = ModelSignature(
     outputs=Schema([ColSpec("string", name="label"), ColSpec("double", name="score")]),
 )
 
-
-# Order is important here, the first matching pipeline type will be used
-_DEFAULT_SIGNATURE_FOR_PIPELINES = {
-    "TokenClassificationPipeline": _TEXT2TEXT_SIGNATURE,
-    # TODO: ConversationalPipeline is deprecated since Transformers 4.42.0.
-    # Remove this once we drop support for earlier versions.
-    "ConversationalPipeline": _TEXT2TEXT_SIGNATURE,
-    "TranslationPipeline": _TEXT2TEXT_SIGNATURE,
-    "FillMaskPipeline": _TEXT2TEXT_SIGNATURE,
-    "TextGenerationPipeline": _TEXT2TEXT_SIGNATURE,
-    "Text2TextGenerationPipeline": _TEXT2TEXT_SIGNATURE,
-    "TextClassificationPipeline": _CLASSIFICATION_SIGNATURE,
-    "ImageClassificationPipeline": _CLASSIFICATION_SIGNATURE,
-    "ZeroShotClassificationPipeline": ModelSignature(
+# Order is important here, the first matching task type will be used
+_DEFAULT_SIGNATURE_FOR_TASK = {
+    "token-classification": _TEXT2TEXT_SIGNATURE,
+    "translation": _TEXT2TEXT_SIGNATURE,
+    "text-generation": _TEXT2TEXT_SIGNATURE,
+    "text2text-generation": _TEXT2TEXT_SIGNATURE,
+    "text-classification": _CLASSIFICATION_SIGNATURE,
+    "conversational": _TEXT2TEXT_SIGNATURE,
+    "fill-mask": _TEXT2TEXT_SIGNATURE,
+    "summarization": _TEXT2TEXT_SIGNATURE,
+    "image-classification": _CLASSIFICATION_SIGNATURE,
+    "zero-shot-classification": ModelSignature(
         inputs=Schema(
             [
                 ColSpec(DataType.string, name="sequences"),
@@ -51,29 +50,29 @@ _DEFAULT_SIGNATURE_FOR_PIPELINES = {
             ]
         ),
     ),
-    "AutomaticSpeechRecognitionPipeline": ModelSignature(
+    "automatic-speech-recognition": ModelSignature(
         inputs=Schema([ColSpec(DataType.binary)]),
         outputs=Schema([ColSpec(DataType.string)]),
     ),
-    "AudioClassificationPipeline": ModelSignature(
+    "audio-classification": ModelSignature(
         inputs=Schema([ColSpec(DataType.binary)]),
         outputs=Schema(
             [ColSpec(DataType.double, name="score"), ColSpec(DataType.string, name="label")]
         ),
     ),
-    "TableQuestionAnsweringPipeline": ModelSignature(
+    "table-question-answering": ModelSignature(
         inputs=Schema(
             [ColSpec(DataType.string, name="query"), ColSpec(DataType.string, name="table")]
         ),
         outputs=Schema([ColSpec(DataType.string)]),
     ),
-    "QuestionAnsweringPipeline": ModelSignature(
+    "question-answering": ModelSignature(
         inputs=Schema(
             [ColSpec(DataType.string, name="question"), ColSpec(DataType.string, name="context")]
         ),
         outputs=Schema([ColSpec(DataType.string)]),
     ),
-    "FeatureExtractionPipeline": ModelSignature(
+    "feature-extraction": ModelSignature(
         inputs=Schema([ColSpec(DataType.string)]),
         outputs=Schema([TensorSpec(np.dtype("float64"), [-1], "double")]),
     ),
@@ -81,7 +80,7 @@ _DEFAULT_SIGNATURE_FOR_PIPELINES = {
 
 
 def infer_or_get_default_signature(
-    pipeline, example=None, model_config=None, flavor_config=None
+    pipeline, task: Optional[str] = None, example=None, model_config=None, flavor_config=None
 ) -> ModelSignature:
     """
     Assigns a default ModelSignature for a given Pipeline type that has pyfunc support. These
@@ -118,14 +117,14 @@ def infer_or_get_default_signature(
                 )
             _logger.warning(msg)
 
-    import transformers
-
-    for pipeline_type, signature in _DEFAULT_SIGNATURE_FOR_PIPELINES.items():
-        if isinstance(pipeline, getattr(transformers, pipeline_type, type(None))):
-            return signature
+    task = task or getattr(pipeline, "task", None)
+    if task.startswith("translation_"):
+        task = "translation"
+    if signature := _DEFAULT_SIGNATURE_FOR_TASK.get(task):
+        return signature
 
     _logger.warning(
-        "An unsupported Pipeline type was supplied for signature inference. Either provide an "
+        "An unsupported task type was supplied for signature inference. Either provide an "
         "`input_example` or generate a signature manually via `infer_signature` to have a "
         "signature recorded in the MLmodel file."
     )
@@ -156,18 +155,16 @@ def _infer_signature_with_example(
     return infer_signature(example, prediction, params)
 
 
-def format_input_example_for_special_cases(input_example, pipeline):
+def format_input_example_for_special_cases(input_example, task):
     """
     Handles special formatting for specific types of Pipelines so that the displayed example
     reflects the correct example input structure that mirrors the behavior of the input parsing
     for pyfunc.
     """
-    import transformers
-
     input_data = input_example[0] if isinstance(input_example, tuple) else input_example
 
     if (
-        isinstance(pipeline, transformers.ZeroShotClassificationPipeline)
+        task == "zero-shot-classification"
         and isinstance(input_data, dict)
         and isinstance(input_data["candidate_labels"], list)
     ):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3686,7 +3686,11 @@ def local_checkpoint_path(tmp_path):
     trainer.save_model(checkpoint_path)
 
     # The tokenizer should also be saved in the checkpoint
-    tokenizer = transformers.AutoTokenizer.from_pretrained("distilgpt2")
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        # Chat template is required to test with llm/v1/chat task
+        "distilgpt2",
+        chat_template=CHAT_TEMPLATE,
+    )
     tokenizer.save_pretrained(checkpoint_path)
 
     return str(checkpoint_path)
@@ -3816,7 +3820,7 @@ def test_save_model_from_local_checkpoint_invalid_arguments(model_path, local_ch
 
     with pytest.raises(
         MlflowException,
-        match=r"The provided directory invalid path does not contain the config.json file.",
+        match=r"The provided directory invalid path does not contain a config.json file.",
     ):
         mlflow.transformers.save_model(
             transformers_model="invalid path",

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3763,6 +3763,10 @@ def test_save_model_from_local_checkpoint_with_custom_tokenizer(model_path, loca
     assert tokenizer.special_tokens_map["additional_special_tokens"] == ["<sushi>"]
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__) < Version("4.34.0"),
+    reason="Chat template is supported since 4.34.0",
+)
 def test_save_model_from_local_checkpoint_with_llm_inference_task(
     model_path, local_checkpoint_path
 ):

--- a/tests/transformers/test_transformers_signature.py
+++ b/tests/transformers/test_transformers_signature.py
@@ -145,7 +145,7 @@ def test_signature_inference(pipeline_name, example, expected_signature, request
     default_signature = infer_or_get_default_signature(pipeline)
     assert default_signature == expected_signature
 
-    signature_from_input_example = infer_or_get_default_signature(pipeline, example)
+    signature_from_input_example = infer_or_get_default_signature(pipeline, example=example)
     assert signature_from_input_example == expected_signature
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13070?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13070/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13070
```

</p>
</details>

### What changes are proposed in this pull request?

#### Problem

The `mlflow.transformers.log_model()` API requires pipeline or model instance to be specified for `transformer_model` argument. This blocks users from logging a huge foundation models like llama-3.1-70B because loading those models into memory highly likely cause OOM in the typical notebook environment. Consequently, users need to spin up an expensive cluster just to log a model even though they don't run the model there at all.

```
# Instantiating model is an expensive operation as it requires loading the model onto memory.
model = AutoModel.from_pretrained("local/snapshot/path")
tokenizer = AutoTokenizer.from_pretrained("/local/snapshot/path")

with mlflow.start_run():
     mlflow.transformers.log_model(
        transformers_model={
            "model": model,
            "tokenizer": tokenizer,
        },
        artifact_path="model",
    )
```

#### Solution

This PR addresses the gap by allowing users to log Transformer models with a string that represents a path to the local model checkpoint.

```
with mlflow.start_run():
     mlflow.transformers.log_model(
        transformers_model="/local/snapshot/path",
        task="text-generation",
        artifact_path="model",
    )
```

During the logging operation or registration, MLflow does not load the model into memory at all. The model metadata such as class name is retrieved from the HuggingFace Hub and the model weights are directly uploaded to the artifact store without deserializing it. The logged model should look identical to the one logged with pipeline instance.

#### Notes
The original plan was to fetch the HF repository name from the `config.json` file in the checkpoint and retrieve various metadata and tokenizer from there. However, it turns out that it is not guaranteed that the `config.json` file to have HF repo name. For example, [llama3.1](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B/tree/main), [dbrx](https://huggingface.co/databricks/dbrx-instruct/tree/main), does not have it. Eventually it turned out that we cannot reliably get the base repository name from the checkpoint.

Therefore, I updated the logic not to rely on HF hub. However, we cannot infer everything from the local checkpoint and we need to ask a few input from users:

1. The `task` parameter needs to be specified. We cannot infer it from model checkpoint.
2. The tokenizer must be saved in the local checkpoint directory as well. This is not always True and for such case users need to run `tokenizer.save_pretrained()` before logging the model.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with fine-tuned GPT2 model.

```
import mlflow

# Memory-efficient logging from checkpoint
with mlflow.start_run(run_name="checkpoint"):
    model_info = mlflow.transformers.log_model(
        transformers_model="/tmp/transformers/gpt2-gerchef",
        task="text-generation",
        artifact_path="model",
    )
```

The model weight is uploaded to the artifact store.

![Screenshot 2024-09-05 at 0 20 27](https://github.com/user-attachments/assets/7adf445f-b007-4ccd-b46f-9c5877cd7bcb)

The model can be loaded and used for prediction.
```
loaded_pipeline = mlflow.transformers.load_model(model_info.model_uri)
loaded_pipeline("Die Nudeln Kochen, Fleisch anbraten")
```

Also tested with larger model (8B) and confirm there is no memory usage spike.

![Screenshot 2024-09-05 at 2 55 33](https://github.com/user-attachments/assets/57e9b97d-7075-4d21-9029-825598e005ef)


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Will update in a follow-up PR.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow Transformer flavor supports logging model with a path to the local checkpoint, rather than pipeline or model instance. Now it does not require loading the model into memory, allowing logging fine-tuned LLMs without expensive compute resources.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
