### PR TITLE
Isolate mlserver dependencies

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
-          pip install pyspark torch transformers langchain langchain-experimental
+          pip install pyspark torch transformers langchain langchain-experimental '.[genai]'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
@@ -334,7 +334,7 @@ jobs:
           source .venv/Scripts/activate
           python -m pip install -U pip
           pip install --no-dependencies tests/resources/mlflow-test-plugin
-          pip install .[extras]
+          pip install '.[extras,genai]'
           pip install pyspark
           pip install mleap
           # Install Hugging Face datasets to test Hugging Face usage with MLflow dataset tracking

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
-          pip install pyspark langchain langchain-community
+          pip install pyspark langchain langchain-community '.[mlserver]'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Run tests

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -144,8 +144,6 @@ def build(package_type: PackageType) -> None:
                 ],
                 "mlserver": [
                     # Required to serve models through MLServer
-                    # NOTE: remove the upper version pin once protobuf is no longer pinned in
-                    # mlserver. Reference issue: https://github.com/SeldonIO/MLServer/issues/1089
                     "mlserver>=1.2.0,!=1.3.1",
                     "mlserver-mlflow>=1.2.0,!=1.3.1",
                 ],

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -130,11 +130,6 @@ def build(package_type: PackageType) -> None:
                     # Required by the mlflow.projects module, when running projects against
                     # a remote Kubernetes cluster
                     "kubernetes",
-                    # Required to serve models through MLServer
-                    # NOTE: remove the upper version pin once protobuf is no longer pinned in
-                    # mlserver. Reference issue: https://github.com/SeldonIO/MLServer/issues/1089
-                    "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-                    "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
                     "virtualenv",
                     # Required for exporting metrics from the MLflow server to Prometheus
                     # as part of the MLflow server monitoring add-on
@@ -146,6 +141,13 @@ def build(package_type: PackageType) -> None:
                     "google-cloud-storage>=1.30.0",
                     "boto3>1",
                     "botocore",
+                ],
+                "mlserver": [
+                    # Required to serve models through MLServer
+                    # NOTE: remove the upper version pin once protobuf is no longer pinned in
+                    # mlserver. Reference issue: https://github.com/SeldonIO/MLServer/issues/1089
+                    "mlserver>=1.2.0,!=1.3.1",
+                    "mlserver-mlflow>=1.2.0,!=1.3.1",
                 ],
                 "gateway": gateways_requirements,
                 "genai": gateways_requirements,

--- a/docs/source/deployment/deploy-model-to-kubernetes/tutorial.rst
+++ b/docs/source/deployment/deploy-model-to-kubernetes/tutorial.rst
@@ -54,7 +54,7 @@ First, please install mlflow to your local machine using the following command:
 
 .. code-block:: bash
 
-  pip install mlflow[extras]
+  pip install mlflow[mlserver]
 
 ``[extras]`` will install additional dependencies required for this tutorial including `mlserver <https://mlserver.readthedocs.io/en/latest/>`_ and
 `scikit-learn <https://scikit-learn.org/stable/>`_. Note that scikit-learn is not required for deployment, just for training the example model used in this tutorial.

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -671,6 +671,7 @@ langchain:
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
           "langchain-openai",
           "langgraph",
+          # Required to run tests/openai/mock_openai.py
           "fastapi",
           "uvicorn",
         ]
@@ -710,6 +711,7 @@ langchain:
           "spacy",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
           "pytest-asyncio", # for testing runnable async functions patches
+          # Required to run tests/openai/mock_openai.py
           "fastapi",
           "uvicorn",
         ]
@@ -744,6 +746,9 @@ llama_index:
           "llama-index-embeddings-databricks",
           # Required to test external vector stores
           "llama-index-vector-stores-qdrant",
+          # Required to run tests/openai/mock_openai.py
+          "fastapi",
+          "uvicorn",
         ]
       ">= 0.11.0": ["fastapi>=0.100.0"]
     run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
@@ -753,7 +758,12 @@ llama_index:
     python:
       "== dev": "3.9"
     requirements:
-      ">= 0.0.0": ["openai"]
+      ">= 0.0.0": [
+          "openai",
+          # Required to run tests/openai/mock_openai.py
+          "fastapi",
+          "uvicorn",
+        ]
       ">= 0.11.0": ["fastapi>=0.100.0"]
     run: pytest tests/llama_index/test_llama_index_autolog.py tests/llama_index/test_llama_index_tracer.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -671,6 +671,8 @@ langchain:
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
           "langchain-openai",
           "langgraph",
+          "fastapi",
+          "uvicorn",
         ]
       # langchain-openai 0.1.22 is imcomptible with earlier langchain-core due to
       # https://github.com/langchain-ai/langchain/commit/b83f1eb0d56dbf99605a1fce93953ee09d77aabf
@@ -708,6 +710,8 @@ langchain:
           "spacy",
           "langchain-core!=0.1.39", # https://github.com/langchain-ai/langchain/issues/19947
           "pytest-asyncio", # for testing runnable async functions patches
+          "fastapi",
+          "uvicorn",
         ]
     run: |
       pytest tests/langchain/test_langchain_autolog.py

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -57,8 +57,6 @@ extras = [
   "azureml-core>=1.2.0",
   "pysftp",
   "kubernetes",
-  "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-  "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
   "virtualenv",
   "prometheus-flask-exporter",
 ]
@@ -68,6 +66,7 @@ databricks = [
   "boto3>1",
   "botocore",
 ]
+mlserver = ["mlserver>=1.2.0,!=1.3.1", "mlserver-mlflow>=1.2.0,!=1.3.1"]
 gateway = [
   "pydantic<3,>=1.0",
   "fastapi<1",

--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -53,8 +53,6 @@ extras = [
   "azureml-core>=1.2.0",
   "pysftp",
   "kubernetes",
-  "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-  "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
   "virtualenv",
   "prometheus-flask-exporter",
 ]
@@ -64,6 +62,7 @@ databricks = [
   "boto3>1",
   "botocore",
 ]
+mlserver = ["mlserver>=1.2.0,!=1.3.1", "mlserver-mlflow>=1.2.0,!=1.3.1"]
 gateway = [
   "pydantic<3,>=1.0",
   "fastapi<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,6 @@ extras = [
   "azureml-core>=1.2.0",
   "pysftp",
   "kubernetes",
-  "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-  "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
   "virtualenv",
   "prometheus-flask-exporter",
 ]
@@ -80,6 +78,7 @@ databricks = [
   "boto3>1",
   "botocore",
 ]
+mlserver = ["mlserver>=1.2.0,!=1.3.1", "mlserver-mlflow>=1.2.0,!=1.3.1"]
 gateway = [
   "pydantic<3,>=1.0",
   "fastapi<1",

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -25,10 +25,6 @@ flaml[automl]
 # this is pinned because huggingface_hub >= 0.24.0 causes setfit to be unimportable, see
 # https://github.com/huggingface/setfit/issues/544
 huggingface_hub<0.24.0
-# Pinned due to protobuf requirement pinning in 1.3.0 of ml-server that is incompatible
-# 1.4.0 does not support pydantic v2 https://github.com/SeldonIO/MLServer/pull/1595
-mlserver>=1.2.0,!=1.3.1,<1.4.0
-mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0
 # Required by evaluator tests
 shap
 # Required to evaluate language models in `mlflow.evaluate`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -467,8 +467,8 @@ def test_mlflow_models_serve(enable_mlserver):
                 artifact_path="model",
                 python_model=model,
                 extra_pip_requirements=[
-                    "mlserver>=1.2.0,!=1.3.1,<1.4.0",
-                    "mlserver-mlflow>=1.2.0,!=1.3.1,<1.4.0",
+                    "mlserver>=1.2.0,!=1.3.1",
+                    "mlserver-mlflow>=1.2.0,!=1.3.1",
                     PROTOBUF_REQUIREMENT,
                 ],
             )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13178?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13178/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13178
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://github.com/mlflow-automation/mlflow/actions/runs/10903980766/job/30273563810#step:12:15322

```
  File "/home/runner/work/mlflow/mlflow/tests/openai/mock_openai.py", line 4, in <module>
    import fastapi
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/fastapi/__init__.py", line 7, in <module>
    from .applications import FastAPI as FastAPI
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/fastapi/applications.py", line 15, in <module>
    from fastapi import routing
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/fastapi/routing.py", line 22, in <module>
    from fastapi import params
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/fastapi/params.py", line 4, in <module>
    from pydantic.fields import FieldInfo, Undefined
ImportError: cannot import name 'Undefined' from 'pydantic.fields' (/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pydantic/fields.py)
```

`mlserver` requires an old version of fastapi which is incompatible with `pydantic` v2. This PR isolates mlserver dependencies to avoid fastapi being pined by them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
