### PR TITLE
Databricks SDK based models artifact repo

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -652,3 +652,11 @@ MLFLOW_ENABLE_DB_SDK = _BooleanEnvironmentVariable("MLFLOW_ENABLE_DB_SDK", True)
 _MLFLOW_IN_CAPTURE_MODULE_PROCESS = _BooleanEnvironmentVariable(
     "MLFLOW_IN_CAPTURE_MODULE_PROCESS", False
 )
+
+#: Use DatabricksSDKModelsArtifactRepository when registering and loading models to and from
+#: Databricks UC. This is required for SEG(Secure Egress Gateway) enabled workspaces and helps
+#: eliminate models exfiltration risk associated with temporary scoped token generation used in
+#: existing model artifact repo classes.
+MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC = _BooleanEnvironmentVariable(
+    "MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC", False
+)

--- a/mlflow/store/artifact/cloud_artifact_repo.py
+++ b/mlflow/store/artifact/cloud_artifact_repo.py
@@ -266,6 +266,7 @@ class CloudArtifactRepository(ArtifactRepository):
         file_infos = self.list_artifacts(parent_dir)
         file_info = [info for info in file_infos if info.path == remote_file_path]
         file_size = file_info[0].file_size if len(file_info) == 1 else None
+
         # NB: FUSE mounts do not support file write from a non-0th index seek position.
         # Due to this limitation (writes must start at the beginning of a file),
         # offset writes are disabled if FUSE is the local_path destination.
@@ -274,6 +275,9 @@ class CloudArtifactRepository(ArtifactRepository):
             or not file_size
             or file_size < MLFLOW_MULTIPART_DOWNLOAD_MINIMUM_FILE_SIZE.get()
             or is_fuse_or_uc_volumes_uri(local_path)
+            # DatabricksSDKModelsArtifactRepository can only download file via databricks sdk
+            # rather than presigned uri used in _parallelized_download_from_cloud.
+            or type(self).__name__ == "DatabricksSDKModelsArtifactRepository"
         ):
             self._download_from_cloud(remote_file_path, local_path)
         else:

--- a/mlflow/store/artifact/databricks_sdk_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_models_artifact_repo.py
@@ -1,0 +1,80 @@
+import posixpath
+
+from mlflow.entities import FileInfo
+from mlflow.store.artifact.cloud_artifact_repo import CloudArtifactRepository
+
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024 * 1024
+
+
+def _get_databricks_workspace_client():
+    from databricks.sdk import WorkspaceClient
+
+    return WorkspaceClient()
+
+
+class DatabricksSDKModelsArtifactRepository(CloudArtifactRepository):
+    """
+    Stores and retrieves model artifacts via Databricks SDK, agnostic to the underlying cloud
+    that stores the model artifacts.
+    """
+
+    def __init__(self, model_name, model_version):
+        self.model_name = model_name
+        self.model_version = model_version
+        self.model_base_path = f"/Models/{model_name.replace('.', '/')}/{model_version}"
+        self.client = _get_databricks_workspace_client()
+        super().__init__(self.model_base_path)
+
+    def list_artifacts(self, path=None):
+        dest_path = self.model_base_path
+        if path:
+            dest_path = posixpath.join(dest_path, path)
+
+        file_infos = []
+        resp = self.client.files.list_directory_contents(dest_path)
+        for directory_entry in resp:
+            relative_path = posixpath.relpath(directory_entry.path, self.model_base_path)
+            file_infos.append(
+                FileInfo(
+                    path=relative_path,
+                    is_dir=directory_entry.is_directory,
+                    file_size=directory_entry.file_size,
+                )
+            )
+
+        return sorted(file_infos, key=lambda f: f.path)
+
+    def _upload_to_cloud(self, cloud_credential_info, src_file_path, artifact_file_path=None):
+        dest_path = self.model_base_path
+        if artifact_file_path:
+            dest_path = posixpath.join(dest_path, artifact_file_path)
+
+        with open(src_file_path, "rb") as f:
+            self.client.files.upload(dest_path, f, overwrite=True)
+
+    def log_artifact(self, local_file, artifact_path=None):
+        self._upload_to_cloud(
+            cloud_credential_info=None,
+            src_file_path=local_file,
+            artifact_file_path=artifact_path,
+        )
+
+    def _download_from_cloud(self, remote_file_path, local_path):
+        dest_path = self.model_base_path
+        if remote_file_path:
+            dest_path = posixpath.join(dest_path, remote_file_path)
+
+        resp = self.client.files.download(dest_path)
+        contents = resp.contents
+
+        with open(local_path, "wb") as f:
+            while chunk := contents.read(DOWNLOAD_CHUNK_SIZE):
+                f.write(chunk)
+
+    def _get_write_credential_infos(self, remote_file_paths):
+        # Databricks sdk based model download/upload don't need any extra credentials
+        return [None] * len(remote_file_paths)
+
+    def _get_read_credential_infos(self, remote_file_paths):
+        # Databricks sdk based model download/upload don't need any extra credentials
+        return [None] * len(remote_file_paths)

--- a/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
+++ b/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
@@ -1,5 +1,6 @@
 import base64
 
+from mlflow.environment_variables import MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
@@ -11,6 +12,9 @@ from mlflow.protos.databricks_uc_registry_messages_pb2 import (
 from mlflow.protos.databricks_uc_registry_service_pb2 import UcModelRegistryService
 from mlflow.store._unity_catalog.lineage.constants import _DATABRICKS_LINEAGE_ID_HEADER
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
+from mlflow.store.artifact.databricks_sdk_models_artifact_repo import (
+    DatabricksSDKModelsArtifactRepository,
+)
 from mlflow.store.artifact.presigned_url_artifact_repo import PresignedUrlArtifactRepository
 from mlflow.store.artifact.utils.models import (
     get_model_name_and_version,
@@ -120,6 +124,8 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
         Get underlying ArtifactRepository instance for model version blob
         storage
         """
+        if MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC.get():
+            return DatabricksSDKModelsArtifactRepository(self.model_name, self.model_version)
         scoped_token = self._get_scoped_token(lineage_header_info=lineage_header_info)
         if scoped_token.storage_mode == StorageMode.DEFAULT_STORAGE:
             return PresignedUrlArtifactRepository(

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -20,6 +20,7 @@ _INVALID_DB_URI_MSG = (
 _DBFS_FUSE_PREFIX = "/dbfs/"
 _DBFS_HDFS_URI_PREFIX = "dbfs:/"
 _uc_volume_URI_PREFIX = "/Volumes/"
+_uc_model_URI_PREFIX = "/Models/"
 _UC_DBFS_SYMLINK_PREFIX = "/.fuse-mounts/"
 _DATABRICKS_UNITY_CATALOG_SCHEME = "databricks-uc"
 _OSS_UNITY_CATALOG_SCHEME = "uc"
@@ -101,6 +102,7 @@ def is_fuse_or_uc_volumes_uri(uri):
             _DBFS_FUSE_PREFIX,
             _DBFS_HDFS_URI_PREFIX,
             _uc_volume_URI_PREFIX,
+            _uc_model_URI_PREFIX,
             _UC_DBFS_SYMLINK_PREFIX,
         ]
     )

--- a/tests/store/artifact/test_databricks_sdk_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_sdk_models_artifact_repo.py
@@ -1,0 +1,191 @@
+import io
+from unittest import mock
+
+import pytest
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.files import DirectoryEntry, DownloadResponse
+
+from mlflow.entities.file_info import FileInfo
+from mlflow.entities.model_registry import ModelVersion
+from mlflow.store._unity_catalog.registry.rest_store import (
+    UcModelRegistryStore,
+)
+from mlflow.store.artifact.databricks_sdk_models_artifact_repo import (
+    DatabricksSDKModelsArtifactRepository,
+)
+from mlflow.store.artifact.unity_catalog_models_artifact_repo import (
+    UnityCatalogModelsArtifactRepository,
+)
+
+TEST_MODEL_NAME = "catalog.schema.model"
+TEST_CATALOG = "catalog"
+TEST_SCHEMA = "schema"
+TEST_MODEL = "model"
+TEST_MODEL_VERSION = 1
+TEST_MODEL_BASE_PATH = f"/Models/{TEST_CATALOG}/{TEST_SCHEMA}/{TEST_MODEL}/{TEST_MODEL_VERSION}"
+
+
+@pytest.fixture
+def mock_databricks_workspace_client():
+    mock_databricks_workspace_client = mock.MagicMock(autospec=WorkspaceClient)
+    with mock.patch(
+        "mlflow.store.artifact.databricks_sdk_models_artifact_repo._get_databricks_workspace_client",
+        return_value=mock_databricks_workspace_client,
+    ):
+        yield mock_databricks_workspace_client
+
+
+def test_list_artifacts_empty(mock_databricks_workspace_client):
+    repo = DatabricksSDKModelsArtifactRepository(TEST_MODEL_NAME, TEST_MODEL_VERSION)
+    mock_databricks_workspace_client.files.list_directory_contents.return_value = iter([])
+    assert repo.list_artifacts() == []
+
+
+def test_list_artifacts_single_file(mock_databricks_workspace_client):
+    repo = DatabricksSDKModelsArtifactRepository(TEST_MODEL_NAME, TEST_MODEL_VERSION)
+
+    entry = DirectoryEntry(is_directory=False, path=f"{TEST_MODEL_BASE_PATH}/file")
+    mock_databricks_workspace_client.files.list_directory_contents.return_value = iter([entry])
+
+    assert repo.list_artifacts() == [FileInfo(is_dir=False, path="file", file_size=None)]
+
+
+def test_list_artifacts_many_files(mock_databricks_workspace_client):
+    repo = DatabricksSDKModelsArtifactRepository(TEST_MODEL_NAME, TEST_MODEL_VERSION)
+
+    # Directory structure:
+    root = DirectoryEntry(is_directory=True, path=f"{TEST_MODEL_BASE_PATH}/root")
+    file1 = DirectoryEntry(
+        is_directory=False, path=f"{TEST_MODEL_BASE_PATH}/root/file1", file_size=1
+    )
+    file2 = DirectoryEntry(
+        is_directory=False, path=f"{TEST_MODEL_BASE_PATH}/root/file2", file_size=2
+    )
+    subdir1 = DirectoryEntry(is_directory=True, path=f"{TEST_MODEL_BASE_PATH}/root/subdir1")
+    file3 = DirectoryEntry(
+        is_directory=False, path=f"{TEST_MODEL_BASE_PATH}/root/subdir1/file3", file_size=3
+    )
+    subdir2 = DirectoryEntry(is_directory=True, path=f"{TEST_MODEL_BASE_PATH}/root/subdir2")
+    file4 = DirectoryEntry(
+        is_directory=False, path=f"{TEST_MODEL_BASE_PATH}/root/subdir2/file4", file_size=4
+    )
+    file5 = DirectoryEntry(
+        is_directory=False, path=f"{TEST_MODEL_BASE_PATH}/root/subdir2/file5", file_size=5
+    )
+
+    def list_directory_contents_side_effect(path):
+        if path is None or path == TEST_MODEL_BASE_PATH:
+            return iter([root])
+        elif path == f"{TEST_MODEL_BASE_PATH}/root":
+            return iter([file1, file2, subdir1, subdir2])
+        elif path == f"{TEST_MODEL_BASE_PATH}/root/subdir1":
+            return iter([file3])
+        elif path == f"{TEST_MODEL_BASE_PATH}/root/subdir2":
+            return iter([file4, file5])
+
+    mock_databricks_workspace_client.files.list_directory_contents.side_effect = (
+        list_directory_contents_side_effect
+    )
+
+    observed_artifacts = repo.list_artifacts()
+    assert observed_artifacts == [FileInfo(is_dir=True, path="root", file_size=None)]
+
+    observed_artifacts = repo.list_artifacts("root")
+    assert observed_artifacts == [
+        FileInfo(is_dir=False, path="root/file1", file_size=1),
+        FileInfo(is_dir=False, path="root/file2", file_size=2),
+        FileInfo(is_dir=True, path="root/subdir1", file_size=None),
+        FileInfo(is_dir=True, path="root/subdir2", file_size=None),
+    ]
+
+    observed_artifacts = repo.list_artifacts("root/subdir1")
+    assert observed_artifacts == [
+        FileInfo(is_dir=False, path="root/subdir1/file3", file_size=3),
+    ]
+
+    observed_artifacts = repo.list_artifacts("root/subdir2")
+    assert observed_artifacts == [
+        FileInfo(is_dir=False, path="root/subdir2/file4", file_size=4),
+        FileInfo(is_dir=False, path="root/subdir2/file5", file_size=5),
+    ]
+
+
+def test_upload_to_cloud(mock_databricks_workspace_client, tmp_path):
+    # write some content to a file at a local path
+    file_name = "a.txt"
+    file_content = b"file_content"
+    local_file_path = tmp_path.joinpath(file_name)
+    local_file_path.write_bytes(file_content)
+
+    # assert that databricks sdk file upload function is called to upload that content
+    # to expected_remote_file_path
+    repo = DatabricksSDKModelsArtifactRepository(TEST_MODEL_NAME, TEST_MODEL_VERSION)
+    repo._upload_to_cloud(None, local_file_path, file_name)
+
+    expected_remote_file_path = f"{TEST_MODEL_BASE_PATH}/a.txt"
+    mock_databricks_workspace_client.files.upload.assert_called_once_with(
+        expected_remote_file_path, mock.ANY, overwrite=mock.ANY
+    )
+
+
+def test_download_from_cloud(mock_databricks_workspace_client, tmp_path):
+    # write some content to a file at a local path
+    file_name = "a.txt"
+    local_file_path = tmp_path.joinpath(file_name)
+
+    # assert that databricks sdk file download function is called to download
+    # from expected_remote_file_path to local_file_path
+    mock_databricks_workspace_client.files.download.return_value = DownloadResponse(
+        contents=io.BytesIO(b"file_content")
+    )
+    repo = DatabricksSDKModelsArtifactRepository(TEST_MODEL_NAME, TEST_MODEL_VERSION)
+    repo._download_from_cloud(file_name, local_file_path)
+
+    expected_remote_file_path = f"{TEST_MODEL_BASE_PATH}/a.txt"
+    mock_databricks_workspace_client.files.download.assert_called_once_with(
+        expected_remote_file_path
+    )
+
+
+def test_log_artifact(mock_databricks_workspace_client, tmp_path):
+    # write some content to a file at a local path
+    file_name = "a.txt"
+    file_content = b"file_content"
+    local_file_path = tmp_path.joinpath(file_name)
+    local_file_path.write_bytes(file_content)
+
+    # assert that databricks sdk file upload function is called to upload that content
+    # to expected_remote_file_path
+    repo = DatabricksSDKModelsArtifactRepository(TEST_MODEL_NAME, TEST_MODEL_VERSION)
+    repo.log_artifact(local_file_path, file_name)
+
+    expected_remote_file_path = f"{TEST_MODEL_BASE_PATH}/a.txt"
+    mock_databricks_workspace_client.files.upload.assert_called_once_with(
+        expected_remote_file_path, mock.ANY, overwrite=mock.ANY
+    )
+
+
+def test_mlflow_use_databricks_sdk_model_artifacts_repo_for_uc(tmp_path, monkeypatch):
+    monkeypatch.setenv("MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC", "true")
+    monkeypatch.setenvs(
+        {
+            "DATABRICKS_HOST": "my-host",
+            "DATABRICKS_TOKEN": "my-token",
+        }
+    )
+    uc_repo = UnityCatalogModelsArtifactRepository("models:/a.b.c/1", "databricks-uc")
+    repo = uc_repo._get_artifact_repo()
+    assert isinstance(repo, DatabricksSDKModelsArtifactRepository)
+
+    store = UcModelRegistryStore(store_uri="databricks-uc", tracking_uri=str(tmp_path))
+    assert isinstance(
+        store._get_artifact_repo(
+            ModelVersion(
+                name="name",
+                version="version",
+                creation_timestamp=1,
+            ),
+            TEST_MODEL_NAME,
+        ),
+        DatabricksSDKModelsArtifactRepository,
+    )


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
<!-- Please fill in changes proposed in this PR. -->
Context:
A small subset of Databricks SEG(workspaces with Internet access turned off) customers will be blocked from using MLFlow due to the fact that mlflow client talks to S3/Azure for model registry. This PR will unblock those customers by allowing model artifacts download/upload through Databricks SDK which internally uses Presigned URL / Files API.

- If MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC is set to true, use the new `DatabricksSDKModelsArtifactRepository` to register and download models to and from UC.
- `DatabricksSDKModelsArtifactRepository` implements `CloudArtifactRepository` to list artifacts, download/upload artifacts to cloud using the [Databricks SDK Files interface](https://databricks-sdk-py.readthedocs.io/en/latest/workspace/files/files.html).


### How is this PR tested?
- Unit Tests
- Download / Upload models to databricks workspace works

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
