### PR TITLE
Fix prophet docker test

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -457,6 +457,8 @@ prophet:
     minimum: "1.1.1"
     maximum: "1.1.5"
     requirements:
+      # Prophet does not handle numpy 2 yet. https://github.com/facebook/prophet/issues/2595
+      ">= 0.0.0": ["numpy<2"]
       # Avoid holidays 0.25 due to https://github.com/dr-prodigy/python-holidays/issues/1200 on
       # older version of prophet. Compatibility updates have been released as part of the 1.1.4
       # release of prophet.

--- a/tests/pyfunc/docker/conftest.py
+++ b/tests/pyfunc/docker/conftest.py
@@ -53,7 +53,7 @@ def get_released_mlflow_version():
     return str(sorted(versions, reverse=True)[0])
 
 
-def save_model_with_latest_mlflow_version(flavor, **kwargs):
+def save_model_with_latest_mlflow_version(flavor, extra_pip_requirements=None, **kwargs):
     """
     Save a model with overriding MLflow version from dev version to the latest released version.
     By default a model is saved with the dev version of MLflow, which is not available on PyPI.
@@ -65,6 +65,8 @@ def save_model_with_latest_mlflow_version(flavor, **kwargs):
     if flavor == "langchain":
         kwargs["pip_requirements"] = [f"mlflow[gateway]=={latest_mlflow_version}", "langchain"]
     else:
-        kwargs["extra_pip_requirements"] = [f"mlflow=={latest_mlflow_version}"]
+        extra_pip_requirements = extra_pip_requirements or []
+        extra_pip_requirements.append(f"mlflow=={latest_mlflow_version}")
+        kwargs["extra_pip_requirements"] = extra_pip_requirements
     flavor_module = getattr(mlflow, flavor)
     flavor_module.save_model(**kwargs)

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -330,6 +330,8 @@ def prophet_model(model_path, prophet_raw_model):
         pr_model=prophet_raw_model.model,
         path=model_path,
         input_example=prophet_raw_model.data[:1],
+        # Prophet does not handle numpy 2 yet. https://github.com/facebook/prophet/issues/2595
+        extra_pip_requirements=["numpy<2"],
     )
     return model_path
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13100?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13100/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13100
```

</p>
</details>

### Related Issues/PRs

Fix Docker test https://github.com/mlflow-automation/mlflow/actions/runs/10760237830/job/29837920664

### What changes are proposed in this pull request?

Prophet does not handle `numpy` v2 yet but does not pin its version.
Pin numpy until https://github.com/facebook/prophet/issues/2595 is resolved in both docker test and cross-version test (which will also fail when we migrate python version to 3.9).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

` MLFLOW_RUN_SLOW_TESTS=true pytest tests/pyfunc/docker/test_docker_flavors.py::test_build_image_and_serve[prophet]` passed on devbox.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
