### PR TITLE
Use None for schema and profile when fields are absent in proto

### DIFF
--- a/mlflow/entities/dataset.py
+++ b/mlflow/entities/dataset.py
@@ -73,5 +73,10 @@ class Dataset(_MlflowObject):
     @classmethod
     def from_proto(cls, proto):
         return cls(
-            proto.name, proto.digest, proto.source_type, proto.source, proto.schema, proto.profile
+            proto.name,
+            proto.digest,
+            proto.source_type,
+            proto.source,
+            proto.schema if proto.HasField("schema") else None,
+            proto.profile if proto.HasField("profile") else None,
         )

--- a/tests/entities/test_dataset.py
+++ b/tests/entities/test_dataset.py
@@ -37,3 +37,29 @@ def test_creation_and_hydration():
 
     dataset3 = Dataset.from_dictionary(as_dict)
     _check(dataset3, name, digest, source_type, source, schema, profile)
+
+
+def test_absent_fields():
+    name = "my_name"
+    digest = "my_digest"
+    source_type = "my_source_type"
+    source = "my_source"
+    dataset = Dataset(name, digest, source_type, source)
+    _check(dataset, name, digest, source_type, source)
+
+    as_dict = {
+        "name": name,
+        "digest": digest,
+        "source_type": source_type,
+        "source": source,
+        "profile": None,
+        "schema": None,
+    }
+    assert dict(dataset) == as_dict
+
+    proto = dataset.to_proto()
+    dataset2 = Dataset.from_proto(proto)
+    _check(dataset2, name, digest, source_type, source)
+
+    dataset3 = Dataset.from_dictionary(as_dict)
+    _check(dataset3, name, digest, source_type, source)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nojaf/mlflow/pull/13233?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13233/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13233
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

We noticed that `tests/store/tracking/test_sqlalchemy_store.py::test_log_inputs_with_large_inputs_limit_check` was failing for our Go implementation because the conversation from a proto to an entity will use an empty string when the dynamic property (f.ex. `profile`) is accessed.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
We want to check in the `from_proto` function if the field is actually present.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
