### PR TITLE
[MLflow] Support multiple retrievers schema via set_retriever_schema

### DIFF
--- a/tests/models/test_dependencies_schema.py
+++ b/tests/models/test_dependencies_schema.py
@@ -1,3 +1,6 @@
+import pytest
+
+from mlflow.exceptions import MlflowException
 from mlflow.models.dependencies_schemas import (
     DependenciesSchemas,
     DependenciesSchemasType,
@@ -94,7 +97,7 @@ def test_set_retriever_schema_creation():
         other_columns=["column1", "column2"],
     )
     with _get_dependencies_schemas() as schema:
-        assert schema.retriever_schemas[0].to_dict() == {
+        assert schema.to_dict()["dependencies_schemas"] == {
             DependenciesSchemasType.RETRIEVERS.value: [
                 {
                     "doc_uri": "doc-uri",
@@ -121,7 +124,7 @@ def test_set_retriever_schema_creation_with_name():
         other_columns=["column1", "column2"],
     )
     with _get_dependencies_schemas() as schema:
-        assert schema.retriever_schemas[0].to_dict() == {
+        assert schema.to_dict()["dependencies_schemas"] == {
             DependenciesSchemasType.RETRIEVERS.value: [
                 {
                     "doc_uri": "doc-uri",
@@ -142,3 +145,69 @@ def test_set_retriever_schema_creation_with_name():
 def test_set_retriever_schema_empty_creation():
     with _get_dependencies_schemas() as schema:
         assert schema.to_dict() is None
+
+
+def test_multiple_set_retriever_schema_creation_with_name():
+    set_retriever_schema(
+        name="my_ret_1",
+        primary_key="primary-key-2",
+        text_column="text-column-1",
+        doc_uri="doc-uri-3",
+        other_columns=["column1", "column2"],
+    )
+
+    set_retriever_schema(
+        name="my_ret_2",
+        primary_key="primary-key",
+        text_column="text-column",
+        doc_uri="doc-uri",
+        other_columns=["column1", "column2"],
+    )
+    with _get_dependencies_schemas() as schema:
+        assert schema.to_dict()["dependencies_schemas"] == {
+            DependenciesSchemasType.RETRIEVERS.value: [
+                {
+                    "doc_uri": "doc-uri-3",
+                    "name": "my_ret_1",
+                    "other_columns": ["column1", "column2"],
+                    "primary_key": "primary-key-2",
+                    "text_column": "text-column-1",
+                },
+                {
+                    "doc_uri": "doc-uri",
+                    "name": "my_ret_2",
+                    "other_columns": ["column1", "column2"],
+                    "primary_key": "primary-key",
+                    "text_column": "text-column",
+                },
+            ]
+        }
+
+    # Schema is automatically reset
+    with _get_dependencies_schemas() as schema:
+        assert schema.to_dict() is None
+    assert _get_retriever_schema() == []
+
+
+def test_multiple_set_retriever_schema_with_same_name():
+    set_retriever_schema(
+        name="my_ret_1",
+        primary_key="primary-key-2",
+        text_column="text-column-1",
+        doc_uri="doc-uri-3",
+        other_columns=["column1", "column2"],
+    )
+
+    with pytest.raises(
+        MlflowException, match=r"A retriever schema with the name 'my_ret_1' already exists."
+    ):
+        set_retriever_schema(
+            name="my_ret_1",
+            primary_key="primary-key",
+            text_column="text-column",
+            doc_uri="doc-uri",
+            other_columns=["column1", "column2"],
+        )
+
+    # If there is an error, the schema is cleared
+    assert _get_retriever_schema() == []


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/13246?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13246/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13246
```

</p>
</details>

### What changes are proposed in this pull request?
[MLflow] Support multiple retrievers schema via set_retriever_schema
With RAG and agent tool calling, users pass in multiple retrievers with different schemas. Using set_retriever_schema, users can pass in multiple retrievers with different names and use that to represent schemas for each retriever tool

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support passing multiple retrievers schema via set_retriever_schema

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
