### PR TITLE
Fix Exception Handling for Databricks Dependencies

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -246,8 +246,9 @@ def _traverse_runnable(
         try:
             # Visit the variables of the function as well to extract dependencies
             if hasattr(lc_model, "func") and lc_model.func is not None:
-                for node in inspect.getclosurevars(lc_model.func).globals.values():
-                    yield from _traverse_runnable(node, visited)
+                if inspect.isfunction(lc_model.func) or inspect.ismethod(lc_model.func):
+                    for node in inspect.getclosurevars(lc_model.func).globals.values():
+                        yield from _traverse_runnable(node, visited)
         except Exception as e:
             _logger.warning(
                 "Unable to detect Databricks dependencies through closure values"

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -243,10 +243,15 @@ def _traverse_runnable(
         for node in lc_model.get_graph().nodes.values():
             yield from _traverse_runnable(node.data, visited)
 
-        # Visit the variables of the function as well to extract dependencies
-        if hasattr(lc_model, "func") and lc_model.func is not None:
-            for node in inspect.getclosurevars(lc_model.func).globals.values():
-                yield from _traverse_runnable(node, visited)
+        try:
+            # Visit the variables of the function as well to extract dependencies
+            if hasattr(lc_model, "func") and lc_model.func is not None:
+                for node in inspect.getclosurevars(lc_model.func).globals.values():
+                    yield from _traverse_runnable(node, visited)
+        except Exception as e:
+            _logger.warning(
+                "Unable to detect Databricks dependencies through closure values"
+            )
     else:
         # No-op for non-runnable, if any
         pass


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aravind-segu/mlflow/pull/13154?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13154/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13154
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Previously we added a change to get closure variables of a function and extract dependencies from it so we can extract agent dependencies. However before this we did not check whether a module is a function or not. This adds the check to only do this if its a function and also wraps it in a try catch to make sure we dont fail loudly and break all dependency extraction

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests
- Testing in notebooks here: https://docs.google.com/document/d/1G0OAnSV9X68A9x_zQYgwTfefT2mru2LtPVrIxvhb9Bg/edit
<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
