### PR TITLE
Fix LC autologging not to require langchain-community

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -1021,15 +1021,14 @@ def autolog(
         inspected_modules = set()
 
         # Get all installed LangChain packages
-        lc_pkgs = [
-            d.metadata["Name"]
-            for d in importlib.metadata.distributions()
-            if d.metadata["Name"].startswith("langchain")
-        ]
-        lc_modules = [importlib.import_module(pkg.replace("-", "_")) for pkg in lc_pkgs]
-
-        for module in lc_modules:
-            _inspect_module_and_patch_cls(module, inspected_modules, patched_classes)
+        for pkg in importlib.metadata.distributions():
+            if pkg.metadata["Name"].startswith("langchain"):
+                module_name = pkg.metadata["Name"].replace("-", "_")
+                try:
+                    module = importlib.import_module(module_name)
+                    _inspect_module_and_patch_cls(module, inspected_modules, patched_classes)
+                except Exception:
+                    pass
 
         if extra_model_classes:
             from langchain_core.runnables import Runnable

--- a/mlflow/langchain/utils/__init__.py
+++ b/mlflow/langchain/utils/__init__.py
@@ -225,9 +225,6 @@ def _get_map_of_special_chain_class_to_loader_arg():
 
 @lru_cache
 def _get_supported_llms():
-    import langchain.chat_models
-    import langchain.llms
-
     supported_llms = set()
 
     def try_adding_llm(module, class_name):
@@ -247,9 +244,10 @@ def _get_supported_llms():
     safe_import_and_add("langchain.llms", "HuggingFacePipeline")
     safe_import_and_add("langchain.langchain_huggingface", "HuggingFacePipeline")
     safe_import_and_add("langchain_openai", "OpenAI")
+    safe_import_and_add("langchain_databricks", "ChatDatabricks")
 
     for llm_name in ["Databricks", "Mlflow"]:
-        try_adding_llm(langchain.llms, llm_name)
+        safe_import_and_add("langchain.llms", llm_name)
 
     for chat_model_name in [
         "ChatDatabricks",
@@ -257,7 +255,7 @@ def _get_supported_llms():
         "ChatOpenAI",
         "AzureChatOpenAI",
     ]:
-        try_adding_llm(langchain.chat_models, chat_model_name)
+        safe_import_and_add("langchain.chat_models", chat_model_name)
 
     return supported_llms
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -696,8 +696,7 @@ langchain:
     requirements:
       ">= 0.0.0": [
           "pyspark",
-          # Pinning for the same reason as in the models section
-          "openai<1.8.0",
+          "openai",
           "google-search-results",
           "psutil",
           "faiss-cpu",

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -705,13 +705,9 @@ langchain:
           "spacy",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
           "pytest-asyncio", # for testing runnable async functions patches
-      ]
-      "< 0.3.0": [
-          "langchain_openai<0.2.0",
-      ]
-      ">= 0.3.0": [
-          "langchain-openai>=0.2.0",
-      ]
+        ]
+      "< 0.3.0": ["langchain_openai<0.2.0"]
+      ">= 0.3.0": ["langchain-openai>=0.2.0"]
     run: |
       pytest tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -706,7 +706,11 @@ langchain:
           "pytest-asyncio", # for testing runnable async functions patches
         ]
       "< 0.3.0": ["langchain_openai<0.2.0"]
-      ">= 0.3.0": ["langchain-openai>=0.2.0"]
+      ">= 0.3.0": [
+          # Need to bump FasAPI version to support pydantic v2
+          "fastapi>=0.100.0",
+          "langchain-openai>=0.2.0",
+        ]
     run: |
       pytest tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2
@@ -717,7 +721,7 @@ langchain:
         echo "Testing langchain autolog with pydantic v2"
         pytest tests/langchain/test_langchain_autolog.py
       fi
-      pip install langchain-community
+      pip install langchain-community --no-deps
       sleep 10
       pytest tests/langchain/test_langchain_autolog.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -721,8 +721,10 @@ langchain:
         echo "Testing langchain autolog with pydantic v2"
         pytest tests/langchain/test_langchain_autolog.py
       fi
-      pip install langchain-community --no-deps
-      sleep 10
+
+      echo "Testing langchain autolog with langchain-community"
+      # Install with 'langchain' to ensure the compatible version is installed
+      pip install langchain langchain-community
       pytest tests/langchain/test_langchain_autolog.py
 
 llama_index:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -705,8 +705,13 @@ langchain:
           "spacy",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
           "pytest-asyncio", # for testing runnable async functions patches
-          "langchain_openai",
-        ]
+      ]
+      "< 0.3.0": [
+          "langchain_openai<0.2.0",
+      ]
+      ">= 0.3.0": [
+          "langchain-openai>=0.2.0",
+      ]
     run: |
       pytest tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -701,7 +701,6 @@ langchain:
           "google-search-results",
           "psutil",
           "faiss-cpu",
-          "langchain-experimental",
           "numexpr",
           "spacy",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
@@ -717,6 +716,11 @@ langchain:
         echo "Testing langchain autolog with pydantic v2"
         pytest tests/langchain/test_langchain_autolog.py
       fi
+      # test with langchain-community package installed
+      LC_VERSION=$(python -c "import langchain; print(langchain.__version__)")
+      pip install langchain-community==$LC_VERSION
+      sleep 10
+      pytest tests/langchain/test_langchain_autolog.py
 
 llama_index:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -717,9 +717,7 @@ langchain:
         echo "Testing langchain autolog with pydantic v2"
         pytest tests/langchain/test_langchain_autolog.py
       fi
-      # test with langchain-community package installed
-      LC_VERSION=$(python -c "import langchain; print(langchain.__version__)")
-      pip install langchain-community==$LC_VERSION
+      pip install langchain-community
       sleep 10
       pytest tests/langchain/test_langchain_autolog.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -705,6 +705,7 @@ langchain:
           "spacy",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
           "pytest-asyncio", # for testing runnable async functions patches
+          "langchain_openai",
         ]
     run: |
       pytest tests/langchain/test_langchain_autolog.py

--- a/tests/langchain/conftest.py
+++ b/tests/langchain/conftest.py
@@ -1,7 +1,11 @@
 import importlib
+from typing import List
 
+import numpy as np
 import openai
 import pytest
+from langchain.embeddings.base import Embeddings
+from pydantic import BaseModel
 
 from tests.helper_functions import start_mock_openai_server
 
@@ -22,3 +26,19 @@ def set_envs(monkeypatch, mock_openai):
 def mock_openai():
     with start_mock_openai_server() as base_url:
         yield base_url
+
+
+# Define a special embedding for testing
+class DeterministicDummyEmbeddings(Embeddings, BaseModel):
+    size: int
+
+    def _get_embedding(self, text: str) -> List[float]:
+        seed = abs(hash(text)) % (10**8)
+        np.random.seed(seed)
+        return list(np.random.normal(size=self.size))
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [self._get_embedding(t) for t in texts]
+
+    def embed_query(self, text: str) -> List[float]:
+        return self._get_embedding(text)

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -382,6 +382,7 @@ def test_loaded_llmchain_autolog():
         assert signature == infer_signature(question, [TEST_CONTENT])
 
 
+@pytest.mark.skipif(not _LC_COMMUNITY_INSTALLED, reason="This test requires langchain_community")
 @mock.patch("mlflow.tracing.export.mlflow.get_display_handler")
 def test_loaded_llmchain_within_model_evaluation(mock_get_display, tmp_path, async_logging_enabled):
     # Disable autolog here as it is enabled in other tests.

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -19,7 +19,6 @@ from langchain_core.prompts import PromptTemplate
 from langchain_core.prompts.chat import ChatPromptTemplate
 from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough
 from langchain_core.runnables.config import RunnableConfig
-from langchain_text_splitters.character import CharacterTextSplitter
 
 # NB: We run this test suite twice - once with langchain_community installed and once without.
 try:
@@ -34,6 +33,12 @@ except ImportError:
     from langchain_openai import ChatOpenAI, OpenAI
 
     _LC_COMMUNITY_INSTALLED = False
+
+# langchain-text-splitters is moved to a separate package since LangChain v0.1.10
+try:
+    from langchain_text_splitters.character import CharacterTextSplitter
+except ImportError:
+    from langchain.text_splitter import CharacterTextSplitter
 
 from packaging.version import Version
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -6,19 +6,36 @@ from unittest import mock
 import openai
 import pytest
 from langchain.chains.llm import LLMChain
-from langchain.chat_models import ChatOpenAI
-from langchain.document_loaders import TextLoader
-from langchain.llms import OpenAI
-from langchain.prompts import PromptTemplate
-from langchain.schema.runnable.config import RunnableConfig
-from langchain.text_splitter import CharacterTextSplitter
 from langchain_core.callbacks.base import (
     AsyncCallbackHandler,
     BaseCallbackHandler,
     BaseCallbackManager,
 )
+from langchain_core.callbacks.manager import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import SimpleChatModel
+from langchain_core.messages.base import BaseMessage
+from langchain_core.output_parsers.string import StrOutputParser
+from langchain_core.prompts import PromptTemplate
+from langchain_core.prompts.chat import ChatPromptTemplate
+from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough
+from langchain_core.runnables.config import RunnableConfig
+from langchain_text_splitters.character import CharacterTextSplitter
+
+# NB: We run this test suite twice - once with langchain_community installed and once without.
+try:
+    from langchain_community.chat_models import ChatOpenAI
+    from langchain_community.document_loaders import TextLoader
+    from langchain_community.llms import OpenAI
+    from langchain_community.vectorstores import FAISS
+    from test_langchain_model_export import DeterministicDummyEmbeddings
+
+    _LC_COMMUNITY_INSTALLED = True
+except ImportError:
+    from langchain_openai import ChatOpenAI, OpenAI
+
+    _LC_COMMUNITY_INSTALLED = False
+
 from packaging.version import Version
-from test_langchain_model_export import FAISS, DeterministicDummyEmbeddings
 
 import mlflow
 from mlflow import MlflowClient
@@ -41,14 +58,6 @@ MODEL_DIR = "model"
 # The mock OpenAI endpoint simply echos the prompt back as the completion.
 # So the expected output will be the prompt itself.
 TEST_CONTENT = "What is MLflow?"
-
-from langchain_community.callbacks.mlflow_callback import (
-    get_text_complexity_metrics,
-    mlflow_callback_metrics,
-)
-
-MLFLOW_CALLBACK_METRICS = mlflow_callback_metrics()
-TEXT_COMPLEXITY_METRICS = get_text_complexity_metrics()
 
 
 def get_mlflow_model(artifact_uri, model_subpath=MODEL_DIR):
@@ -118,10 +127,6 @@ def create_retriever(tmp_path):
 
 
 def create_fake_chat_model():
-    from langchain.callbacks.manager import CallbackManagerForLLMRun
-    from langchain.chat_models.base import SimpleChatModel
-    from langchain.schema.messages import BaseMessage
-
     class FakeChatModel(SimpleChatModel):
         """Fake Chat Model wrapper for testing purposes."""
 
@@ -142,9 +147,6 @@ def create_fake_chat_model():
 
 
 def create_runnable_sequence():
-    from langchain.schema.output_parser import StrOutputParser
-    from langchain.schema.runnable import RunnableLambda
-
     prompt_with_history_str = """
     Here is a history between you and a human: {chat_history}
 
@@ -251,8 +253,6 @@ def test_resolve_tags():
 
 
 def test_autolog_record_exception(async_logging_enabled):
-    from langchain.schema.runnable import RunnableLambda
-
     def always_fail(input):
         raise Exception("Error!")
 
@@ -345,6 +345,7 @@ def test_llmchain_autolog_with_registered_model_name():
     assert registered_model.name == registered_model_name
 
 
+@pytest.mark.skipif(not _LC_COMMUNITY_INSTALLED, reason="This test requires langchain_community")
 def test_loaded_llmchain_autolog():
     mlflow.langchain.autolog(log_models=True, log_input_examples=True)
     model = create_openai_llmchain()
@@ -371,6 +372,7 @@ def test_loaded_llmchain_autolog():
         assert signature == infer_signature(question, [TEST_CONTENT])
 
 
+@pytest.mark.skipif(not _LC_COMMUNITY_INSTALLED, reason="This test requires langchain_community")
 @mock.patch("mlflow.tracing.export.mlflow.get_display_handler")
 def test_loaded_llmchain_within_model_evaluation(mock_get_display, tmp_path, async_logging_enabled):
     # Disable autolog here as it is enabled in other tests.
@@ -400,6 +402,7 @@ def test_loaded_llmchain_within_model_evaluation(mock_get_display, tmp_path, asy
     mock_display_handler.display_traces.assert_not_called()
 
 
+@pytest.mark.skipif(not _LC_COMMUNITY_INSTALLED, reason="This test requires langchain_community")
 def test_agent_autolog(async_logging_enabled):
     mlflow.langchain.autolog(log_models=True)
     model = create_openai_llmagent()
@@ -515,6 +518,7 @@ def test_loaded_runnable_sequence_autolog():
         assert signature == infer_signature(input_example, [TEST_CONTENT])
 
 
+@pytest.mark.skipif(not _LC_COMMUNITY_INSTALLED, reason="This test requires langchain_community")
 def test_retriever_autolog(tmp_path, async_logging_enabled):
     mlflow.langchain.autolog(log_models=True)
     model, query = create_retriever(tmp_path)
@@ -538,11 +542,8 @@ def test_retriever_autolog(tmp_path, async_logging_enabled):
     assert spans[0].outputs[0]["metadata"] == {"source": "tests/langchain/state_of_the_union.txt"}
 
 
+@pytest.mark.skipif(not _LC_COMMUNITY_INSTALLED, reason="This test requires langchain_community")
 def test_unsupported_log_model_models_autolog(tmp_path):
-    from langchain.prompts import ChatPromptTemplate
-    from langchain.schema.output_parser import StrOutputParser
-    from langchain.schema.runnable import RunnablePassthrough
-
     mlflow.langchain.autolog(log_models=True)
     retriever, _ = create_retriever(tmp_path)
     prompt = ChatPromptTemplate.from_template(
@@ -887,11 +888,8 @@ async def test_langchain_autolog_callback_injection_in_astream(
         assert set(handlers[0].logs) == {"chain_start", "chain_end"}
 
 
+@pytest.mark.skipif(not _LC_COMMUNITY_INSTALLED, reason="This test requires langchain_community")
 def test_langchain_autolog_produces_expected_traces_with_streaming(tmp_path, async_logging_enabled):
-    from langchain.prompts import ChatPromptTemplate
-    from langchain.schema.output_parser import StrOutputParser
-    from langchain.schema.runnable import RunnablePassthrough
-
     mlflow.langchain.autolog()
     retriever, _ = create_retriever(tmp_path)
     prompt = ChatPromptTemplate.from_template(
@@ -959,8 +957,6 @@ def test_langchain_tracer_injection_for_arbitrary_runnables(log_traces, async_lo
 
 
 def test_langchain_autolog_extra_model_classes_no_duplicate_patching():
-    from langchain.schema.runnable import Runnable
-
     class CustomRunnable(Runnable):
         def invoke(self, input, config=None):
             return "test"
@@ -984,8 +980,6 @@ def test_langchain_autolog_extra_model_classes_no_duplicate_patching():
 
 
 def test_langchain_autolog_extra_model_classes_warning():
-    from langchain.schema.runnable import Runnable
-
     class NotARunnable:
         def __init__(self, x):
             self.x = x

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -64,7 +64,6 @@ from langchain_community.llms import OpenAI
 from langchain_community.utilities import SQLDatabase, TextRequestsWrapper
 from langchain_community.vectorstores import FAISS
 from langchain_core.callbacks.base import BaseCallbackHandler
-from langchain_experimental.sql import SQLDatabaseChain
 from packaging import version
 from packaging.version import Version
 from pydantic import BaseModel
@@ -1040,6 +1039,8 @@ def load_db(persist_dir):
     reason="LangChain 0.1.14 and 0.1.15 has a bug in loading SQLDatabaseChain",
 )
 def test_log_and_load_sql_database_chain(tmp_path):
+    from langchain_experimental.sql import SQLDatabaseChain
+
     # Create the SQLDatabaseChain
     db_file_path = tmp_path / "my_database.db"
     sqlite_uri = f"sqlite:///{db_file_path}"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13172?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13172/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13172
```

</p>
</details>

### What changes are proposed in this pull request?

LangChain Autologging does not work when `langchain-community` is not installed because of [this import statement](https://github.com/mlflow/mlflow/blob/master/mlflow/langchain/__init__.py#L1011). Also, it only patches classes from `langchain` or `langchain-community` packages, meaning that modules from partner packages are not patched (note that this doesn't mean autologging doesn't work for chain including partner package components - we only need to patch top-level class of the chain, which is typically RunnableXXX that belongs to `langchain` namespace).

This PR updates the autologging logic not to fail on those optional imports, and fix a few errors when running tests without `langchain-community`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Validated the traces are auto-generated in a notebook where `langchain-community` is not installed. 

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix the issue that LangChain autologging does not work when `langchain-community` is not installed.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
