### PR TITLE
Potential fix for OOM in `get_metric_history_bulk_interval_impl`

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1286,13 +1286,17 @@ def get_metric_history_bulk_interval_impl(request_message):
         # get a list of all steps for all runs. this is necessary
         # because we can't assume that every step was logged, so
         # sampling needs to be done on the steps that actually exist
+        max_results = (
+            int(v)
+            if (v := os.environ.get("MLFLOW_GET_METRIC_HISTORY_BULK_BATCH_SIZE"))
+            else MAX_RESULTS_PER_RUN
+        )
+
         def fetch_all_metrics(run_id, key, token=None):
             """
             Fetch all metrics in chunks of MAX_RESULTS_PER_RUN to avoid OOM errors.
             """
-            page = store.get_metric_history(
-                run_id, key, max_results=MAX_RESULTS_PER_RUN, page_token=token
-            )
+            page = store.get_metric_history(run_id, key, max_results=max_results, page_token=token)
             if page.token:
                 return page + fetch_all_metrics(run_id, key, page.token)
             else:

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1293,11 +1293,14 @@ def get_metric_history_bulk_interval_impl(request_message):
             page = store.get_metric_history(
                 run_id, key, max_results=MAX_RESULTS_PER_RUN, page_token=token
             )
-            return page + fetch_all_metrics(run_id, key, page.token) if page.token else page
+            if page.token:
+                return page + fetch_all_metrics(run_id, key, page.token)
+            else:
+                return page
 
         all_runs = []
         for run_id in run_ids:
-            all_runs.extend({m.step for m in fetch_all_metrics(run_id, metric_key, None)})
+            all_runs.append({m.step for m in fetch_all_metrics(run_id, metric_key, None)})
 
         # save mins and maxes to be added back later
         all_mins_and_maxes = {step for run in all_runs if run for step in [min(run), max(run)]}

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1286,7 +1286,7 @@ def get_metric_history_bulk_interval_impl(request_message):
         # get a list of all steps for all runs. this is necessary
         # because we can't assume that every step was logged, so
         # sampling needs to be done on the steps that actually exist
-        max_results = (
+        batch_size = (
             int(v)
             if (v := os.environ.get("MLFLOW_GET_METRIC_HISTORY_BULK_BATCH_SIZE"))
             else MAX_RESULTS_PER_RUN
@@ -1296,7 +1296,7 @@ def get_metric_history_bulk_interval_impl(request_message):
             """
             Fetch all metrics in chunks of MAX_RESULTS_PER_RUN to avoid OOM errors.
             """
-            page = store.get_metric_history(run_id, key, max_results=max_results, page_token=token)
+            page = store.get_metric_history(run_id, key, max_results=batch_size, page_token=token)
             if page.token:
                 return page + fetch_all_metrics(run_id, key, page.token)
             else:


### PR DESCRIPTION
## Install mlflow this PR branch:

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13229/merge
```

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for the following error:

```python
[2024-09-06 19:04:18 +0000] [70] [CRITICAL] WORKER TIMEOUT (pid:96705)
[2024-09-06 19:04:19 +0000] [70] [CRITICAL] WORKER TIMEOUT (pid:74)
[2024-09-06 19:04:19 +0000] [70] [ERROR] Worker (pid:96705) was sent SIGKILL! Perhaps out of memory?
[2024-09-06 19:04:19 +0000] [111771] [INFO] Booting worker with pid: 111771
[2024-09-06 19:04:19 +0000] [70] [ERROR] Worker (pid:74) was sent SIGKILL! Perhaps out of memory?
[2024-09-06 19:04:19 +0000] [111772] [INFO] Booting worker with pid: 111772
[2024-09-06 19:04:20 +0000] [70] [CRITICAL] WORKER TIMEOUT (pid:72)
[2024-09-06 19:04:21 +0000] [70] [ERROR] Worker (pid:72) was sent SIGKILL! Perhaps out of memory?
[2024-09-06 19:04:21 +0000] [111899] [INFO] Booting worker with pid: 111899
[2024-09-06 19:04:23 +0000] [70] [CRITICAL] WORKER TIMEOUT (pid:107485)
[2024-09-06 19:04:23 +0000] [107485] [ERROR] Error handling request /ajax-api/2.0/mlflow/metrics/get-history-bulk-interval?run_ids=65d452179357427793fbda1f4a9a5699&run_ids=ab77ad63757b4cef845318c74a97c33f&metric_key=val%2Fcount%2Fsign-predicted_step&max_results=320
Traceback (most recent call last):
  File "/opt/bitnami/python/lib/python3.10/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/opt/bitnami/python/lib/python3.10/site-packages/gunicorn/workers/sync.py", line 178, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/opt/bitnami/python/lib/python3.10/site-packages/flask/app.py", line 1498, in __call__
    return self.wsgi_app(environ, start_response)
  File "/opt/bitnami/python/lib/python3.10/site-packages/flask/app.py", line 1473, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/bitnami/python/lib/python3.10/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/bitnami/python/lib/python3.10/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/opt/bitnami/python/lib/python3.10/site-packages/mlflow/server/handlers.py", line 561, in wrapper
    return func(*args, **kwargs)
  File "/opt/bitnami/python/lib/python3.10/site-packages/mlflow/server/handlers.py", line 602, in wrapper
    return func(*args, **kwargs)
  File "/opt/bitnami/python/lib/python3.10/site-packages/mlflow/server/handlers.py", line 1296, in get_metric_history_bulk_interval_handler
    metrics_with_run_ids = _default_history_bulk_interval_impl()
  File "/opt/bitnami/python/lib/python3.10/site-packages/mlflow/server/handlers.py", line 1283, in _default_history_bulk_interval_impl
    steps = _get_sampled_steps(run_ids, metric_key, max_results)
  File "/opt/bitnami/python/lib/python3.10/site-packages/mlflow/server/handlers.py", line 1260, in _get_sampled_steps
    all_runs = [
  File "/opt/bitnami/python/lib/python3.10/site-packages/mlflow/server/handlers.py", line 1261, in <listcomp>
    [m.step for m in store.get_metric_history(run_id, metric_key)] for run_id in run_ids
  File "/opt/bitnami/python/lib/python3.10/site-packages/mlflow/store/tracking/sqlalchemy_store.py", line 920, in get_metric_history
    metrics = session.query(SqlMetric).filter_by(run_uuid=run_id, key=metric_key).all()
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/orm/query.py", line 2673, in all
    return self._iter().all()  # type: ignore
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/orm/query.py", line 2827, in _iter
    result: Union[ScalarResult[_T], Result[_T]] = self.session.execute(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 2351, in execute
    return self._execute_internal(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 2236, in _execute_internal
    result: Result[Any] = compile_state_cls.orm_execute_statement(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/orm/context.py", line 293, in orm_execute_statement
    result = conn.execute(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1418, in execute
    return meth(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/sql/elements.py", line 515, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1640, in _execute_clauseelement
    ret = self._execute_context(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1846, in _execute_context
    return self._exec_single_context(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1986, in _exec_single_context
    self._handle_dbapi_exception(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2356, in _handle_dbapi_exception
    raise exc_info[1].with_traceback(exc_info[2])
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
    self.dialect.do_execute(
  File "/opt/bitnami/python/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 924, in do_execute
    cursor.execute(statement, parameters)
  File "/opt/bitnami/python/lib/python3.10/encodings/utf_8.py", line 15, in decode
    def decode(input, errors='strict'):
  File "/opt/bitnami/python/lib/python3.10/site-packages/gunicorn/workers/base.py", line 203, in handle_abort
    sys.exit(1)
SystemExit: 1
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
