### PR TITLE
Update Dependency Extraction for Agents

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -242,7 +242,8 @@ def _traverse_runnable(
         # Visit the returned graph
         for node in lc_model.get_graph().nodes.values():
             yield from _traverse_runnable(node.data, visited)
-        
+
+        # Visit the variables of the function as well to extract dependencies
         if hasattr(lc_model, "func"):
             for node in inspect.getclosurevars(lc_model.func).globals.values():
                 yield from _traverse_runnable(node, visited)

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -242,6 +242,10 @@ def _traverse_runnable(
         # Visit the returned graph
         for node in lc_model.get_graph().nodes.values():
             yield from _traverse_runnable(node.data, visited)
+        
+        if hasattr(lc_model, "func"):
+            for node in inspect.getclosurevars(lc_model.func).globals.values():
+                yield from _traverse_runnable(node, visited)
     else:
         # No-op for non-runnable, if any
         pass

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -244,7 +244,7 @@ def _traverse_runnable(
             yield from _traverse_runnable(node.data, visited)
 
         # Visit the variables of the function as well to extract dependencies
-        if hasattr(lc_model, "func"):
+        if hasattr(lc_model, "func") and lc_model.func is not None:
             for node in inspect.getclosurevars(lc_model.func).globals.values():
                 yield from _traverse_runnable(node, visited)
     else:

--- a/tests/langchain/sample_code/langgraph_agent.py
+++ b/tests/langchain/sample_code/langgraph_agent.py
@@ -1,0 +1,74 @@
+from typing import Any, List, Literal, Optional
+
+from langchain_core.runnables import RunnableLambda
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+
+import mlflow
+
+
+def get_fake_chat_model(endpoint="fake-endpoint"):
+    from langchain.callbacks.manager import CallbackManagerForLLMRun
+    from langchain.chat_models import ChatDatabricks, ChatMlflow
+    from langchain.schema.messages import BaseMessage
+    from langchain_core.outputs import ChatResult
+
+    class FakeChatModel(ChatDatabricks):
+        """Fake Chat Model wrapper for testing purposes."""
+
+        endpoint: str = "fake-endpoint"
+
+        def _generate(
+            self,
+            messages: List[BaseMessage],
+            stop: Optional[List[str]] = None,
+            run_manager: Optional[CallbackManagerForLLMRun] = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            response = {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "test_content",
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            return ChatMlflow._create_chat_result(response)
+
+        @property
+        def _llm_type(self) -> str:
+            return "fake chat model"
+
+    return FakeChatModel(endpoint=endpoint)
+
+
+@tool
+def get_weather(city: Literal["nyc", "sf"]):
+    """Use this to get weather information."""
+    if city == "nyc":
+        return "It might be cloudy in nyc"
+    elif city == "sf":
+        return "It's always sunny in sf"
+
+
+llm = get_fake_chat_model()
+tools = [get_weather]
+agent = create_react_agent(llm, tools)
+
+
+def wrap_lg(input):
+    if not isinstance(input, dict):
+        if isinstance(input, list) and len(input) > 0:
+            # Extract the content from the HumanMessage
+            content = input[0].content.strip('"')
+            input = {"messages": [{"role": "user", "content": content}]}
+    return agent.invoke(input)
+
+
+chain = RunnableLambda(wrap_lg)
+
+mlflow.models.set_model(chain)

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3503,3 +3503,26 @@ def test_signature_inference_fails(monkeypatch: pytest.MonkeyPatch):
             input_example={"chat": []},
         )
         assert model_info.signature is None
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="Langgraph are not supported the way we want in earlier versions",
+)
+def test_langgraph_agent_log_model_from_code():
+    input_example = {"messages": [{"role": "user", "content": "what is the weather in sf?"}]}
+
+    pyfunc_artifact_path = "weather_agent"
+    with mlflow.start_run() as run:
+        mlflow.langchain.log_model(
+            lc_model="tests/langchain/sample_code/langgraph_agent.py",
+            artifact_path=pyfunc_artifact_path,
+            input_example=input_example,
+        )
+    pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
+    pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
+    reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
+    actual = reloaded_model.resources["databricks"]
+    expected = {"serving_endpoint": [{"name": "fake-endpoint"}]}
+    assert all(item in actual["serving_endpoint"] for item in expected["serving_endpoint"])
+    assert all(item in expected["serving_endpoint"] for item in actual["serving_endpoint"])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aravind-segu/mlflow/pull/13105?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13105/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13105
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Even though the dependency extraction works in unit tests, it was not working in a notebook environment when the langchain model was passed in as a path. The input was just the RunnableLambda, and the embedded agent was not part of the graph that we traverse. 

Therefore this pr introduces a change to also go through the global variables of the function and extract dependencies from that as well. In our current setup, agent is passed as a runnable lambda wrapped in a function, so we can extract dependencies from the agent.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

ML model file with resources: https://e2-dogfood.staging.cloud.databricks.com/ml/experiments/4238698598521536/runs/61d86d25755d4b1487d25326aa124849/artifacts?o=6051921418418893

Notebooks to register model: https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/4238698598521536?o=6051921418418893#command/4238698598521543

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
