### PR TITLE
Change `@mlflow-automation autoformat` to `/autoformat` 

### DIFF
--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -56,13 +56,6 @@ const createReaction = async (context, github) => {
     comment_id,
     content: "rocket",
   });
-};
-
-const createStatus = async (context, github, core) => {
-  const { head_sha, head_ref, repository } = await getPullInformation(context, github);
-  if (repository === "mlflow/mlflow" && head_ref === "master") {
-    core.setFailed("Running autoformat bot against master branch of mlflow/mlflow is not allowed.");
-  }
 
   if (isOldCommand(context.payload.comment)) {
     await github.rest.issues.createComment({
@@ -71,6 +64,13 @@ const createStatus = async (context, github, core) => {
       issue_number: context.issue.number,
       body: "The command `@mlflow-automation autoformat` has been deprecated and will be removed soon. Please use `/autoformat` instead.",
     });
+  }
+};
+
+const createStatus = async (context, github, core) => {
+  const { head_sha, head_ref, repository } = await getPullInformation(context, github);
+  if (repository === "mlflow/mlflow" && head_ref === "master") {
+    core.setFailed("Running autoformat bot against master branch of mlflow/mlflow is not allowed.");
   }
   await createCommitStatus(context, github, head_sha, "pending");
 };

--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -14,7 +14,7 @@ const createCommitStatus = async (context, github, sha, state) => {
 };
 
 const shouldAutoformat = (comment) => {
-  return /^@mlflow-automation\s+autoformat$/.test(comment.body.trim());
+  return comment.body.trim() === "/autoformat";
 };
 
 const getPullInformation = async (context, github) => {

--- a/.github/workflows/autoformat.md
+++ b/.github/workflows/autoformat.md
@@ -19,6 +19,6 @@
    ```
 
 1. Create a PR from the branch containing the dummy changes in your fork.
-1. Comment `@mlflow-automation autoformat` on the PR and ensure the workflow runs successfully.
+1. Comment `/autoformat` on the PR and ensure the workflow runs successfully.
    The workflow status can be checked at https://github.com/{your_username}/mlflow/actions/workflows/autoformat.yml.
 1. Delete the GitHub token and reset the default branch.

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -16,7 +16,7 @@ jobs:
   check-comment:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/autoformat') }}
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'autoformat') }}
     permissions:
       statuses: write # autoformat.createStatus
       pull-requests: write # autoformat.createReaction on PRs

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -16,7 +16,7 @@ jobs:
   check-comment:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '@mlflow-automation') && contains(github.event.comment.body, 'autoformat') }}
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/autoformat') }}
     permissions:
       statuses: write # autoformat.createStatus
       pull-requests: write # autoformat.createReaction on PRs

--- a/dev/format.py
+++ b/dev/format.py
@@ -15,9 +15,7 @@ def transform(stdout: str, is_maintainer: bool) -> str:
         if m := MESSAGE_REGEX.match(line):
             path = m.group(1)
             command = (
-                "`ruff format .` or comment `@mlflow-automation autoformat`"
-                if is_maintainer
-                else "`ruff format .`"
+                "`ruff format .` or comment `/autoformat`" if is_maintainer else "`ruff format .`"
             )
             line = f"{path}: Unformatted file. Run {command} to format."
 

--- a/dev/ruff.py
+++ b/dev/ruff.py
@@ -13,9 +13,7 @@ def transform(stdout: str, is_maintainer: bool) -> str:
         if m := MESSAGE_REGEX.match(line):
             if m.group(2) is not None:
                 command = (
-                    "`ruff --fix .` or comment `@mlflow-automation autoformat`"
-                    if is_maintainer
-                    else "`ruff --fix .`"
+                    "`ruff --fix .` or comment `/autoformat`" if is_maintainer else "`ruff --fix .`"
                 )
                 line = f"{line}. Run {command} to fix this error."
             else:

--- a/dev/test-generate-protos.sh
+++ b/dev/test-generate-protos.sh
@@ -5,7 +5,7 @@ python ./dev/generate_protos.py
 
 GIT_STATUS="$(git status --porcelain)"
 if [ "$GIT_STATUS" ]; then 
-	echo "Protobufs were not generated with protoc. Please run 'python ./dev/generate_protos.py' or comment '@mlflow-automation autoformat' on the PR"
+	echo "Protobufs were not generated with protoc. Please run 'python ./dev/generate_protos.py' or comment '/autoformat' on the PR"
 	echo "Git status is"
 	echo "------------------------------------------------------------------"
 	echo "$GIT_STATUS"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13238?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13238/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13238
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The current command `@mlflow-automation autoformat` is too long to type. We already have a few slash commands such as `/rerun`. We should follow that convention.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
