### PR TITLE
Fix D417 (`undocumented param`) for public APIs

### DIFF
--- a/mlflow/h2o/__init__.py
+++ b/mlflow/h2o/__init__.py
@@ -73,7 +73,7 @@ def get_default_conda_env():
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
-def save_model(  # noqa: D417
+def save_model(
     h2o_model,
     path,
     conda_env=None,
@@ -94,6 +94,7 @@ def save_model(  # noqa: D417
         conda_env: {{ conda_env }}
         code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
+        settings: Settings to pass to ``h2o.init()`` when loading the model.
         signature: {{ signature }}
         input_example: {{ input_example }}
         pip_requirements: {{ pip_requirements }}

--- a/mlflow/keras/autologging.py
+++ b/mlflow/keras/autologging.py
@@ -110,7 +110,7 @@ def _log_keras_model(
 
 @experimental
 @autologging_integration("keras")
-def autolog(  # noqa: D417
+def autolog(
     log_every_epoch=True,
     log_every_n_steps=None,
     log_models=True,
@@ -157,6 +157,9 @@ def autolog(  # noqa: D417
             `False`, autologged content is logged to the active fluent run, which may be
             user-created.  disable_for_unsupported_versions: If `True`, disable autologging for
             incompatible Keras versions.
+        disable_for_unsupported_versions: If ``True``, disable autologging for versions of keras
+            that have not been tested against this version of the MLflow client or are
+            incompatible.
         silent: If `True`, suppress all event logs and warnings from MLflow during Keras
             autologging.  If `True`, show all events and warnings during Keras autologging.
         registered_model_name: If set, each time a model is trained, it is registered as a new model

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2228,7 +2228,7 @@ def _validate_function_python_model(python_model):
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
 @trace_disabled  # Suppress traces for internal predict calls while saving model
-def save_model(  # noqa: D417
+def save_model(
     path,
     loader_module=None,
     data_path=None,
@@ -2425,6 +2425,10 @@ def save_model(  # noqa: D417
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
+        streamable: A boolean value indicating if the model supports streaming prediction,
+                    If None, MLflow will try to inspect if the model supports streaming
+                    by checking if `predict_stream` method exists. Default None.
+        kwargs: Extra keyword arguments.
     """
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
     _validate_pyfunc_model_config(model_config)

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -142,7 +142,7 @@ def get_default_conda_env(is_spark_connect_model=False):
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="pyspark"))
-def log_model(  # noqa: D417
+def log_model(
     spark_model,
     artifact_path,
     conda_env=None,
@@ -195,8 +195,6 @@ def log_model(  # noqa: D417
             the array into Spark ML vector and then invoke Spark model for inference. Similarly,
             if the model has vector type output, MLflow internally converts Spark ML vector
             output data into ``Array[double]`` type inference result.
-
-            Example:
 
             .. code-block:: python
 

--- a/mlflow/statsmodels/__init__.py
+++ b/mlflow/statsmodels/__init__.py
@@ -214,7 +214,7 @@ def save_model(
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
-def log_model(  # noqa: D417
+def log_model(
     statsmodels_model,
     artifact_path,
     conda_env=None,
@@ -251,6 +251,7 @@ def log_model(  # noqa: D417
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: {{ metadata }}
+        kwargs: Extra kwargs to pass to ``mlflow.models.Model.log``.
 
     Returns:
         A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the metadata

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -460,7 +460,7 @@ class MlflowClient:
 
         Args:
             request_id: String ID of the trace to fetch.
-            display: If ``True``, display the trace using the configured display handler.
+            display: If ``True``, display the trace on the notebook.
 
         Returns:
             The retrieved :py:class:`Trace <mlflow.entities.Trace>`.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -454,12 +454,13 @@ class MlflowClient:
         )
 
     @experimental
-    def get_trace(self, request_id: str, display=True) -> Trace:  # noqa: D417
+    def get_trace(self, request_id: str, display=True) -> Trace:
         """
         Get the trace matching the specified ``request_id``.
 
         Args:
             request_id: String ID of the trace to fetch.
+            display: If ``True``, display the trace using the configured display handler.
 
         Returns:
             The retrieved :py:class:`Trace <mlflow.entities.Trace>`.
@@ -1386,12 +1387,13 @@ class MlflowClient:
         """
         self._tracking_client.restore_experiment(experiment_id)
 
-    def rename_experiment(self, experiment_id: str, new_name: str) -> None:  # noqa: D417
+    def rename_experiment(self, experiment_id: str, new_name: str) -> None:
         """
         Update an experiment's name. The new name must be unique.
 
         Args:
             experiment_id: The experiment ID returned from ``create_experiment``.
+            new_name: The new name for the experiment.
 
         .. code-block:: python
             :caption: Example
@@ -1624,7 +1626,7 @@ class MlflowClient:
         """
         self._tracking_client.set_experiment_tag(experiment_id, key, value)
 
-    def set_tag(  # noqa: D417
+    def set_tag(
         self, run_id: str, key: str, value: Any, synchronous: Optional[bool] = None
     ) -> Optional[RunOperations]:
         """
@@ -1637,7 +1639,7 @@ class MlflowClient:
                 length 250, but some may support larger keys.
             value: Tag value, but will be string-ified if not. All backend stores will support
                 values up to length 5000, but some may support larger values.
-           synchronous: *Experimental* If True, blocks until the metric is logged successfully.
+            synchronous: *Experimental* If True, blocks until the metric is logged successfully.
                 If False, logs the metric asynchronously and returns a future representing the
                 logging operation. If None, read from environment variable
                 `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
@@ -1874,16 +1876,13 @@ class MlflowClient:
         """
         self._tracking_client.log_inputs(run_id, datasets)
 
-    def log_artifact(self, run_id, local_path, artifact_path=None) -> None:  # noqa: D417
+    def log_artifact(self, run_id, local_path, artifact_path=None) -> None:
         """Write a local file or directory to the remote ``artifact_uri``.
 
         Args:
+            run_id: String ID of run.
             local_path: Path to the file or directory to write.
             artifact_path: If provided, the directory in ``artifact_uri`` to write to.
-            synchronous: *Experimental* If True, blocks until the metric is logged successfully.
-                If False, logs the metric asynchronously and returns a future representing the
-                logging operation. If None, read from environment variable
-                `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
 
         .. code-block:: python
             :caption: Example
@@ -1923,12 +1922,13 @@ class MlflowClient:
             )
         self._tracking_client.log_artifact(run_id, local_path, artifact_path)
 
-    def log_artifacts(  # noqa: D417
+    def log_artifacts(
         self, run_id: str, local_dir: str, artifact_path: Optional[str] = None
     ) -> None:
         """Write a directory of files to the remote ``artifact_uri``.
 
         Args:
+            run_id: String ID of run.
             local_dir: Path to the directory of files to write.
             artifact_path: If provided, the directory in ``artifact_uri`` to write to.
 
@@ -2169,7 +2169,7 @@ class MlflowClient:
             else:
                 raise TypeError(f"Unsupported figure object type: '{type(figure)}'")
 
-    def log_image(  # noqa: D417
+    def log_image(
         self,
         run_id: str,
         image: Union["numpy.ndarray", "PIL.Image.Image", "mlflow.Image"],
@@ -2240,6 +2240,10 @@ class MlflowClient:
             step: Integer training step (iteration) at which the image was saved.
                 Defaults to 0.
             timestamp: Time when this image was saved. Defaults to the current system time.
+            synchronous: *Experimental* If True, blocks until the metric is logged successfully.
+                If False, logs the metric asynchronously and returns a future representing the
+                logging operation. If None, read from environment variable
+                `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
 
         .. code-block:: python
             :caption: Time-stepped image logging numpy example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -819,7 +819,7 @@ def delete_tag(key: str) -> None:
     MlflowClient().delete_tag(run_id, key)
 
 
-def log_metric(  # noqa: D417
+def log_metric(
     key: str,
     value: float,
     step: Optional[int] = None,
@@ -847,6 +847,8 @@ def log_metric(  # noqa: D417
             successfully. If False, logs the metric asynchronously and
             returns a future representing the logging operation. If None, read from environment
             variable `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
+        run_id: If specified, log the metric to the specified run. If not specified, log the metric
+            to the currently active run.
 
     Returns:
         When `synchronous=True`, returns None.
@@ -879,7 +881,7 @@ def log_metric(  # noqa: D417
     )
 
 
-def log_metrics(  # noqa: D417
+def log_metrics(
     metrics: Dict[str, float],
     step: Optional[int] = None,
     synchronous: Optional[bool] = None,
@@ -901,6 +903,8 @@ def log_metrics(  # noqa: D417
             successfully. If False, logs the metrics asynchronously and
             returns a future representing the logging operation. If None, read from environment
             variable `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
+        run_id: Run ID. If specified, log metrics to the specified run. If not specified, log
+            metrics to the currently active run.
         timestamp: Time when these metrics were calculated. Defaults to the current system time.
 
     Returns:
@@ -1090,7 +1094,7 @@ def set_tags(tags: Dict[str, Any], synchronous: Optional[bool] = None) -> Option
     )
 
 
-def log_artifact(  # noqa: D417
+def log_artifact(
     local_path: str, artifact_path: Optional[str] = None, run_id: Optional[str] = None
 ) -> None:
     """
@@ -1100,6 +1104,8 @@ def log_artifact(  # noqa: D417
     Args:
         local_path: Path to the file to write.
         artifact_path: If provided, the directory in ``artifact_uri`` to write to.
+        run_id: If specified, log the artifact to the specified run. If not specified, log the
+            artifact to the currently active run.
 
     .. code-block:: python
         :test:
@@ -1124,7 +1130,7 @@ def log_artifact(  # noqa: D417
     MlflowClient().log_artifact(run_id, local_path, artifact_path)
 
 
-def log_artifacts(  # noqa: D417
+def log_artifacts(
     local_dir: str, artifact_path: Optional[str] = None, run_id: Optional[str] = None
 ) -> None:
     """
@@ -1134,6 +1140,8 @@ def log_artifacts(  # noqa: D417
     Args:
         local_dir: Path to the directory of files to write.
         artifact_path: If provided, the directory in ``artifact_uri`` to write to.
+        run_id: If specified, log the artifacts to the specified run. If not specified, log the
+            artifacts to the currently active run.
 
     .. code-block:: python
         :test:
@@ -1162,7 +1170,7 @@ def log_artifacts(  # noqa: D417
     MlflowClient().log_artifacts(run_id, local_dir, artifact_path)
 
 
-def log_text(text: str, artifact_file: str, run_id: Optional[str] = None) -> None:  # noqa: D417
+def log_text(text: str, artifact_file: str, run_id: Optional[str] = None) -> None:
     """
     Log text as an artifact.
 
@@ -1170,6 +1178,8 @@ def log_text(text: str, artifact_file: str, run_id: Optional[str] = None) -> Non
         text: String containing text to log.
         artifact_file: The run-relative artifact file path in posixpath format to which
             the text is saved (e.g. "dir/file.txt").
+        run_id: If specified, log the artifact to the specified run. If not specified, log the
+            artifact to the currently active run.
 
     .. code-block:: python
         :test:
@@ -1192,7 +1202,7 @@ def log_text(text: str, artifact_file: str, run_id: Optional[str] = None) -> Non
     MlflowClient().log_text(run_id, text, artifact_file)
 
 
-def log_dict(dictionary: Dict[str, Any], artifact_file: str, run_id: Optional[str] = None) -> None:  # noqa: D417
+def log_dict(dictionary: Dict[str, Any], artifact_file: str, run_id: Optional[str] = None) -> None:
     """
     Log a JSON/YAML-serializable object (e.g. `dict`) as an artifact. The serialization
     format (JSON or YAML) is automatically inferred from the extension of `artifact_file`.
@@ -1203,6 +1213,8 @@ def log_dict(dictionary: Dict[str, Any], artifact_file: str, run_id: Optional[st
         dictionary: Dictionary to log.
         artifact_file: The run-relative artifact file path in posixpath format to which
             the dictionary is saved (e.g. "dir/data.json").
+        run_id: If specified, log the dictionary to the specified run. If not specified, log the
+            dictionary to the currently active run.
 
     .. code-block:: python
         :test:
@@ -1414,7 +1426,7 @@ def log_image(
 
 
 @experimental
-def log_table(  # noqa: D417
+def log_table(
     data: Union[Dict[str, Any], "pandas.DataFrame"],
     artifact_file: str,
     run_id: Optional[str] = None,
@@ -1427,6 +1439,8 @@ def log_table(  # noqa: D417
         data: Dictionary or pandas.DataFrame to log.
         artifact_file: The run-relative artifact file path in posixpath format to which
             the table is saved (e.g. "dir/file.json").
+        run_id: If specified, log the table to the specified run. If not specified, log the
+            table to the currently active run.
 
     .. code-block:: python
         :test:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -450,7 +450,7 @@ def save_model(
             of `mlflow.models.signature`.
 
             .. code-block:: python
-                caption: Example
+                :caption: Example
 
                 from mlflow.models import infer_signature
                 from mlflow.transformers import generate_signature_output

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -971,7 +971,7 @@ def log_model(
             of `mlflow.models.signature`.
 
             .. code-block:: python
-                caption: Example
+                :caption: Example
 
                 from mlflow.models import infer_signature
                 from mlflow.transformers import generate_signature_output

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -450,6 +450,7 @@ def save_model(
             of `mlflow.models.signature`.
 
             .. code-block:: python
+                caption: Example
 
                 from mlflow.models import infer_signature
                 from mlflow.transformers import generate_signature_output
@@ -970,6 +971,7 @@ def log_model(
             of `mlflow.models.signature`.
 
             .. code-block:: python
+                caption: Example
 
                 from mlflow.models import infer_signature
                 from mlflow.transformers import generate_signature_output

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -270,7 +270,7 @@ def get_default_conda_env(model):
 @experimental
 @docstring_version_compatibility_warning(integration_name=FLAVOR_NAME)
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
-def save_model(  # noqa: D417
+def save_model(
     transformers_model,
     path: str,
     processor=None,
@@ -373,6 +373,10 @@ def save_model(  # noqa: D417
             pipeline utilities within the transformers library will be used to infer the
             correct task type. If the value specified is not a supported type,
             an Exception will be thrown.
+        torch_dtype: The Pytorch dtype applied to the model when loading back. This is useful
+            when you want to save the model with a specific dtype that is different from the
+            dtype of the model when it was trained. If not specified, the current dtype of the
+            model instance will be used.
         model_card: An Optional `ModelCard` instance from `huggingface-hub`. If provided, the
             contents of the model card will be saved along with the provided
             `transformers_model`. If not provided, an attempt will be made to fetch
@@ -444,8 +448,6 @@ def save_model(  # noqa: D417
         signature: A Model Signature object that describes the input and output Schema of the
             model. The model signature can be inferred using `infer_signature` function
             of `mlflow.models.signature`.
-
-            Example:
 
             .. code-block:: python
 
@@ -788,7 +790,7 @@ def save_model(  # noqa: D417
 @experimental
 @docstring_version_compatibility_warning(integration_name=FLAVOR_NAME)
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
-def log_model(  # noqa: D417
+def log_model(
     transformers_model,
     artifact_path: str,
     processor=None,
@@ -967,8 +969,6 @@ def log_model(  # noqa: D417
             model. The model signature can be inferred using `infer_signature` function
             of `mlflow.models.signature`.
 
-            Example:
-
             .. code-block:: python
 
                 from mlflow.models import infer_signature
@@ -1001,6 +1001,7 @@ def log_model(  # noqa: D417
             a supported type, this inference functionality will not function correctly
             and a warning will be issued. In order to ensure that a precise signature
             is logged, it is recommended to explicitly provide one.
+
         input_example: {{ input_example }}
         await_registration_for: Number of seconds to wait for the model version
             to finish being created and is in ``READY`` status.

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1003,7 +1003,6 @@ def log_model(
             a supported type, this inference functionality will not function correctly
             and a warning will be issued. In order to ensure that a precise signature
             is logged, it is recommended to explicitly provide one.
-
         input_example: {{ input_example }}
         await_registration_for: Number of seconds to wait for the model version
             to finish being created and is in ``READY`` status.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13200?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13200/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13200
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #13198 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Document undocumented parameters in public APIs. In #13181, we'll add many new arguments to public APIs. This PR helps prevent undocumented params.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
