### PR TITLE
Update ChatCompletionResponse to populate object type

### DIFF
--- a/mlflow/langchain/output_parsers.py
+++ b/mlflow/langchain/output_parsers.py
@@ -32,7 +32,8 @@ class ChatCompletionsOutputParser(BaseTransformOutputParser[Dict[str, Any]]):
     def parse(self, text: str) -> Dict[str, Any]:
         return asdict(
             ChatCompletionResponse(
-                choices=[ChainCompletionChoice(message=Message(role="assistant", content=text))]
+                choices=[ChainCompletionChoice(message=Message(role="assistant", content=text))],
+                object="chat.completion",
             )
         )
 

--- a/mlflow/models/rag_signatures.py
+++ b/mlflow/models/rag_signatures.py
@@ -62,6 +62,7 @@ class ChainCompletionChunk:
 @experimental
 class ChatCompletionResponse:
     choices: List[ChainCompletionChoice] = field(default_factory=lambda: [ChainCompletionChoice()])
+    object: str = field(default="chat.completion")
     # TODO: support ChainCompletionChunk in the future
 
 

--- a/mlflow/models/rag_signatures.py
+++ b/mlflow/models/rag_signatures.py
@@ -62,7 +62,7 @@ class ChainCompletionChunk:
 @experimental
 class ChatCompletionResponse:
     choices: List[ChainCompletionChoice] = field(default_factory=lambda: [ChainCompletionChoice()])
-    object: str = field(default="chat.completion")
+    object: str = "chat.completion"
     # TODO: support ChainCompletionChunk in the future
 
 

--- a/tests/langchain/test_langchain_output_parsers.py
+++ b/tests/langchain/test_langchain_output_parsers.py
@@ -13,7 +13,8 @@ def test_chatcompletions_output_parser_parse_response():
                 "index": 0,
                 "message": {"content": "The weather today is", "role": "assistant"},
             }
-        ]
+        ],
+        "object": "chat.completion",
     }
 
 

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -311,7 +311,8 @@ def test_signature_for_rag():
             '"message": {"type": "object", "properties": '
             '{"content": {"type": "string", "required": true}, '
             '"role": {"type": "string", "required": true}}, '
-            '"required": true}}}, "name": "choices", "required": true}]'
+            '"required": true}}}, "name": "choices", "required": true}, '
+            '{"type": "string", "name": "object", "required": true}]'
         ),
         "params": None,
     }

--- a/tests/pyfunc/test_rag_model.py
+++ b/tests/pyfunc/test_rag_model.py
@@ -38,6 +38,7 @@ def test_rag_model_works_with_type_hint(tmp_path):
 
     response = loaded_model.predict(input_example)
     assert response["choices"][0]["message"]["content"] == "What is mlflow?"
+    assert response["object"] == "chat.completion"
 
     # confirm the input example is set
     mlflow_model = Model.load(tmp_path)
@@ -52,4 +53,6 @@ def test_rag_model_works_with_type_hint(tmp_path):
     )
 
     expect_status_code(response, 200)
-    assert json.loads(response.content)["choices"][0]["message"]["content"] == "What is mlflow?"
+    json_response = json.loads(response.content)
+    assert json_response["choices"][0]["message"]["content"] == "What is mlflow?"
+    assert json_response["object"] == "chat.completion"

--- a/tests/pyfunc/test_rag_model.py
+++ b/tests/pyfunc/test_rag_model.py
@@ -21,6 +21,7 @@ class TestRagModel(mlflow.pyfunc.PythonModel):
         return asdict(
             ChatCompletionResponse(
                 choices=[ChainCompletionChoice(message=Message(role="assistant", content=message))]
+                # NB: intentionally validating the default population of the object field
             )
         )
 

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1780,7 +1780,12 @@ def test_convert_dataclass_to_schema_for_rag():
             },
             "name": "choices",
             "required": True,
-        }
+        },
+        {
+            "name": "object",
+            "required": True,
+            "type": "string",
+        },
     ]
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/13102?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13102/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13102
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Updates the ChatCompletionResponse schema definition to populate the object field that is required by downstream UI components. 

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
