### PR TITLE
Fix add_trace in model-from-code

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -25,6 +25,7 @@ from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing import provider
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.display import get_display_handler
+from mlflow.tracing.provider import is_trace_enabled
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import (
     SPANS_COLUMN_NAME,
@@ -611,6 +612,10 @@ def add_trace(trace: Union[Trace, Dict[str, Any]], target: Optional[LiveSpan] = 
             - If not provided and there is no active span, a new span named "Remote Trace <...>"
               will be created and the trace will be merged under it.
     """
+    if not is_trace_enabled():
+        _logger.debug("Tracing is disabled. Skipping add_trace.")
+        return
+
     if isinstance(trace, dict):
         try:
             trace = Trace.from_dict(trace)
@@ -689,6 +694,8 @@ def _merge_trace(
             _logger.warning(
                 f"Parent trace with request ID {target_request_id} not found. Skipping merge."
             )
+            return
+
         new_trace_id = parent_trace.span_dict[target_parent_span_id]._trace_id
 
     for span in trace.data.spans:

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -25,7 +25,7 @@ from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing import provider
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.display import get_display_handler
-from mlflow.tracing.provider import is_trace_enabled
+from mlflow.tracing.provider import is_tracing_enabled
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import (
     SPANS_COLUMN_NAME,
@@ -612,7 +612,7 @@ def add_trace(trace: Union[Trace, Dict[str, Any]], target: Optional[LiveSpan] = 
             - If not provided and there is no active span, a new span named "Remote Trace <...>"
               will be created and the trace will be merged under it.
     """
-    if not is_trace_enabled():
+    if not is_tracing_enabled():
         _logger.debug("Tracing is disabled. Skipping add_trace.")
         return
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -189,7 +189,7 @@ def disable():
         assert len(mlflow.search_traces()) == 1
 
     """
-    if not is_trace_enabled():
+    if not is_tracing_enabled():
         return
 
     _setup_tracer_provider(disabled=True)
@@ -229,7 +229,7 @@ def enable():
         assert len(mlflow.search_traces()) == 2
 
     """
-    if is_trace_enabled() and _MLFLOW_TRACER_PROVIDER_INITIALIZED.done:
+    if is_tracing_enabled() and _MLFLOW_TRACER_PROVIDER_INITIALIZED.done:
         _logger.info("Tracing is already enabled")
         return
 
@@ -262,7 +262,7 @@ def trace_disabled(f):
         is_func_called = False
         result = None
         try:
-            if is_trace_enabled():
+            if is_tracing_enabled():
                 disable()
                 try:
                     is_func_called, result = True, f(*args, **kwargs)
@@ -304,7 +304,7 @@ def reset_tracer_setup():
 
 
 @raise_as_trace_exception
-def is_trace_enabled() -> bool:
+def is_tracing_enabled() -> bool:
     """
     Check if tracing is enabled based on whether the global tracer
     is instantiated or not.

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -189,7 +189,7 @@ def disable():
         assert len(mlflow.search_traces()) == 1
 
     """
-    if not _is_enabled():
+    if not is_trace_enabled():
         return
 
     _setup_tracer_provider(disabled=True)
@@ -229,7 +229,7 @@ def enable():
         assert len(mlflow.search_traces()) == 2
 
     """
-    if _is_enabled() and _MLFLOW_TRACER_PROVIDER_INITIALIZED.done:
+    if is_trace_enabled() and _MLFLOW_TRACER_PROVIDER_INITIALIZED.done:
         _logger.info("Tracing is already enabled")
         return
 
@@ -262,7 +262,7 @@ def trace_disabled(f):
         is_func_called = False
         result = None
         try:
-            if _is_enabled():
+            if is_trace_enabled():
                 disable()
                 try:
                     is_func_called, result = True, f(*args, **kwargs)
@@ -304,7 +304,7 @@ def reset_tracer_setup():
 
 
 @raise_as_trace_exception
-def _is_enabled() -> bool:
+def is_trace_enabled() -> bool:
     """
     Check if tracing is enabled based on whether the global tracer
     is instantiated or not.

--- a/tests/tracing/sample_code/model_with_add_trace.py
+++ b/tests/tracing/sample_code/model_with_add_trace.py
@@ -1,0 +1,56 @@
+import mlflow
+
+_SAMPLE_TRACE = {
+    "info": {
+        "request_id": "2e72d64369624e6888324462b62dc120",
+        "experiment_id": "0",
+        "timestamp_ms": 1726145090860,
+        "execution_time_ms": 162,
+        "status": "OK",
+        "request_metadata": {
+            "mlflow.trace_schema.version": "2",
+            "mlflow.traceInputs": '{"x": 1}',
+            "mlflow.traceOutputs": '{"prediction": 1}',
+        },
+        "tags": {
+            "fruit": "apple",
+            "food": "pizza",
+        },
+    },
+    "data": {
+        "spans": [
+            {
+                "name": "remote",
+                "context": {
+                    "span_id": "0x337af925d6629c01",
+                    "trace_id": "0x05e82d1fc4486f3986fae6dd7b5352b1",
+                },
+                "parent_id": None,
+                "start_time": 1726145091022155863,
+                "end_time": 1726145091022572053,
+                "status_code": "OK",
+                "status_message": "",
+                "attributes": {
+                    "mlflow.traceRequestId": '"2e72d64369624e6888324462b62dc120"',
+                    "mlflow.spanType": '"UNKNOWN"',
+                    "mlflow.spanInputs": '{"x": 1}',
+                    "mlflow.spanOutputs": '{"prediction": 1}',
+                },
+                "events": [
+                    {"name": "event", "timestamp": 1726145091022287, "attributes": {"foo": "bar"}}
+                ],
+            },
+        ],
+        "request": '{"x": 1}',
+        "response": '{"prediction": 1}',
+    },
+}
+
+
+class Model(mlflow.pyfunc.PythonModel):
+    def predict(self, context, model_input):
+        mlflow.add_trace(_SAMPLE_TRACE)
+        return 1
+
+
+mlflow.models.set_model(Model())

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -15,7 +15,7 @@ from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
 from mlflow.tracing.provider import (
     _get_tracer,
     _setup_tracer_provider,
-    is_trace_enabled,
+    is_tracing_enabled,
     reset_tracer_setup,
     start_span_in_context,
     trace_disabled,
@@ -97,7 +97,7 @@ def test_disable_enable_tracing():
 
     # enable() / disable() should only raise MlflowTracingException
     with mock.patch(
-        "mlflow.tracing.provider.is_trace_enabled", side_effect=ValueError("error")
+        "mlflow.tracing.provider.is_tracing_enabled", side_effect=ValueError("error")
     ) as is_enabled_mock:
         with pytest.raises(MlflowTracingException, match="error"):
             mlflow.tracing.disable()
@@ -112,7 +112,7 @@ def test_disable_enable_tracing():
 def test_trace_disabled_decorator(enabled_initially):
     if not enabled_initially:
         mlflow.tracing.disable()
-    assert is_trace_enabled() == enabled_initially
+    assert is_tracing_enabled() == enabled_initially
     call_count = 0
 
     @trace_disabled
@@ -128,7 +128,7 @@ def test_trace_disabled_decorator(enabled_initially):
     assert call_count == 1
 
     # Recover the initial state
-    assert is_trace_enabled() == enabled_initially
+    assert is_tracing_enabled() == enabled_initially
 
     # Tracing should be enabled back even if the function raises an exception
     @trace_disabled
@@ -142,7 +142,7 @@ def test_trace_disabled_decorator(enabled_initially):
     assert call_count == 2
 
     assert len(TRACE_BUFFER) == 0
-    assert is_trace_enabled() == enabled_initially
+    assert is_tracing_enabled() == enabled_initially
 
     # @trace_disabled should not block the decorated function even
     # if it fails to disable tracing
@@ -180,9 +180,9 @@ def test_disable_enable_tracing_not_mutate_otel_provider():
     assert trace.get_tracer_provider() is otel_tracer_provider
 
 
-def test_is_trace_enabled():
+def test_is_tracing_enabled():
     # Before doing anything -> tracing is considered as "on"
-    assert is_trace_enabled()
+    assert is_tracing_enabled()
 
     # Generate a trace -> tracing is still "on"
     @mlflow.trace
@@ -190,26 +190,26 @@ def test_is_trace_enabled():
         pass
 
     foo()
-    assert is_trace_enabled()
+    assert is_tracing_enabled()
 
     # Disable tracing
     mlflow.tracing.disable()
-    assert is_trace_enabled() is False
+    assert is_tracing_enabled() is False
 
     # Try to generate a trace -> tracing is still "off"
     foo()
-    assert is_trace_enabled() is False
+    assert is_tracing_enabled() is False
 
     # Re-enable tracing
     mlflow.tracing.enable()
-    assert is_trace_enabled() is True
+    assert is_tracing_enabled() is True
 
-    # is_trace_enabled() should only raise MlflowTracingException
+    # is_tracing_enabled() should only raise MlflowTracingException
     with mock.patch(
         "mlflow.tracing.provider._get_tracer", side_effect=ValueError("error")
     ) as get_tracer_mock:
         with pytest.raises(MlflowTracingException, match="error"):
-            assert is_trace_enabled() is False
+            assert is_tracing_enabled() is False
         assert get_tracer_mock.call_count == 1
 
 

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -14,8 +14,8 @@ from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
 from mlflow.tracing.provider import (
     _get_tracer,
-    _is_enabled,
     _setup_tracer_provider,
+    is_trace_enabled,
     reset_tracer_setup,
     start_span_in_context,
     trace_disabled,
@@ -97,7 +97,7 @@ def test_disable_enable_tracing():
 
     # enable() / disable() should only raise MlflowTracingException
     with mock.patch(
-        "mlflow.tracing.provider._is_enabled", side_effect=ValueError("error")
+        "mlflow.tracing.provider.is_trace_enabled", side_effect=ValueError("error")
     ) as is_enabled_mock:
         with pytest.raises(MlflowTracingException, match="error"):
             mlflow.tracing.disable()
@@ -112,7 +112,7 @@ def test_disable_enable_tracing():
 def test_trace_disabled_decorator(enabled_initially):
     if not enabled_initially:
         mlflow.tracing.disable()
-    assert _is_enabled() == enabled_initially
+    assert is_trace_enabled() == enabled_initially
     call_count = 0
 
     @trace_disabled
@@ -128,7 +128,7 @@ def test_trace_disabled_decorator(enabled_initially):
     assert call_count == 1
 
     # Recover the initial state
-    assert _is_enabled() == enabled_initially
+    assert is_trace_enabled() == enabled_initially
 
     # Tracing should be enabled back even if the function raises an exception
     @trace_disabled
@@ -142,7 +142,7 @@ def test_trace_disabled_decorator(enabled_initially):
     assert call_count == 2
 
     assert len(TRACE_BUFFER) == 0
-    assert _is_enabled() == enabled_initially
+    assert is_trace_enabled() == enabled_initially
 
     # @trace_disabled should not block the decorated function even
     # if it fails to disable tracing
@@ -180,9 +180,9 @@ def test_disable_enable_tracing_not_mutate_otel_provider():
     assert trace.get_tracer_provider() is otel_tracer_provider
 
 
-def test_is_enabled():
+def test_is_trace_enabled():
     # Before doing anything -> tracing is considered as "on"
-    assert _is_enabled()
+    assert is_trace_enabled()
 
     # Generate a trace -> tracing is still "on"
     @mlflow.trace
@@ -190,26 +190,26 @@ def test_is_enabled():
         pass
 
     foo()
-    assert _is_enabled()
+    assert is_trace_enabled()
 
     # Disable tracing
     mlflow.tracing.disable()
-    assert _is_enabled() is False
+    assert is_trace_enabled() is False
 
     # Try to generate a trace -> tracing is still "off"
     foo()
-    assert _is_enabled() is False
+    assert is_trace_enabled() is False
 
     # Re-enable tracing
     mlflow.tracing.enable()
-    assert _is_enabled() is True
+    assert is_trace_enabled() is True
 
-    # _is_enabled() should only raise MlflowTracingException
+    # is_trace_enabled() should only raise MlflowTracingException
     with mock.patch(
         "mlflow.tracing.provider._get_tracer", side_effect=ValueError("error")
     ) as get_tracer_mock:
         with pytest.raises(MlflowTracingException, match="error"):
-            assert _is_enabled() is False
+            assert is_trace_enabled() is False
         assert get_tracer_mock.call_count == 1
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13208?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13208/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13208
```

</p>
</details>

### What changes are proposed in this pull request?

The `add_trace()` code throws NPE at [this line](https://github.com/mlflow/mlflow/blob/master/mlflow/tracing/fluent.py#L692) when the model is logged via model-from-code. The root cause itself is super stupid, I forgot to add early `return` after the null check.

The tricky thing why this was not captured in unit test is that this only happens for model-from-code. In normal situation, we create a parent span if there is no active one, so the `parent_trace` will never be null. The issue is that during model-from-code, we **disable** tracing (so MLflow won't create trace for some artificial prediction during logging e.g. infer signature).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Model code:
```
import mlflow
from mlflow.deployments import get_deploy_client
import pandas as pd

class MyModel(mlflow.pyfunc.PythonModel):
    def predict(self, context, model_input):
        if isinstance(model_input, pd.DataFrame):
            req = model_input.to_dict("records")[0]
        else:
            req = model_input
 
        req["tools"] = [
            {"type": "uc_function", "uc_function": {"name": name}}
            for name in config.get("tools").get("uc_functions")
        ]
        req["databricks_options"] = {"return_trace": True}

        client = mlflow.deployments.get_deploy_client("databricks")

        completion = client.predict(endpoint=config.get("model_name"), inputs=req)

        if trace := completion.pop("databricks_output", {})["trace"]:
            mlflow.add_trace(trace)
        return completion
    
agent = MyModel()
mlflow.models.set_model(agent)
```

Logging code:
```
import os
import mlflow

input_example = {"messages": [{"role": "user", "content": "what is 23423 * 98023?"}]}

with mlflow.start_run():
    logged_chain_info = mlflow.pyfunc.log_model(
        python_model="agent.py",
        artifact_path="model",
        input_example=input_example,
        model_config="config.yml",
        resources="resources.yml",
    )
```

Loading as pyfunc and confirmed the merged trace is generated:
```
loaded_agent = mlflow.pyfunc.load_model(logged_chain_info.model_uri)
loaded_agent.predict(input_example)
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
