### PR TITLE
Fix input schema check for LangGraph

### DIFF
--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -225,8 +225,8 @@ def _convert_chat_request_or_throw(chat_request: Dict):
 
 def _get_lc_model_input_fields(lc_model) -> Set[str]:
     try:
-        if hasattr(lc_model, "input_schema") and callable(lc_model.input_schema):
-            return set(lc_model.input_schema().__fields__)
+        if hasattr(lc_model, "input_schema"):
+            return set(lc_model.input_schema.__fields__)
     except Exception as e:
         _logger.debug(
             f"Unexpected exception while checking LangChain input schema for"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13095?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13095/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13095
```

</p>
</details>

### Related Issues/PRs

Fix cross version test failure: https://github.com/mlflow-automation/mlflow/actions/runs/10760254784/job/29841176079#step:12:2373

### What changes are proposed in this pull request?

In the pyfunc prediction logic for LangChain models, we check the underlying LC model's input schema to see if it is chat format or not. We get the schema by `lc_model.input_schema().__fields__`, but indeed `input_schema` is a property ([code](https://github.com/langchain-ai/langchain/blob/76bce4262955d3460e5b6cadd738cf710a4dbebb/libs/core/langchain_core/runnables/base.py#L282)) so we don't need the trailing brackets. The `input_schema` property returns a pydantic class and we can access `__fields__` directly.

Interestingly, it has been working ok until now, because the returned pydantic classes does not contain any required fields i.e. all fields are optional. Thus, instantiating the class with empty brackets `()` succeeds. However, the newly introduced [input schema](https://github.com/langchain-ai/langgraph/blame/1c9b1d29c31d70f4ac90d4a794b6da5c13fa0de8/libs/langgraph/langgraph/graph/state.py#L484-L489) for LangGraph graph actually includes mandatory fields. Consequently, MLflow failed to get the input schema and falsely convert input data, which results in the error during the cross version test.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
