### PR TITLE
Add run_id parameter to the search_trace API

### DIFF
--- a/docs/source/llms/tracing/index.rst
+++ b/docs/source/llms/tracing/index.rst
@@ -884,7 +884,7 @@ For example, in the following code, the traces are generated within the ``start_
     mlflow.set_experiment("Run Associated Tracing")
 
     # Start a new MLflow Run
-    with mlflow.start_run():
+    with mlflow.start_run() as run:
         # Initiate a trace by starting a Span context from within the Run context
         with mlflow.start_span(name="Run Span") as parent_span:
             parent_span.set_inputs({"input": "a"})
@@ -903,6 +903,19 @@ well as providing a link to navigate to the run within the MLflow UI. See the be
     :alt: Tracing within a Run Context
     :width: 100%
     :align: center
+
+You can also programmatically retrieve the traces associated to a particular Run by using the :py:meth:`mlflow.client.MlflowClient.search_traces` method.
+
+.. code-block:: python
+
+    from mlflow import MlflowClient
+
+    client = MlflowClient()
+
+    # Retrieve traces associated with a specific Run
+    traces = client.search_traces(run_id=run.info.run_id)
+
+    print(traces)
 
 
 Q: Can I use the fluent API and the client API together?

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -417,9 +417,11 @@ def search_traces(
 
         import mlflow
 
+
         @mlflow.trace
         def traced_func(x):
             return x + 1
+
 
         with mlflow.start_run() as run:
             traced_func(1)

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -415,10 +415,11 @@ def search_traces(
         :test:
         :caption: Search traces by run ID
 
+        import mlflow
+
         @mlflow.trace
         def traced_func(x):
             return x + 1
-
 
         with mlflow.start_run() as run:
             traced_func(1)

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -330,6 +330,7 @@ def get_trace(request_id: str) -> Optional[Trace]:
 @experimental
 def search_traces(
     experiment_ids: Optional[List[str]] = None,
+    run_id: Optional[str] = None,
     filter_string: Optional[str] = None,
     max_results: Optional[int] = None,
     order_by: Optional[List[str]] = None,
@@ -348,6 +349,9 @@ def search_traces(
     Args:
         experiment_ids: List of experiment ids to scope the search. If not provided, the search
             will be performed across the current active experiment.
+        run_id: A run id to scope the search. When a trace is created under an active run,
+            it will be associated with the run and you can filter on the run id to retrieve the
+            trace. See the example below for how to filter traces by run id.
         filter_string: A search filter string.
         max_results: Maximum number of traces desired. If None, all traces matching the search
             expressions will be returned.
@@ -406,6 +410,21 @@ def search_traces(
         mlflow.search_traces(
             extract_fields=["non_dict_span.inputs", "non_dict_span.outputs"],
         )
+
+    .. code-block:: python
+        :test:
+        :caption: Search traces by run ID
+
+        @mlflow.trace
+        def traced_func(x):
+            return x + 1
+
+
+        with mlflow.start_run() as run:
+            traced_func(1)
+
+        mlflow.search_traces(run_id=run.info.run_id)
+
     """
     # Check if pandas is installed early to avoid unnecessary computation
     if importlib.util.find_spec("pandas") is None:
@@ -428,6 +447,7 @@ def search_traces(
     def pagination_wrapper_func(number_to_get, next_page_token):
         return MlflowClient().search_traces(
             experiment_ids=experiment_ids,
+            run_id=run_id,
             max_results=number_to_get,
             filter_string=filter_string,
             order_by=order_by,

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -330,11 +330,11 @@ def get_trace(request_id: str) -> Optional[Trace]:
 @experimental
 def search_traces(
     experiment_ids: Optional[List[str]] = None,
-    run_id: Optional[str] = None,
     filter_string: Optional[str] = None,
     max_results: Optional[int] = None,
     order_by: Optional[List[str]] = None,
     extract_fields: Optional[List[str]] = None,
+    run_id: Optional[str] = None,
 ) -> "pandas.DataFrame":
     """
     Return traces that match the given list of search expressions within the experiments.
@@ -349,9 +349,6 @@ def search_traces(
     Args:
         experiment_ids: List of experiment ids to scope the search. If not provided, the search
             will be performed across the current active experiment.
-        run_id: A run id to scope the search. When a trace is created under an active run,
-            it will be associated with the run and you can filter on the run id to retrieve the
-            trace. See the example below for how to filter traces by run id.
         filter_string: A search filter string.
         max_results: Maximum number of traces desired. If None, all traces matching the search
             expressions will be returned.
@@ -378,6 +375,9 @@ def search_traces(
 
                 # span name and field name contain a dot
                 extract_fields = ["`span.name`.inputs.`field.name`"]
+        run_id: A run id to scope the search. When a trace is created under an active run,
+            it will be associated with the run and you can filter on the run id to retrieve the
+            trace. See the example below for how to filter traces by run id.
 
     Returns:
         A Pandas DataFrame containing information about traces that satisfy the search expressions.

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -309,11 +309,11 @@ class TrackingServiceClient:
     def search_traces(
         self,
         experiment_ids: List[str],
-        run_id: Optional[str] = None,
         filter_string: Optional[str] = None,
         max_results: int = SEARCH_TRACES_DEFAULT_MAX_RESULTS,
         order_by: Optional[List[str]] = None,
         page_token: Optional[str] = None,
+        run_id: Optional[str] = None,
     ) -> PagedList[Trace]:
         def download_trace_data(trace_info: TraceInfo) -> Optional[Trace]:
             """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -483,18 +483,17 @@ class MlflowClient:
     def search_traces(
         self,
         experiment_ids: List[str],
-        run_id: Optional[str] = None,
         filter_string: Optional[str] = None,
         max_results: int = SEARCH_TRACES_DEFAULT_MAX_RESULTS,
         order_by: Optional[List[str]] = None,
         page_token: Optional[str] = None,
+        run_id: Optional[str] = None,
     ) -> PagedList[Trace]:
         """
         Return traces that match the given list of search expressions within the experiments.
 
         Args:
             experiment_ids: List of experiment ids to scope the search.
-            run_id: A run id to scope the search. When a trace is created under an active run,
                 it will be associated with the run and you can filter on the run id to retrieve
                 the trace.
             filter_string: A search filter string.
@@ -502,6 +501,7 @@ class MlflowClient:
             order_by: List of order_by clauses.
             page_token: Token specifying the next page of results. It should be obtained from
                 a ``search_traces`` call.
+            run_id: A run id to scope the search. When a trace is created under an active run,
 
         Returns:
             A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
@@ -513,11 +513,11 @@ class MlflowClient:
         """
         traces = self._tracking_client.search_traces(
             experiment_ids=experiment_ids,
-            run_id=run_id,
             filter_string=filter_string,
             max_results=max_results,
             order_by=order_by,
             page_token=page_token,
+            run_id=run_id,
         )
 
         get_display_handler().display_traces(traces)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -483,6 +483,7 @@ class MlflowClient:
     def search_traces(
         self,
         experiment_ids: List[str],
+        run_id: Optional[str] = None,
         filter_string: Optional[str] = None,
         max_results: int = SEARCH_TRACES_DEFAULT_MAX_RESULTS,
         order_by: Optional[List[str]] = None,
@@ -493,6 +494,9 @@ class MlflowClient:
 
         Args:
             experiment_ids: List of experiment ids to scope the search.
+            run_id: A run id to scope the search. When a trace is created under an active run,
+                it will be associated with the run and you can filter on the run id to retrieve
+                the trace.
             filter_string: A search filter string.
             max_results: Maximum number of traces desired.
             order_by: List of order_by clauses.
@@ -509,6 +513,7 @@ class MlflowClient:
         """
         traces = self._tracking_client.search_traces(
             experiment_ids=experiment_ids,
+            run_id=run_id,
             filter_string=filter_string,
             max_results=max_results,
             order_by=order_by,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13251?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13251/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13251
```

</p>
</details>

### What changes are proposed in this pull request?

Add `run_id` parameter to the `search_trace` API (both fluent and client APIs) so that users can easily find traces associated with a specific run. Run ID is recorded as a request metadata entity which is already supported in the filter string, so we can simply append the filter string with given run ID.

We cannot support multiple run IDs, because the filter string does not support `IN` syntax for trace tags and request metadata.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
