### PR TITLE
Fix LangChain model test for 0.3.x

### DIFF
--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -50,12 +50,12 @@ Autologging is a powerful one stop solution to achieve all the above benefits wi
 
 Supported Elements in MLflow LangChain Integration
 --------------------------------------------------
-- `LLMChain <https://python.langchain.com/docs/modules/chains/foundational/llm_chain>`_
 - `Agents <https://python.langchain.com/docs/modules/agents/>`_
-- `RetrievalQA <https://js.langchain.com/docs/modules/chains/popular/vector_db_qa>`_
 - `Retrievers <https://python.langchain.com/docs/modules/data_connection/retrievers/>`_
 - `Runnables <https://python.langchain.com/v0.1/docs/expression_language/interface/>`_
 - `LangGraph Complied Graph <https://langchain-ai.github.io/langgraph/reference/graphs/>`_ (only supported via `Model-from-Code <#logging-models-from-code>`_)
+- `LLMChain <https://python.langchain.com/docs/modules/chains/foundational/llm_chain>`_ (deprecated, only support for ``< langchain 0.3.0``)
+- `RetrievalQA <https://js.langchain.com/docs/modules/chains/popular/vector_db_qa>`_ (deprecated, only support for ``< langchain 0.3.0``)
 
 
 .. warning::

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -54,8 +54,8 @@ Supported Elements in MLflow LangChain Integration
 - `Retrievers <https://python.langchain.com/docs/modules/data_connection/retrievers/>`_
 - `Runnables <https://python.langchain.com/v0.1/docs/expression_language/interface/>`_
 - `LangGraph Complied Graph <https://langchain-ai.github.io/langgraph/reference/graphs/>`_ (only supported via `Model-from-Code <#logging-models-from-code>`_)
-- `LLMChain <https://python.langchain.com/docs/modules/chains/foundational/llm_chain>`_ (deprecated, only support for ``< langchain 0.3.0``)
-- `RetrievalQA <https://js.langchain.com/docs/modules/chains/popular/vector_db_qa>`_ (deprecated, only support for ``< langchain 0.3.0``)
+- `LLMChain <https://python.langchain.com/docs/modules/chains/foundational/llm_chain>`_ (deprecated, only support for ``langchain<0.3.0``)
+- `RetrievalQA <https://js.langchain.com/docs/modules/chains/popular/vector_db_qa>`_ (deprecated, only support for ``langchain<0.3.0``)
 
 
 .. warning::

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -2,7 +2,6 @@ import inspect
 import logging
 from typing import Generator, List, Optional, Set
 
-import pydantic
 from packaging import version
 
 from mlflow.models.resources import (
@@ -12,8 +11,6 @@ from mlflow.models.resources import (
     DatabricksVectorSearchIndex,
     Resource,
 )
-
-IS_PYDANTIC_V2 = version.parse(pydantic.version.VERSION) >= version.parse("2.0")
 
 _logger = logging.getLogger(__name__)
 
@@ -232,6 +229,7 @@ def _traverse_runnable(
     by lc_model.get_graph().nodes.values().
     This function supports arbitrary LCEL chain.
     """
+    import pydantic
     from langchain_core.runnables import Runnable, RunnableLambda
 
     visited = visited or set()
@@ -245,7 +243,9 @@ def _traverse_runnable(
 
     if isinstance(lc_model, Runnable):
         # Visit the returned graph
-        if isinstance(lc_model, RunnableLambda) and IS_PYDANTIC_V2:
+        if isinstance(lc_model, RunnableLambda) and version.parse(
+            pydantic.version.VERSION
+        ) >= version.parse("2.0"):
             nodes = _get_nodes_from_runnable_lambda(lc_model)
         else:
             nodes = lc_model.get_graph().nodes.values()

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -2,6 +2,9 @@ import inspect
 import logging
 from typing import Generator, List, Optional, Set
 
+import pydantic
+from packaging import version
+
 from mlflow.models.resources import (
     DatabricksFunction,
     DatabricksServingEndpoint,
@@ -9,6 +12,8 @@ from mlflow.models.resources import (
     DatabricksVectorSearchIndex,
     Resource,
 )
+
+IS_PYDANTIC_V2 = version.parse(pydantic.version.VERSION) >= version.parse("2.0")
 
 _logger = logging.getLogger(__name__)
 
@@ -227,7 +232,7 @@ def _traverse_runnable(
     by lc_model.get_graph().nodes.values().
     This function supports arbitrary LCEL chain.
     """
-    from langchain_core.runnables import Runnable
+    from langchain_core.runnables import Runnable, RunnableLambda
 
     visited = visited or set()
     current_object_id = id(lc_model)
@@ -240,11 +245,49 @@ def _traverse_runnable(
 
     if isinstance(lc_model, Runnable):
         # Visit the returned graph
-        for node in lc_model.get_graph().nodes.values():
+        if isinstance(lc_model, RunnableLambda) and IS_PYDANTIC_V2:
+            nodes = _get_nodes_from_runnable_lambda(lc_model)
+        else:
+            nodes = lc_model.get_graph().nodes.values()
+
+        for node in nodes:
             yield from _traverse_runnable(node.data, visited)
     else:
         # No-op for non-runnable, if any
         pass
+
+
+def _get_nodes_from_runnable_lambda(lc_model):
+    """
+    This is a workaround for the LangGraph issue: https://github.com/langchain-ai/langgraph/issues/1856
+
+    For RunnableLambda, we calling lc_model.get_graph() to get the nodes, which inspect
+    the input and output schema using wrapped function's type annotation. However, the
+    prebuilt graph (e.g. create_react_agent) from LangGraph uses typing.TypeDict annotation,
+    which is not supported by Pydantic V2 on Python < 3.12. If we try to inspect such
+    function, it will raise the following error:
+
+        pydantic.errors.PydanticUserError: Please use `typing_extensions.TypedDict`
+        instead of`typing.TypedDict` on Python < 3.12. For further information visit
+        https://errors.pydantic.dev/2.9/u/typed-dict-version
+
+    Therefore, we cannot use get_graph() for RunnableLambda until LangGraph fixes this issue.
+    Luckily, we are not interested in the input/output nodes for extracting databricks
+    dependencies. We only care about lc_models.deps, which contains the components that
+    the RunnableLambda depends on. Therefore, this function extracts the necessary parts
+    from the original get_graph() function, dropping the input/output related logic.
+    https://github.com/langchain-ai/langchain/blob/2ea5f60cc5747a334550273a5dba1b70b11414c1/libs/core/langchain_core/runnables/base.py#L4493C1-L4512C46
+    """
+    if deps := lc_model.deps:
+        nodes = []
+        for dep in deps:
+            dep_graph = dep.get_graph()
+            dep_graph.trim_first_node()
+            dep_graph.trim_last_node()
+            nodes.extend(dep_graph.nodes.values())
+    else:
+        nodes = lc_model.get_graph().nodes.values()
+    return nodes
 
 
 def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> List[Resource]:

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -232,6 +232,11 @@ def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in
     ]
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) >= Version("0.3.0"),
+    reason="This fix is broken once https://github.com/langchain-ai/langchain/pull/26649 "
+    "is released in langchain-community package",
+)
 def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain.agents import initialize_agent
@@ -292,6 +297,11 @@ def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.1.0"),
     reason="Tools are not supported the way we want in earlier versions",
+)
+@pytest.mark.skipif(
+    Version(langchain.__version__) >= Version("0.3.0"),
+    reason="This fix is broken once https://github.com/langchain-ai/langchain/pull/26649 "
+    "is released in langchain-community package",
 )
 def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
     from databricks.sdk.service.catalog import FunctionInfo

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -232,11 +232,6 @@ def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in
     ]
 
 
-@pytest.mark.skipif(
-    Version(langchain.__version__) >= Version("0.3.0"),
-    reason="This fix is broken once https://github.com/langchain-ai/langchain/pull/26649 "
-    "is released in langchain-community package",
-)
 def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain.agents import initialize_agent
@@ -297,11 +292,6 @@ def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.1.0"),
     reason="Tools are not supported the way we want in earlier versions",
-)
-@pytest.mark.skipif(
-    Version(langchain.__version__) >= Version("0.3.0"),
-    reason="This fix is broken once https://github.com/langchain-ai/langchain/pull/26649 "
-    "is released in langchain-community package",
 )
 def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
     from databricks.sdk.service.catalog import FunctionInfo

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -553,7 +553,8 @@ def test_langchain_log_huggingface_hub_model_metadata(model_path):
 
     assert isinstance(loaded_model, RunnableSequence)
     assert loaded_model.steps[0] == prompt
-    assert isinstance(loaded_model.steps[1], HuggingFacePipeline)
+    # TODO: Check the type once https://github.com/langchain-ai/langchain/issues/22520 is resolved
+    assert type(loaded_model.steps[1]).__name__ == "HuggingFacePipeline"
 
 
 @pytest.mark.skipif(
@@ -920,7 +921,7 @@ def load_requests_wrapper(_):
     return TextRequestsWrapper(headers=None, aiosession=None)
 
 
-@pytest.mark.skipif(IS_LANGCHAIN_03, "APIChain is deprecated")
+@pytest.mark.skipif(IS_LANGCHAIN_03, reason="APIChain is deprecated")
 def test_log_and_load_api_chain():
     llm = OpenAI(temperature=0)
     apichain = APIChain.from_llm_and_api_docs(
@@ -943,7 +944,7 @@ def test_log_and_load_api_chain():
     assert loaded_model == apichain
 
 
-@pytest.mark.skipif(IS_LANGCHAIN_03, "LLMChain is deprecated")
+@pytest.mark.skipif(IS_LANGCHAIN_03, reason="LLMChain is deprecated")
 def test_log_and_load_subclass_of_specialized_chain():
     class APIChainSubclass(APIChain):
         pass
@@ -1951,6 +1952,11 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
     Version(langchain.__version__) < Version("0.2.0"),
     reason="Langgraph are not supported the way we want in earlier versions",
 )
+@pytest.mark.skipif(
+    IS_LANGCHAIN_03,
+    reason="This fix is broken once https://github.com/langchain-ai/langchain/pull/26649 "
+    "is released in langchain-community package",
+)
 def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
     from langchain_community.chat_models import ChatDatabricks
     from langchain_core.runnables import RunnableLambda
@@ -2006,6 +2012,11 @@ def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.1.0"),
     reason="Tools are not supported the way we want in earlier versions",
+)
+@pytest.mark.skipif(
+    IS_LANGCHAIN_03,
+    reason="This fix is broken once https://github.com/langchain-ai/langchain/pull/26649 "
+    "is released in langchain-community package",
 )
 def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
     from langchain_community.chat_models import ChatDatabricks
@@ -3417,7 +3428,20 @@ def test_agent_executor_model_with_messages_input():
     assert list(response) == [
         {
             "output": "Databricks",
-            "messages": [AIMessage(content="Databricks")],
+            "messages": [
+                {
+                    "additional_kwargs": {},
+                    "content": "Databricks",
+                    "example": False,
+                    "id": None,
+                    "invalid_tool_calls": [],
+                    "name": None,
+                    "response_metadata": {},
+                    "tool_calls": [],
+                    "type": "ai",
+                    "usage_metadata": None,
+                }
+            ],
         }
     ]
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -98,8 +98,10 @@ VECTORSTORE_KWARGS = (
     {"allow_dangerous_deserialization": True} if IS_PICKLE_SERIALIZATION_RESTRICTED else {}
 )
 
+IS_LANGCHAIN_03 = version.parse(langchain.__version__) >= version.parse("0.3.0")
+
 # The mock OAI completion endpoint returns payload as it is
-TEST_CONTENT = "What is MLflow?"
+TEST_CONTENT = '[{"role": "user", "content": "What is MLflow?"}]'
 
 
 @pytest.fixture
@@ -113,26 +115,6 @@ def spark():
         yield s
 
 
-def create_huggingface_model(model_path):
-    import transformers
-
-    architecture = "distilgpt2"
-    mlflow.transformers.save_model(
-        transformers_model={
-            "model": transformers.AutoModelWithLMHead.from_pretrained(architecture),
-            "tokenizer": transformers.AutoTokenizer.from_pretrained(architecture),
-        },
-        path=model_path,
-    )
-    llm = mlflow.transformers.load_model(model_path)
-    prompt = PromptTemplate(
-        input_variables=["product"],
-        template="What is a good name for a company that makes {product}?",
-    )
-    hf_pipe = HuggingFacePipeline(pipeline=llm)
-    return LLMChain(llm=hf_pipe, prompt=prompt)
-
-
 def create_openai_llmchain():
     llm = OpenAI(temperature=0.9)
     prompt = PromptTemplate(
@@ -140,6 +122,16 @@ def create_openai_llmchain():
         template="What is {product}?",
     )
     return LLMChain(llm=llm, prompt=prompt)
+
+
+def create_openai_runnable():
+    from langchain_core.output_parsers import StrOutputParser
+
+    prompt = PromptTemplate(
+        input_variables=["product"],
+        template="What is {product}?",
+    )
+    return prompt | ChatOpenAI(temperature=0.9) | StrOutputParser()
 
 
 def create_qa_eval_chain():
@@ -395,18 +387,8 @@ def fake_classifier_chat_model():
     return FakeMlflowClassifier()
 
 
-def test_langchain_native_save_and_load_model(model_path):
-    model = create_openai_llmchain()
-    mlflow.langchain.save_model(model, model_path)
-
-    loaded_model = mlflow.langchain.load_model(model_path)
-    assert type(loaded_model) == LLMChain
-    assert type(loaded_model.llm) == OpenAI
-    assert type(loaded_model.prompt) == PromptTemplate
-    assert loaded_model.prompt.template == "What is {product}?"
-
-
-def test_langchain_native_log_and_load_model():
+@pytest.mark.skipif(IS_LANGCHAIN_03, reason="LLMChain is deprecated")
+def test_langchain_llm_chain():
     model = create_openai_llmchain()
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
@@ -415,7 +397,7 @@ def test_langchain_native_log_and_load_model():
 
     assert "langchain" in logged_model.flavors
     assert str(logged_model.signature.inputs) == "['product': string (required)]"
-    assert str(logged_model.signature.outputs) == "['text': string (required)]"
+    assert str(logged_model.signature.outputs) == "[string (required)]"
 
     assert type(loaded_model) == LLMChain
     assert type(loaded_model.llm) == OpenAI
@@ -423,48 +405,49 @@ def test_langchain_native_log_and_load_model():
     assert loaded_model.prompt.template == "What is {product}?"
 
 
-def test_langchain_model_predict():
-    model = create_openai_llmchain()
+def test_langchain_native_log_and_load_model():
+    model = create_openai_runnable()
+
     with mlflow.start_run():
-        logged_model = mlflow.langchain.log_model(model, "langchain_model")
+        logged_model = mlflow.langchain.log_model(
+            model, "langchain_model", input_example={"product": "MLflow"}
+        )
+
+    loaded_model = mlflow.langchain.load_model(logged_model.model_uri)
+
+    assert "langchain" in logged_model.flavors
+    assert str(logged_model.signature.inputs) == "['product': string (required)]"
+    assert str(logged_model.signature.outputs) == "[string (required)]"
+
+    assert type(loaded_model) == RunnableSequence
+    assert loaded_model.steps[0].template == "What is {product}?"
+    assert type(loaded_model.steps[1]) == ChatOpenAI
+
+    # Predict
     loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
     result = loaded_model.predict([{"product": "MLflow"}])
     assert result == [TEST_CONTENT]
 
-
-def test_langchain_model_predict_stream():
-    model = create_openai_llmchain()
-    with mlflow.start_run():
-        logged_model = mlflow.langchain.log_model(model, "langchain_model")
-    loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
+    # Predict stream
     result = loaded_model.predict_stream([{"product": "MLflow"}])
     assert inspect.isgenerator(result)
-    assert list(result) == [{"product": "MLflow", "text": TEST_CONTENT}]
+    assert list(result) == ["Hello", " world"]
 
 
 def test_pyfunc_spark_udf_with_langchain_model(spark):
-    model = create_openai_llmchain()
+    model = create_openai_runnable()
     with mlflow.start_run():
-        logged_model = mlflow.langchain.log_model(model, "langchain_model")
+        logged_model = mlflow.langchain.log_model(
+            model, "langchain_model", input_example={"product": "MLflow"}
+        )
     loaded_model = mlflow.pyfunc.spark_udf(spark, logged_model.model_uri, result_type="string")
     df = spark.createDataFrame([("MLflow",), ("Spark",)], ["product"])
     df = df.withColumn("answer", loaded_model())
     pdf = df.toPandas()
-    assert pdf["answer"].tolist() == ["What is MLflow?", "What is Spark?"]
-
-
-def test_save_and_load_chat_openai(model_path):
-    llm = ChatOpenAI(temperature=0.9)
-    prompt = PromptTemplate.from_template("What is {product}?")
-    chain = LLMChain(llm=llm, prompt=prompt)
-    mlflow.langchain.save_model(chain, model_path)
-
-    loaded_model = mlflow.langchain.load_model(model_path)
-    assert loaded_model == chain
-
-    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
-    prediction = loaded_pyfunc_model.predict([{"product": "MLflow"}])
-    assert prediction == ['[{"role": "user", "content": "What is MLflow?"}]']
+    assert pdf["answer"].tolist() == [
+        '[{"role": "user", "content": "What is MLflow?"}]',
+        '[{"role": "user", "content": "What is Spark?"}]',
+    ]
 
 
 def test_save_and_load_azure_chat_openai(model_path, monkeypatch):
@@ -473,11 +456,15 @@ def test_save_and_load_azure_chat_openai(model_path, monkeypatch):
 
     llm = AzureChatOpenAI(temperature=0.9)
     prompt = PromptTemplate.from_template("What is a good name for a company that makes {product}?")
-    chain = LLMChain(llm=llm, prompt=prompt)
+    parser = StrOutputParser()
+    chain = prompt | llm | parser
     mlflow.langchain.save_model(chain, model_path)
 
     loaded_model = mlflow.langchain.load_model(model_path)
-    assert loaded_model == chain
+    assert isinstance(loaded_model, RunnableSequence)
+    assert loaded_model.steps[0] == prompt
+    assert loaded_model.steps[1]._identifying_params == llm._identifying_params
+    assert loaded_model.steps[2] == parser
 
 
 def test_save_model_with_partner_package(tmp_path):
@@ -543,21 +530,30 @@ mlflow.models.set_model(chain)
 
 
 def test_langchain_log_huggingface_hub_model_metadata(model_path):
-    model = create_huggingface_model(model_path)
+    import transformers
+
+    prompt = PromptTemplate(
+        input_variables=["product"],
+        template="What is a good name for a company that makes {product}?",
+    )
+    pipeline = transformers.pipeline("text-generation", model="distilgpt2")
+    hf_pipe = HuggingFacePipeline(pipeline=pipeline)
+    model = prompt | hf_pipe | StrOutputParser()
+
     with mlflow.start_run():
-        logged_model = mlflow.langchain.log_model(model, "langchain_model")
+        logged_model = mlflow.langchain.log_model(
+            model, "langchain_model", input_example={"product": "MLflow"}
+        )
 
     loaded_model = mlflow.langchain.load_model(logged_model.model_uri)
 
     assert "langchain" in logged_model.flavors
     assert str(logged_model.signature.inputs) == "['product': string (required)]"
-    assert str(logged_model.signature.outputs) == "['text': string (required)]"
+    assert str(logged_model.signature.outputs) == "[string (required)]"
 
-    assert type(loaded_model) == langchain.chains.llm.LLMChain
-    # TODO: Check the type once https://github.com/langchain-ai/langchain/issues/22520 is resolved
-    assert type(loaded_model.llm).__name__ == "HuggingFacePipeline"
-    assert type(loaded_model.prompt) == langchain.prompts.PromptTemplate
-    assert loaded_model.prompt.template == "What is a good name for a company that makes {product}?"
+    assert isinstance(loaded_model, RunnableSequence)
+    assert loaded_model.steps[0] == prompt
+    assert isinstance(loaded_model.steps[1], HuggingFacePipeline)
 
 
 @pytest.mark.skipif(
@@ -650,29 +646,13 @@ def test_langchain_agent_model_predict_stream():
     assert inspect.isgenerator(response)
     assert list(response) == [
         {
-            "actions": [
-                {
-                    "log": mock.ANY,
-                    "message_log": [mock.ANY],
-                    "tool": "multiply",
-                    "tool_call_id": "123",
-                    "tool_input": {"a": 2, "b": 3},
-                    "type": "AgentActionMessageLog",
-                }
-            ],
+            "actions": [mock.ANY],
             "messages": [mock.ANY],
         },
         {
             "steps": [
                 {
-                    "action": {
-                        "log": mock.ANY,
-                        "message_log": [mock.ANY],
-                        "tool": "multiply",
-                        "tool_call_id": "123",
-                        "tool_input": {"a": 2, "b": 3},
-                        "type": mock.ANY,
-                    },
+                    "action": mock.ANY,
                     "observation": 6,
                 }
             ],
@@ -685,6 +665,7 @@ def test_langchain_agent_model_predict_stream():
     ]
 
 
+@pytest.mark.skipif(IS_LANGCHAIN_03, reason="Saving QAEvalChain does not work with LangChain 0.3.0")
 def test_langchain_native_log_and_load_qaevalchain():
     # QAEvalChain is a subclass of LLMChain
     model = create_qa_eval_chain()
@@ -695,6 +676,7 @@ def test_langchain_native_log_and_load_qaevalchain():
     assert model == loaded_model
 
 
+@pytest.mark.skipif(IS_LANGCHAIN_03, reason="Saving QAEvalChain does not work with LangChain 0.3.0")
 def test_langchain_native_log_and_load_qa_with_sources_chain():
     # StuffDocumentsChain is a subclass of Chain
     model = create_qa_with_sources_chain()
@@ -705,6 +687,7 @@ def test_langchain_native_log_and_load_qa_with_sources_chain():
     assert model == loaded_model
 
 
+@pytest.mark.skipif(IS_LANGCHAIN_03, reason="RetrievalQA is deprecated")
 def test_log_and_load_retrieval_qa_chain(tmp_path):
     # Create the vector db, persist the db to a local fs folder
     loader = TextLoader("tests/langchain/state_of_the_union.txt")
@@ -764,6 +747,7 @@ def test_log_and_load_retrieval_qa_chain(tmp_path):
     response["predictions"][0].startswith("Use the following pieces of context")
 
 
+@pytest.mark.skipif(IS_LANGCHAIN_03, reason="RetrievalQA is deprecated")
 def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
     # Create the vector db, persist the db to a local fs folder
     loader = TextLoader("tests/langchain/state_of_the_union.txt")
@@ -936,6 +920,7 @@ def load_requests_wrapper(_):
     return TextRequestsWrapper(headers=None, aiosession=None)
 
 
+@pytest.mark.skipif(IS_LANGCHAIN_03, "APIChain is deprecated")
 def test_log_and_load_api_chain():
     llm = OpenAI(temperature=0)
     apichain = APIChain.from_llm_and_api_docs(
@@ -958,6 +943,7 @@ def test_log_and_load_api_chain():
     assert loaded_model == apichain
 
 
+@pytest.mark.skipif(IS_LANGCHAIN_03, "LLMChain is deprecated")
 def test_log_and_load_subclass_of_specialized_chain():
     class APIChainSubclass(APIChain):
         pass
@@ -1019,6 +1005,9 @@ def load_db(persist_dir):
 @pytest.mark.skipif(
     version.parse(langchain.__version__) in (version.parse("0.1.14"), version.parse("0.1.15")),
     reason="LangChain 0.1.14 and 0.1.15 has a bug in loading SQLDatabaseChain",
+)
+@pytest.mark.skipif(
+    IS_LANGCHAIN_03, reason="Saving SQLDatabaseChain does not work with LangChain 0.3.0"
 )
 def test_log_and_load_sql_database_chain(tmp_path):
     from langchain_experimental.sql import SQLDatabaseChain
@@ -1386,9 +1375,8 @@ def test_simple_chat_model_inference():
 
 
 def test_save_load_complex_runnable_parallel():
-    chain = create_openai_llmchain()
-    runnable = RunnableParallel({"llm": chain})
-    expected_result = {"llm": {"product": "MLflow", "text": TEST_CONTENT}}
+    runnable = RunnableParallel({"llm": create_openai_runnable()})
+    expected_result = {"llm": TEST_CONTENT}
     assert runnable.invoke({"product": "MLflow"}) == expected_result
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(
@@ -1411,6 +1399,11 @@ def test_save_load_complex_runnable_parallel():
     }
 
 
+@pytest.mark.skipif(
+    IS_LANGCHAIN_03,
+    reason="RunnableAssign has a bug in LangChain 0.3.x. "
+    "https://github.com/langchain-ai/langchain/issues/26862",
+)
 def test_save_load_runnable_parallel_and_assign_in_sequence():
     def fake_llm(prompt: str) -> str:
         return "completion"
@@ -1447,6 +1440,11 @@ def test_save_load_runnable_parallel_and_assign_in_sequence():
     }
 
 
+@pytest.mark.skipif(
+    IS_LANGCHAIN_03,
+    reason="RunnableAssign has a bug in LangChain 0.3.x. "
+    "https://github.com/langchain-ai/langchain/issues/26862",
+)
 def test_save_load_complex_runnable_assign(fake_chat_model):
     prompt = ChatPromptTemplate.from_template(
         "What is a good name for a company that makes {product}?"
@@ -1517,35 +1515,6 @@ def test_save_load_long_runnable_sequence(model_path):
     assert type(loaded_model.steps[2]) == StrOutputParser
     for i in range(3, 13):
         assert type(loaded_model.steps[i]) == RunnablePassthrough
-
-
-def test_save_load_complex_runnable_sequence():
-    llm_chain = create_openai_llmchain()
-    chain = llm_chain | RunnablePassthrough()
-    expected_result = {"product": "MLflow", "text": TEST_CONTENT}
-    assert chain.invoke({"product": "MLflow"}) == expected_result
-
-    with mlflow.start_run():
-        model_info = mlflow.langchain.log_model(
-            chain, "model_path", input_example=[{"product": "MLflow"}]
-        )
-
-    loaded_model = mlflow.langchain.load_model(model_info.model_uri)
-    result = loaded_model.invoke({"product": "MLflow"})
-    assert result == expected_result
-    pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
-
-    inference_payload = load_serving_example(model_info.model_uri)
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-    assert PredictionsResponse.from_json(response.content.decode("utf-8")) == {
-        "predictions": [expected_result]
-    }
 
 
 def test_save_load_runnable_sequence_with_chat_openai():
@@ -2125,15 +2094,16 @@ def test_databricks_dependency_extraction_log_errors_as_warnings(mock_warning):
     assert reloaded_model.resources is None
 
 
+class ChatModel(SimpleChatModel):
+    def _call(self, messages, stop, run_manager, **kwargs):
+        return "\n".join([f"{message.type}: {message.content}" for message in messages])
+
+    @property
+    def _llm_type(self) -> str:
+        return "chat model"
+
+
 def test_predict_with_builtin_pyfunc_chat_conversion(spark):
-    class ChatModel(SimpleChatModel):
-        def _call(self, messages, stop, run_manager, **kwargs):
-            return "\n".join([f"{message.type}: {message.content}" for message in messages])
-
-        @property
-        def _llm_type(self) -> str:
-            return "chat model"
-
     input_example = {
         "messages": [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -2221,27 +2191,6 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
 
     with pytest.raises(MlflowException, match="Unrecognized chat message role"):
         pyfunc_loaded_model.predict({"messages": [{"role": "foobar", "content": "test content"}]})
-
-    udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri)
-    df = spark.createDataFrame([(input_example["messages"],)], ["messages"])
-    with mock.patch("time.time", return_value=1677858242):
-        df = df.withColumn("answer", udf("messages"))
-        assert (
-            df.collect()[0]["answer"].asDict(recursive=True)["choices"][0]["message"]["content"]
-            == content
-        )
-
-    inference_payload = load_serving_example(model_info.model_uri)
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-    assert (
-        json.loads(response.content.decode("utf-8"))[0]["choices"][0]["message"]["content"]
-        == content
-    )
 
 
 def test_predict_with_builtin_pyfunc_chat_conversion_for_aimessage_response():
@@ -2396,6 +2345,7 @@ def test_pyfunc_builtin_chat_request_conversion_fails_gracefully():
     ]
 
 
+@pytest.mark.skipif(IS_LANGCHAIN_03, reason="LLMChain is deprecated")
 def test_pyfunc_builtin_chat_response_conversion_fails_gracefully():
     llm = OpenAI(temperature=0.9)
     prompt = PromptTemplate(
@@ -3135,7 +3085,7 @@ def test_langchain_model_inject_callback_in_model_serving(
     monkeypatch.setenv("MLFLOW_ENABLE_TRACE_IN_SERVING", "true")
     monkeypatch.setenv("ENABLE_MLFLOW_TRACING", str(enable_mlflow_tracing).lower())
 
-    model = create_openai_llmchain()
+    model = create_openai_runnable()
     mlflow.langchain.save_model(model, model_path)
 
     loaded_model = mlflow.pyfunc.load_model(model_path)
@@ -3168,7 +3118,7 @@ def test_langchain_model_not_inject_callback_when_disabled(monkeypatch, model_pa
     # Disable tracing
     monkeypatch.setenv(env_var, "false")
 
-    model = create_openai_llmchain()
+    model = create_openai_runnable()
     mlflow.langchain.save_model(model, model_path)
 
     loaded_model = mlflow.pyfunc.load_model(model_path)

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -397,7 +397,7 @@ def test_langchain_llm_chain():
 
     assert "langchain" in logged_model.flavors
     assert str(logged_model.signature.inputs) == "['product': string (required)]"
-    assert str(logged_model.signature.outputs) == "[string (required)]"
+    assert str(logged_model.signature.outputs) == "['text': string (required)]"
 
     assert type(loaded_model) == LLMChain
     assert type(loaded_model.llm) == OpenAI

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1952,11 +1952,6 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
     Version(langchain.__version__) < Version("0.2.0"),
     reason="Langgraph are not supported the way we want in earlier versions",
 )
-@pytest.mark.skipif(
-    IS_LANGCHAIN_03,
-    reason="This fix is broken once https://github.com/langchain-ai/langchain/pull/26649 "
-    "is released in langchain-community package",
-)
 def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
     from langchain_community.chat_models import ChatDatabricks
     from langchain_core.runnables import RunnableLambda
@@ -2012,11 +2007,6 @@ def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.1.0"),
     reason="Tools are not supported the way we want in earlier versions",
-)
-@pytest.mark.skipif(
-    IS_LANGCHAIN_03,
-    reason="This fix is broken once https://github.com/langchain-ai/langchain/pull/26649 "
-    "is released in langchain-community package",
 )
 def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
     from langchain_community.chat_models import ChatDatabricks

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1384,7 +1384,7 @@ def test_save_load_complex_runnable_parallel():
             runnable, "model_path", input_example=[{"product": "MLflow"}]
         )
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
-    assert loaded_model.invoke("MLflow") == expected_result
+    assert loaded_model.invoke({"product": "MLflow"}) == expected_result
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_loaded_model.predict([{"product": "MLflow"}]) == [expected_result]
 
@@ -3415,7 +3415,8 @@ def test_agent_executor_model_with_messages_input():
     # Test stream output
     response = pyfunc_model.predict_stream(question)
     assert inspect.isgenerator(response)
-    assert list(response) == [
+
+    expected_response = [
         {
             "output": "Databricks",
             "messages": [
@@ -3429,11 +3430,13 @@ def test_agent_executor_model_with_messages_input():
                     "response_metadata": {},
                     "tool_calls": [],
                     "type": "ai",
-                    "usage_metadata": None,
                 }
             ],
         }
     ]
+    if Version(langchain.__version__) >= Version("0.2.0"):
+        expected_response[0]["messages"][0]["usage_metadata"] = None
+    assert list(response) == expected_response
 
 
 def test_signature_inference_fails(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13243?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13243/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13243
```

</p>
</details>

### What changes are proposed in this pull request?

Fix cross version test for LangChain 0.3.x.

https://github.com/mlflow-automation/mlflow/actions/runs/11014747693/job/30601076206#step:12:8102

While the number of failure is large, most of them come from legacy chain class like `LLMChain`, which was already deprecated in LangChain 0.1.x. This PR does not try to fix logging for such legacy classes, instead, use runnables or skip such test cases.

The only actual compatibility issue is in Databricks dependency extraction. The traversal logic fails due to an issue in LangChain side (https://github.com/langchain-ai/langgraph/issues/1856) with pydantic V2. I added a workaround to bypassing the issue.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
