### PR TITLE
Add a warning about langchain partner pacakge and promote model-from-code

### DIFF
--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -60,7 +60,7 @@ Supported Elements in MLflow LangChain Integration
 
 .. warning::
 
-    There is a known deserialization issue when logging chain/agent that includes LangChain components from `the partner packages <https://python.langchain.com/v0.1/docs/integrations/platforms/#partner-packages>`_ such as ``langchain-openai``. If you log such models using the legacy serialization based logging, the some components might be loaded from ``langchain-community`` package instead of the partner package, which can lead to unexpected behavior.
+    There is a known deserialization issue when logging chains or agents dependent upon LangChain components from `the partner packages <https://python.langchain.com/v0.1/docs/integrations/platforms/#partner-packages>`_ such as ``langchain-openai``. If you log such models using the legacy serialization based logging, some components may be loaded from the respective ``langchain-community`` package instead of the partner package library, which can lead to unexpected behavior or import errors when executing your code.
     To avoid this issue, we strongly recommend using the `Model-from-Code <#logging-models-from-code>`_ method for logging such models. This method allows you to bypass the model serialization and robustly save the model definition.
 
 
@@ -174,7 +174,7 @@ The feature provides several benefits to manage LangChain models:
 
 1. **Avoid Serialization Complication**: File handles, sockets, external connections, dynamic references, lambda functions and system resources are unpicklable. Some LangChain components do not support native serialization, e.g. ``RunnableLambda``.
 
-2. **No Pickeling**: Loading a pickle or cloudpickle file in a Python version that was different than the one used to serialize the object does not guarantee compatibility.
+2. **No Pickling**: Loading a pickle or cloudpickle file in a Python version that was different than the one used to serialize the object does not guarantee compatibility.
 
 3. **Readability**: The serialized objects are often hardly readable by humans. Model-from-code allows you to review your model definition via code.
 

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -54,6 +54,14 @@ Supported Elements in MLflow LangChain Integration
 - `Agents <https://python.langchain.com/docs/modules/agents/>`_
 - `RetrievalQA <https://js.langchain.com/docs/modules/chains/popular/vector_db_qa>`_
 - `Retrievers <https://python.langchain.com/docs/modules/data_connection/retrievers/>`_
+- `Runnables <https://python.langchain.com/v0.1/docs/expression_language/interface/>`_
+- `LangGraph Complied Graph <https://langchain-ai.github.io/langgraph/reference/graphs/>`_ (only supported via `Model-from-Code <#logging-models-from-code>`_)
+
+
+.. warning::
+
+    There is a known deserialization issue when logging chain/agent that includes LangChain components from `the partner packages <https://python.langchain.com/v0.1/docs/integrations/platforms/#partner-packages>`_ such as ``langchain-openai``. If you log such models using the legacy serialization based logging, the some components might be loaded from ``langchain-community`` package instead of the partner package, which can lead to unexpected behavior.
+    To avoid this issue, we strongly recommend using the `Model-from-Code <#logging-models-from-code>`_ method for logging such models. This method allows you to bypass the model serialization and robustly save the model definition.
 
 
 .. attention::
@@ -156,6 +164,133 @@ exploring these more advanced use cases.
     </section>
 
 
+
+Logging models from Code
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since MLflow 2.12.2, MLflow introduced the ability to log LangChain models directly from a code definition.
+
+The feature provides several benefits to manage LangChain models:
+
+1. **Avoid Serialization Complication**: File handles, sockets, external connections, dynamic references, lambda functions and system resources are unavailable for pickling. Some LangChain components does not support native serialization, e.g. ``RunnableLambda``.
+
+2. **No Pickeling**: Loading a pickle or cloudpickle file in a Python version that was different than the one used to serialize the object does not guarantee compatibility.
+
+3. **Readability**: The serialized objects are often hardly readable by humans. Model-from-code allows you to review your model definition via code.
+
+
+Refer to the `Models From Code feature documentation <../../models.html#models-from-code>`_ for more information about this feature.
+
+In order to use this feature, you will utilize the :py:func:`mlflow.models.set_model` API to define the chain that you would like to log as an MLflow model. 
+After having this set within your code that defines your chain, when logging your model, you will specify the **path** to the file that defines your chain. 
+
+The following example demonstrates how to log a simple chain with this method:
+
+
+1. Define the chain in a separate Python file.**
+
+    .. tip::
+
+        If you are using Jupyter Notebook, you can use the `%%writefile` magic command to write the code cell directly to a file, without leaving the notebook to create it manually.
+
+    .. code-block:: python
+
+        %%writefile chain.py
+
+        import os
+        from operator import itemgetter
+
+        from langchain_core.output_parsers import StrOutputParser
+        from langchain_core.prompts import PromptTemplate
+        from langchain_core.runnables import RunnableLambda
+        from langchain_openai import OpenAI
+
+        import mlflow
+
+        mlflow.set_experiment("Homework Helper")
+
+        mlflow.langchain.autolog()
+
+        prompt = PromptTemplate(
+            template="You are a helpful tutor that evaluates my homework assignments and provides suggestions on areas for me to study further."
+            " Here is the question: {question} and my answer which I got wrong: {answer}",
+            input_variables=["question", "answer"],
+        )
+
+
+        def get_question(input):
+            default = "What is your name?"
+            if isinstance(input_data[0], dict):
+                return input_data[0].get("content").get("question", default)
+            return default
+
+
+        def get_answer(input):
+            default = "My name is Bobo"
+            if isinstance(input_data[0], dict):
+                return input_data[0].get("content").get("answer", default)
+            return default
+
+
+        model = OpenAI(temperature=0.95)
+
+        chain = (
+            {
+                "question": itemgetter("messages") | RunnableLambda(get_question),
+                "answer": itemgetter("messages") | RunnableLambda(get_answer),
+            }
+            | prompt
+            | model
+            | StrOutputParser()
+        )
+
+        mlflow.models.set_model(chain)
+
+2. Then from the main notebook, log the model via supplying the path to the file that defines the chain:
+
+    .. code-block:: python
+
+        from pprint import pprint
+
+        import mlflow
+
+        chain_path = "chain.py"
+
+        with mlflow.start_run():
+            info = mlflow.langchain.log_model(lc_model=chain_path, artifact_path="chain")
+
+3. The model defined in ``chain.py`` is now logged to MLflow. You can load the model back and run inference:
+
+    .. code-block:: python
+
+        # Load the model and run inference
+        homework_chain = mlflow.langchain.load_model(model_uri=info.model_uri)
+
+        exam_question = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": {
+                        "question": "What is the primary function of control rods in a nuclear reactor?",
+                        "answer": "To stir the primary coolant so that the neutrons are mixed well.",
+                    },
+                },
+            ]
+        }
+
+        response = homework_chain.invoke(exam_question)
+
+        pprint(response)
+
+    You can see the model is logged as a code on MLflow UI:
+
+    .. figure:: ../../_static/images/tutorials/llms/langchain-code-model.png
+            :alt: Logging a LangChain model from a code script file
+            :width: 100%
+            :align: center
+
+
+
 `Detailed Documentation <guide/index.html>`_
 --------------------------------------------
 
@@ -247,106 +382,6 @@ How can I use a streaming API with LangChain?
     As of the MLflow 2.12.2 release, LangChain models that support streaming responses that have been saved using MLflow 2.12.2 (or higher) can be loaded and used for 
     streamable inference using the ``predict_stream`` API. Ensure that you are consuming the return type correctly, as the return from these models is a ``Generator`` object.
     To learn more, refer to the `predict_stream guide <https://mlflow.org/docs/latest/models.html#how-to-load-and-score-python-function-models>`_.
-
-How can I log my chain from code?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- **Models from Code**: MLflow 2.12.2 introduced the ability to log LangChain models directly from a code definition. 
-
-    In order to use this feature, you will utilize the :py:func:`mlflow.models.set_model` API to define the chain that you would like to log as an MLflow model. 
-    After having this set within your code that defines your chain, when logging your model, you will specify the **path** to the file that defines your chain. 
-
-    For example, here is a simple chain defined in a file named ``langchain_code_chain.py``:
-
-    .. code-block:: python
-        
-        import os
-        from operator import itemgetter
-
-        from langchain_core.output_parsers import StrOutputParser
-        from langchain_core.prompts import PromptTemplate
-        from langchain_core.runnables import RunnableLambda
-        from langchain_openai import OpenAI
-
-        import mlflow
-
-        mlflow.set_experiment("Homework Helper")
-
-        mlflow.langchain.autolog()
-
-        prompt = PromptTemplate(
-            template="You are a helpful tutor that evaluates my homework assignments and provides suggestions on areas for me to study further."
-            " Here is the question: {question} and my answer which I got wrong: {answer}",
-            input_variables=["question", "answer"],
-        )
-
-
-        def get_question(input):
-            default = "What is your name?"
-            if isinstance(input_data[0], dict):
-                return input_data[0].get("content").get("question", default)
-            return default
-
-
-        def get_answer(input):
-            default = "My name is Bobo"
-            if isinstance(input_data[0], dict):
-                return input_data[0].get("content").get("answer", default)
-            return default
-
-
-        model = OpenAI(temperature=0.95)
-
-        chain = (
-            {
-                "question": itemgetter("messages") | RunnableLambda(get_question),
-                "answer": itemgetter("messages") | RunnableLambda(get_answer),
-            }
-            | prompt
-            | model
-            | StrOutputParser()
-        )
-
-        mlflow.models.set_model(chain)
-
-    From a different file (in this case, a Jupyter Notebook), logging the model directly via supplying the path to the file that defines the chain:
-
-    .. code-block:: python
-
-        from pprint import pprint
-
-        import mlflow
-
-        chain_path = "langchain_code_chain.py"
-
-        with mlflow.start_run():
-            info = mlflow.langchain.log_model(lc_model=chain_path, artifact_path="chain")
-
-        # Load the model and run inference
-        homework_chain = mlflow.langchain.load_model(model_uri=info.model_uri)
-
-        exam_question = {
-            "messages": [
-                {
-                    "role": "user",
-                    "content": {
-                        "question": "What is the primary function of control rods in a nuclear reactor?",
-                        "answer": "To stir the primary coolant so that the neutrons are mixed well.",
-                    },
-                },
-            ]
-        }
-
-        response = homework_chain.invoke(exam_question)
-
-        pprint(response)
-    
-    The model will be logged as a script within the MLflow UI:
-
-    .. figure:: ../../_static/images/tutorials/llms/langchain-code-model.png
-            :alt: Logging a LangChain model from a code script file
-            :width: 100%
-            :align: center
 
 
 How can I log an agent built with LangGraph to MLflow?

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -172,7 +172,7 @@ Since MLflow 2.12.2, MLflow introduced the ability to log LangChain models direc
 
 The feature provides several benefits to manage LangChain models:
 
-1. **Avoid Serialization Complication**: File handles, sockets, external connections, dynamic references, lambda functions and system resources are unavailable for pickling. Some LangChain components does not support native serialization, e.g. ``RunnableLambda``.
+1. **Avoid Serialization Complication**: File handles, sockets, external connections, dynamic references, lambda functions and system resources are unpicklable. Some LangChain components do not support native serialization, e.g. ``RunnableLambda``.
 
 2. **No Pickeling**: Loading a pickle or cloudpickle file in a Python version that was different than the one used to serialize the object does not guarantee compatibility.
 
@@ -181,8 +181,8 @@ The feature provides several benefits to manage LangChain models:
 
 Refer to the `Models From Code feature documentation <../../models.html#models-from-code>`_ for more information about this feature.
 
-In order to use this feature, you will utilize the :py:func:`mlflow.models.set_model` API to define the chain that you would like to log as an MLflow model. 
-After having this set within your code that defines your chain, when logging your model, you will specify the **path** to the file that defines your chain. 
+In order to use this feature, you will utilize the :py:func:`mlflow.models.set_model` API to define the chain that you would like to log as an MLflow model.
+After having this set within your code that defines your chain, when logging your model, you will specify the **path** to the file that defines your chain.
 
 The following example demonstrates how to log a simple chain with this method:
 
@@ -293,6 +293,9 @@ The following example demonstrates how to log a simple chain with this method:
             :width: 100%
             :align: center
 
+.. warning::
+
+    When logging models from code, make sure that your code does not contain any sensitive information, such as API keys, passwords, or other confidential data. The code will be stored in plain text in the MLflow model artifact, and anyone with access to the artifact will be able to view the code.
 
 
 `Detailed Documentation <guide/index.html>`_

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -193,6 +193,8 @@ The following example demonstrates how to log a simple chain with this method:
 
         If you are using Jupyter Notebook, you can use the `%%writefile` magic command to write the code cell directly to a file, without leaving the notebook to create it manually.
 
+    .. blacken-docs:off
+
     .. code-block:: python
 
         %%writefile chain.py
@@ -245,6 +247,8 @@ The following example demonstrates how to log a simple chain with this method:
         )
 
         mlflow.models.set_model(chain)
+
+    .. blacken-docs:on
 
 2. Then from the main notebook, log the model via supplying the path to the file that defines the chain:
 

--- a/docs/source/model/models-from-code.rst
+++ b/docs/source/model/models-from-code.rst
@@ -6,7 +6,7 @@ Models From Code Guide
     you are required to use the legacy serialization methods outlined in the `Custom Python Model <../models.html#custom-python-models>`_ documentation.
 
 .. note::
-    Models from code is only available for `LangChain <../llms/langchain/index.html>`_ and custom ``pyfunc`` (PythonModel instances) models. If you are 
+    Models from code is only available for `LangChain <../llms/langchain/index.html>`_, `LlamaIndex <../llm/llama-index/index.html>`, and custom ``pyfunc`` (PythonModel instances) models. If you are 
     using other libraries directly, using the provided saving and logging functionality within specific model flavors is recommended.
 
 
@@ -67,6 +67,10 @@ via a script that may not be immediately apparent.
 .. tip::
     If you define import statements that are never used within your script, these will still be included in the requirements listing. It is recommended to use a linter
     that is capable of determining unused import statements while writing your implementation so that you are not including irrelevant package dependencies.
+
+.. warning::
+
+    When logging models from code, make sure that your code does not contain any sensitive information, such as API keys, passwords, or other confidential data. The code will be stored in plain text in the MLflow model artifact, and anyone with access to the artifact will be able to view the code.
 
 Using Models From Code in a Jupyter Notebook
 --------------------------------------------


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13140?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13140/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13140
```

</p>
</details>

### What changes are proposed in this pull request?

Logging LangChain model that contains a component from partner packages such as `langchain-openai` is problematic because it will be loaded back from `langchain-community` package instead. This PR adds a warning to the doc and promote model-from-code logging because it doesn't suffer from the issue.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
