### PR TITLE
Fix some of the D417 (undocumented-param)

### DIFF
--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -176,13 +176,13 @@ class BertDataModule(L.LightningDataModule):
             print(f"Number of samples used for validation: {self.val_count}")
             print(f"Number of samples used for test: {self.test_count}")
 
-    def create_data_loader(self, source, count):  # noqa: D417
+    def create_data_loader(self, source, count):
         """
         Generic data loader function
 
         Args:
-            df: Input dataframe.
-            tokenizer: bert tokenizer.
+            source: Input dataframe.
+            count: Number of samples to load.
 
         Returns:
             Returns the constructed dataloader.

--- a/mlflow/data/dataset_source.py
+++ b/mlflow/data/dataset_source.py
@@ -97,11 +97,11 @@ class DatasetSource:
         """
 
     @classmethod
-    def from_json(cls, source_json: str) -> "DatasetSource":  # noqa: D417
+    def from_json(cls, source_json: str) -> "DatasetSource":
         """Constructs an instance of the DatasetSource from a JSON string representation.
 
         Args:
-            source_dict: A JSON string representation of the DatasetSource.
+            source_json: A JSON string representation of the DatasetSource.
 
         Returns:
             A DatasetSource instance.

--- a/mlflow/data/spark_delta_utils.py
+++ b/mlflow/data/spark_delta_utils.py
@@ -99,11 +99,11 @@ def _try_get_delta_table_latest_version_from_table_name(table_name: str) -> Opti
         )
 
 
-def _get_delta_table_latest_version(j_delta_table) -> int:  # noqa: D417
+def _get_delta_table_latest_version(j_delta_table) -> int:
     """Obtains the latest version of the specified Delta table Java class.
 
     Args:
-        delta_table: A Java DeltaTable class instance.
+        j_delta_table: A Java DeltaTable class instance.
 
     Returns:
         The version of the Delta table.

--- a/mlflow/entities/evaluation_tag.py
+++ b/mlflow/entities/evaluation_tag.py
@@ -38,12 +38,12 @@ class EvaluationTag(_MlflowObject):
         }
 
     @classmethod
-    def from_dictionary(cls, evaluation_tag_dict: Dict[str, str]):  # noqa: D417
+    def from_dictionary(cls, evaluation_tag_dict: Dict[str, str]):
         """
         Create an EvaluationTag object from a dictionary.
 
         Args:
-            evaluation_dict (dict): Dictionary containing evaluation tag information.
+            evaluation_tag_dict (dict): Dictionary containing evaluation tag information.
 
         Returns:
             Evaluation: The EvaluationTag object created from the dictionary.

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -688,7 +688,6 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
         dst_path: The local filesystem path to which to download the model artifact.
             This directory must already exist. If unspecified, a local output
             path will be created.
-        kwargs: Ignore additional arguments.
 
     Returns:
         A

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -665,7 +665,7 @@ def _load_model(model_uri, dfs_tmpdir_base=None, local_model_path=None):
     return nlp.load(path=local_model_path)
 
 
-def load_model(model_uri, dfs_tmpdir=None, dst_path=None, **kwargs):  # noqa: D417
+def load_model(model_uri, dfs_tmpdir=None, dst_path=None, **kwargs):
     """
     Load the Johnsnowlabs MLflow model from the path.
 
@@ -688,6 +688,7 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None, **kwargs):  # noqa: D4
         dst_path: The local filesystem path to which to download the model artifact.
             This directory must already exist. If unspecified, a local output
             path will be created.
+        **kwargs: Ignore additional arguments.
 
     Returns:
         A

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -688,7 +688,7 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None, **kwargs):
         dst_path: The local filesystem path to which to download the model artifact.
             This directory must already exist. If unspecified, a local output
             path will be created.
-        **kwargs: Ignore additional arguments.
+        kwargs: Ignore additional arguments.
 
     Returns:
         A

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -665,7 +665,7 @@ def _load_model(model_uri, dfs_tmpdir_base=None, local_model_path=None):
     return nlp.load(path=local_model_path)
 
 
-def load_model(model_uri, dfs_tmpdir=None, dst_path=None, **kwargs):
+def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
     """
     Load the Johnsnowlabs MLflow model from the path.
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -645,14 +645,14 @@ def _is_string(value):
     return isinstance(value, str)
 
 
-def _evaluate_metric(metric_tuple, eval_fn_args):  # noqa: D417
+def _evaluate_metric(metric_tuple, eval_fn_args):
     """
     This function calls the metric function and performs validations on the returned
     result to ensure that they are in the expected format. It will warn and will not log metrics
     that are in the wrong format.
 
     Args:
-        extra_metric_tuple: Containing a user provided function and its index in the
+        metric_tuple: Containing a user provided function and its index in the
             ``extra_metrics`` parameter of ``mlflow.evaluate``
         eval_fn_args: A dictionary of args needed to compute the eval metrics.
 

--- a/mlflow/models/wheeled_model.py
+++ b/mlflow/models/wheeled_model.py
@@ -176,14 +176,14 @@ class WheeledModel:
         with open(conda_env_path, "w") as out:
             yaml.safe_dump(new_conda_env, stream=out, default_flow_style=False)
 
-    def _update_mlflow_model(self, original_model_metadata, mlflow_model):  # noqa: D417
+    def _update_mlflow_model(self, original_model_metadata, mlflow_model):
         """
         Modifies the MLModel file to reflect updated information such as the run_id,
         utc_time_created. Additionally, this also adds `wheels` to the MLModel file to indicate that
         this is a `wheeled` model.
 
         Args:
-            original_model_file_path: The model metadata stored in the original MLmodel file.
+            original_model_metadata: The model metadata stored in the original MLmodel file.
             mlflow_model: :py:mod:`mlflow.models.Model` configuration of the newly created
                           wheeled model
         """

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -576,7 +576,7 @@ def _load_model(path, device=None, **kwargs):
     """
     Args:
         path: The path to a serialized PyTorch model.
-        device: If not None, load the model on the specified device.
+        device: If specified, load the model on the specified device.
         kwargs: Additional kwargs to pass to the PyTorch ``torch.load`` function.
     """
     import torch

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -572,10 +572,11 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-def _load_model(path, device=None, **kwargs):  # noqa: D417
+def _load_model(path, device=None, **kwargs):
     """
     Args:
         path: The path to a serialized PyTorch model.
+        device: If not None, load the model on the specified device.
         kwargs: Additional kwargs to pass to the PyTorch ``torch.load`` function.
     """
     import torch

--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -148,13 +148,14 @@ class __MlflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
         # pytorch-lightning >= 1.3.0
 
         @rank_zero_only
-        def on_train_epoch_end(self, trainer, pl_module, *args):  # noqa: D417
+        def on_train_epoch_end(self, trainer, pl_module, *args):
             """
             Log loss and other metrics values after each train epoch
 
             Args:
                 trainer: pytorch lightning trainer instance
                 pl_module: pytorch lightning base module
+                args: additional positional arguments
             """
             # If validation loop is enabled (meaning `validation_step` is overridden),
             # log metrics in `on_validaion_epoch_end` to avoid logging the same metrics
@@ -187,13 +188,14 @@ class __MlflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
             self._log_epoch_metrics(trainer, pl_module)
 
     @rank_zero_only
-    def on_train_batch_end(self, trainer, pl_module, *args):  # noqa: D417
+    def on_train_batch_end(self, trainer, pl_module, *args):
         """
         Log metric values after each step
 
         Args:
             trainer: pytorch lightning trainer instance
             pl_module: pytorch lightning base module
+            args: additional positional arguments
         """
         if not self.log_every_n_step:
             return

--- a/mlflow/recipes/utils/tracking.py
+++ b/mlflow/recipes/utils/tracking.py
@@ -270,7 +270,7 @@ def get_run_tags_env_vars(recipe_root_path: str) -> Dict[str, str]:
     return {MLFLOW_RUN_CONTEXT.name: json.dumps({**run_context_tags, **git_tags})}
 
 
-def log_code_snapshot(  # noqa: D417
+def log_code_snapshot(
     recipe_root: str,
     run_id: str,
     artifact_path: str = "recipe_snapshot",
@@ -280,7 +280,7 @@ def log_code_snapshot(  # noqa: D417
     Logs a recipe code snapshot as mlflow artifacts.
 
     Args:
-        recipe_root_path: String file path to the directory where the recipe is defined.
+        recipe_root: String file path to the directory where the recipe is defined.
         run_id: Run ID to which the code snapshot is logged.
         artifact_path: Directory within the run's artifact director (default: "snapshots").
         recipe_config: Dict containing the full recipe configuration at runtime.

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -154,16 +154,17 @@ class AbstractStore:
         Restore deleted experiment unless it is permanently deleted.
 
         Args:
-            experiment_id: String id for the experiment
+            experiment_id: String id for the experiment.
         """
 
     @abstractmethod
-    def rename_experiment(self, experiment_id, new_name):  # noqa: D417
+    def rename_experiment(self, experiment_id, new_name):
         """
         Update an experiment's name. The new name must be unique.
 
         Args:
-            experiment_id: String id for the experiment
+            experiment_id: String id for the experiment.
+            new_name: New name for the experiment.
         """
 
     @abstractmethod
@@ -201,8 +202,8 @@ class AbstractStore:
         and the start time to the current time.
 
         Args:
-            experiment_id: String id of the experiment for this run
-            user_id: ID of the user launching this run
+            experiment_id: String id of the experiment for this run.
+            user_id: ID of the user launching this run.
 
         Returns:
             The created Run object
@@ -214,17 +215,17 @@ class AbstractStore:
         Delete a run.
 
         Args:
-            run_id: Description of run_id.
+            run_id: The ID of the run to delete.
 
         """
 
     @abstractmethod
-    def restore_run(self, run_id):  # noqa: D417
+    def restore_run(self, run_id):
         """
         Restore a run.
 
         Args:
-            run_id:
+            run_id: The ID of the run to restore.
 
         """
 
@@ -428,8 +429,8 @@ class AbstractStore:
         Log a param for the specified run in async fashion.
 
         Args:
-            run_id: String id for the run
-            param: :py:class:`mlflow.entities.Param` instance to log
+            run_id: String id for the run.
+            param: :py:class:`mlflow.entities.Param` instance to log.
         """
         return self.log_batch_async(run_id, metrics=[], params=[param], tags=[])
 
@@ -438,8 +439,8 @@ class AbstractStore:
         Set a tag for the specified experiment
 
         Args:
-            experiment_id: String id for the experiment
-            tag: :py:class:`mlflow.entities.ExperimentTag` instance to set
+            experiment_id: String id for the experiment.
+            tag: :py:class:`mlflow.entities.ExperimentTag` instance to set.
         """
 
     def set_tag(self, run_id, tag):
@@ -447,8 +448,8 @@ class AbstractStore:
         Set a tag for the specified run
 
         Args:
-            run_id: String id for the run
-            tag: :py:class:`mlflow.entities.RunTag` instance to set
+            run_id: String id for the run.
+            tag: :py:class:`mlflow.entities.RunTag` instance to set.
         """
         self.log_batch(run_id, metrics=[], params=[], tags=[tag])
 
@@ -457,8 +458,8 @@ class AbstractStore:
         Set a tag for the specified run in async fashion.
 
         Args:
-            run_id: String id for the run
-            tag: :py:class:`mlflow.entities.RunTag` instance to set
+            run_id: String id for the run.
+            tag: :py:class:`mlflow.entities.RunTag` instance to set.
         """
         return self.log_batch_async(run_id, metrics=[], params=[], tags=[tag])
 

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -180,7 +180,7 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(UpdateRun, req_body)
         return RunInfo.from_proto(response_proto.run_info)
 
-    def create_run(self, experiment_id, user_id, start_time, tags, run_name):  # noqa: D417
+    def create_run(self, experiment_id, user_id, start_time, tags, run_name):
         """
         Create a run under the specified experiment ID, setting the run's status to "RUNNING"
         and the start time to the current time.
@@ -190,7 +190,7 @@ class RestStore(AbstractStore):
             user_id: ID of the user launching this run.
             start_time: timestamp of the initialization of the run.
             tags: tags to apply to this run at initialization.
-            name: Name of this run.
+            run_name: Name of this run.
 
         Returns:
             The created Run object.

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -668,7 +668,7 @@ def add_trace(trace: Union[Trace, Dict[str, Any]], target: Optional[LiveSpan] = 
         )
 
 
-def _merge_trace(  # noqa: D417
+def _merge_trace(
     trace: Trace,
     target_request_id: str,
     target_parent_span_id: str,
@@ -678,7 +678,7 @@ def _merge_trace(  # noqa: D417
 
     Args:
         trace: The trace object to be merged.
-        paretarget_request_idnt_request_id: The request ID of the parent trace.
+        target_request_id: The request ID of the parent trace.
         target_parent_span_id: The parent span ID, under which the child trace should be merged.
     """
     trace_manager = InMemoryTraceManager.get_instance()

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -522,11 +522,12 @@ class TrackingServiceClient:
         """
         self.store.restore_experiment(experiment_id)
 
-    def rename_experiment(self, experiment_id, new_name):  # noqa: D417
+    def rename_experiment(self, experiment_id, new_name):
         """Update an experiment's name. The new name must be unique.
 
         Args:
             experiment_id: The experiment ID returned from ``create_experiment``.
+            new_name: New name for the experiment.
 
         """
         self.store.rename_experiment(experiment_id, new_name)
@@ -756,7 +757,7 @@ class TrackingServiceClient:
         """Log one or more dataset inputs to a run.
 
         Args:
-            run_id: String ID of the run
+            run_id: String ID of the run.
             datasets: List of :py:class:`mlflow.entities.DatasetInput` instances to log.
 
         Raises:
@@ -803,11 +804,12 @@ class TrackingServiceClient:
             utils._artifact_repos_cache[run_id] = artifact_repo
             return artifact_repo
 
-    def log_artifact(self, run_id, local_path, artifact_path=None):  # noqa: D417
+    def log_artifact(self, run_id, local_path, artifact_path=None):
         """
         Write a local file or directory to the remote ``artifact_uri``.
 
         Args:
+            run_id: String ID of the run.
             local_path: Path to the file or directory to write.
             artifact_path: If provided, the directory in ``artifact_uri`` to write to.
         """
@@ -830,11 +832,12 @@ class TrackingServiceClient:
         trace_data_json = json.dumps(trace_data.to_dict(), cls=TraceJSONEncoder, ensure_ascii=False)
         return artifact_repo.upload_trace_data(trace_data_json)
 
-    def _log_artifact_async(self, run_id, filename, artifact_path=None, artifact=None):  # noqa: D417
+    def _log_artifact_async(self, run_id, filename, artifact_path=None, artifact=None):
         """
         Write an artifact to the remote ``artifact_uri`` asynchronously.
 
         Args:
+            run_id: String ID of the run.
             filename: Filename of the artifact to be logged.
             artifact_path: If provided, the directory in ``artifact_uri`` to write to.
             artifact: The artifact to be logged.
@@ -842,10 +845,11 @@ class TrackingServiceClient:
         artifact_repo = self._get_artifact_repo(run_id)
         artifact_repo._log_artifact_async(filename, artifact_path, artifact)
 
-    def log_artifacts(self, run_id, local_dir, artifact_path=None):  # noqa: D417
+    def log_artifacts(self, run_id, local_dir, artifact_path=None):
         """Write a directory of files to the remote ``artifact_uri``.
 
         Args:
+            run_id: String ID of the run.
             local_dir: Path to the directory of files to write.
             artifact_path: If provided, the directory in ``artifact_uri`` to write to.
 
@@ -903,10 +907,11 @@ class TrackingServiceClient:
         _logger.info(f"🏃 View run {run_name} at: {run_url}.")
         _logger.info(f"🧪 View experiment at: {experment_url}.")
 
-    def set_terminated(self, run_id, status=None, end_time=None):  # noqa: D417
+    def set_terminated(self, run_id, status=None, end_time=None):
         """Set a run's status to terminated.
 
         Args:
+            run_id: String ID of the run.
             status: A string value of :py:class:`mlflow.entities.RunStatus`. Defaults to "FINISHED".
             end_time: If not provided, defaults to the current time.
         """

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -43,7 +43,7 @@ _request_header_provider_registry.register(DefaultRequestHeaderProvider)
 _request_header_provider_registry.register_entrypoints()
 
 
-def resolve_request_headers(request_headers=None):  # noqa: D417
+def resolve_request_headers(request_headers=None):
     """Generate a set of request headers from registered providers.
 
     Request headers are resolved in the order that providers are registered. Argument headers are
@@ -52,8 +52,8 @@ def resolve_request_headers(request_headers=None):  # noqa: D417
     :py:class:`mlflow.tracking.request_header.RequestHeaderProvider`.
 
     Args:
-        tags: A dictionary of request headers to override. If specified, headers passed in this
-            argument will override those inferred from the context.
+        request_headers: A dictionary of request headers to override. If specified, headers passed
+            in this argument will override those inferred from the context.
 
     Returns:
         A dictionary of resolved headers.

--- a/mlflow/transformers/llm_inference_utils.py
+++ b/mlflow/transformers/llm_inference_utils.py
@@ -415,7 +415,7 @@ def preprocess_llm_embedding_params(
     return input_data, params
 
 
-def postprocess_output_for_llm_v1_embedding_task(  # noqa: D417
+def postprocess_output_for_llm_v1_embedding_task(
     input_prompts: List[str],
     output_tensors: List[List[float]],
     tokenizer,
@@ -446,7 +446,7 @@ def postprocess_output_for_llm_v1_embedding_task(  # noqa: D417
 
     Args:
         input_prompts: text input prompts
-        output_tensers: List of output tensors that contain the generated embeddings
+        output_tensors: List of output tensors that contain the generated embeddings
         tokenizer: The tokenizer object used for inference.
 
     Returns:

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -17,14 +17,14 @@ _COMPONENTS_BINARY_DIR_NAME = "components"
 _PROCESSOR_BINARY_DIR_NAME = "processor"
 
 
-def save_pipeline_pretrained_weights(path, pipeline, flavor_conf, processor=None):  # noqa: D417
+def save_pipeline_pretrained_weights(path, pipeline, flavor_conf, processor=None):
     """
     Save the binary artifacts of the pipeline to the specified local path.
 
     Args:
         path: The local path to save the pipeline
         pipeline: Transformers pipeline instance
-        flavor_config: The flavor configuration constructed for the pipeline
+        flavor_conf: The flavor configuration constructed for the pipeline
         processor: Optional processor instance to save alongside the pipeline
     """
     model = get_peft_base_model(pipeline.model) if is_peft_model(pipeline.model) else pipeline.model
@@ -42,14 +42,14 @@ def save_pipeline_pretrained_weights(path, pipeline, flavor_conf, processor=None
         processor.save_pretrained(component_dir.joinpath(_PROCESSOR_BINARY_DIR_NAME))
 
 
-def save_local_checkpoint(path, checkpoint_dir, flavor_conf, processor=None):  # noqa: D417
+def save_local_checkpoint(path, checkpoint_dir, flavor_conf, processor=None):
     """
     Save the local checkpoint of the model and other components to the specified local path.
 
     Args:
         path: The local path to save the pipeline
         checkpoint_dir: The local path to the checkpoint directory
-        flavor_config: The flavor configuration constructed for the pipeline
+        flavor_conf: The flavor configuration constructed for the pipeline
         processor: Optional processor instance to save alongside the pipeline
     """
     # Copy files within checkpoint dir to the model path

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -1134,7 +1134,7 @@ class ParamSpec:
         )
 
     @classmethod
-    def enforce_param_datatype(cls, name, value, dtype: DataType):  # noqa: D417
+    def enforce_param_datatype(cls, name, value, dtype: DataType):
         """
         Enforce the value matches the data type.
 
@@ -1150,7 +1150,7 @@ class ParamSpec:
         Args:
             name: parameter name
             value: parameter value
-            t: expected data type
+            dtype: expected data type
         """
         if value is None:
             return

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -73,7 +73,7 @@ def get_default_host_creds(store_uri):
     )
 
 
-def login(backend: str = "databricks", interactive: bool = True) -> None:  # noqa: D417
+def login(backend: str = "databricks", interactive: bool = True) -> None:
     """Configure MLflow server authentication and connect MLflow to tracking server.
 
     This method provides a simple way to connect MLflow to its tracking server. Currently only
@@ -84,7 +84,7 @@ def login(backend: str = "databricks", interactive: bool = True) -> None:  # noq
         backend: string, the backend of the tracking server. Currently only "databricks" is
             supported.
 
-        interacive: bool, controls request for user input on missing credentials. If true, user
+        interactive: bool, controls request for user input on missing credentials. If true, user
             input will be requested if no credentials are found, otherwise an exception will be
             raised if no credentials are found.
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -773,11 +773,11 @@ def get_databricks_run_url(tracking_uri: str, run_id: str, artifact_path=None) -
         return None
 
 
-def get_databricks_model_version_url(registry_uri: str, name: str, version: str) -> Optional[str]:  # noqa: D417
+def get_databricks_model_version_url(registry_uri: str, name: str, version: str) -> Optional[str]:
     """Obtains a Databricks URL corresponding to the specified Model Version.
 
     Args:
-        tracking_uri: The URI of the Model Registry server containing the Model Version.
+        registry_uri: The URI of the Model Registry server containing the Model Version.
         name: The name of the registered model containing the Model Version.
         version: Version number of the Model Version.
 

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -87,13 +87,13 @@ class ParamDocs(dict):
         replacements = _replace_keys_with_placeholders(kwargs)
         return ParamDocs({k: _replace_all(v, replacements) for k, v in self.items()})
 
-    def format_docstring(self, docstring: str) -> str:  # noqa: D417
+    def format_docstring(self, docstring: str) -> str:
         """
         Formats placeholders in `docstring`.
 
         Args:
-            p1: {{ p1 }}
-            p2: {{ p2 }}
+            docstring: A docstring with placeholders to be replaced.
+                If provided with None, will return None.
 
         .. code-block:: text
             :caption: Example

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -524,13 +524,14 @@ def make_tarfile(output_filename, source_dir, archive_name, custom_filter=None):
         os.close(unzipped_file_handle)
 
 
-def _copy_project(src_path, dst_path=""):  # noqa: D417
+def _copy_project(src_path, dst_path=""):
     """Internal function used to copy MLflow project during development.
 
     Copies the content of the whole directory tree except patterns defined in .dockerignore.
     The MLflow is assumed to be accessible as a local directory in this case.
 
     Args:
+        src_path: Path to the original MLflow project
         dst_path: MLflow will be copied here
 
     Returns:

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -290,11 +290,11 @@ def _add_code_from_conf_to_system_path(local_path, conf, code_key=FLAVOR_CONFIG_
         _add_code_to_system_path(code_path)
 
 
-def _validate_onnx_session_options(onnx_session_options):  # noqa: D417
+def _validate_onnx_session_options(onnx_session_options):
     """Validates that the specified onnx_session_options dict is valid.
 
     Args:
-        ort_session_options: The onnx_session_options dict to validate.
+        onnx_session_options: The onnx_session_options dict to validate.
     """
     import onnxruntime as ort
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -25,13 +25,13 @@ _DATABRICKS_UNITY_CATALOG_SCHEME = "databricks-uc"
 _OSS_UNITY_CATALOG_SCHEME = "uc"
 
 
-def is_local_uri(uri, is_tracking_or_registry_uri=True):  # noqa: D417
+def is_local_uri(uri, is_tracking_or_registry_uri=True):
     """Returns true if the specified URI is a local file path (/foo or file:/foo).
 
     Args:
         uri: The URI.
-        is_tracking_uri: Whether or not the specified URI is an MLflow Tracking or MLflow
-            Model Registry URI. Examples of other URIs are MLflow artifact URIs,
+        is_tracking_or_registry_uri: Whether or not the specified URI is an MLflow Tracking or
+            MLflow Model Registry URI. Examples of other URIs are MLflow artifact URIs,
             filesystem paths, etc.
     """
     if uri == "databricks" and is_tracking_or_registry_uri:

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -775,11 +775,11 @@ class EndpointOperation:
     Endpoint is associated with the operation that was most recently invoked on it.
     """
 
-    def __init__(self, latency_seconds, pending_status, completed_status):  # noqa: D417
+    def __init__(self, latency_seconds, pending_status, completed_status):
         """
         Args:
-            latency: The latency of the operation, in seconds. Before the time window specified
-                by this latency elapses, the operation will have the status specified by
+            latency_seconds: The latency of the operation, in seconds. Before the time window
+                specified by this latency elapses, the operation will have the status specified by
                 ``pending_status``. After the time window elapses, the operation will
                 have the status  specified by ``completed_status``.
             pending_status: The status that the operation should reflect *before* the latency


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/levscaut/mlflow/pull/13224?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13224/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13224
```

</p>
</details>

### Related Issues/PRs

Resolve #13210 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR fixes some of the function docstring conflicts against rule D417. I have corrected those with obvious typos, mismatched argument names, and those that could be easily inferred based on my experience. There are still some remaining conflicts against rule D417 that need to be resolved.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
