### PR TITLE
Add support for LLM response refusal

### DIFF
--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -67,16 +67,27 @@ class ChatMessage(_BaseDataclass):
     Args:
         role (str): The role of the entity that sent the message (e.g. ``"user"``, ``"system"``).
         content (str): The content of the message.
+            **Optional** Supplied if a non-refusal response is provided.
+        refusal (str): The refusal message content.
+            **Optional** Supplied if a refusal response is provided.
         name (str): The name of the entity that sent the message. **Optional**.
     """
 
     role: str
-    content: str
+    content: Optional[str] = None
+    refusal: Optional[str] = None
     name: Optional[str] = None
 
     def __post_init__(self):
         self._validate_field("role", str, True)
-        self._validate_field("content", str, True)
+
+        if self.refusal:
+            self._validate_field("refusal", str, True)
+            if self.content:
+                raise ValueError("Both `content` and `refusal` cannot be set")
+        else:
+            self._validate_field("content", str, True)
+
         self._validate_field("name", str, False)
 
 

--- a/tests/pyfunc/test_chat_model_validation.py
+++ b/tests/pyfunc/test_chat_model_validation.py
@@ -92,15 +92,45 @@ MOCK_OPENAI_CHAT_COMPLETION_RESPONSE = {
 }
 
 
+MOCK_OPENAI_CHAT_REFUSAL_RESPONSE = {
+    "id": "chatcmpl-123",
+    "object": "chat.completion",
+    "created": 1721596428,
+    "model": "gpt-4o-mini",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "refusal": "I'm sorry, I cannot assist with that request.",
+            },
+            "logprobs": None,
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 81, "completion_tokens": 11, "total_tokens": 92},
+}
+
+
 @pytest.mark.parametrize(
     ("data", "error", "match"),
     [
-        ({"role": "user"}, TypeError, "required positional argument"),  # missing required field
+        ({"content": "hello"}, TypeError, "required positional argument"),  # missing required field
         (
             {"role": "user", "content": "hello", "name": 1},
             ValueError,
             "`name` must be of type str",
         ),  # field of wrong type
+        (
+            {"role": "user", "refusal": "I can't answer that.", "content": "hi"},
+            ValueError,
+            "Both `content` and `refusal` cannot be set",
+        ),  # conflicting schema
+        (
+            {"role": "user", "name": "name"},
+            ValueError,
+            "`content` is required",
+        ),  # missing one-of required field
         (
             {"role": "user", "content": "hello", "extra": "field"},
             TypeError,
@@ -149,7 +179,10 @@ def test_list_validation_throws_on_invalid_lists(data, match):
         ChatRequest(**data)
 
 
-@pytest.mark.parametrize("sample_output", [MOCK_RESPONSE, MOCK_OPENAI_CHAT_COMPLETION_RESPONSE])
+@pytest.mark.parametrize(
+    "sample_output",
+    [MOCK_RESPONSE, MOCK_OPENAI_CHAT_COMPLETION_RESPONSE, MOCK_OPENAI_CHAT_REFUSAL_RESPONSE],
+)
 def test_dataclass_constructs_nested_types_from_dict(sample_output):
     response = ChatResponse(**sample_output)
     assert isinstance(response.usage, TokenUsageStats)
@@ -157,7 +190,10 @@ def test_dataclass_constructs_nested_types_from_dict(sample_output):
     assert isinstance(response.choices[0].message, ChatMessage)
 
 
-@pytest.mark.parametrize("sample_output", [MOCK_RESPONSE, MOCK_OPENAI_CHAT_COMPLETION_RESPONSE])
+@pytest.mark.parametrize(
+    "sample_output",
+    [MOCK_RESPONSE, MOCK_OPENAI_CHAT_COMPLETION_RESPONSE, MOCK_OPENAI_CHAT_REFUSAL_RESPONSE],
+)
 def test_to_dict_converts_nested_dataclasses(sample_output):
     response = ChatResponse(**sample_output).to_dict()
     assert isinstance(response["choices"][0], dict)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/13071?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13071/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13071
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add support for the new 'refusal' message response for chat models (OpenAI) that FMAPI now supports.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
