### PR TITLE
Fix rate limiting and max token failures

### DIFF
--- a/mlflow/openai/api_request_parallel_processor.py
+++ b/mlflow/openai/api_request_parallel_processor.py
@@ -115,7 +115,7 @@ class APIRequest:
                 error = response_json["error"]
                 logging.warning(f"Request #{self.index} failed with error {error}")
                 # Rate limit error
-                if "Rate limit" in error.get("message", ""):
+                if response.status_code == 429:
                     _logger.debug(f"Request #{self.index} failed with {error!r}")
                     current_time = time.time()
                     status_tracker.time_of_last_rate_limit_error = current_time


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/gsornsen/mlflow/pull/13228?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13228/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13228
```

</p>
</details>

### Related Issues/PRs

Fixes Issues:
- #11694 
- #11377 

### What changes are proposed in this pull request?

#### Rate limit handling

This PR enhances the rate limiting handling by looking for the `429` response code returned by OpenAI [per their docs](https://platform.openai.com/docs/guides/error-codes/api-errors) and fixes #11377 

#### Setting max tokens per minute as an environment variable

This PR enables user to set the maximum tokens per minute via the `MAX_TOKENS_PER_MINUTE` environment variable, so they can configure their flows based on their [organization rate limits](https://platform.openai.com/settings/organization/limits) as suggested in #11694 

#### Waits for token capacity

This PR will wait for token capacity before resuming instead of failing and raising a `MLflowException` and fixes #11694 



### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

#### Failure
```bash
2024/09/23 20:20:21 DEBUG mlflow.openai.api_request_parallel_processor: Request #20 succeeded
2024-09-23 20:20:21,248 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:20:21,258 - DEBUG - http://127.0.0.1:5000 "GET /api/2.0/mlflow/runs/get?run_uuid=0aba066834a44f5991adfb79bc9d870b&run_id=0aba066834a44f5991adfb79bc9d870b HTTP/11" 200 8783
2024/09/23 20:20:21 INFO mlflow.tracking._tracking_service.client: 🏃 View run amusing-skunk-452 at: http://127.0.0.1:5000/#/experiments/681916535377301264/runs/0aba066834a44f5991adfb79bc9d870b.
2024/09/23 20:20:21 INFO mlflow.tracking._tracking_service.client: 🧪 View experiment at: http://127.0.0.1:5000/#/experiments/681916535377301264.
2024-09-23 20:20:21,260 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:20:21,264 - DEBUG - http://127.0.0.1:5000 "POST /api/2.0/mlflow/runs/update HTTP/11" 200 453
Traceback (most recent call last):
  File "/Users/gerald/git/summarization_analytics/writing_assistant/eval/reviews_ground_truth.py", line 309, in <module>
    gpt_4o_grade = log_run(
                   ^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/writing_assistant/eval/reviews_ground_truth.py", line 160, in log_run
    generated = mlflow.evaluate(
                ^^^^^^^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/models/evaluation/base.py", line 1650, in evaluate
    evaluate_result = _evaluate(
                      ^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/models/evaluation/base.py", line 786, in _evaluate
    eval_result = evaluator.evaluate(
                  ^^^^^^^^^^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/models/evaluation/default_evaluator.py", line 2112, in evaluate
    evaluation_result = self._evaluate(model, is_baseline_model=False)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/models/evaluation/default_evaluator.py", line 1976, in _evaluate
    self._generate_model_predictions(compute_latency=compute_latency)
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/models/evaluation/default_evaluator.py", line 1496, in _generate_model_predictions
    model_predictions = self.predict_fn(X_copy)
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/models/evaluation/default_evaluator.py", line 200, in new_pred_fn
    return pred_fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/pyfunc/__init__.py", line 755, in predict
    return self._predict(data, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/pyfunc/__init__.py", line 793, in _predict
    return self._predict_fn(data, params=params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/openai/__init__.py", line 793, in predict
    return self._predict_chat(data, params or {})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/openai/__init__.py", line 717, in _predict_chat
    results = process_api_requests(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/mlflow/openai/api_request_parallel_processor.py", line 387, in process_api_requests
    raise mlflow.MlflowException(
mlflow.exceptions.MlflowException: 27 tasks failed. See logs for details.
```

#### Success
```bash
2024-09-23 20:37:18,082 - DEBUG - Starting new HTTPS connection (1): api.openai.com:443
2024-09-23 20:37:18,665 - DEBUG - https://api.openai.com:443 "POST /v1/chat/completions HTTP/11" 200 None
2024-09-23 20:37:19,977 - DEBUG - https://api.openai.com:443 "POST /v1/chat/completions HTTP/11" 200 None
2024/09/23 20:37:19 INFO mlflow.models.evaluation.default_evaluator: Testing metrics on first row...
2024-09-23 20:37:20,179 - INFO - PyTorch version 2.4.1 available.
2024-09-23 20:37:20,180 - INFO - TensorFlow version 2.17.0 available.
2024-09-23 20:37:24,451 - DEBUG - Falling back to TensorFlow client; we recommended you install the Cloud TPU client directly with pip install cloud-tpu-client.
2024-09-23 20:37:24,705 - DEBUG - Creating converter from 7 to 5
2024-09-23 20:37:24,705 - DEBUG - Creating converter from 5 to 7
2024-09-23 20:37:24,705 - DEBUG - Creating converter from 7 to 5
2024-09-23 20:37:24,705 - DEBUG - Creating converter from 5 to 7
2024-09-23 20:37:26,042 - DEBUG - Starting new HTTPS connection (1): s3.amazonaws.com:443
2024-09-23 20:37:26,501 - DEBUG - https://s3.amazonaws.com:443 "HEAD /datasets.huggingface.co/datasets/metrics/evaluate-measurement/toxicity/evaluate-measurement/toxicity.py HTTP/11" 404 0
2024-09-23 20:37:26,520 - DEBUG - Starting new HTTPS connection (1): huggingface.co:443
2024-09-23 20:37:26,969 - DEBUG - https://huggingface.co:443 "HEAD /spaces/evaluate-measurement/toxicity/resolve/v0.4.3/toxicity.py HTTP/11" 404 0
2024-09-23 20:37:26,970 - DEBUG - Starting new HTTPS connection (1): huggingface.co:443
2024-09-23 20:37:27,349 - DEBUG - https://huggingface.co:443 "HEAD /spaces/evaluate-measurement/toxicity/resolve/main/toxicity.py HTTP/11" 200 0
2024-09-23 20:37:27,360 - DEBUG - Attempting to acquire lock 13437936528 on /Users/gerald/.cache/huggingface/modules/evaluate_modules/metrics/evaluate-measurement--toxicity.lock
2024-09-23 20:37:27,361 - DEBUG - Lock 13437936528 acquired on /Users/gerald/.cache/huggingface/modules/evaluate_modules/metrics/evaluate-measurement--toxicity.lock
2024-09-23 20:37:27,361 - DEBUG - Attempting to release lock 13437936528 on /Users/gerald/.cache/huggingface/modules/evaluate_modules/metrics/evaluate-measurement--toxicity.lock
2024-09-23 20:37:27,361 - DEBUG - Lock 13437936528 released on /Users/gerald/.cache/huggingface/modules/evaluate_modules/metrics/evaluate-measurement--toxicity.lock
2024-09-23 20:37:27,370 - WARNING - Using default facebook/roberta-hate-speech-dynabench-r4-target checkpoint
2024-09-23 20:37:27,371 - DEBUG - Starting new HTTPS connection (1): huggingface.co:443
2024-09-23 20:37:27,744 - DEBUG - https://huggingface.co:443 "HEAD /facebook/roberta-hate-speech-dynabench-r4-target/resolve/main/config.json HTTP/11" 200 0
2024/09/23 20:37:27 WARNING mlflow.metrics.metric_definitions: Failed to load 'toxicity' metric (error: RuntimeError('Failed to import transformers.models.roberta.modeling_tf_roberta because of the following error (look up to see its traceback):\nYour currently installed version of Keras is Keras 3, but this is not yet supported in Transformers. Please install the backwards-compatible tf-keras package with `pip install tf-keras`.')), skipping metric logging.
2024/09/23 20:37:27 WARNING mlflow.models.evaluation.default_evaluator: Did not log builtin metric 'toxicity' because it returned None.
2024/09/23 20:37:27 WARNING mlflow.models.evaluation.default_evaluator: Did not log builtin metric 'exact_match' because it returned None.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 694.54it/s]
/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/numpy/core/fromnumeric.py:3504: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,
/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/numpy/core/_methods.py:129: RuntimeWarning: invalid value encountered in scalar divide
  ret = ret.dtype.type(ret / rcount)
/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/numpy/core/fromnumeric.py:3787: RuntimeWarning: Degrees of freedom <= 0 for slice
  return _methods._var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/numpy/core/_methods.py:163: RuntimeWarning: invalid value encountered in divide
  arrmean = um.true_divide(arrmean, div, out=arrmean,
/Users/gerald/git/summarization_analytics/venv/lib/python3.12/site-packages/numpy/core/_methods.py:198: RuntimeWarning: invalid value encountered in scalar divide
  ret = ret.dtype.type(ret / rcount)
2024-09-23 20:37:28,012 - DEBUG - Starting new HTTPS connection (1): s3.amazonaws.com:443
2024-09-23 20:37:28,419 - DEBUG - https://s3.amazonaws.com:443 "HEAD /datasets.huggingface.co/datasets/metrics/evaluate-measurement/toxicity/evaluate-measurement/toxicity.py HTTP/11" 404 0
2024-09-23 20:37:28,420 - DEBUG - Starting new HTTPS connection (1): huggingface.co:443
2024-09-23 20:37:28,861 - DEBUG - https://huggingface.co:443 "HEAD /spaces/evaluate-measurement/toxicity/resolve/v0.4.3/toxicity.py HTTP/11" 404 0
2024-09-23 20:37:28,863 - DEBUG - Starting new HTTPS connection (1): huggingface.co:443
2024-09-23 20:37:29,175 - DEBUG - https://huggingface.co:443 "HEAD /spaces/evaluate-measurement/toxicity/resolve/main/toxicity.py HTTP/11" 200 0
2024-09-23 20:37:29,180 - DEBUG - Attempting to acquire lock 13432577808 on /Users/gerald/.cache/huggingface/modules/evaluate_modules/metrics/evaluate-measurement--toxicity.lock
2024-09-23 20:37:29,181 - DEBUG - Lock 13432577808 acquired on /Users/gerald/.cache/huggingface/modules/evaluate_modules/metrics/evaluate-measurement--toxicity.lock
2024-09-23 20:37:29,181 - DEBUG - Attempting to release lock 13432577808 on /Users/gerald/.cache/huggingface/modules/evaluate_modules/metrics/evaluate-measurement--toxicity.lock
2024-09-23 20:37:29,181 - DEBUG - Lock 13432577808 released on /Users/gerald/.cache/huggingface/modules/evaluate_modules/metrics/evaluate-measurement--toxicity.lock
2024-09-23 20:37:29,181 - WARNING - Using default facebook/roberta-hate-speech-dynabench-r4-target checkpoint
2024-09-23 20:37:29,339 - DEBUG - https://huggingface.co:443 "HEAD /facebook/roberta-hate-speech-dynabench-r4-target/resolve/main/config.json HTTP/11" 200 0
2024/09/23 20:37:29 WARNING mlflow.metrics.metric_definitions: Failed to load 'toxicity' metric (error: RuntimeError('Failed to import transformers.models.roberta.modeling_tf_roberta because of the following error (look up to see its traceback):\nYour currently installed version of Keras is Keras 3, but this is not yet supported in Transformers. Please install the backwards-compatible tf-keras package with `pip install tf-keras`.')), skipping metric logging.
2024/09/23 20:37:29 WARNING mlflow.models.evaluation.default_evaluator: Did not log builtin metric 'toxicity' because it returned None.
2024/09/23 20:37:29 WARNING mlflow.models.evaluation.default_evaluator: Did not log builtin metric 'exact_match' because it returned None.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 13574.24it/s]
2024-09-23 20:37:29,433 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,443 - DEBUG - http://127.0.0.1:5000 "POST /api/2.0/mlflow/runs/log-batch HTTP/11" 200 2
2024-09-23 20:37:29,446 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,450 - DEBUG - http://127.0.0.1:5000 "GET /api/2.0/mlflow-artifacts/artifacts?path=681916535377301264%2Ff0dab16df3604ca6ae6740a93168d5d2%2Fartifacts HTTP/11" 200 76
2024-09-23 20:37:29,454 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,464 - DEBUG - http://127.0.0.1:5000 "PUT /api/2.0/mlflow-artifacts/artifacts/681916535377301264/f0dab16df3604ca6ae6740a93168d5d2/artifacts/eval_results_table.json HTTP/11" 200 2
2024-09-23 20:37:29,466 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,475 - DEBUG - http://127.0.0.1:5000 "GET /api/2.0/mlflow/runs/get?run_uuid=f0dab16df3604ca6ae6740a93168d5d2&run_id=f0dab16df3604ca6ae6740a93168d5d2 HTTP/11" 200 10058
2024-09-23 20:37:29,477 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,481 - DEBUG - http://127.0.0.1:5000 "POST /api/2.0/mlflow/runs/set-tag HTTP/11" 200 2
2024-09-23 20:37:29,483 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,493 - DEBUG - http://127.0.0.1:5000 "GET /api/2.0/mlflow/runs/get?run_uuid=f0dab16df3604ca6ae6740a93168d5d2&run_id=f0dab16df3604ca6ae6740a93168d5d2 HTTP/11" 200 10206
2024-09-23 20:37:29,496 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,498 - DEBUG - http://127.0.0.1:5000 "GET /api/2.0/mlflow-artifacts/artifacts?path=681916535377301264%2Ff0dab16df3604ca6ae6740a93168d5d2%2Fartifacts HTTP/11" 200 179
2024-09-23 20:37:29,500 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,504 - DEBUG - http://127.0.0.1:5000 "PUT /api/2.0/mlflow-artifacts/artifacts/681916535377301264/f0dab16df3604ca6ae6740a93168d5d2/artifacts/genai_custom_metrics.json HTTP/11" 200 2
2024-09-23 20:37:29,506 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,518 - DEBUG - http://127.0.0.1:5000 "GET /api/2.0/mlflow/runs/get?run_uuid=f0dab16df3604ca6ae6740a93168d5d2&run_id=f0dab16df3604ca6ae6740a93168d5d2 HTTP/11" 200 10206
2024-09-23 20:37:29,520 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,523 - DEBUG - http://127.0.0.1:5000 "POST /api/2.0/mlflow/runs/set-tag HTTP/11" 200 2
2024-09-23 20:37:29,524 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,534 - DEBUG - http://127.0.0.1:5000 "GET /api/2.0/mlflow/runs/get?run_uuid=f0dab16df3604ca6ae6740a93168d5d2&run_id=f0dab16df3604ca6ae6740a93168d5d2 HTTP/11" 200 10270
2024-09-23 20:37:29,537 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,555 - DEBUG - http://127.0.0.1:5000 "GET /api/2.0/mlflow/runs/get?run_uuid=f0dab16df3604ca6ae6740a93168d5d2&run_id=f0dab16df3604ca6ae6740a93168d5d2 HTTP/11" 200 10270
2024/09/23 20:37:29 INFO mlflow.tracking._tracking_service.client: 🏃 View run skillful-sow-156 at: http://127.0.0.1:5000/#/experiments/681916535377301264/runs/f0dab16df3604ca6ae6740a93168d5d2.
2024/09/23 20:37:29 INFO mlflow.tracking._tracking_service.client: 🧪 View experiment at: http://127.0.0.1:5000/#/experiments/681916535377301264.
2024-09-23 20:37:29,557 - DEBUG - Resetting dropped connection: 127.0.0.1
2024-09-23 20:37:29,562 - DEBUG - http://127.0.0.1:5000 "POST /api/2.0/mlflow/runs/update HTTP/11" 200 454
```

I ran the unit tests, but I didn't see any that covered this portion of code.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions
  
At least I couldn't find any relevant docs. Happy to update if I missed anything!

![image](https://github.com/user-attachments/assets/051664de-0103-40ce-bd40-303a62aa2173)


### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a bug when OpenAI API requests are being rate limited. Fixes a bug where users hit an `MLflowException` when running large experiments using `mlflow.evaluate()`

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations


<a name="release-note-category">#user-content-release-note-category</a>


#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes`

<details>
<summary>What is a minor/patch release?</summary>


- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
