### PR TITLE
Remove pydantic import warning for Langchain >= 0.3.0

### DIFF
--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -262,14 +262,11 @@ def _save_internal_runnables(runnable, path, loader_fn, persist_dir):
         if hasattr(runnable, "save"):
             runnable.save(model_path)
         elif hasattr(runnable, "dict"):
-            try:
-                runnable_dict = runnable.dict()
-                with open(model_path, "w") as f:
-                    yaml.dump(runnable_dict, f, default_flow_style=False)
-                # if the model cannot be loaded back, then `dict` is not enough for saving.
-                _load_model_from_config(path, conf)
-            except Exception:
-                raise Exception("Cannot save runnable without `save` method.")
+            runnable_dict = runnable.dict()
+            with open(model_path, "w") as f:
+                yaml.dump(runnable_dict, f, default_flow_style=False)
+            # if the model cannot be loaded back, then `dict` is not enough for saving.
+            _load_model_from_config(path, conf)
         else:
             raise Exception("Cannot save runnable without `save` or `dict` methods.")
     return conf

--- a/mlflow/langchain/utils/serialization.py
+++ b/mlflow/langchain/utils/serialization.py
@@ -1,5 +1,7 @@
 import inspect
 
+from packaging.version import Version
+
 
 def convert_to_serializable(response):
     """
@@ -8,11 +10,21 @@ def convert_to_serializable(response):
     LangChain response objects often contains Pydantic objects, which causes an serialization
     error when the model is served behind REST endpoint.
     """
-    from langchain_core.pydantic_v1 import BaseModel
+    import langchain
 
-    if isinstance(response, BaseModel):
-        return response.dict()
-    elif inspect.isgenerator(response):
+    # LangChain >= 0.3.0 uses Pydantic 2.x while < 0.3.0 is based on Pydantic 1.x.
+    if Version(langchain.__version__) >= Version("0.3.0"):
+        from pydantic import BaseModel
+
+        if isinstance(response, BaseModel):
+            return response.model_dump()
+    else:
+        from langchain_core.pydantic_v1 import BaseModel as LangChainBaseModel
+
+        if isinstance(response, LangChainBaseModel):
+            return response.dict()
+
+    if inspect.isgenerator(response):
         return (convert_to_serializable(chunk) for chunk in response)
     elif isinstance(response, dict):
         return {k: convert_to_serializable(v) for k, v in response.items()}

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -47,15 +47,19 @@ class TraceJSONEncoder(json.JSONEncoder):
 
     def default(self, obj):
         try:
-            # LangChain does some trick to keep both Pydantic 1.x and 2.x support, so checking
+            import langchain
+
+            # LangChain < 0.3.0 does some trick to support Pydantic 1.x and 2.x, so checking
             # type with installed Pydantic version might not work for some models.
             # https://github.com/langchain-ai/langchain/blob/b66a4f48fa5656871c3e849f7e1790dfb5a4c56b/libs/core/langchain_core/pydantic_v1/__init__.py#L7
-            from langchain_core.pydantic_v1 import BaseModel as LangChainBaseModel
+            if Version(langchain.__version__) < Version("0.3.0"):
+                from langchain_core.pydantic_v1 import BaseModel as LangChainBaseModel
 
-            if isinstance(obj, LangChainBaseModel):
-                return obj.dict()
+                if isinstance(obj, LangChainBaseModel):
+                    return obj.dict()
         except ImportError:
             pass
+
         try:
             import pydantic
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13190?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13190/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13190
```

</p>
</details>

### What changes are proposed in this pull request?

Creating a trace with Langchain `0.3.0` emits a warning for the usage of old pydantic import

![Screenshot 2024-09-19 at 10 56 04](https://github.com/user-attachments/assets/faffe126-7d74-4741-b7c2-76fdf4eda81c)

This PR removes this warning by updating the import statement.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

No warning is issued when this patch is installed:

![Screenshot 2024-09-19 at 10 51 23](https://github.com/user-attachments/assets/4d72e532-970e-4881-81af-db66a48fa109)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
