### PR TITLE
Make Evaluation metrics callable

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -617,7 +617,7 @@ def make_genai_metric(
         metric_details=evaluation_context["eval_prompt"].__str__(),
         metric_metadata=metric_metadata,
         genai_metric_args=genai_metric_args,
-        standard_signature=True,
+        require_strict_signature=True,
     )
 
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -250,6 +250,8 @@ def make_genai_metric_from_prompt(
         )
 
     """
+    import numpy as np
+
     prompt_template = PromptTemplate([judge_prompt, _PROMPT_FORMATTING_WRAPPER])
     allowed_variables = prompt_template.variables
 
@@ -284,6 +286,7 @@ def make_genai_metric_from_prompt(
                 message=f"Missing variable inputs to eval_fn: {missing_variables}",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        kwargs = {k: [v] if np.isscalar(v) else v for k, v in kwargs.items()}
         grading_payloads = pd.DataFrame(kwargs).to_dict(orient="records")
         arg_strings = [prompt_template.format(**payload) for payload in grading_payloads]
         scores, justifications = _score_model_on_payloads(
@@ -307,8 +310,6 @@ def make_genai_metric_from_prompt(
         name=name,
         metric_metadata=metric_metadata,
         genai_metric_args=genai_metric_args,
-        return_genai_metric=True,
-        with_llm_judge=True,
     )
 
 
@@ -616,7 +617,7 @@ def make_genai_metric(
         metric_details=evaluation_context["eval_prompt"].__str__(),
         metric_metadata=metric_metadata,
         genai_metric_args=genai_metric_args,
-        return_genai_metric=True,
+        strict_signature=True,
     )
 
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -17,6 +17,7 @@ from mlflow.metrics.genai.base import EvaluationExample
 from mlflow.metrics.genai.prompt_template import PromptTemplate
 from mlflow.metrics.genai.utils import _get_default_model, _get_latest_metric_version
 from mlflow.models import EvaluationMetric, make_metric
+from mlflow.models.evaluation.base import _make_metric
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     INTERNAL_ERROR,
@@ -609,7 +610,7 @@ def make_genai_metric(
     # extra params in grading_context_columns can only be passed as positional args
     eval_fn.__signature__ = Signature(signature_parameters)
 
-    return make_metric(
+    return _make_metric(
         eval_fn=eval_fn,
         greater_is_better=greater_is_better,
         name=name,

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -617,7 +617,7 @@ def make_genai_metric(
         metric_details=evaluation_context["eval_prompt"].__str__(),
         metric_metadata=metric_metadata,
         genai_metric_args=genai_metric_args,
-        strict_signature=True,
+        standard_signature=True,
     )
 
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -156,7 +156,24 @@ class EvaluationMetric:
         return "EvaluationMetric(" + ", ".join(parts) + ")"
 
 
+# NB: we need this function because we cannot modify the signature of
+# a class's __call__ method after the class has been defined.
+# This is also useful to distinguish between the signatures with/without llm_judge.
 def dynamically_generate_genai_eval_metric(eval_fn, with_llm_judge=False):
+    """
+    Dynamically generate a GenAIEvaluationMetric class that can be used to evaluate the metric
+    on the given input data. The generated class is callable with a __call__ method that
+    takes the arguments specified in the signature of the eval_fn function.
+
+    Args:
+        eval_fn: the evaluation function of the EvaluationMetric.
+        with_llm_judge: whether the metric is used with the LLM judge. Default to False.
+            This should only be used internally by MLflow. When generating a metric from
+            `make_genai_metric_from_prompt`, this should be set to True.
+
+    Returns:
+        A dynamically generated callable GenAIEvaluation class.
+    """
     from mlflow.metrics.base import MetricValue
 
     if with_llm_judge:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -167,16 +167,19 @@ def dynamically_generate_eval_metric(eval_fn, strict_signature=False):
 
     Args:
         eval_fn: the evaluation function of the EvaluationMetric.
-        strict_signature: Whether the metric follows a strict signature, if True then
+        strict_signature: (Optional) Whether the metric follows a strict signature, if True then
             the eval_fn must follow below signature:
-                ```
-                def eval_fn(
-                    predictions: "pd.Series",
-                    metrics: Dict[str, MetricValue],
-                    inputs: "pd.Series",
-                    *args,
-                ) -> MetricValue:
-                ```
+
+                .. code-block:: python
+
+                    def eval_fn(
+                        predictions: "pd.Series",
+                        metrics: Dict[str, MetricValue],
+                        inputs: "pd.Series",
+                        *args,
+                    ) -> MetricValue:
+                        pass
+
             When generating a metric from `make_genai_metric`, this should be set to True.
             Default to False.
 
@@ -405,14 +408,17 @@ def make_metric(
             are persisted so that we can deserialize the same metric object later.
         strict_signature: (Optional) Whether the metric follows a strict signature, if True then
             the eval_fn must follow below signature:
-                ```
-                def eval_fn(
-                    predictions: "pd.Series",
-                    metrics: Dict[str, MetricValue],
-                    inputs: "pd.Series",
-                    *args,
-                ) -> MetricValue:
-                ```
+
+                .. code-block:: python
+
+                    def eval_fn(
+                        predictions: "pd.Series",
+                        metrics: Dict[str, MetricValue],
+                        inputs: "pd.Series",
+                        *args,
+                    ) -> MetricValue:
+                        pass
+
             When generating a metric from `make_genai_metric`, this should be set to True.
             Default to False.
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -384,21 +384,6 @@ def make_metric(
         genai_metric_args: (Optional) A dictionary containing arguments specified by users
             when calling make_genai_metric or make_genai_metric_from_prompt. Those args
             are persisted so that we can deserialize the same metric object later.
-        require_strict_signature: (Optional) Whether the eval_fn needs to follow a strict signature.
-            If True, then the eval_fn must follow below signature:
-
-                .. code-block:: python
-
-                    def eval_fn(
-                        predictions: "pd.Series",
-                        metrics: Dict[str, MetricValue],
-                        inputs: "pd.Series",
-                        *args,
-                    ) -> MetricValue:
-                        pass
-
-            When generating a metric from `make_genai_metric`, this should be set to True.
-            Default to False.
 
     .. seealso::
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -322,7 +322,7 @@ def _convert_val_to_pd_Series(val, name):
     return val
 
 
-def make_metric(
+def make_metric(  # noqa: D417
     *,
     eval_fn,
     greater_is_better,

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -159,7 +159,7 @@ class EvaluationMetric:
 # NB: we need this function because we cannot modify the signature of
 # a class's __call__ method after the class has been defined.
 # This is also useful to distinguish between the metric signatures with different eval_fn signatures
-def dynamically_generate_eval_metric(eval_fn, standard_signature=False):
+def _dynamically_generate_eval_metric(eval_fn, require_strict_signature=False):
     """
     Dynamically generate a GenAIEvaluationMetric class that can be used to evaluate the metric
     on the given input data. The generated class is callable with a __call__ method that
@@ -167,8 +167,8 @@ def dynamically_generate_eval_metric(eval_fn, standard_signature=False):
 
     Args:
         eval_fn: the evaluation function of the EvaluationMetric.
-        standard_signature: (Optional) Whether the metric follows a strict signature, if True then
-            the eval_fn must follow below signature:
+        require_strict_signature: (Optional) Whether the eval_fn needs to follow a strict signature.
+            If True, then the eval_fn must follow below signature:
 
                 .. code-block:: python
 
@@ -188,7 +188,7 @@ def dynamically_generate_eval_metric(eval_fn, standard_signature=False):
     """
     from mlflow.metrics.base import MetricValue
 
-    if standard_signature:
+    if require_strict_signature:
         allowed_kwargs_names = [
             param_name
             for param_name in inspect.signature(eval_fn).parameters.keys()
@@ -330,7 +330,7 @@ def make_metric(
     metric_details=None,
     metric_metadata=None,
     genai_metric_args=None,
-    standard_signature=False,
+    require_strict_signature=False,
 ):
     '''
     A factory function to create an :py:class:`EvaluationMetric` object.
@@ -382,8 +382,8 @@ def make_metric(
         genai_metric_args: (Optional) A dictionary containing arguments specified by users
             when calling make_genai_metric or make_genai_metric_from_prompt. Those args
             are persisted so that we can deserialize the same metric object later.
-        standard_signature: (Optional) Whether the metric follows a strict signature, if True then
-            the eval_fn must follow below signature:
+        require_strict_signature: (Optional) Whether the eval_fn needs to follow a strict signature.
+            If True, then the eval_fn must follow below signature:
 
                 .. code-block:: python
 
@@ -453,9 +453,9 @@ def make_metric(
         "metric_metadata": metric_metadata,
         "genai_metric_args": genai_metric_args,
     }
-    return dynamically_generate_eval_metric(eval_fn, standard_signature=standard_signature)(
-        **init_args
-    )
+    return _dynamically_generate_eval_metric(
+        eval_fn, require_strict_signature=require_strict_signature
+    )(**init_args)
 
 
 @developer_stable

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -25,7 +25,6 @@ from mlflow.data.evaluation_dataset import (
 from mlflow.entities.dataset_input import DatasetInput
 from mlflow.entities.input_tag import InputTag
 from mlflow.exceptions import MlflowException
-from mlflow.metrics.base import MetricValue
 from mlflow.models.evaluation.validation import (
     MetricThreshold,
     ModelValidationFailedException,
@@ -158,6 +157,8 @@ class EvaluationMetric:
 
 
 def dynamically_generate_genai_eval_metric(eval_fn, with_llm_judge=False):
+    from mlflow.metrics.base import MetricValue
+
     if with_llm_judge:
 
         def gen_ai_with_llm_judge_call_method(

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -194,7 +194,10 @@ def dynamically_generate_genai_eval_metric(eval_fn, with_llm_judge=False):
                     annotation=bool,
                     default=False,
                 ),
-                *[Parameter(name, Parameter.KEYWORD_ONLY) for name in allowed_kwargs_params.keys()],
+                *[
+                    Parameter(name, Parameter.KEYWORD_ONLY, annotation=Union[pd.Series, list])
+                    for name in allowed_kwargs_params.keys()
+                ],
             ]
         )
         call_method = gen_ai_with_llm_judge_call_method
@@ -281,7 +284,10 @@ def dynamically_generate_genai_eval_metric(eval_fn, with_llm_judge=False):
                     annotation=bool,
                     default=False,
                 ),
-                *[Parameter(name, Parameter.KEYWORD_ONLY) for name in allowed_kwargs_names],
+                *[
+                    Parameter(name, Parameter.KEYWORD_ONLY, annotation=Union[pd.Series, str, list])
+                    for name in allowed_kwargs_names
+                ],
             ]
         )
         call_method = genai_call_method

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2141,14 +2141,16 @@ def test_make_metric_name_inference():
     def metric(_df, _metrics):
         return 1
 
-    metric = make_metric(eval_fn=metric, greater_is_better=True)
-    assert metric.name == "metric"
+    eval_metric = make_metric(eval_fn=metric, greater_is_better=True)
+    assert eval_metric.name == "metric"
 
-    metric = make_metric(eval_fn=metric, greater_is_better=True, name="my_metric")
-    assert metric.name == "my_metric"
+    eval_metric = make_metric(eval_fn=metric, greater_is_better=True, name="my_metric")
+    assert eval_metric.name == "my_metric"
 
-    metric = make_metric(eval_fn=lambda _df, _metrics: 0, greater_is_better=True, name="metric")
-    assert metric.name == "metric"
+    eval_metric = make_metric(
+        eval_fn=lambda _df, _metrics: 0, greater_is_better=True, name="metric"
+    )
+    assert eval_metric.name == "metric"
 
     with pytest.raises(
         MlflowException, match="`name` must be specified if `eval_fn` is a lambda function."

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -1279,11 +1279,8 @@ def test_genai_metrics_with_llm_judge_callable():
         metric_metadata={"metadata_field": "metadata_value"},
     )
 
-    inputs = ["What is MLflow?", "What is Spark?"]
-    outputs = [
-        "MLflow is an open-source platform",
-        "Apache Spark is an open-source distributed framework",
-    ]
+    inputs = "What is MLflow?"
+    outputs = "MLflow is an open-source platform"
 
     with mock.patch.object(
         model_utils,
@@ -1291,27 +1288,27 @@ def test_genai_metrics_with_llm_judge_callable():
         return_value=properly_formatted_openai_response1,
     ):
         expected_result = custom_judge_prompt_metric.eval_fn(
-            input=pd.Series(inputs), output=pd.Series(outputs)
+            input=pd.Series([inputs]), output=pd.Series([outputs])
         )
         metric_value = custom_judge_prompt_metric(
-            input=pd.Series(inputs),
-            output=pd.Series(outputs),
+            input=inputs,
+            output=outputs,
         )
         scores = custom_judge_prompt_metric(
-            input=pd.Series(inputs),
-            output=pd.Series(outputs),
+            input=[inputs],
+            output=[outputs],
             return_only_scores=True,
         )
 
     assert metric_value == expected_result
-    assert metric_value.scores == [3, 3]
-    assert metric_value.justifications == [openai_justification1, openai_justification1]
+    assert metric_value.scores == [3]
+    assert metric_value.justifications == [openai_justification1]
     assert metric_value.aggregate_results == {
         "mean": 3,
         "variance": 0,
         "p90": 3,
     }
-    assert scores == [3, 3]
+    assert scores == [3]
     assert set(inspect.signature(custom_judge_prompt_metric).parameters.keys()) == {
         "input",
         "output",

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -1266,7 +1266,9 @@ def test_genai_metrics_callable_errors(custom_metric):
     with pytest.raises(MlflowException, match=r"Unexpected arguments: {'data'}"):
         custom_metric(**data, targets=mlflow_ground_truth, data="data")
 
-    with pytest.raises(TypeError, match=r"Expected predictions to be a string or list"):
+    with pytest.raises(
+        TypeError, match=r"Expected predictions to be a string, list, or Pandas Series"
+    ):
         custom_metric(predictions=1, inputs="What is MLflow?", targets=mlflow_ground_truth)
 
 

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -1229,10 +1229,6 @@ def test_genai_metrics_callable(custom_metric):
             pd.Series([mlflow_ground_truth]),
         )
         metric_value = custom_metric(**data)
-        scores = custom_metric(
-            **data,
-            return_only_scores=True,
-        )
 
     assert metric_value == expected_result
     assert metric_value.scores == [3]
@@ -1242,12 +1238,10 @@ def test_genai_metrics_callable(custom_metric):
         "variance": 0,
         "p90": 3,
     }
-    assert scores == [3]
     assert set(inspect.signature(custom_metric).parameters.keys()) == {
         "predictions",
         "inputs",
         "metrics",
-        "return_only_scores",
         "targets",
     }
 
@@ -1296,11 +1290,6 @@ def test_genai_metrics_with_llm_judge_callable():
             input=inputs,
             output=outputs,
         )
-        scores = custom_judge_prompt_metric(
-            input=[inputs],
-            output=[outputs],
-            return_only_scores=True,
-        )
 
     assert metric_value == expected_result
     assert metric_value.scores == [3]
@@ -1310,9 +1299,7 @@ def test_genai_metrics_with_llm_judge_callable():
         "variance": 0,
         "p90": 3,
     }
-    assert scores == [3]
     assert set(inspect.signature(custom_judge_prompt_metric).parameters.keys()) == {
         "input",
         "output",
-        "return_only_scores",
     }

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -141,8 +141,9 @@ example_definition = (
 )
 
 
-def test_make_genai_metric_correct_response():
-    custom_metric = make_genai_metric(
+@pytest.fixture
+def custom_metric():
+    return make_genai_metric(
         name="correctness",
         version="v1",
         definition=example_definition,
@@ -155,6 +156,8 @@ def test_make_genai_metric_correct_response():
         aggregations=["mean", "variance", "p90"],
     )
 
+
+def test_make_genai_metric_correct_response(custom_metric):
     assert [
         param.name for param in inspect.signature(custom_metric.eval_fn).parameters.values()
     ] == ["predictions", "metrics", "inputs", "targets"]
@@ -1165,20 +1168,7 @@ def test_log_make_genai_metric_from_prompt_fn_args():
     assert custom_metric.genai_metric_args == expected_genai_metric_args
 
 
-def test_log_make_genai_metric_fn_args():
-    custom_metric = make_genai_metric(
-        name="correctness",
-        version="v1",
-        definition=example_definition,
-        grading_prompt=example_grading_prompt,
-        examples=[mlflow_example],
-        model="gateway:/gpt-4o-mini",
-        grading_context_columns=["targets"],
-        parameters={"temperature": 0.0},
-        greater_is_better=True,
-        aggregations=["mean", "variance", "p90"],
-    )
-
+def test_log_make_genai_metric_fn_args(custom_metric):
     expected_keys = set(inspect.signature(make_genai_metric).parameters.keys())
     expected_keys.update(["mlflow_version", "fn_name"])
     # When updating the function signature of make_genai_metric, please update
@@ -1219,3 +1209,111 @@ def test_log_make_genai_metric_fn_args():
 def test_metric_metadata_on_prebuilt_genai_metrics(metric_fn):
     metric = metric_fn(metric_metadata={"metadata_field": "metadata_value"})
     assert metric.metric_metadata == {"metadata_field": "metadata_value"}
+
+
+def test_genai_metrics_callable(custom_metric):
+    data = {
+        "predictions": mlflow_prediction,
+        "inputs": "What is MLflow?",
+        "targets": mlflow_ground_truth,
+    }
+    with mock.patch.object(
+        model_utils,
+        "score_model_on_payload",
+        return_value=properly_formatted_openai_response1,
+    ):
+        expected_result = custom_metric.eval_fn(
+            pd.Series([mlflow_prediction]),
+            {},
+            pd.Series(["What is MLflow?"]),
+            pd.Series([mlflow_ground_truth]),
+        )
+        metric_value = custom_metric(**data)
+        scores = custom_metric(
+            **data,
+            return_only_scores=True,
+        )
+
+    assert metric_value == expected_result
+    assert metric_value.scores == [3]
+    assert metric_value.justifications == [openai_justification1]
+    assert metric_value.aggregate_results == {
+        "mean": 3,
+        "variance": 0,
+        "p90": 3,
+    }
+    assert scores == [3]
+    assert set(inspect.signature(custom_metric).parameters.keys()) == {
+        "predictions",
+        "inputs",
+        "metrics",
+        "return_only_scores",
+        "targets",
+    }
+
+
+def test_genai_metrics_callable_errors(custom_metric):
+    with pytest.raises(TypeError, match=r"missing 1 required keyword-only argument: 'inputs'"):
+        custom_metric(predictions=mlflow_prediction)
+
+    data = {
+        "predictions": mlflow_prediction,
+        "inputs": "What is MLflow?",
+    }
+    with pytest.raises(MlflowException, match=r"Missing required arguments: {'targets'}"):
+        custom_metric(**data)
+
+    with pytest.raises(MlflowException, match=r"Unexpected arguments: {'data'}"):
+        custom_metric(**data, targets=mlflow_ground_truth, data="data")
+
+    with pytest.raises(TypeError, match=r"Expected predictions to be a string or list"):
+        custom_metric(predictions=1, inputs="What is MLflow?", targets=mlflow_ground_truth)
+
+
+def test_genai_metrics_with_llm_judge_callable():
+    custom_judge_prompt = "This is a custom judge prompt that uses {input} and {output}"
+
+    custom_judge_prompt_metric = make_genai_metric_from_prompt(
+        name="custom",
+        judge_prompt=custom_judge_prompt,
+        metric_metadata={"metadata_field": "metadata_value"},
+    )
+
+    inputs = ["What is MLflow?", "What is Spark?"]
+    outputs = [
+        "MLflow is an open-source platform",
+        "Apache Spark is an open-source distributed framework",
+    ]
+
+    with mock.patch.object(
+        model_utils,
+        "score_model_on_payload",
+        return_value=properly_formatted_openai_response1,
+    ):
+        expected_result = custom_judge_prompt_metric.eval_fn(
+            input=pd.Series(inputs), output=pd.Series(outputs)
+        )
+        metric_value = custom_judge_prompt_metric(
+            input=pd.Series(inputs),
+            output=pd.Series(outputs),
+        )
+        scores = custom_judge_prompt_metric(
+            input=pd.Series(inputs),
+            output=pd.Series(outputs),
+            return_only_scores=True,
+        )
+
+    assert metric_value == expected_result
+    assert metric_value.scores == [3, 3]
+    assert metric_value.justifications == [openai_justification1, openai_justification1]
+    assert metric_value.aggregate_results == {
+        "mean": 3,
+        "variance": 0,
+        "p90": 3,
+    }
+    assert scores == [3, 3]
+    assert set(inspect.signature(custom_judge_prompt_metric).parameters.keys()) == {
+        "input",
+        "output",
+        "return_only_scores",
+    }

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -1,3 +1,6 @@
+import inspect
+import io
+import sys
 from unittest import mock
 
 import pandas as pd
@@ -358,3 +361,15 @@ def test_ndcg_at_k():
     targets = pd.Series([["a", "b"]])
     result = ndcg_at_k(k=3).eval_fn(predictions, targets)
     assert result.scores[0] == 0.0
+
+
+def test_builtin_metric_call_signature():
+    metric = ndcg_at_k(3)
+    assert set(inspect.signature(metric).parameters.keys()) == {"predictions", "targets"}
+
+    captured_output = io.StringIO()
+    sys.stdout = captured_output
+    help(metric)
+    sys.stdout = sys.__stdout__
+
+    assert "__call__ = _call_method(self, *, predictions, targets)" in captured_output.getvalue()

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -69,6 +69,7 @@ def test_toxicity():
     assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
     assert result.scores[0] < result.aggregate_results["p90"] < result.scores[1]
     assert "variance" in result.aggregate_results
+    assert toxicity()(predictions=predictions) == result
 
 
 def test_flesch_kincaid_grade_level():
@@ -86,6 +87,7 @@ def test_flesch_kincaid_grade_level():
     assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
     assert result.scores[0] < result.aggregate_results["p90"] < result.scores[1]
     assert "variance" in result.aggregate_results
+    assert flesch_kincaid_grade_level()(predictions=predictions) == result
 
 
 def test_ari_grade_level():
@@ -103,6 +105,7 @@ def test_ari_grade_level():
     assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
     assert result.scores[0] < result.aggregate_results["p90"] < result.scores[1]
     assert "variance" in result.aggregate_results
+    assert ari_grade_level()(predictions=predictions) == result
 
 
 def test_exact_match():
@@ -111,6 +114,7 @@ def test_exact_match():
 
     result = exact_match().eval_fn(predictions, targets, {})
     assert result.aggregate_results["exact_match"] == 1.0
+    assert exact_match()(predictions=predictions, targets=targets) == result
 
     predictions = pd.Series(["not sentence", "random text", "b", "c"])
     targets = pd.Series(["sentence not", "random text", "a", "c"])
@@ -127,6 +131,7 @@ def test_rouge1():
     assert result.aggregate_results["mean"] == 0.25
     assert result.aggregate_results["p90"] == 0.45
     assert result.aggregate_results["variance"] == 0.0625
+    assert rouge1()(predictions=predictions, targets=targets) == result
 
 
 def test_rouge2():
@@ -138,6 +143,7 @@ def test_rouge2():
     assert result.aggregate_results["mean"] == 0.75
     assert result.aggregate_results["p90"] == 0.95
     assert result.aggregate_results["variance"] == 0.0625
+    assert rouge2()(predictions=predictions, targets=targets) == result
 
 
 def test_rougeL():
@@ -149,6 +155,7 @@ def test_rougeL():
     assert result.aggregate_results["mean"] == 0.5
     assert result.aggregate_results["p90"] == 0.9
     assert result.aggregate_results["variance"] == 0.25
+    assert rougeL(predictions=predictions, targets=targets) == result
 
 
 def test_rougeLsum():
@@ -160,6 +167,7 @@ def test_rougeLsum():
     assert result.aggregate_results["mean"] == 0.5
     assert result.aggregate_results["p90"] == 0.9
     assert result.aggregate_results["variance"] == 0.25
+    assert rougeLsum()(predictions=predictions, targets=targets) == result
 
 
 def test_fails_to_load_metric():
@@ -185,6 +193,7 @@ def test_mae():
     targets = pd.Series([1.0, 2.0, 3.0])
     result = mae().eval_fn(predictions, targets, {})
     assert result.aggregate_results["mean_absolute_error"] == 1.0
+    assert mae()(predictions=predictions, targets=targets) == result
 
 
 def test_mse():
@@ -192,6 +201,7 @@ def test_mse():
     targets = pd.Series([1.0, 2.0, 3.0])
     result = mse().eval_fn(predictions, targets, {})
     assert result.aggregate_results["mean_squared_error"] == 3.0
+    assert mse()(predictions=predictions, targets=targets) == result
 
 
 def test_rmse():
@@ -199,6 +209,7 @@ def test_rmse():
     targets = pd.Series([1.0, 2.0, 3.0])
     result = rmse().eval_fn(predictions, targets, {})
     assert result.aggregate_results["root_mean_squared_error"] == 3.0
+    assert rmse()(predictions=predictions, targets=targets) == result
 
 
 def test_r2_score():
@@ -206,6 +217,7 @@ def test_r2_score():
     targets = pd.Series([3.0, 2.0, 1.0])
     result = r2_score().eval_fn(predictions, targets, {})
     assert result.aggregate_results["r2_score"] == -3.0
+    assert r2_score()(predictions=predictions, targets=targets) == result
 
 
 def test_max_error():
@@ -213,6 +225,7 @@ def test_max_error():
     targets = pd.Series([3.0, 2.0, 1.0])
     result = max_error().eval_fn(predictions, targets, {})
     assert result.aggregate_results["max_error"] == 2.0
+    assert max_error()(predictions=predictions, targets=targets) == result
 
 
 def test_mape_error():
@@ -220,6 +233,7 @@ def test_mape_error():
     targets = pd.Series([2.0, 2.0, 2.0])
     result = mape().eval_fn(predictions, targets, {})
     assert result.aggregate_results["mean_absolute_percentage_error"] == 0.5
+    assert mape()(predictions=predictions, targets=targets) == result
 
 
 def test_binary_recall_score():
@@ -227,6 +241,7 @@ def test_binary_recall_score():
     targets = pd.Series([1, 1, 1, 1, 0, 0, 0, 0])
     result = recall_score().eval_fn(predictions, targets, {})
     assert abs(result.aggregate_results["recall_score"] - 0.5) < 1e-3
+    assert recall_score()(predictions=predictions, targets=targets) == result
 
 
 def test_binary_precision():
@@ -234,6 +249,7 @@ def test_binary_precision():
     targets = pd.Series([1, 1, 1, 1, 0, 0, 0, 0])
     result = precision_score().eval_fn(predictions, targets, {})
     assert abs(result.aggregate_results["precision_score"] == 0.666) < 1e-3
+    assert precision_score()(predictions=predictions, targets=targets) == result
 
 
 def test_binary_f1_score():
@@ -241,6 +257,7 @@ def test_binary_f1_score():
     targets = pd.Series([1, 1, 1, 1, 0, 0, 0, 0])
     result = f1_score().eval_fn(predictions, targets, {})
     assert abs(result.aggregate_results["f1_score"] - 0.5713) < 1e-3
+    assert f1_score()(predictions=predictions, targets=targets) == result
 
 
 def test_precision_at_k():
@@ -254,6 +271,7 @@ def test_precision_at_k():
         "p90": 1.0,
         "variance": 0.171875,
     }
+    assert precision_at_k(4)(predictions=predictions, targets=targets) == result
 
 
 def test_recall_at_k():
@@ -267,6 +285,7 @@ def test_recall_at_k():
         "p90": 0.8,
         "variance": 0.1,
     }
+    assert recall_at_k(4)(predictions=predictions, targets=targets) == result
 
 
 def test_ndcg_at_k():
@@ -283,6 +302,7 @@ def test_ndcg_at_k():
     predictions = data["prediction"]
     targets = data["target"]
     result = ndcg_at_k(3).eval_fn(predictions, targets)
+    assert ndcg_at_k(3)(predictions=predictions, targets=targets) == result
 
     assert result.scores == data["ndcg"].to_list()
     assert pytest.approx(result.aggregate_results["mean"]) == 0.4

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -155,7 +155,7 @@ def test_rougeL():
     assert result.aggregate_results["mean"] == 0.5
     assert result.aggregate_results["p90"] == 0.9
     assert result.aggregate_results["variance"] == 0.25
-    assert rougeL(predictions=predictions, targets=targets) == result
+    assert rougeL()(predictions=predictions, targets=targets) == result
 
 
 def test_rougeLsum():

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -365,11 +365,13 @@ def test_ndcg_at_k():
 
 def test_builtin_metric_call_signature():
     metric = ndcg_at_k(3)
-    assert set(inspect.signature(metric).parameters.keys()) == {"predictions", "targets"}
+    assert inspect.signature(metric).parameters.keys() == {"predictions", "targets"}
 
     captured_output = io.StringIO()
     sys.stdout = captured_output
-    help(metric)
-    sys.stdout = sys.__stdout__
+    try:
+        help(metric)
+    finally:
+        sys.stdout = sys.__stdout__
 
     assert "__call__ = _call_method(self, *, predictions, targets)" in captured_output.getvalue()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13144?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13144/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13144
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
For metrics generated by make_genai_metric_from_prompt and make_genai_metric, we add __call__ function on the class to make it callable.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/6bc1c6f9-30db-44a8-9362-41d5be0df606">

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/ffc7998c-c2e4-4b52-a5de-a7369f64ac40">

`help` on the metric:
```
from mlflow.metrics import mae

metric = mae()
help(metric)
```
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/d2ecf416-c426-49ea-adc2-c77484aae3db">


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
