### PR TITLE
Fix tracing for LangGraph

### DIFF
--- a/tests/langchain/test_langgraph.py
+++ b/tests/langchain/test_langgraph.py
@@ -6,6 +6,8 @@ from packaging.version import Version
 
 import mlflow
 
+from tests.tracing.helper import get_traces
+
 
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.2.0"),
@@ -34,6 +36,7 @@ def test_langgraph_save_as_code():
     messages = response["messages"]
     assert len(messages) == 4
     for msg, (role, expected_content) in zip(messages, expected_messages):
+        assert msg.role == role
         assert msg.content == expected_content
 
     # Need to reload to reset the iterator in FakeOpenAI
@@ -48,6 +51,7 @@ def test_langgraph_save_as_code():
     messages = response["messages"]
     assert len(messages) == 4
     for msg, (role, expected_content) in zip(messages, expected_messages):
+        assert msg["role"] == role
         assert msg["content"] == expected_content
     # response should be json serializable
     assert json.dumps(response) is not None
@@ -56,3 +60,47 @@ def test_langgraph_save_as_code():
     response = loaded_pyfunc.predict_stream(input_example)
     for chunk, (role, expected_content) in zip(response, expected_messages[1:]):
         assert chunk[role]["messages"][0]["content"] == expected_content
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="Agent behavior is not stable across minor versions",
+)
+def test_langgraph_tracing():
+    mlflow.langchain.autolog()
+
+    input_example = {"messages": [{"role": "user", "content": "what is the weather in sf?"}]}
+
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            lc_model="tests/langchain/sample_code/langgraph.py",
+            artifact_path="langgraph",
+            input_example=input_example,
+        )
+
+    loaded_graph = mlflow.langchain.load_model(model_info.model_uri)
+
+    # No trace should be created for the first call
+    assert mlflow.get_last_active_trace() is None
+
+    loaded_graph.invoke(input_example)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert traces[0].data.spans[0].name == "LangGraph"
+    assert traces[0].data.spans[0].inputs == input_example
+
+    # (type, content)
+    expected_messages = [
+        ("human", "what is the weather in sf?"),
+        ("ai", ""),  # tool message does not have content
+        ("tool", "It's always sunny in sf"),
+        ("ai", "The weather in San Francisco is always sunny!"),
+    ]
+
+    messages = traces[0].data.spans[0].outputs["messages"]
+    assert len(messages) == 4
+    for msg, (type, expected_content) in zip(messages, expected_messages):
+        assert msg["type"] == type
+        assert msg["content"] == expected_content

--- a/tests/langchain/test_langgraph.py
+++ b/tests/langchain/test_langgraph.py
@@ -36,7 +36,6 @@ def test_langgraph_save_as_code():
     messages = response["messages"]
     assert len(messages) == 4
     for msg, (role, expected_content) in zip(messages, expected_messages):
-        assert msg.role == role
         assert msg.content == expected_content
 
     # Need to reload to reset the iterator in FakeOpenAI
@@ -51,7 +50,6 @@ def test_langgraph_save_as_code():
     messages = response["messages"]
     assert len(messages) == 4
     for msg, (role, expected_content) in zip(messages, expected_messages):
-        assert msg["role"] == role
         assert msg["content"] == expected_content
     # response should be json serializable
     assert json.dumps(response) is not None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13215?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13215/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13215
```

</p>
</details>

### What changes are proposed in this pull request?

Auto tracing did not work for LangGraph. Only subpart of the graph is traced, and generated as separate traces.

The root cause was LangGraph classes are not patched. We only patch classes from `langchain-xxx` module ([code](https://github.com/mlflow/mlflow/blob/master/mlflow/langchain/__init__.py#L1025)). As a result, traces are created for the sub components of the graph that belongs to `langchain-xxx`.

This PR fixes the issue by taking `langgraph` module into account when patching. However, one tricky thing is that `langgraph` does not declare submodules under the root module. As a result, the current recursive patching approach using `inspect.submodule` does not work. Therefore, we instead hard code a few submodules like `langgraph.prebuilt`. This may be broken when they largely refactor the module structure, but we should be able to detect it reasonably early in cross version test.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Trace is generated with the correct structure (same as LangSmith trace)

![Screenshot 2024-09-20 at 18 38 03](https://github.com/user-attachments/assets/ef92be22-fdef-4ac5-bba4-09b62113e154)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix tracing issue when auto-tracing LangGraph execution with `mlflow.langchain.autolog()`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
