### PR TITLE
Remove usage of a stale model from Transformers tests

### DIFF
--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -60,7 +60,10 @@ if _MLFLOW_RUN_SLOW_TESTS.get():
     )
     from tests.statsmodels.model_fixtures import ols_model
     from tests.tensorflow.test_tensorflow2_core_model_export import tf2_toy_model  # noqa: F401
-    from tests.transformers.helper import load_small_qa_pipeline, load_small_seq2seq_pipeline
+    from tests.transformers.helper import (
+        load_small_qa_tf_pipeline,
+        load_text_classification_pipeline,
+    )
 
 
 pytestmark = pytest.mark.skipif(
@@ -424,7 +427,7 @@ def tensorflow_model(model_path, tf2_toy_model):
 
 @pytest.fixture
 def transformers_pt_model(model_path):
-    pipeline = load_small_seq2seq_pipeline()
+    pipeline = load_text_classification_pipeline()
     save_model_with_latest_mlflow_version(
         flavor="transformers",
         transformers_model=pipeline,
@@ -436,7 +439,7 @@ def transformers_pt_model(model_path):
 
 @pytest.fixture
 def transformers_tf_model(model_path):
-    pipeline = load_small_qa_pipeline()
+    pipeline = load_small_qa_tf_pipeline()
     save_model_with_latest_mlflow_version(
         flavor="transformers",
         transformers_model=pipeline,

--- a/tests/transformers/conftest.py
+++ b/tests/transformers/conftest.py
@@ -14,7 +14,7 @@ from tests.transformers.helper import (
     load_small_conversational_model,
     load_small_multi_modal_pipeline,
     load_small_qa_pipeline,
-    load_small_seq2seq_pipeline,
+    load_small_qa_tf_pipeline,
     load_small_vision_model,
     load_summarizer_pipeline,
     load_table_question_answering_pipeline,
@@ -28,13 +28,13 @@ from tests.transformers.helper import (
 
 
 @pytest.fixture
-def small_seq2seq_pipeline():
-    return load_small_seq2seq_pipeline()
+def small_qa_pipeline():
+    return load_small_qa_pipeline()
 
 
 @pytest.fixture
-def small_qa_pipeline():
-    return load_small_qa_pipeline()
+def small_qa_tf_pipeline():
+    return load_small_qa_tf_pipeline()
 
 
 @pytest.fixture

--- a/tests/transformers/conftest.py
+++ b/tests/transformers/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from packaging.version import Version
 
 from tests.transformers.helper import (
     load_audio_classification_pipeline,
@@ -84,6 +85,14 @@ def text_generation_pipeline():
 
 @pytest.fixture
 def translation_pipeline():
+    import transformers
+
+    if Version(transformers.__version__) > Version("4.44.2"):
+        pytest.skip(
+            reason="T5 translation pipeline has a loading issue with Transformers 4.45.x. "
+            "See https://github.com/huggingface/transformers/issues/33398 for more details."
+        )
+
     return load_translation_pipeline()
 
 

--- a/tests/transformers/conftest.py
+++ b/tests/transformers/conftest.py
@@ -89,7 +89,7 @@ def translation_pipeline():
 
     if Version(transformers.__version__) > Version("4.44.2"):
         pytest.skip(
-            reason="T5 translation pipeline has a loading issue with Transformers 4.45.x. "
+            reason="This multi-task pipeline has a loading issue with Transformers 4.45.x. "
             "See https://github.com/huggingface/transformers/issues/33398 for more details."
         )
 
@@ -103,6 +103,14 @@ def text_classification_pipeline():
 
 @pytest.fixture
 def summarizer_pipeline():
+    import transformers
+
+    if Version(transformers.__version__) > Version("4.44.2"):
+        pytest.skip(
+            reason="This multi-task pipeline has a loading issue with Transformers 4.45.x. "
+            "See https://github.com/huggingface/transformers/issues/33398 for more details."
+        )
+
     return load_summarizer_pipeline()
 
 

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -28,21 +28,22 @@ def prefetch(func):
 
 @prefetch
 @flaky()
-def load_small_seq2seq_pipeline():
-    architecture = "lordtt13/emo-mobilebert"
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-    model = transformers.TFAutoModelForSequenceClassification.from_pretrained(architecture)
-    return transformers.pipeline(task="text-classification", model=model, tokenizer=tokenizer)
-
-
-@prefetch
-@flaky()
 def load_small_qa_pipeline():
     architecture = "csarron/mobilebert-uncased-squad-v2"
     tokenizer = transformers.AutoTokenizer.from_pretrained(architecture, low_cpu_mem_usage=True)
     model = transformers.MobileBertForQuestionAnswering.from_pretrained(
         architecture, low_cpu_mem_usage=True
     )
+    return transformers.pipeline(task="question-answering", model=model, tokenizer=tokenizer)
+
+
+@prefetch
+@flaky()
+def load_small_qa_tf_pipeline():
+    # Same architecture as above but loaded as a Tensorflow based model
+    architecture = "csarron/mobilebert-uncased-squad-v2"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
+    model = transformers.TFAutoModelForQuestionAnswering.from_pretrained(architecture)
     return transformers.pipeline(task="question-answering", model=model, tokenizer=tokenizer)
 
 

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -181,7 +181,7 @@ def load_zero_shot_pipeline():
 @flaky()
 def load_table_question_answering_pipeline():
     return transformers.pipeline(
-        task="table-question-answering", model="google/tapas-tiny-finetuned-wtq"
+        task="table-question-answering", model="google/tapas-tiny-finetuned-sqa"
     )
 
 

--- a/tests/transformers/test_flavor_configs.py
+++ b/tests/transformers/test_flavor_configs.py
@@ -34,18 +34,18 @@ def multi_modal_pipeline(component_multi_modal):
     return pipeline, task, processor, components
 
 
-def test_flavor_config_tf(small_seq2seq_pipeline):
+def test_flavor_config_tf(small_qa_tf_pipeline):
     expected = {
-        "task": "text-classification",
-        "instance_type": "TextClassificationPipeline",
-        "pipeline_model_type": "TFMobileBertForSequenceClassification",
-        "source_model_name": "lordtt13/emo-mobilebert",
+        "task": "question-answering",
+        "instance_type": "QuestionAnsweringPipeline",
+        "pipeline_model_type": "TFMobileBertForQuestionAnswering",
+        "source_model_name": "csarron/mobilebert-uncased-squad-v2",
         "model_binary": "model",
         "framework": "tf",
         "components": ["tokenizer"],
         "tokenizer_type": "MobileBertTokenizerFast",
     }
-    conf = build_flavor_config(small_seq2seq_pipeline)
+    conf = build_flavor_config(small_qa_tf_pipeline)
     assert conf == expected
 
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -125,7 +125,7 @@ def image_for_test():
     ("pipeline", "expected_requirements"),
     [
         ("small_qa_pipeline", {"transformers", "torch", "torchvision"}),
-        ("small_seq2seq_pipeline", {"transformers", "tensorflow"}),
+        ("small_qa_tf_pipeline", {"transformers", "tensorflow"}),
         pytest.param(
             "peft_pipeline",
             {"peft", "transformers", "torch", "torchvision"},
@@ -148,7 +148,7 @@ def test_default_requirements(pipeline, expected_requirements, request):
     assert _strip_requirements(conda_requirements) == (expected_requirements | {"mlflow"})
 
 
-def test_inference_task_validation(small_seq2seq_pipeline):
+def test_inference_task_validation(small_qa_pipeline):
     with pytest.raises(
         MlflowException, match="The task provided is invalid. 'llm/v1/invalid' is not"
     ):
@@ -156,7 +156,7 @@ def test_inference_task_validation(small_seq2seq_pipeline):
     with pytest.raises(
         MlflowException, match="The task provided is invalid. 'llm/v1/completions' is not"
     ):
-        _validate_llm_inference_task_type("llm/v1/completions", small_seq2seq_pipeline)
+        _validate_llm_inference_task_type("llm/v1/completions", small_qa_pipeline)
     _validate_llm_inference_task_type("llm/v1/completions", "text-generation")
 
 
@@ -164,7 +164,6 @@ def test_inference_task_validation(small_seq2seq_pipeline):
     ("model", "result"),
     [
         ("small_qa_pipeline", True),
-        ("small_seq2seq_pipeline", True),
         ("small_multi_modal_pipeline", False),
         ("small_vision_model", True),
     ],
@@ -305,11 +304,11 @@ def test_vision_model_save_model_for_task_and_card_inference(small_vision_model,
     assert flavor_config["source_model_name"] == "google/mobilenet_v2_1.0_224"
 
 
-def test_qa_model_save_model_for_task_and_card_inference(small_seq2seq_pipeline, model_path):
+def test_qa_model_save_model_for_task_and_card_inference(small_qa_pipeline, model_path):
     mlflow.transformers.save_model(
         transformers_model={
-            "model": small_seq2seq_pipeline.model,
-            "tokenizer": small_seq2seq_pipeline.tokenizer,
+            "model": small_qa_pipeline.model,
+            "tokenizer": small_qa_pipeline.tokenizer,
         },
         path=model_path,
     )
@@ -317,13 +316,12 @@ def test_qa_model_save_model_for_task_and_card_inference(small_seq2seq_pipeline,
     with model_path.joinpath("requirements.txt").open() as file:
         requirements = file.read()
     reqs = {req.split("==")[0] for req in requirements.split("\n")}
-    expected_requirements = {"tensorflow", "transformers"}
+    expected_requirements = {"torch", "transformers"}
     assert reqs.intersection(expected_requirements) == expected_requirements
     # validate that the card was acquired by model reference
     card_data = yaml.safe_load(model_path.joinpath("model_card_data.yaml").read_bytes())
-    assert card_data["datasets"] == ["emo"]
-    # The creator of this model did not include tag data in the card. Ensure it is missing.
-    assert "tags" not in card_data
+    assert card_data["datasets"] == ["squad_v2"]
+    assert "tags" in card_data
     # verify the license file has been written
     license_file = model_path.joinpath("LICENSE.txt").read_text()
     assert len(license_file) > 0
@@ -334,10 +332,10 @@ def test_qa_model_save_model_for_task_and_card_inference(small_seq2seq_pipeline,
     # validate MLmodel files
     mlmodel = yaml.safe_load(model_path.joinpath("MLmodel").read_bytes())
     flavor_config = mlmodel["flavors"]["transformers"]
-    assert flavor_config["instance_type"] == "TextClassificationPipeline"
-    assert flavor_config["pipeline_model_type"] == "TFMobileBertForSequenceClassification"
-    assert flavor_config["task"] == "text-classification"
-    assert flavor_config["source_model_name"] == "lordtt13/emo-mobilebert"
+    assert flavor_config["instance_type"] == "QuestionAnsweringPipeline"
+    assert flavor_config["pipeline_model_type"] == "MobileBertForQuestionAnswering"
+    assert flavor_config["task"] == "question-answering"
+    assert flavor_config["source_model_name"] == "csarron/mobilebert-uncased-squad-v2"
 
 
 def test_qa_model_save_and_override_card(small_qa_pipeline, model_path):
@@ -377,17 +375,17 @@ def test_qa_model_save_and_override_card(small_qa_pipeline, model_path):
     assert flavor_config["source_model_name"] == "csarron/mobilebert-uncased-squad-v2"
 
 
-def test_basic_save_model_and_load_text_pipeline(small_seq2seq_pipeline, model_path):
+def test_basic_save_model_and_load_text_pipeline(text_classification_pipeline, model_path):
     mlflow.transformers.save_model(
         transformers_model={
-            "model": small_seq2seq_pipeline.model,
-            "tokenizer": small_seq2seq_pipeline.tokenizer,
+            "model": text_classification_pipeline.model,
+            "tokenizer": text_classification_pipeline.tokenizer,
         },
         path=model_path,
     )
     loaded = mlflow.transformers.load_model(model_path)
     result = loaded("MLflow is a really neat tool!")
-    assert result[0]["label"] == "happy"
+    assert result[0]["label"] == "POSITIVE"
     assert result[0]["score"] > 0.5
 
 
@@ -569,15 +567,17 @@ def test_log_and_load_transformers_pipeline(small_qa_pipeline, tmp_path, should_
         mlflow.end_run()
 
 
-def test_load_pipeline_from_remote_uri_succeeds(small_seq2seq_pipeline, model_path, mock_s3_bucket):
-    mlflow.transformers.save_model(transformers_model=small_seq2seq_pipeline, path=model_path)
+def test_load_pipeline_from_remote_uri_succeeds(
+    text_classification_pipeline, model_path, mock_s3_bucket
+):
+    mlflow.transformers.save_model(transformers_model=text_classification_pipeline, path=model_path)
     artifact_root = f"s3://{mock_s3_bucket}"
     artifact_path = "model"
     artifact_repo = S3ArtifactRepository(artifact_root)
     artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
     model_uri = os.path.join(artifact_root, artifact_path)
     loaded = mlflow.transformers.load_model(model_uri=str(model_uri), return_type="pipeline")
-    assert loaded("I like it when CI checks pass and are never flaky!")[0]["label"] == "happy"
+    assert loaded("I like it when CI checks pass and are never flaky!")[0]["label"] == "POSITIVE"
 
 
 def test_transformers_log_model_calls_register_model(small_qa_pipeline, tmp_path):
@@ -738,11 +738,11 @@ def test_transformers_log_with_duplicate_extra_pip_requirements(small_multi_moda
     importlib.util.find_spec("accelerate") is not None, reason="fails when accelerate is installed"
 )
 def test_transformers_tf_model_save_without_conda_env_uses_default_env_with_expected_dependencies(
-    small_seq2seq_pipeline, model_path
+    small_qa_tf_pipeline, model_path
 ):
-    mlflow.transformers.save_model(small_seq2seq_pipeline, model_path)
+    mlflow.transformers.save_model(small_qa_tf_pipeline, model_path)
     _assert_pip_requirements(
-        model_path, mlflow.transformers.get_default_pip_requirements(small_seq2seq_pipeline.model)
+        model_path, mlflow.transformers.get_default_pip_requirements(small_qa_tf_pipeline.model)
     )
     pip_requirements = _get_deps_from_requirement_file(model_path)
     assert "tensorflow" in pip_requirements
@@ -783,14 +783,14 @@ def test_transformers_pt_model_save_dependencies_without_accelerate(
     importlib.util.find_spec("accelerate") is not None, reason="fails when accelerate is installed"
 )
 def test_transformers_tf_model_log_without_conda_env_uses_default_env_with_expected_dependencies(
-    small_seq2seq_pipeline,
+    small_qa_tf_pipeline,
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.transformers.log_model(small_seq2seq_pipeline, artifact_path)
+        mlflow.transformers.log_model(small_qa_tf_pipeline, artifact_path)
         model_uri = mlflow.get_artifact_uri(artifact_path)
     _assert_pip_requirements(
-        model_uri, mlflow.transformers.get_default_pip_requirements(small_seq2seq_pipeline.model)
+        model_uri, mlflow.transformers.get_default_pip_requirements(small_qa_tf_pipeline.model)
     )
     pip_requirements = _get_deps_from_requirement_file(model_uri)
     assert "tensorflow" in pip_requirements
@@ -826,21 +826,21 @@ def test_log_model_with_code_paths(small_qa_pipeline):
         add_mock.assert_called()
 
 
-def test_non_existent_model_card_entry(small_seq2seq_pipeline, model_path):
+def test_non_existent_model_card_entry(small_qa_pipeline, model_path):
     with mock.patch("mlflow.transformers._fetch_model_card", return_value=None):
-        mlflow.transformers.save_model(transformers_model=small_seq2seq_pipeline, path=model_path)
+        mlflow.transformers.save_model(transformers_model=small_qa_pipeline, path=model_path)
 
         contents = {item.name for item in model_path.iterdir()}
         assert not contents.intersection({"model_card.txt", "model_card_data.yaml"})
 
 
-def test_huggingface_hub_not_installed(small_seq2seq_pipeline, model_path):
+def test_huggingface_hub_not_installed(small_qa_pipeline, model_path):
     with mock.patch.dict("sys.modules", {"huggingface_hub": None}):
-        result = mlflow.transformers._fetch_model_card(small_seq2seq_pipeline.model.name_or_path)
+        result = mlflow.transformers._fetch_model_card(small_qa_pipeline.model.name_or_path)
 
         assert result is None
 
-        mlflow.transformers.save_model(transformers_model=small_seq2seq_pipeline, path=model_path)
+        mlflow.transformers.save_model(transformers_model=small_qa_pipeline, path=model_path)
 
         contents = {item.name for item in model_path.iterdir()}
         assert not contents.intersection({"model_card.txt", "model_card_data.yaml"})
@@ -2829,9 +2829,11 @@ def test_qa_pipeline_pyfunc_predict_with_kwargs(small_qa_pipeline):
     ]
 
 
-def test_uri_directory_renaming_handling_pipeline(model_path, small_seq2seq_pipeline):
+def test_uri_directory_renaming_handling_pipeline(model_path, text_classification_pipeline):
     with mlflow.start_run():
-        mlflow.transformers.save_model(transformers_model=small_seq2seq_pipeline, path=model_path)
+        mlflow.transformers.save_model(
+            transformers_model=text_classification_pipeline, path=model_path
+        )
 
     absolute_model_directory = os.path.join(model_path, "model")
     renamed_to_old_convention = os.path.join(model_path, "pipeline")
@@ -2855,10 +2857,10 @@ def test_uri_directory_renaming_handling_pipeline(model_path, small_seq2seq_pipe
     assert isinstance(prediction["label"][0], str)
 
 
-def test_uri_directory_renaming_handling_components(model_path, small_seq2seq_pipeline):
+def test_uri_directory_renaming_handling_components(model_path, text_classification_pipeline):
     components = {
-        "tokenizer": small_seq2seq_pipeline.tokenizer,
-        "model": small_seq2seq_pipeline.model,
+        "tokenizer": text_classification_pipeline.tokenizer,
+        "model": text_classification_pipeline.model,
     }
 
     with mlflow.start_run():
@@ -3561,10 +3563,10 @@ def test_save_and_load_pipeline_without_save_pretrained_false(
 
 # Patch tempdir just to verify the invocation
 @mock.patch("mlflow.transformers.TempDir", side_effect=mlflow.utils.file_utils.TempDir)
-def test_persist_pretrained_model(mock_tmpdir, small_seq2seq_pipeline):
+def test_persist_pretrained_model(mock_tmpdir, small_qa_tf_pipeline):
     with mlflow.start_run():
         model_info = mlflow.transformers.log_model(
-            transformers_model=small_seq2seq_pipeline,
+            transformers_model=small_qa_tf_pipeline,
             artifact_path="model",
             save_pretrained=False,
             pip_requirements=["mlflow"],  # For speed up logging

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3008,6 +3008,11 @@ def test_basic_model_with_accelerate_device_mapping_fails_save(tmp_path, model_p
         mlflow.transformers.save_model(transformers_model=pipeline, path=model_path)
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__) > Version("4.44.2"),
+    reason="Multi-task pipeline (t5) has a loading issue with Transformers 4.45.x. "
+    "See https://github.com/huggingface/transformers/issues/33398 for more details.",
+)
 def test_basic_model_with_accelerate_homogeneous_mapping_works(model_path):
     task = "translation_en_to_de"
     architecture = "t5-small"

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -846,7 +846,7 @@ def test_huggingface_hub_not_installed(small_qa_pipeline, model_path):
         assert not contents.intersection({"model_card.txt", "model_card_data.yaml"})
 
         license_data = model_path.joinpath("LICENSE.txt").read_text()
-        assert license_data.rstrip().endswith("mobilebert")
+        assert license_data.rstrip().endswith("mobilebert-uncased-squad-v2")
 
 
 @pytest.mark.skipif(

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -767,11 +767,11 @@ def test_transformers_pt_model_save_without_conda_env_uses_default_env_with_expe
     importlib.util.find_spec("accelerate") is not None, reason="fails when accelerate is installed"
 )
 def test_transformers_pt_model_save_dependencies_without_accelerate(
-    translation_pipeline, model_path
+    text_generation_pipeline, model_path
 ):
-    mlflow.transformers.save_model(translation_pipeline, model_path)
+    mlflow.transformers.save_model(text_generation_pipeline, model_path)
     _assert_pip_requirements(
-        model_path, mlflow.transformers.get_default_pip_requirements(translation_pipeline.model)
+        model_path, mlflow.transformers.get_default_pip_requirements(text_generation_pipeline.model)
     )
     pip_requirements = _get_deps_from_requirement_file(model_path)
     assert "tensorflow" not in pip_requirements

--- a/tests/transformers/test_transformers_prompt_templating.py
+++ b/tests/transformers/test_transformers_prompt_templating.py
@@ -180,6 +180,12 @@ def test_prompt_formatting(saved_transformers_model_path):
 def test_prompt_used_in_predict(task, pipeline_fixture, output_key, request, tmp_path):
     pipeline = request.getfixturevalue(pipeline_fixture)
 
+    if task == "summarization" and Version(transformers.__version__) > Version("4.44.2"):
+        pytest.skip(
+            reason="Multi-task pipeline has a loading issue with Transformers 4.45.x. "
+            "See https://github.com/huggingface/transformers/issues/33398 for more details."
+        )
+
     model_path = tmp_path / "model"
     mlflow.transformers.save_model(
         transformers_model=pipeline,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13098?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13098/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13098
```

</p>
</details>

### Related Issues/PRs

Fix cross version test failure: https://github.com/mlflow-automation/mlflow/actions/runs/10760254784/job/29841206565#step:12:4541

### What changes are proposed in this pull request?

Recently Transformers merged a PR to apply a strict rule for the model config stored in the repository (https://github.com/huggingface/transformers/pull/32659). The rule prohibit the `config.json` file to contain any parameters that are used for inference such as `max_length`, because they recommend declare those inference params in a different file (generation config).

One of the test model we are using ([lordtt13/emo-mobilebert](https://huggingface.co/lordtt13/emo-mobilebert)) violates this rule and caused a test failure. This PR replace it to another model.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
