### PR TITLE
Add tool calling support for ChatModel

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -398,6 +398,14 @@ nitpick_ignore = [
     ("py:class", "pytorch_lightning.core.module.LightningModule"),
     ("py:class", "pytorch_lightning.core.LightningModule"),
     ("py:class", "torch.dtype"),
+    ("py:class", "function"),
+    ("py:class", "string"),
+    ("py:class", "number"),
+    ("py:class", "integer"),
+    ("py:class", "object"),
+    ("py:class", "array"),
+    ("py:class", "boolean"),
+    ("py:class", "null"),
 ]
 
 

--- a/mlflow/pyfunc/loaders/chat_model.py
+++ b/mlflow/pyfunc/loaders/chat_model.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Iterator, Optional
 
 from mlflow.exceptions import MlflowException
+from mlflow.models.utils import _convert_llm_ndarray_to_list
 from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
 from mlflow.pyfunc.model import (
     _load_context_model_and_signature,
@@ -45,7 +46,8 @@ class _ChatModelPyfuncWrapper:
             dict_input = model_input
         elif isinstance(model_input, pandas.DataFrame):
             dict_input = {
-                key: value[0] for key, value in model_input.to_dict(orient="list").items()
+                k: _convert_llm_ndarray_to_list(v[0]) if isinstance(v[0], list) else v[0]
+                for k, v in model_input.to_dict(orient="list").items()
             }
         else:
             raise MlflowException(

--- a/mlflow/pyfunc/loaders/chat_model.py
+++ b/mlflow/pyfunc/loaders/chat_model.py
@@ -46,7 +46,7 @@ class _ChatModelPyfuncWrapper:
             dict_input = model_input
         elif isinstance(model_input, pandas.DataFrame):
             dict_input = {
-                k: _convert_llm_ndarray_to_list(v[0]) if isinstance(v[0], list) else v[0]
+                k: _convert_llm_ndarray_to_list(v[0])
                 for k, v in model_input.to_dict(orient="list").items()
             }
         else:

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -157,8 +157,8 @@ class ToolCall(_BaseDataclass):
     A tool call made by the model.
 
     Args:
-        id (str): The ID of the tool call.
         function (:py:class:`FunctionToolCallArguments`): The arguments of the function tool call.
+        id (str): The ID of the tool call. Defaults to a random UUID.
         type (str): The type of the object. Currently only "function" is supported.
     """
 

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -145,7 +145,9 @@ class FunctionToolCallArguments(_BaseDataclass):
         self._validate_field("name", str, True)
         self._validate_field("arguments", str, True)
 
-    def to_tool_call(self, id=uuid.uuid4().hex):
+    def to_tool_call(self, id=None):
+        if id is None:
+            id = str(uuid.uuid4())
         return ToolCall(id=id, function=self)
 
 
@@ -160,8 +162,8 @@ class ToolCall(_BaseDataclass):
         type (str): The type of the object. Currently only "function" is supported.
     """
 
-    id: str
     function: FunctionToolCallArguments
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
     type: Literal["function"] = "function"
 
     def __post_init__(self):

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import asdict, dataclass, field, fields
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional
 
 from mlflow.types.schema import Array, ColSpec, DataType, Map, Object, Property, Schema
 
@@ -13,6 +13,9 @@ from mlflow.types.schema import Array, ColSpec, DataType, Map, Object, Property,
 #       is not supported, so the code here is a little ugly.
 
 
+JSON_SCHEMA_TYPES = ["string", "number", "integer", "object", "array", "boolean", "null"]
+
+
 class _BaseDataclass:
     def _validate_field(self, key, val_type, required):
         value = getattr(self, key, None)
@@ -22,6 +25,13 @@ class _BaseDataclass:
             raise ValueError(
                 f"`{key}` must be of type {val_type.__name__}, got {type(value).__name__}"
             )
+
+    def _validate_literal(self, key, allowed_values, required):
+        value = getattr(self, key, None)
+        if required and value is None:
+            raise ValueError(f"`{key}` is required")
+        if value is not None and value not in allowed_values:
+            raise ValueError(f"`{key}` must be one of {allowed_values}, got {value}")
 
     def _validate_list(self, key, val_type, required):
         values = getattr(self, key, None)
@@ -76,6 +86,33 @@ class _BaseDataclass:
                     f"Items in `{key}` must all have the same type: {cls.__name__} or dict"
                 )
 
+    def _convert_dataclass_map(self, key, cls, required=True):
+        mapping = getattr(self, key)
+        if mapping is None:
+            if required:
+                raise ValueError(f"`{key}` is required")
+            return
+
+        if not isinstance(mapping, dict):
+            raise ValueError(f"`{key}` must be a dict")
+
+        # create a new map to avoid mutating the original
+        new_mapping = {}
+        for k, v in mapping.items():
+            if isinstance(v, cls):
+                new_mapping[k] = v
+            elif isinstance(v, dict):
+                try:
+                    new_mapping[k] = cls.from_dict(v)
+                except TypeError as e:
+                    raise ValueError(f"Error when coercing {v} to {cls.__name__}: {e}")
+            else:
+                raise ValueError(
+                    f"Items in `{key}` must be either an instance of `{cls.__name__}` "
+                    f"or a dict matching the schema. Received `{type(v).__name__}`"
+                )
+        setattr(self, key, new_mapping)
+
     def to_dict(self):
         return asdict(self, dict_factory=lambda obj: {k: v for (k, v) in obj if v is not None})
 
@@ -91,23 +128,72 @@ class _BaseDataclass:
 
 
 @dataclass
+class FunctionToolCallArguments(_BaseDataclass):
+    """
+    The arguments of a function tool call made by the model.
+
+    Args:
+        arguments (str): A JSON string of arguments that should be passed to the tool.
+        name (str): The name of the tool that is being called.
+    """
+
+    name: str
+    arguments: str
+
+    def __post_init__(self):
+        self._validate_field("name", str, True)
+        self._validate_field("arguments", str, True)
+
+    def to_tool_call(self, id):
+        return ToolCall(id=id, function=self)
+
+
+@dataclass
+class ToolCall(_BaseDataclass):
+    """
+    A tool call made by the model.
+
+    Args:
+        id (str): The ID of the tool call.
+        function (:py:class:`FunctionToolCallArguments`): The arguments of the function tool call.
+        type (str): The type of the object. Currently only "function" is supported.
+    """
+
+    id: str
+    function: FunctionToolCallArguments
+    type: Literal["function"] = "function"
+
+    def __post_init__(self):
+        self._validate_field("id", str, True)
+        self._convert_dataclass("function", FunctionToolCallArguments, True)
+        self._validate_field("type", str, True)
+
+
+@dataclass
 class ChatMessage(_BaseDataclass):
     """
     A message in a chat request or response.
 
     Args:
-        role (str): The role of the entity that sent the message (e.g. ``"user"``, ``"system"``).
+        role (str): The role of the entity that sent the message (e.g. ``"user"``,
+            ``"system"``, ``"assistant"``, ``"tool"``).
         content (str): The content of the message.
-            **Optional** Supplied if a non-refusal response is provided.
+            **Optional** Can be null if refusal or tool_calls are provided.
         refusal (str): The refusal message content.
             **Optional** Supplied if a refusal response is provided.
         name (str): The name of the entity that sent the message. **Optional**.
+        tool_calls (List[:py:class:`ToolCall`]): A list of tool calls made by the model.
+            **Optional**
+        tool_call_id (str): The ID of the tool call that this message is a response to.
+            **Optional**
     """
 
     role: str
     content: Optional[str] = None
     refusal: Optional[str] = None
     name: Optional[str] = None
+    tool_calls: Optional[List[ToolCall]] = None
+    tool_call_id: Optional[str] = None
 
     def __post_init__(self):
         self._validate_field("role", str, True)
@@ -116,10 +202,127 @@ class ChatMessage(_BaseDataclass):
             self._validate_field("refusal", str, True)
             if self.content:
                 raise ValueError("Both `content` and `refusal` cannot be set")
+        elif self.tool_calls:
+            self._validate_field("content", str, False)
         else:
             self._validate_field("content", str, True)
 
         self._validate_field("name", str, False)
+        self._convert_dataclass_list("tool_calls", ToolCall, False)
+        self._validate_field("tool_call_id", str, False)
+
+
+@dataclass
+class ParamType(_BaseDataclass):
+    type: Literal["string", "number", "integer", "object", "array", "boolean", "null"]
+
+    def __post_init__(self):
+        self._validate_literal("type", JSON_SCHEMA_TYPES, True)
+
+
+@dataclass
+class ParamProperty(ParamType):
+    """
+    A single parameter within a function definition.
+
+    Args:
+        type (str): The type of the parameter. Possible values are "string", "number", "integer",
+            "object", "array", "boolean", or "null", conforming to the JSON Schema specification.
+        description (str): A description of the parameter.
+            **Optional**, defaults to ``None``
+        enum (List[str]): Used to constrain the possible values for the parameter.
+            **Optional**, defaults to ``None``
+        items (:py:class:`ParamProperty`): If the param is of ``array`` type, this field can be
+            used to specify the type of its items. **Optional**, defaults to ``None``
+    """
+
+    description: Optional[str] = None
+    enum: Optional[List[str]] = None
+    items: Optional[ParamType] = None
+
+    def __post_init__(self):
+        self._validate_field("description", str, False)
+        self._validate_list("enum", str, False)
+        self._convert_dataclass("items", ParamType, False)
+        super().__post_init__()
+
+
+@dataclass
+class ToolParamsSchema(_BaseDataclass):
+    """
+    A tool parameter definition.
+
+    Args:
+        properties (Dict[str, :py:class:`ParamProperty`]): A mapping of parameter names to
+            their definitions.
+        type (str): The type of the parameter. Currently only "object" is supported.
+        required (List[str]): A list of required parameter names. **Optional**, defaults to ``None``
+        additionalProperties (bool): Whether additional properties are allowed in the object.
+            **Optional**, defaults to ``None``
+    """
+
+    properties: Dict[str, ParamProperty]
+    type: Literal["object"] = "object"
+    required: Optional[List[str]] = None
+    additionalProperties: Optional[bool] = None
+
+    def __post_init__(self):
+        self._convert_dataclass_map("properties", ParamProperty, True)
+        self._validate_literal("type", ["object"], True)
+        self._validate_list("required", str, False)
+        self._validate_field("additionalProperties", bool, False)
+
+
+@dataclass
+class FunctionToolDefinition(_BaseDataclass):
+    """
+    Definition for function tools (currently the only supported type of tool).
+
+    Args:
+        name (str): The name of the tool.
+        description (str): A description of what the tool does, and how it should be used.
+            **Optional**, defaults to ``None``
+        parameters (Dict[str, :py:class:`ToolParams`]): A mapping of parameter names to their
+            definitions. If not provided, this defines a function without parameters.
+            **Optional**, defaults to ``None``
+        strict (bool): Whether or not to opt into structured outputs.
+            **Optional**, defaults to ``None``.
+    """
+
+    name: str
+    description: Optional[str] = None
+    parameters: ToolParamsSchema = None
+    strict: Optional[bool] = None
+
+    def __post_init__(self):
+        self._validate_field("name", str, True)
+        self._validate_field("description", str, False)
+        self._convert_dataclass("parameters", ToolParamsSchema, False)
+        self._validate_field("strict", bool, False)
+
+    def to_tool_definition(self):
+        """
+        Convenience function for wrapping this in a ToolDefiniton
+        """
+        return ToolDefinition(type="function", function=self)
+
+
+@dataclass
+class ToolDefinition(_BaseDataclass):
+    """
+    Definition for tools that can be called by the model.
+
+    Args:
+        function (:py:class:`FunctionToolDefinition`): The definition of a function tool.
+        type (str): The type of the tool. Currently only "function" is supported.
+    """
+
+    function: FunctionToolDefinition
+    type: Literal["function"] = "function"
+
+    def __post_init__(self):
+        self._validate_literal("type", ["function"], True)
+        self._convert_dataclass("function", FunctionToolDefinition, True)
 
 
 @dataclass
@@ -153,6 +356,8 @@ class ChatParams(_BaseDataclass):
         metadata (Dict[str, str]): An optional param to provide arbitrary additional context
             to the model. Both the keys and the values must be strings (i.e. nested dictionaries
             are not supported).
+        tools (List[:py:class:`ToolDefinition`]): An optional list of tools that can be called by
+            the model.
     """
 
     temperature: float = 1.0
@@ -167,6 +372,7 @@ class ChatParams(_BaseDataclass):
     presence_penalty: Optional[float] = None
 
     metadata: Optional[Dict[str, str]] = None
+    tools: Optional[List[ToolDefinition]] = None
 
     def __post_init__(self):
         self._validate_field("temperature", float, True)
@@ -179,6 +385,7 @@ class ChatParams(_BaseDataclass):
         self._validate_field("top_k", int, False)
         self._validate_field("frequency_penalty", float, False)
         self._validate_field("presence_penalty", float, False)
+        self._convert_dataclass_list("tools", ToolDefinition, False)
 
         # validate that the metadata field is a map from string to string
         if self.metadata is not None:
@@ -410,6 +617,72 @@ CHAT_MODEL_INPUT_SCHEMA = Schema(
         ColSpec(name="top_k", type=DataType.long, required=False),
         ColSpec(name="frequency_penalty", type=DataType.double, required=False),
         ColSpec(name="presence_penalty", type=DataType.double, required=False),
+        ColSpec(
+            name="tools",
+            type=Array(
+                Object(
+                    [
+                        Property("type", DataType.string),
+                        Property(
+                            "function",
+                            Object(
+                                [
+                                    Property("name", DataType.string),
+                                    Property("description", DataType.string, False),
+                                    Property(
+                                        "parameters",
+                                        Object(
+                                            [
+                                                Property(
+                                                    "properties",
+                                                    Map(
+                                                        Object(
+                                                            [
+                                                                Property("type", DataType.string),
+                                                                Property(
+                                                                    "description",
+                                                                    DataType.string,
+                                                                    False,
+                                                                ),
+                                                                Property(
+                                                                    "enum",
+                                                                    Array(DataType.string),
+                                                                    False,
+                                                                ),
+                                                                Property(
+                                                                    "items",
+                                                                    Object(
+                                                                        [
+                                                                            Property(
+                                                                                "type",
+                                                                                DataType.string,
+                                                                            ),
+                                                                        ]
+                                                                    ),
+                                                                    False,
+                                                                ),
+                                                            ]
+                                                        )
+                                                    ),
+                                                ),
+                                                Property("type", DataType.string, False),
+                                                Property("required", Array(DataType.string), False),
+                                                Property(
+                                                    "additionalProperties", DataType.boolean, False
+                                                ),
+                                            ]
+                                        ),
+                                        False,
+                                    ),
+                                    Property("strict", DataType.boolean, False),
+                                ]
+                            ),
+                        ),
+                    ]
+                ),
+            ),
+            required=False,
+        ),
         ColSpec(name="metadata", type=Map(DataType.string), required=False),
     ]
 )

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -602,8 +602,31 @@ CHAT_MODEL_INPUT_SCHEMA = Schema(
                 Object(
                     [
                         Property("role", DataType.string),
-                        Property("content", DataType.string),
+                        Property("content", DataType.string, False),
                         Property("name", DataType.string, False),
+                        Property("refusal", DataType.string, False),
+                        Property(
+                            "tool_calls",
+                            Array(
+                                Object(
+                                    [
+                                        Property("id", DataType.string),
+                                        Property(
+                                            "function",
+                                            Object(
+                                                [
+                                                    Property("name", DataType.string),
+                                                    Property("arguments", DataType.string),
+                                                ]
+                                            ),
+                                        ),
+                                        Property("type", DataType.string),
+                                    ]
+                                )
+                            ),
+                            False,
+                        ),
+                        Property("tool_call_id", DataType.string, False),
                     ]
                 )
             ),
@@ -704,8 +727,33 @@ CHAT_MODEL_OUTPUT_SCHEMA = Schema(
                             Object(
                                 [
                                     Property("role", DataType.string),
-                                    Property("content", DataType.string),
+                                    Property("content", DataType.string, False),
                                     Property("name", DataType.string, False),
+                                    Property("refusal", DataType.string, False),
+                                    Property(
+                                        "tool_calls",
+                                        Array(
+                                            Object(
+                                                [
+                                                    Property("id", DataType.string),
+                                                    Property(
+                                                        "function",
+                                                        Object(
+                                                            [
+                                                                Property("name", DataType.string),
+                                                                Property(
+                                                                    "arguments", DataType.string
+                                                                ),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                    Property("type", DataType.string),
+                                                ]
+                                            )
+                                        ),
+                                        False,
+                                    ),
+                                    Property("tool_call_id", DataType.string, False),
                                 ]
                             ),
                         ),

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -282,7 +282,7 @@ class FunctionToolDefinition(_BaseDataclass):
         name (str): The name of the tool.
         description (str): A description of what the tool does, and how it should be used.
             **Optional**, defaults to ``None``
-        parameters (Dict[str, :py:class:`ToolParams`]): A mapping of parameter names to their
+        parameters (Dict[str, :py:class:`ToolParamsSchema`]): A mapping of parameter names to their
             definitions. If not provided, this defines a function without parameters.
             **Optional**, defaults to ``None``
         strict (bool): Whether or not to opt into structured outputs.

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 from dataclasses import asdict, dataclass, field, fields
 from typing import Dict, List, Literal, Optional
 
@@ -144,7 +145,7 @@ class FunctionToolCallArguments(_BaseDataclass):
         self._validate_field("name", str, True)
         self._validate_field("arguments", str, True)
 
-    def to_tool_call(self, id):
+    def to_tool_call(self, id=uuid.uuid4().hex):
         return ToolCall(id=id, function=self)
 
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds basic tool calling functionality for ChatModel, matching the [OpenAI spec](https://platform.openai.com/docs/api-reference/chat/create). Here's a screenshot reference for the created classes:

## Messages schema

<img width="589" alt="Screenshot 2024-09-19 at 1 01 20 PM" src="https://github.com/user-attachments/assets/3fb92aae-a49f-417e-8f96-1983263e453d">

## Tool Definitions

Top level (the API spec doesn't go completely into details)
<img width="644" alt="Screenshot 2024-09-19 at 4 56 19 PM" src="https://github.com/user-attachments/assets/c818bb1b-bd5a-4d83-9c63-fc49d6724758">

Deep dive to params schema

<img width="651" alt="Screenshot 2024-09-19 at 5 13 52 PM" src="https://github.com/user-attachments/assets/0d3ee699-6b14-4653-91cb-70eaeadc821d">

The PR adds the required dataclasses, and updates the chatmodel input/output schemas. Check out the gists below to see how the workflow looks.

More documentation is definitely needed for ChatModel, I'll add a specific section to the docs in a follow up PR.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested a basic tool calling workflow with `gpt-4o-mini`. The scripts are a bit long for a PR description so here are some gists:

1. Defining a tool calling ChatModel: 
  a. This is a toy model that simply forwards the user input to OpenAI
  b. https://gist.github.com/daniellok-db/43aca672266bcdc1eae42db470c415e5
2. Interacting with a tool calling ChatModel:
  a. This script demonstrates two rounds of message passing, involving a tool call by the model to get the weather
  b. https://gist.github.com/daniellok-db/3337f78d3f93d0260cccab0b41f940b9


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.pyfunc.ChatModel` now supports tool calling! Check out the documentation for details.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
