### PR TITLE
Add `from_dict()` function to ChatModel dataclasses

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -395,6 +395,7 @@ support additional params.
 In summary, use the function-based Model when you have a simple function to serialize.
 If you need more power, use  the class-based model.
 """
+
 import collections
 import functools
 import importlib
@@ -2539,14 +2540,16 @@ def save_model(
                     if isinstance(each_message, ChatMessage):
                         messages.append(each_message)
                     else:
-                        messages.append(ChatMessage(**each_message))
+                        messages.append(ChatMessage.from_dict(each_message))
             else:
                 # If the input example is a dictionary, convert it to ChatMessage format
                 messages = [
-                    ChatMessage(**m) if isinstance(m, dict) else m
+                    ChatMessage.from_dict(m) if isinstance(m, dict) else m
                     for m in input_example["messages"]
                 ]
-                params = ChatParams(**{k: v for k, v in input_example.items() if k != "messages"})
+                params = ChatParams.from_dict(
+                    {k: v for k, v in input_example.items() if k != "messages"}
+                )
             input_example = {
                 "messages": [m.to_dict() for m in messages],
                 **params.to_dict(),
@@ -2562,8 +2565,8 @@ def save_model(
                 raise MlflowException(
                     "Failed to save ChatModel. Please ensure that the model's predict() method "
                     "returns a ChatResponse object. If your predict() method currently returns "
-                    "a dict, you can instantiate a ChatResponse by unpacking the output, e.g. "
-                    "`ChatResponse(**output)`",
+                    "a dict, you can instantiate a ChatResponse using `from_dict()`, e.g. "
+                    "`ChatResponse.from_dict(output)`",
                 )
         elif isinstance(python_model, PythonModel):
             saved_example = _save_example(mlflow_model, input_example, path, example_no_conversion)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2547,9 +2547,7 @@ def save_model(
                     ChatMessage.from_dict(m) if isinstance(m, dict) else m
                     for m in input_example["messages"]
                 ]
-                params = ChatParams.from_dict(
-                    {k: v for k, v in input_example.items() if k != "messages"}
-                )
+                params = ChatParams.from_dict(input_example)
             input_example = {
                 "messages": [m.to_dict() for m in messages],
                 **params.to_dict(),

--- a/mlflow/pyfunc/loaders/chat_model.py
+++ b/mlflow/pyfunc/loaders/chat_model.py
@@ -54,8 +54,8 @@ class _ChatModelPyfuncWrapper:
                 error_code=INTERNAL_ERROR,
             )
 
-        messages = [ChatMessage(**message) for message in dict_input.pop("messages", [])]
-        params = ChatParams(**dict_input)
+        messages = [ChatMessage.from_dict(message) for message in dict_input.pop("messages", [])]
+        params = ChatParams.from_dict(dict_input)
         return messages, params
 
     def predict(

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -34,7 +34,7 @@ class _BaseDataclass:
             elif not isinstance(values, list):
                 raise ValueError(f"`{key}` must be a list, got {type(values).__name__}")
 
-    def _convert_dataclass(self, key: str, cls: '_BaseDataclass', required=True):
+    def _convert_dataclass(self, key: str, cls: "_BaseDataclass", required=True):
         value = getattr(self, key)
         if value is None:
             if required:
@@ -49,7 +49,7 @@ class _BaseDataclass:
         except TypeError as e:
             raise ValueError(f"Error when coercing {value} to {cls.__name__}: {e}")
 
-    def _convert_dataclass_list(self, key: str, cls: '_BaseDataclass', required=True):
+    def _convert_dataclass_list(self, key: str, cls: "_BaseDataclass", required=True):
         values = getattr(self, key)
         if values is None:
             if required:

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -80,14 +80,14 @@ class _BaseDataclass:
         return asdict(self, dict_factory=lambda obj: {k: v for (k, v) in obj if v is not None})
 
     @classmethod
-    def from_dict(self, data):
+    def from_dict(cls, data):
         """
         Create an instance of the class from a dict, ignoring any undefined fields.
         This is useful when the dict contains extra fields, causing cls(**data) to fail.
         """
-        field_names = [field.name for field in fields(self)]
+        field_names = [field.name for field in fields(cls)]
         filtered_data = {k: v for k, v in data.items() if k in field_names}
-        return self(**filtered_data)
+        return cls(**filtered_data)
 
 
 @dataclass

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -44,6 +44,12 @@ class _BaseDataclass:
         if isinstance(value, cls):
             return
 
+        if not isinstance(value, dict):
+            raise ValueError(
+                f"Expected `{key}` to be either an instance of `{cls.__name__}` or "
+                f"a dict matching the schema. Received `{type(value).__name__}`"
+            )
+
         try:
             setattr(self, key, cls.from_dict(value))
         except TypeError as e:

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -1,5 +1,5 @@
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from typing import Dict, List, Optional
 
 from mlflow.types.schema import Array, ColSpec, DataType, Map, Object, Property, Schema
@@ -34,7 +34,22 @@ class _BaseDataclass:
             elif not isinstance(values, list):
                 raise ValueError(f"`{key}` must be a list, got {type(values).__name__}")
 
-    def _convert_dataclass_list(self, key, cls, required=True):
+    def _convert_dataclass(self, key: str, cls: '_BaseDataclass', required=True):
+        value = getattr(self, key)
+        if value is None:
+            if required:
+                raise ValueError(f"`{key}` is required")
+            return
+
+        if isinstance(value, cls):
+            return
+
+        try:
+            setattr(self, key, cls.from_dict(value))
+        except TypeError as e:
+            raise ValueError(f"Error when coercing {value} to {cls.__name__}: {e}")
+
+    def _convert_dataclass_list(self, key: str, cls: '_BaseDataclass', required=True):
         values = getattr(self, key)
         if values is None:
             if required:
@@ -47,7 +62,7 @@ class _BaseDataclass:
             # if the items are all dicts, try to convert them to the desired class
             if all(isinstance(v, dict) for v in values):
                 try:
-                    setattr(self, key, [cls(**v) for v in values])
+                    setattr(self, key, [cls.from_dict(v) for v in values])
                 except TypeError as e:
                     raise ValueError(f"Error when coercing {values} to {cls.__name__}: {e}")
             elif any(not isinstance(v, cls) for v in values):
@@ -57,6 +72,16 @@ class _BaseDataclass:
 
     def to_dict(self):
         return asdict(self, dict_factory=lambda obj: {k: v for (k, v) in obj if v is not None})
+
+    @classmethod
+    def from_dict(self, data):
+        """
+        Create an instance of the class from a dict, ignoring any undefined fields.
+        This is useful when the dict contains extra fields, causing cls(**data) to fail.
+        """
+        field_names = [field.name for field in fields(self)]
+        filtered_data = {k: v for k, v in data.items() if k in field_names}
+        return self(**filtered_data)
 
 
 @dataclass
@@ -292,18 +317,8 @@ class ChatChoice(_BaseDataclass):
     def __post_init__(self):
         self._validate_field("index", int, True)
         self._validate_field("finish_reason", str, True)
-        if isinstance(self.message, dict):
-            self.message = ChatMessage(**self.message)
-        if not isinstance(self.message, ChatMessage):
-            raise ValueError(
-                f"Expected `message` to be of type ChatMessage or dict, got {type(self.message)}"
-            )
-        if isinstance(self.logprobs, dict):
-            self.logprobs = ChatChoiceLogProbs(**self.logprobs)
-        if self.logprobs and not isinstance(self.logprobs, ChatChoiceLogProbs):
-            raise ValueError(
-                f"Expected `logprobs` to be of type LogProbs or dict, got {type(self.logprobs)}"
-            )
+        self._convert_dataclass("message", ChatMessage, True)
+        self._convert_dataclass("logprobs", ChatChoiceLogProbs, False)
 
 
 @dataclass
@@ -363,9 +378,7 @@ class ChatResponse(_BaseDataclass):
         self._validate_field("created", int, True)
         self._validate_field("model", str, False)
         self._convert_dataclass_list("choices", ChatChoice)
-        if isinstance(self.usage, dict):
-            self.usage = TokenUsageStats(**self.usage)
-        self._validate_field("usage", TokenUsageStats, False)
+        self._convert_dataclass("usage", TokenUsageStats, False)
 
 
 CHAT_MODEL_INPUT_SCHEMA = Schema(

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -70,7 +70,7 @@ def get_mock_response(messages, params):
 class TestChatModel(mlflow.pyfunc.ChatModel):
     def predict(self, context, messages: List[ChatMessage], params: ChatParams) -> ChatResponse:
         mock_response = get_mock_response(messages, params)
-        return ChatResponse(**mock_response)
+        return ChatResponse.from_dict(mock_response)
 
 
 class ChatModelWithContext(mlflow.pyfunc.ChatModel):
@@ -80,14 +80,14 @@ class ChatModelWithContext(mlflow.pyfunc.ChatModel):
 
     def predict(self, context, messages: List[ChatMessage], params: ChatParams) -> ChatResponse:
         message = ChatMessage(role="assistant", content=self.predict_fn())
-        return ChatResponse(**get_mock_response([message], params))
+        return ChatResponse.from_dict(get_mock_response([message], params))
 
 
 class ChatModelWithTrace(mlflow.pyfunc.ChatModel):
     @mlflow.trace
     def predict(self, context, messages: List[ChatMessage], params: ChatParams) -> ChatResponse:
         mock_response = get_mock_response(messages, params)
-        return ChatResponse(**mock_response)
+        return ChatResponse.from_dict(mock_response)
 
 
 class ChatModelWithMetadata(mlflow.pyfunc.ChatModel):
@@ -129,7 +129,7 @@ def test_chat_model_with_trace(tmp_path):
     assert len(traces) == 1
     assert traces[0].info.tags[TraceTagKey.TRACE_NAME] == "predict"
     request = json.loads(traces[0].data.request)
-    assert request["messages"] == [asdict(ChatMessage(**msg)) for msg in messages]
+    assert request["messages"] == [asdict(ChatMessage.from_dict(msg)) for msg in messages]
 
 
 def test_chat_model_save_throws_with_signature(tmp_path):

--- a/tests/pyfunc/test_chat_model_validation.py
+++ b/tests/pyfunc/test_chat_model_validation.py
@@ -229,6 +229,26 @@ def test_chat_request_metadata_must_be_string_map(metadata, match):
 
 
 @pytest.mark.parametrize(
+    ("cls", "data", "match"),
+    [
+        (
+            ChatChoice,
+            {"index": 0, "message": 123},
+            "Expected `message` to be either an instance of `ChatMessage` or a dict",
+        ),
+        (
+            ChatResponse,
+            {"choices": [], "usage": 123},
+            "Expected `usage` to be either an instance of `TokenUsageStats` or a dict",
+        ),
+    ],
+)
+def test_convert_dataclass_throws_on_invalid_data(cls, data, match):
+    with pytest.raises(ValueError, match=match):
+        cls.from_dict(data)
+
+
+@pytest.mark.parametrize(
     ("cls", "data"),
     [
         (ChatMessage, {"role": "user", "content": "hello", "extra": "field"}),

--- a/tests/pyfunc/test_chat_model_validation.py
+++ b/tests/pyfunc/test_chat_model_validation.py
@@ -196,7 +196,7 @@ def test_to_dict_converts_nested_dataclasses(sample_output):
 
 
 def test_to_dict_excludes_nones():
-    response = ChatResponse(**MOCK_RESPONSE).to_dict()
+    response = ChatResponse.from_dict(MOCK_RESPONSE).to_dict()
     assert "name" not in response["choices"][0]["message"]
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/13180?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13180/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13180
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds a `from_dict()` function to ChatModel dataclasses that will ignore extra fields. Currently, we guide users to instantiate the classes using the `**` operator, but this causes the classes to throw if any additional fields are present.

Switching to `from_dict()` allows us be flexible when people want to dump OpenAI responses directly to ChatModel types. For example, we should be able to do something like this without throwing:

```python
from openai import OpenAI

from mlflow.types.llm import ChatResponse

client = OpenAI()

response = client.chat.completions.create(
    model="gpt-4o-mini",
    messages=[{"role": "user", "content": "Tell me a joke in haiku form"}],
)

print(ChatResponse.from_dict(response.to_dict()))
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Ran the above script, got:

```
ChatResponse(
  choices=[
    ChatChoice(
      index=0,
      message=ChatMessage(
        role='assistant',
        content='A tree on the hill,  \nSaid to the wind, "I\'m stumped!"  \nLeaves laughed—unfurling.', 
        refusal=None, 
        name=None
      ), 
      finish_reason='stop', 
      logprobs=None
  )], 
  usage=TokenUsageStats(prompt_tokens=15, completion_tokens=27, total_tokens=42),
  id='chatcmpl-dVNPV74x9VKIWnWyF6FhJ4JcV', 
  model='gpt-4o-mini-2024-07-18', 
  object='chat.completion',
  created=1726636245, 
  metadata=None
)
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Added the `.from_dict()` method to ChatModel dataclasses which ignores extra fields when constructing the classes.

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
