### PR TITLE
Support evaluating on endpoint without type

### DIFF
--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -150,7 +150,14 @@ def _call_deployments_api(deployment_uri, payload, eval_parameters, wrap_payload
         completion_inputs = {**payload, **eval_parameters}
         response = client.predict(endpoint=deployment_uri, inputs=completion_inputs)
         return _parse_chat_response_format(response)
-
+    elif endpoint_type is None:
+        # If the endpoint type is not specified, we don't assume any format
+        # and directly send the payload to the endpoint. This is primary for Databricks
+        # Managed Agent Evaluation, where the endpoint type may not be specified but the
+        # eval harness ensures that the payload is formatted to the chat format, as well
+        # as parsing the response.
+        chat_inputs = {**payload, **eval_parameters}
+        return client.predict(endpoint=deployment_uri, inputs=chat_inputs)
     else:
         raise MlflowException(
             f"Unsupported endpoint type: {endpoint_type}. Use an "

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -176,7 +176,7 @@ def _call_deployments_api(deployment_uri, payload, eval_parameters, wrap_payload
         # as parsing the response.
         inputs = {**payload, **eval_parameters}
         try:
-            client.predict(endpoint=deployment_uri, inputs=inputs)
+            return client.predict(endpoint=deployment_uri, inputs=inputs)
         except Exception as e:
             raise MlflowException(
                 _PREDICT_ERROR_MSG.format(e=e, uri=deployment_uri, payload=inputs)

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -160,8 +160,8 @@ def _call_deployments_api(deployment_uri, payload, eval_parameters, wrap_payload
         return client.predict(endpoint=deployment_uri, inputs=chat_inputs)
     else:
         raise MlflowException(
-            f"Unsupported endpoint type: {endpoint_type}. Use an "
-            "endpoint of type 'llm/v1/completions' or 'llm/v1/chat' instead.",
+            f"Unsupported endpoint type: {endpoint_type}. Endpoint type, if specified, "
+            "must be 'llm/v1/completions' or 'llm/v1/chat'.",
             error_code=INVALID_PARAMETER_VALUE,
         )
 

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -113,6 +113,14 @@ def _call_openai_api(openai_uri, payload, eval_parameters):
     return _parse_chat_response_format(resp)
 
 
+_PREDICT_ERROR_MSG = """\
+Failed to call the deployment endpoint. Please check the deployment URL\
+is set correctly and the input payload is valid.\n
+- Error: {e}\n
+- Deployment URI: {uri}\n
+- Input payload: {payload}"""
+
+
 def _call_deployments_api(deployment_uri, payload, eval_parameters, wrap_payload=True):
     """Call the deployment endpoint with the given payload and parameters.
 
@@ -142,13 +150,23 @@ def _call_deployments_api(deployment_uri, payload, eval_parameters, wrap_payload
         if wrap_payload:
             payload = {"prompt": payload}
         chat_inputs = {**payload, **eval_parameters}
-        response = client.predict(endpoint=deployment_uri, inputs=chat_inputs)
+        try:
+            response = client.predict(endpoint=deployment_uri, inputs=chat_inputs)
+        except Exception as e:
+            raise MlflowException(
+                _PREDICT_ERROR_MSG.format(e=e, uri=deployment_uri, payload=chat_inputs)
+            ) from e
         return _parse_completions_response_format(response)
     elif endpoint_type == "llm/v1/chat":
         if wrap_payload:
             payload = {"messages": [{"role": "user", "content": payload}]}
         completion_inputs = {**payload, **eval_parameters}
-        response = client.predict(endpoint=deployment_uri, inputs=completion_inputs)
+        try:
+            response = client.predict(endpoint=deployment_uri, inputs=completion_inputs)
+        except Exception as e:
+            raise MlflowException(
+                _PREDICT_ERROR_MSG.format(e=e, uri=deployment_uri, payload=completion_inputs)
+            ) from e
         return _parse_chat_response_format(response)
     elif endpoint_type is None:
         # If the endpoint type is not specified, we don't assume any format
@@ -156,8 +174,13 @@ def _call_deployments_api(deployment_uri, payload, eval_parameters, wrap_payload
         # Managed Agent Evaluation, where the endpoint type may not be specified but the
         # eval harness ensures that the payload is formatted to the chat format, as well
         # as parsing the response.
-        chat_inputs = {**payload, **eval_parameters}
-        return client.predict(endpoint=deployment_uri, inputs=chat_inputs)
+        inputs = {**payload, **eval_parameters}
+        try:
+            client.predict(endpoint=deployment_uri, inputs=inputs)
+        except Exception as e:
+            raise MlflowException(
+                _PREDICT_ERROR_MSG.format(e=e, uri=deployment_uri, payload=inputs)
+            ) from e
     else:
         raise MlflowException(
             f"Unsupported endpoint type: {endpoint_type}. Endpoint type, if specified, "

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from decimal import Decimal
 from inspect import Parameter, Signature
 from types import FunctionType
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import mlflow
 from mlflow.data.dataset import Dataset

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from decimal import Decimal
 from inspect import Parameter, Signature
 from types import FunctionType
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 import mlflow
 from mlflow.data.dataset import Dataset

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -2104,6 +2104,67 @@ def test_evaluate_on_completion_model_endpoint(mock_deploy_client, input_data, f
     assert eval_results_table["outputs"].equals(pd.Series(["This is a response"] * 2))
 
 
+@mock.patch("mlflow.deployments.get_deploy_client")
+def test_evaluate_on_model_endpoint_without_type(mock_deploy_client):
+    # An endpoint that does not have endpoint type. For such endpoint, we simply
+    # pass the input data to the endpoint without any modification and return
+    # the response as is.
+    mock_deploy_client.return_value.get_endpoint.return_value = {}
+    mock_deploy_client.return_value.predict.return_value = "This is a response"
+
+    input_data = pd.DataFrame(
+        {
+            "inputs": [
+                {
+                    "messages": [{"content": q, "role": "user"}],
+                    "max_tokens": 10,
+                }
+                for q in _TEST_QUERY_LIST
+            ],
+            "ground_truth": _TEST_GT_LIST,
+        }
+    )
+
+    with mlflow.start_run():
+        eval_result = mlflow.evaluate(
+            model="endpoints:/random",
+            data=input_data,
+            model_type="question-answering",
+            targets="ground_truth",
+            inference_params={"max_tokens": 10, "temperature": 0.5},
+        )
+
+    # Validate the endpoint is called with correct payloads
+    call_args_list = mock_deploy_client.return_value.predict.call_args_list
+    expected_calls = [
+        mock.call(
+            endpoint="random",
+            inputs={
+                "messages": [{"content": "What is MLflow?", "role": "user"}],
+                "max_tokens": 10,
+                "temperature": 0.5,
+            },
+        ),
+        mock.call(
+            endpoint="random",
+            inputs={
+                "messages": [{"content": "What is Spark?", "role": "user"}],
+                "max_tokens": 10,
+                "temperature": 0.5,
+            },
+        ),
+    ]
+    assert all(call in call_args_list for call in expected_calls)
+
+    # Validate the evaluation metrics
+    expected_metrics_subset = {"toxicity/v1/ratio", "ari_grade_level/v1/mean", "exact_match/v1"}
+    assert expected_metrics_subset.issubset(set(eval_result.metrics.keys()))
+
+    # Validate the model output is passed to the evaluator in the correct format (string)
+    eval_results_table = eval_result.tables["eval_results_table"]
+    assert eval_results_table["outputs"].equals(pd.Series(["This is a response"] * 2))
+
+
 @pytest.mark.parametrize(
     ("input_data", "error_message"),
     [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13226?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13226/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13226
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.evaluate` API allows users to specify endpoint URI as a model ([documentation](https://mlflow.org/docs/latest/llms/llm-evaluate/index.html#evaluating-with-an-mlflow-deployments-endpoint)). Currently it requires the model endpoint to have either `llm/v1/chat` or `llm/v1/completions` as a value of `task` or `endpoint_type` key of the endpoint metadata.

Databricks Eval team requested enhancing this support to arbitral endpoint that conforms to the chat format. This PR addresses that by supporting undetermined endpoint type, where we simply pass request and response without any modification.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Verified with a sample agent endpoint in staging with Mosaic AI Agent Evaluation.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
