### PR TITLE
Update URL when user clicks on an artifact

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactPage.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactPage.intg.test.tsx
@@ -146,7 +146,7 @@ describe('Artifact page, artifact files rendering integration test', () => {
       },
     };
 
-    render(<ArtifactPage runUuid="test-run-uuid" runTags={runTags} />, {
+    render(<ArtifactPage experimentId="test-experiment-uuid" runUuid="test-run-uuid" runTags={runTags} />, {
       wrapper: ({ children }) => (
         <TestRouter
           routes={[
@@ -219,7 +219,7 @@ describe('Artifact page, artifact files rendering integration test', () => {
       },
     };
 
-    render(<ArtifactPage runUuid="test-run-uuid" runTags={runTags} />, {
+    render(<ArtifactPage experimentId="test-experiment-uuid" runUuid="test-run-uuid" runTags={runTags} />, {
       wrapper: ({ children }) => (
         <TestRouter
           routes={[

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
@@ -375,6 +375,14 @@ export class ArtifactViewImpl extends Component<ArtifactViewImplProps, ArtifactV
     return this.props.artifactRootUri;
   }
 
+  getActiveNodeFilePath() {
+    if (this.state.activeNodeId) {
+      const node = ArtifactUtils.findChild(this.props.artifactNode, this.state.activeNodeId);
+      return node.fileInfo.path;
+    }
+    return undefined;
+  }
+
   getActiveNodeSize() {
     if (this.state.activeNodeId) {
       const node = ArtifactUtils.findChild(this.props.artifactNode, this.state.activeNodeId);
@@ -407,7 +415,7 @@ export class ArtifactViewImpl extends Component<ArtifactViewImplProps, ArtifactV
   componentDidUpdate(prevProps: ArtifactViewImplProps, prevState: ArtifactViewImplState) {
     const { activeNodeId } = this.state;
     if (prevState.activeNodeId !== activeNodeId) {
-      this.props.handleActiveNodeChange(this.activeNodeIsDirectory());
+      this.props.handleActiveNodeChange(this.activeNodeIsDirectory(), this.getActiveNodeFilePath());
     }
   }
 

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewArtifactTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewArtifactTab.tsx
@@ -10,6 +10,7 @@ export const RunViewArtifactTab = ({
   runTags,
   artifactUri,
   runUuid,
+  experimentId,
 }: {
   runUuid: string;
   experimentId: string;
@@ -32,6 +33,7 @@ export const RunViewArtifactTab = ({
       }}
     >
       <ArtifactPage
+        experimentId={experimentId}
         runUuid={runUuid}
         runTags={runTags}
         useAutoHeight={useFullHeightPage}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/arnaudh/mlflow/pull/13232?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13232/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13232
```

</p>
</details>

### Related Issues/PRs

Resolve https://github.com/mlflow/mlflow/issues/13056

### What changes are proposed in this pull request?

In the run page under the Artifacts tab, as the user navigates the artifact file tree and clicks on artifact names to render them, the URL is now live updated to contain the path to that specific artifact (e.g. `.../experiments/123456789/runs/123456789abcdef/artifacts/some/filename.txt` - as opposed to the non-specific `.../experiments/123456789/runs/123456789abcdef/artifacts`).
This means the user can now share that URL and have another person open up that exact artifact. This relies on the existing hidden feature to directly jump to a specific artifact (as pointed in the issue [here](https://github.com/mlflow/mlflow/issues/13056#issuecomment-2325960316)).

Note the URL also gets updated when clicking on folders in the tree (e.g. `.../experiments/123456789/runs/123456789abcdef/artifacts/some`). This works as expected - someone opening that URL will see the tree expanded down to that folder, with no artifact being selected and rendered.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

I created a run and logged some artifacts. I ran the dev server locally and navigated to the UI, confirming the URL gets updated as I navigate around the artifact tree. 

https://github.com/user-attachments/assets/9a89d140-1345-4458-beb1-4140ec432f73

**Note**: this doesn't work for artifacts with file path containing special characters that can cause issues in URLs (for example `?&`). It seems the [existing logic to convert an artifact path to URL](https://github.com/arnaudh/mlflow/blob/2283960727fd1fdbaa09b5f5d4dcf78e8f5bb764/mlflow/server/js/src/experiment-tracking/routes.ts#L87) does not escape special characters, and the [existing reverse logic to extract artifact path from URL](https://github.com/arnaudh/mlflow/blob/2283960727fd1fdbaa09b5f5d4dcf78e8f5bb764/mlflow/server/js/src/experiment-tracking/components/ArtifactPage.tsx#L193-L193) also doesn't take into account special characters. The current MR does update the URL for these paths (e.g. to `.../experiments/123456789/runs/123456789abcdef/artifacts/special_name?&`), but that URL does not open that specific artifact, instead it will open the Artifacts tab with no selected artifact (which is the current behaviour, so not so terrible fallback). I believe this should be fixed in a separate issue/MR (with URL encoding/decoding).


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions


### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

It's now possible to share links to specific run artifacts: in the run page under the Artifacts tab, clicking on an artifact name updates the webapp URL to point to that specific artifact. You can share that URL - on load it will display that specific artifact.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

Note: I don't know if this could affect these integrations. I am assuming the artifact route pathing exists and is the same in all integration UIs.

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
