### PR TITLE
Add metadata field for ChatModel

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -395,6 +395,7 @@ support additional params.
 In summary, use the function-based Model when you have a simple function to serialize.
 If you need more power, use  the class-based model.
 """
+
 import collections
 import functools
 import importlib
@@ -2542,7 +2543,10 @@ def save_model(
                         messages.append(ChatMessage(**each_message))
             else:
                 # If the input example is a dictionary, convert it to ChatMessage format
-                messages = [ChatMessage(**m) for m in input_example["messages"]]
+                messages = [
+                    ChatMessage(**m) if isinstance(m, dict) else m
+                    for m in input_example["messages"]
+                ]
                 params = ChatParams(**{k: v for k, v in input_example.items() if k != "messages"})
             input_example = {
                 "messages": [m.to_dict() for m in messages],

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -395,7 +395,6 @@ support additional params.
 In summary, use the function-based Model when you have a simple function to serialize.
 If you need more power, use  the class-based model.
 """
-
 import collections
 import functools
 import importlib

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -489,7 +489,6 @@ from mlflow.types.llm import (
     CHAT_MODEL_OUTPUT_SCHEMA,
     ChatMessage,
     ChatParams,
-    ChatRequest,
     ChatResponse,
 )
 from mlflow.utils import (
@@ -2541,17 +2540,15 @@ def save_model(
                         messages.append(each_message)
                     else:
                         messages.append(ChatMessage(**each_message))
-            elif isinstance(input_example, dict):
+            else:
                 # If the input example is a dictionary, convert it to ChatMessage format
                 messages = [ChatMessage(**m) for m in input_example["messages"]]
                 params = ChatParams(**{k: v for k, v in input_example.items() if k != "messages"})
-            else:
-                raise MlflowException(
-                    "Failed to save ChatModel. "
-                    "Please ensure that the input example is one of the following:\n"
-                    "  1. A list of `ChatMessage`s or dicts matching the `ChatMessage` structure\n"
-                    "  2. A dict matching the `ChatRequest` data structure\n"
-                )
+            input_example = {
+                "messages": [m.to_dict() for m in messages],
+                **params.to_dict(),
+                **(input_params or {}),
+            }
 
             # call load_context() first, as predict may depend on it
             _logger.info("Predicting on input example to validate output")

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -119,6 +119,9 @@ class ChatParams(_BaseDataclass):
         presence_penalty: (float): An optional param of positive or negative value,
             positive values penalize new tokens based on whether they appear in the text so far,
             increasing the model's likelihood to talk about new topics.
+        metadata (Dict[str, str]): An optional param to provide arbitrary additional context
+            to the model. Both the keys and the values must be strings (i.e. nested dictionaries
+            are not supported).
     """
 
     temperature: float = 1.0
@@ -336,11 +339,14 @@ class ChatResponse(_BaseDataclass):
         choices (List[:py:class:`ChatChoice`]): A list of :py:class:`ChatChoice` objects
             containing the generated responses
         usage (:py:class:`TokenUsageStats`): An object describing the tokens used by the request.
+            **Optional**, defaults to ``None``.
         id (str): The ID of the response. **Optional**, defaults to ``None``
         model (str): The name of the model used. **Optional**, defaults to ``None``
         object (str): The object type. The value should always be 'chat.completion'
         created (int): The time the response was created.
             **Optional**, defaults to the current time.
+        metadata (Dict[str, str]): An param that can contain arbitrary additional context.
+            **Optional**, defaults to ``None``
     """
 
     choices: List[ChatChoice]
@@ -441,10 +447,6 @@ CHAT_MODEL_INPUT_EXAMPLE = {
     "stop": ["\n"],
     "n": 1,
     "stream": False,
-    "metadata": {
-        "info": "The metadata field can be used to store arbitrary string data",
-        "foo": "bar",
-    },
 }
 
 COMPLETIONS_MODEL_INPUT_SCHEMA = Schema(

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import asdict, dataclass, field
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Optional
 
 from mlflow.types.schema import Array, ColSpec, DataType, Map, Object, Property, Schema
 

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import asdict, dataclass, field
-from typing import List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from mlflow.types.schema import Array, ColSpec, DataType, Map, Object, Property, Schema
 
@@ -132,7 +132,7 @@ class ChatParams(_BaseDataclass):
     frequency_penalty: Optional[float] = None
     presence_penalty: Optional[float] = None
 
-    metadata: Optional[dict[str, str]] = None
+    metadata: Optional[Dict[str, str]] = None
 
     def __post_init__(self):
         self._validate_field("temperature", float, True)
@@ -156,12 +156,12 @@ class ChatParams(_BaseDataclass):
             for key, value in self.metadata.items():
                 if not isinstance(key, str):
                     raise ValueError(
-                        "Expected `metadata` to be of type `dict[str, str]`, "
+                        "Expected `metadata` to be of type `Dict[str, str]`, "
                         f"received key of type `{type(key).__name__}` (key: {key})"
                     )
                 if not isinstance(value, str):
                     raise ValueError(
-                        "Expected `metadata` to be of type `dict[str, str]`, "
+                        "Expected `metadata` to be of type `Dict[str, str]`, "
                         f"received value of type `{type(value).__name__}` in `metadata['{key}']`)"
                     )
 
@@ -349,7 +349,7 @@ class ChatResponse(_BaseDataclass):
     model: Optional[str] = None
     object: Literal["chat.completion"] = "chat.completion"
     created: int = field(default_factory=lambda: int(time.time()))
-    metadata: Optional[dict[str, str]] = None
+    metadata: Optional[Dict[str, str]] = None
 
     def __post_init__(self):
         self._validate_field("id", str, False)

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -342,7 +342,7 @@ class ChatResponse(_BaseDataclass):
             **Optional**, defaults to ``None``.
         id (str): The ID of the response. **Optional**, defaults to ``None``
         model (str): The name of the model used. **Optional**, defaults to ``None``
-        object (str): The object type. The value should always be 'chat.completion'
+        object (str): The object type. Defaults to 'chat.completion'
         created (int): The time the response was created.
             **Optional**, defaults to the current time.
         metadata (Dict[str, str]): An param that can contain arbitrary additional context.
@@ -353,7 +353,7 @@ class ChatResponse(_BaseDataclass):
     usage: Optional[TokenUsageStats] = None
     id: Optional[str] = None
     model: Optional[str] = None
-    object: Literal["chat.completion"] = "chat.completion"
+    object: str = "chat.completion"
     created: int = field(default_factory=lambda: int(time.time()))
     metadata: Optional[Dict[str, str]] = None
 

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -444,7 +444,7 @@ CHAT_MODEL_INPUT_EXAMPLE = {
     "metadata": {
         "info": "The metadata field can be used to store arbitrary string data",
         "foo": "bar",
-    }
+    },
 }
 
 COMPLETIONS_MODEL_INPUT_SCHEMA = Schema(

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -345,7 +345,7 @@ class ChatResponse(_BaseDataclass):
         object (str): The object type. Defaults to 'chat.completion'
         created (int): The time the response was created.
             **Optional**, defaults to the current time.
-        metadata (Dict[str, str]): An param that can contain arbitrary additional context.
+        metadata (Dict[str, str]): An field that can contain arbitrary additional context.
             **Optional**, defaults to ``None``
     """
 

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -302,8 +302,11 @@ def test_chat_model_works_with_infer_signature_input_example(tmp_path):
     assert model_info.signature.outputs == CHAT_MODEL_OUTPUT_SCHEMA
     mlflow_model = Model.load(model_info.model_uri)
     local_path = _download_artifact_from_uri(model_info.model_uri)
-    assert mlflow_model.load_input_example(local_path)["messages"] == input_example["messages"]
-    assert mlflow_model.load_input_example_params(local_path) == {**DEFAULT_PARAMS, **params_subset}
+    assert mlflow_model.load_input_example(local_path) == {
+        "messages": input_example["messages"],
+        **DEFAULT_PARAMS,
+        **params_subset,
+    }
 
     inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
@@ -336,7 +339,8 @@ def test_chat_model_works_with_chat_message_input_example(tmp_path):
     mlflow_model = Model.load(model_info.model_uri)
     local_path = _download_artifact_from_uri(model_info.model_uri)
     assert mlflow_model.load_input_example(local_path) == {
-        "messages": [message.to_dict() for message in input_example]
+        "messages": [message.to_dict() for message in input_example],
+        **DEFAULT_PARAMS,
     }
 
     inference_payload = load_serving_example(model_info.model_uri)
@@ -378,11 +382,11 @@ def test_chat_model_works_with_infer_signature_multi_input_example(tmp_path):
     assert model_info.signature.outputs == CHAT_MODEL_OUTPUT_SCHEMA
     mlflow_model = Model.load(model_info.model_uri)
     local_path = _download_artifact_from_uri(model_info.model_uri)
-    assert mlflow_model.load_input_example_params(local_path) == {
+    assert mlflow_model.load_input_example(local_path) == {
+        "messages": input_example["messages"],
         **DEFAULT_PARAMS,
         **params_subset,
     }
-    assert mlflow_model.load_input_example(local_path)["messages"] == input_example["messages"]
 
     inference_payload = load_serving_example(model_info.model_uri)
     response = pyfunc_serve_and_score_model(
@@ -425,7 +429,7 @@ def test_chat_model_can_receive_and_return_metadata():
     }
     input_example = {
         "messages": messages,
-        "metadata": params["metadata"],
+        **params,
     }
 
     model = ChatModelWithMetadata()

--- a/tests/pyfunc/test_chat_model_validation.py
+++ b/tests/pyfunc/test_chat_model_validation.py
@@ -218,3 +218,16 @@ def test_chat_response_defaults():
     assert response.model is None
     assert response.id is None
     assert response.choices[0].finish_reason == "stop"
+
+@pytest.mark.parametrize(
+    ("metadata", "match"),
+    [
+        (1, r"Expected `metadata` to be a dictionary, received `int`"),
+        ({"nested": { "dict": "input" }}, r"received value of type `dict` in `metadata\['nested'\]`"),
+        ({1: "example"}, r"received key of type `int` \(key: 1\)"),
+    ],
+)
+def test_chat_request_metadata_must_be_string_map(metadata, match):
+    message = ChatMessage("user", "Hello")
+    with pytest.raises(ValueError, match=match):
+        ChatRequest(messages=[message], metadata=metadata)

--- a/tests/pyfunc/test_chat_model_validation.py
+++ b/tests/pyfunc/test_chat_model_validation.py
@@ -219,11 +219,12 @@ def test_chat_response_defaults():
     assert response.id is None
     assert response.choices[0].finish_reason == "stop"
 
+
 @pytest.mark.parametrize(
     ("metadata", "match"),
     [
         (1, r"Expected `metadata` to be a dictionary, received `int`"),
-        ({"nested": { "dict": "input" }}, r"received value of type `dict` in `metadata\['nested'\]`"),
+        ({"nested": {"dict": "input"}}, r"received value of type `dict` in `metadata\['nested'\]`"),
         ({1: "example"}, r"received key of type `int` \(key: 1\)"),
     ],
 )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/13143?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13143/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13143
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR makes a few improvements to the ChatModel class to make things more flexible for our users:

1. Add a `metadata` field for both inputs and outputs that can contain arbitrary string data. Inputs are enforced to be `Dict[str, str]`, but outputs are not enforced so users can have more flexibility
2. Make token usage field in ChatResponse optional
3. Allow users to change `chat.completion` to something else

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested manually, running this script:
```python
from typing import List

import mlflow
from mlflow.types.llm import ChatMessage, ChatParams, ChatResponse

mlflow.set_tracking_uri("http://localhost:5000")

mock_response = {
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "",
            },
            "finish_reason": "stop",
        },
    ],
    "metadata": {
      "test": "arbitrary metadata",
      "secret undocumented feature": {
        "actually nested dicts are supported": 1234,
        "and types can be whatever": [1, "test", {2: 3}]
      }
    }
}

class TestChatModel(mlflow.pyfunc.ChatModel):
    def predict(self, context, messages: List[ChatMessage], params: ChatParams) -> ChatResponse:
        print("Param Metadata:")
        print("  metadata['image_url']", params.metadata['image_url'])
        print("  metadata['detail']", params.metadata['detail'])
        return ChatResponse(**mock_response)

model = TestChatModel()
test_metadata = {
    "image_url": "example",
    "detail": "high",
}
with mlflow.start_run():
    model_info = mlflow.pyfunc.log_model(
        artifact_path="chat-model-metadata",
        python_model=model,
        input_example={
            "messages": [{"role": "user", "content": "Hello!"}],
            "metadata": test_metadata,
        }
    )

print("Model URI: ", model_info.model_uri)

model = mlflow.pyfunc.load_model(model_info.model_uri)
result = model.predict({
    "messages": [{"content": "hello", "role": "user"}],
    "metadata": test_metadata
})

print("Result: ", result)
```

Also tested the same model from the script in serving, it's able to receive and return metadata:
```
$ curl -X POST http://localhost:8000/invocations \
-H "Content-Type: application/json" \
-d '{
  "messages": [{"content": "hello", "role": "user"}],
  "metadata": {"image_url": "example", "detail": "high"}
}' | jq

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   441  100   327  100   114  84758  29548 --:--:-- --:--:-- --:--:--  143k
{
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": ""
      },
      "finish_reason": "stop"
    }
  ],
  "object": "chat.completion",
  "created": 1726219726,
  "metadata": {
    "test": "arbitrary metadata",
    "secret undocumented feature": {
      "actually nested dicts are supported": 1234,
      "and types can be whatever": [
        1,
        "test",
        {
          "2": 3
        }
      ]
    }
  }
}
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

ChatModel now supports a `metadata` field for inputs and outputs. This field is of type `dict[str, str]`, and can be used to pass arbitrary metadata.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)