### PR TITLE
Fix transformers test

### DIFF
--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -321,7 +321,7 @@ def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_tra
     mlflow.transformers.autolog(disable=False)
 
     setfit_trainer.train()
-    assert len(mlflow.search_runs()) == 1 if SETFIT_PRODUCES_RUN else 0
+    assert len(mlflow.search_runs()) == (1 if SETFIT_PRODUCES_RUN else 0)
     preds = setfit_trainer.model(["Jim, I'm a doctor, not an archaeologist!"])
     assert len(preds) == 1
 
@@ -385,7 +385,7 @@ def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog
 
     client = mlflow.MlflowClient()
     runs = client.search_runs([exp.experiment_id])
-    assert len(runs) == 2 if SETFIT_PRODUCES_RUN else 1
+    assert len(runs) == (2 if SETFIT_PRODUCES_RUN else 1)
     assert runs[0].info == logged_sklearn_data.info
 
 
@@ -463,7 +463,7 @@ def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     client = mlflow.MlflowClient()
     runs = client.search_runs([exp.experiment_id])
 
-    assert len(runs) == 2 if SETFIT_PRODUCES_RUN else 1
+    assert len(runs) == (2 if SETFIT_PRODUCES_RUN else 1)
     assert runs[0].info == logged_sklearn_data.info
 
 

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -8,6 +8,7 @@ import sklearn
 import sklearn.cluster
 import sklearn.datasets
 import torch
+import transformers
 from datasets import load_dataset
 from packaging.version import Version
 from sentence_transformers.losses import CosineSimilarityLoss
@@ -27,7 +28,9 @@ import mlflow
 # For setfit >= 1.1.0, the trainer.train function internally
 # invokes transformers trainer, so autologging is invoked and runs
 # are generated
-SETFIT_PRODUCES_RUN = Version(setfit.__version__) >= Version("1.1.0")
+SETFIT_PRODUCES_RUN = Version(setfit.__version__) >= Version("1.1.0") and Version(
+    transformers.__version__
+) >= Version("4.41.2")
 
 
 @pytest.fixture

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -8,7 +8,6 @@ import sklearn
 import sklearn.cluster
 import sklearn.datasets
 import torch
-import transformers
 from datasets import load_dataset
 from packaging.version import Version
 from sentence_transformers.losses import CosineSimilarityLoss
@@ -24,13 +23,6 @@ from transformers import (
 )
 
 import mlflow
-
-# For setfit >= 1.1.0, the trainer.train function internally
-# invokes transformers trainer, so autologging is invoked and runs
-# are generated
-SETFIT_PRODUCES_RUN = Version(setfit.__version__) >= Version("1.1.0") and Version(
-    transformers.__version__
-) >= Version("4.41.2")
 
 
 @pytest.fixture
@@ -61,7 +53,7 @@ def setfit_trainer():
     #   evaluation_strategy argument is being addressed in the SetFit library.
     training_args.eval_strategy = training_args.evaluation_strategy
 
-    return SetFitTrainer(
+    trainer = SetFitTrainer(
         model=model,
         train_dataset=train_dataset,
         eval_dataset=eval_dataset,
@@ -69,6 +61,18 @@ def setfit_trainer():
         column_mapping={"sentence": "text", "label": "label"},
         args=training_args,
     )
+
+    # setfit >= 1.1.0 defines an internal BCSentenceTransformersTrainer
+    # which directly uses transformers.Trainer, and the default callbacks
+    # include MLflowCallback, so it produces extra runs no matter autologging
+    # is on or off
+    # ref: https://github.com/huggingface/transformers/blob/11c27dd331151e7d2ac20016cce11d9d7c4b1756/src/transformers/integrations/integration_utils.py#L2138
+    if Version(setfit.__version__) >= Version("1.1.0"):
+        from transformers.integrations.integration_utils import MLflowCallback
+
+        trainer.remove_callback(MLflowCallback)
+
+    return trainer
 
 
 @pytest.fixture
@@ -284,10 +288,7 @@ def test_setfit_does_not_autolog(setfit_trainer):
     setfit_trainer.train()
 
     last_run = mlflow.last_active_run()
-    if SETFIT_PRODUCES_RUN:
-        assert last_run
-    else:
-        assert not last_run
+    assert not last_run
     preds = setfit_trainer.model(
         ["Always carry a towel!", "The hobbits are going to Isengard", "What's tatoes, precious?"]
     )
@@ -321,7 +322,7 @@ def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_tra
     mlflow.transformers.autolog(disable=False)
 
     setfit_trainer.train()
-    assert len(mlflow.search_runs()) == (1 if SETFIT_PRODUCES_RUN else 0)
+    assert len(mlflow.search_runs()) == 0
     preds = setfit_trainer.model(["Jim, I'm a doctor, not an archaeologist!"])
     assert len(preds) == 1
 
@@ -385,7 +386,7 @@ def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog
 
     client = mlflow.MlflowClient()
     runs = client.search_runs([exp.experiment_id])
-    assert len(runs) == (2 if SETFIT_PRODUCES_RUN else 1)
+    assert len(runs) == 1
     assert runs[0].info == logged_sklearn_data.info
 
 
@@ -463,7 +464,7 @@ def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     client = mlflow.MlflowClient()
     runs = client.search_runs([exp.experiment_id])
 
-    assert len(runs) == (2 if SETFIT_PRODUCES_RUN else 1)
+    assert len(runs) == 1
     assert runs[0].info == logged_sklearn_data.info
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13219?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13219/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13219
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
setfit>=1.1.0 introduces dependency to transformers (e.g. https://github.com/huggingface/setfit/blob/146c7c9dacdc7dca678b2fffff8ddeb79dd762c2/src/setfit/trainer.py#L569), ~so now if we turn on autologging and train a SetFitTrainer, it triggers transformers autologging and produces runs.~

Update: The extra run is introduced by MLflowCallback that's included as the [default callback](https://github.com/huggingface/transformers/blob/11c27dd331151e7d2ac20016cce11d9d7c4b1756/src/transformers/trainer.py#L596), so no matter autologging is on or off, it always produces extra run.
The fix for the test is to remove the callback from the SetfitTrainer.
While this is only an issue for setfit>=1.1.0 because in 1.1.0 setfit trainer introduces [BCSentenceTransformersTrainer](https://github.com/huggingface/setfit/blob/146c7c9dacdc7dca678b2fffff8ddeb79dd762c2/src/setfit/trainer.py#L37) which internally uses transformers trainer directly.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
