### PR TITLE
Update test to assert string instead

### DIFF
--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -66,7 +66,7 @@ def _mv_maker(
 
 
 def _extract_latest_by_stage(latest_versions):
-    return {mvd.current_stage: mvd.version for mvd in latest_versions}
+    return {mvd.current_stage: str(mvd.version) for mvd in latest_versions}
 
 
 def test_create_registered_model(store):
@@ -258,7 +258,7 @@ def test_get_latest_versions(store):
     mv1 = _mv_maker(store, name)
     assert mv1.version == 1
     rmd2 = store.get_registered_model(name=name)
-    assert _extract_latest_by_stage(rmd2.latest_versions) == {"None": 1}
+    assert _extract_latest_by_stage(rmd2.latest_versions) == {"None": "1"}
 
     # add a bunch more
     mv2 = _mv_maker(store, name)
@@ -290,49 +290,49 @@ def test_get_latest_versions(store):
     # test that correct latest versions are returned for each stage
     rmd4 = store.get_registered_model(name=name)
     assert _extract_latest_by_stage(rmd4.latest_versions) == {
-        "None": 1,
-        "Production": 3,
-        "Staging": 4,
+        "None": "1",
+        "Production": "3",
+        "Staging": "4",
     }
     assert _extract_latest_by_stage(store.get_latest_versions(name=name, stages=None)) == {
-        "None": 1,
-        "Production": 3,
-        "Staging": 4,
+        "None": "1",
+        "Production": "3",
+        "Staging": "4",
     }
     assert _extract_latest_by_stage(store.get_latest_versions(name=name, stages=[])) == {
-        "None": 1,
-        "Production": 3,
-        "Staging": 4,
+        "None": "1",
+        "Production": "3",
+        "Staging": "4",
     }
     assert _extract_latest_by_stage(
         store.get_latest_versions(name=name, stages=["Production"])
-    ) == {"Production": 3}
+    ) == {"Production": "3"}
     assert _extract_latest_by_stage(
         store.get_latest_versions(name=name, stages=["production"])
-    ) == {"Production": 3}  # The stages are case insensitive.
+    ) == {"Production": "3"}  # The stages are case insensitive.
     assert _extract_latest_by_stage(
         store.get_latest_versions(name=name, stages=["pROduction"])
-    ) == {"Production": 3}  # The stages are case insensitive.
+    ) == {"Production": "3"}  # The stages are case insensitive.
     assert _extract_latest_by_stage(
         store.get_latest_versions(name=name, stages=["None", "Production"])
-    ) == {"None": 1, "Production": 3}
+    ) == {"None": "1", "Production": "3"}
 
     # delete latest Production, and should point to previous one
     store.delete_model_version(name=mv3.name, version=mv3.version)
     rmd5 = store.get_registered_model(name=name)
     assert _extract_latest_by_stage(rmd5.latest_versions) == {
-        "None": 1,
-        "Production": 2,
-        "Staging": 4,
+        "None": "1",
+        "Production": "2",
+        "Staging": "4",
     }
     assert _extract_latest_by_stage(store.get_latest_versions(name=name, stages=None)) == {
-        "None": 1,
-        "Production": 2,
-        "Staging": 4,
+        "None": "1",
+        "Production": "2",
+        "Staging": "4",
     }
     assert _extract_latest_by_stage(
         store.get_latest_versions(name=name, stages=["Production"])
-    ) == {"Production": 2}
+    ) == {"Production": "2"}
 
 
 def test_set_registered_model_tag(store):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nojaf/mlflow/pull/13115?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13115/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13115
```

</p>
</details>

### What changes are proposed in this pull request?

This is related to the `mlflow-go` project.

I'd like to change some numbers to strings in `tests/store/model_registry/test_sqlalchemy_store.py`.
The protos say it model_version should be an string. It does appear to be an int in the database.

I initially planned to update the proto but changing the test is far less intrusive.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
