### PR TITLE
Update Databricks dependency extraction to handle the partner package.

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -1,6 +1,8 @@
+import importlib
 import inspect
 import logging
-from typing import Generator, List, Optional, Set
+import warnings
+from typing import Any, Generator, List, Optional, Set
 
 from mlflow.models.resources import (
     DatabricksFunction,
@@ -26,60 +28,33 @@ def _get_embedding_model_endpoint_names(index):
 
 
 def _get_vectorstore_from_retriever(retriever) -> Generator[Resource, None, None]:
-    try:
-        from langchain.embeddings import DatabricksEmbeddings as LegacyDatabricksEmbeddings
-        from langchain.vectorstores import (
-            DatabricksVectorSearch as LegacyDatabricksVectorSearch,
-        )
-    except ImportError:
-        from langchain_community.embeddings import (
-            DatabricksEmbeddings as LegacyDatabricksEmbeddings,
-        )
-        from langchain_community.vectorstores import (
-            DatabricksVectorSearch as LegacyDatabricksVectorSearch,
-        )
-
-    from langchain_community.embeddings import DatabricksEmbeddings
-    from langchain_community.vectorstores import DatabricksVectorSearch
-
     vectorstore = getattr(retriever, "vectorstore", None)
-    if vectorstore:
-        if isinstance(vectorstore, (DatabricksVectorSearch, LegacyDatabricksVectorSearch)):
-            index = vectorstore.index
-            yield DatabricksVectorSearchIndex(index_name=index.name)
-            for embedding_endpoint in _get_embedding_model_endpoint_names(index):
-                yield DatabricksServingEndpoint(endpoint_name=embedding_endpoint)
+    if _isinstance_with_multiple_modules(
+        vectorstore,
+        "DatabricksVectorSearch",
+        ["langchain_databricks", "langchain_community.vectorstores", "langchain.vectorstores"],
+    ):
+        index = vectorstore.index
+        yield DatabricksVectorSearchIndex(index_name=index.name)
+        for embedding_endpoint in _get_embedding_model_endpoint_names(index):
+            yield DatabricksServingEndpoint(endpoint_name=embedding_endpoint)
 
-        embeddings = getattr(vectorstore, "embeddings", None)
-        if isinstance(embeddings, (DatabricksEmbeddings, LegacyDatabricksEmbeddings)):
-            yield DatabricksServingEndpoint(endpoint_name=embeddings.endpoint)
-
-
-def _is_langgraph_tool_node_supported() -> bool:
-    try:
-        from langgraph.prebuilt.tool_node import ToolNode  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
-def _is_langchain_tools_supported() -> bool:
-    try:
-        from langchain_community.tools import BaseTool  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
+    embeddings = getattr(vectorstore, "embeddings", None)
+    if _isinstance_with_multiple_modules(
+        embeddings,
+        "DatabricksEmbeddings",
+        ["langchain_databricks", "langchain_community.embeddings", "langchain.embeddings"],
+    ):
+        yield DatabricksServingEndpoint(endpoint_name=embeddings.endpoint)
 
 
 def _extract_databricks_dependencies_from_tools(tools) -> Generator[Resource, None, None]:
     if isinstance(tools, list):
-        from langchain_community.tools import BaseTool
-
         warehouse_ids = set()
         for tool in tools:
-            if isinstance(tool, BaseTool):
+            if _isinstance_with_multiple_modules(
+                tool, "BaseTool", ["langchain_core.tools", "langchain_community.tools"]
+            ):
                 # Handle Retriever tools
                 if hasattr(tool.func, "keywords") and "retriever" in tool.func.keywords:
                     retriever = tool.func.keywords.get("retriever")
@@ -142,38 +117,62 @@ def _extract_databricks_dependencies_from_retriever(retriever) -> Generator[Reso
 
 
 def _extract_databricks_dependencies_from_llm(llm) -> Generator[Resource, None, None]:
-    try:
-        from langchain.llms import Databricks as LegacyDatabricks
-    except ImportError:
-        from langchain_community.llms import Databricks as LegacyDatabricks
-
-    from langchain_community.llms import Databricks
-
-    if isinstance(llm, (LegacyDatabricks, Databricks)):
+    if _isinstance_with_multiple_modules(
+        llm, "Databricks", ["langchain.llms", "langchain_community.llms"]
+    ):
         yield DatabricksServingEndpoint(endpoint_name=llm.endpoint_name)
 
 
 def _extract_databricks_dependencies_from_chat_model(chat_model) -> Generator[Resource, None, None]:
-    try:
-        from langchain.chat_models import ChatDatabricks as LegacyChatDatabricks
-    except ImportError:
-        from langchain_community.chat_models import (
-            ChatDatabricks as LegacyChatDatabricks,
-        )
-
-    from langchain_community.chat_models import ChatDatabricks
-
-    if isinstance(chat_model, (LegacyChatDatabricks, ChatDatabricks)):
+    if _isinstance_with_multiple_modules(
+        chat_model,
+        "ChatDatabricks",
+        ["langchain_databricks", "langchain.chat_models", "langchain_community.chat_models"],
+    ):
         yield DatabricksServingEndpoint(endpoint_name=chat_model.endpoint)
 
 
 def _extract_databricks_dependencies_from_tool_nodes(tool_node) -> Generator[Resource, None, None]:
-    from langgraph.prebuilt.tool_node import ToolNode
+    try:
+        from langgraph.prebuilt.tool_node import ToolNode
 
-    if isinstance(tool_node, ToolNode):
-        yield from _extract_databricks_dependencies_from_tools(
-            list(tool_node.tools_by_name.values())
-        )
+        if isinstance(tool_node, ToolNode):
+            yield from _extract_databricks_dependencies_from_tools(
+                list(tool_node.tools_by_name.values())
+            )
+    except ImportError:
+        pass
+
+
+def _isinstance_with_multiple_modules(
+    object: Any, class_name: str, from_modules: List[str]
+) -> bool:
+    """
+    Databricks components are defined in different modules in LangChain e.g.
+    langchain, langchain_community, langchain_databricks due to historical migrations.
+    To keep backward compatibility, we need to check if the object is an instance of the
+    class defined in any of those different modules.
+
+    Args:
+        object: The object to check
+        class_name: The name of the class to check
+        from_modules: The list of modules to import the class from.
+    """
+    # Suppress LangChainDeprecationWarning for old imports
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        for module_path in from_modules:
+            try:
+                module = importlib.import_module(module_path)
+                cls = getattr(module, class_name)
+
+                if cls is not None and isinstance(object, cls):
+                    return True
+            except ImportError:
+                pass
+
+    return False
 
 
 _LEGACY_MODEL_ATTR_SET = {
@@ -204,12 +203,8 @@ def _extract_dependency_list_from_lc_model(lc_model) -> Generator[Resource, None
     yield from _extract_databricks_dependencies_from_chat_model(lc_model)
     yield from _extract_databricks_dependencies_from_retriever(lc_model)
     yield from _extract_databricks_dependencies_from_llm(lc_model)
-
-    if _is_langchain_tools_supported():
-        yield from _extract_databricks_dependencies_from_tools(lc_model)
-
-    if _is_langgraph_tool_node_supported():
-        yield from _extract_databricks_dependencies_from_tool_nodes(lc_model)
+    yield from _extract_databricks_dependencies_from_tools(lc_model)
+    yield from _extract_databricks_dependencies_from_tool_nodes(lc_model)
 
     # recursively inspect legacy chain
     for attr_name in _LEGACY_MODEL_ATTR_SET:

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -169,7 +169,7 @@ def _isinstance_with_multiple_modules(
 
                 if cls is not None and isinstance(object, cls):
                     return True
-            except ImportError:
+            except (ImportError, AttributeError):
                 pass
 
     return False

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -690,6 +690,8 @@ langchain:
           # Required to run tests/openai/mock_openai.py
           "fastapi",
           "uvicorn",
+          # Required for testing Databricks dependency extraction
+          "databricks-vectorsearch",
         ]
       # langchain-openai 0.1.22 is imcomptible with earlier langchain-core due to
       # https://github.com/langchain-ai/langchain/commit/b83f1eb0d56dbf99605a1fce93953ee09d77aabf

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -464,6 +464,9 @@ def test_parsing_multiple_dependency_from_agent(monkeypatch, use_partner_package
 
 @pytest.mark.parametrize("use_partner_package", [True, False])
 def test_parsing_dependency_from_databricks_chat(monkeypatch, use_partner_package):
+    if use_partner_package and not _is_partner_package_installed():
+        pytest.skip("`langchain-databricks` is not installed")
+
     if use_partner_package:
         from langchain_databricks import ChatDatabricks
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -1,13 +1,10 @@
 import sys
 from collections import Counter, defaultdict
-from contextlib import contextmanager
-from unittest.mock import MagicMock
+from unittest import mock
 
 import langchain
 import pytest
-from langchain_community.chat_models import ChatDatabricks
-from langchain_community.embeddings import DatabricksEmbeddings
-from langchain_community.vectorstores import DatabricksVectorSearch
+from databricks.vector_search.client import VectorSearchIndex
 from packaging.version import Version
 
 from mlflow.langchain.databricks_dependencies import (
@@ -17,7 +14,6 @@ from mlflow.langchain.databricks_dependencies import (
     _extract_databricks_dependencies_from_retriever,
     _extract_dependency_list_from_lc_model,
 )
-from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
 from mlflow.models.resources import (
     DatabricksFunction,
     DatabricksServingEndpoint,
@@ -45,6 +41,8 @@ class MockDatabricksServingEndpointClient:
 def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch):
     from langchain_community.llms import Databricks
 
+    from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
+
     monkeypatch.setattr(
         "langchain_community.llms.databricks._DatabricksServingEndpointClient",
         MockDatabricksServingEndpointClient,
@@ -63,7 +61,24 @@ def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch)
     ]
 
 
-class MockVectorSearchIndex:
+@pytest.mark.parametrize("use_partner_package", [True, False])
+def test_parsing_dependency_from_databricks_chat(monkeypatch, use_partner_package):
+    if use_partner_package:
+        from langchain_databricks import ChatDatabricks
+
+        # Mock the situation where the langchain_community package is not installed
+        monkeypatch.setitem(sys.modules, "langchain_community", None)
+        with pytest.raises(ImportError, match="No module named 'langchain_community"):
+            from langchain_community.chat_models import ChatDatabricks
+    else:
+        from langchain_community.chat_models import ChatDatabricks
+
+    chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
+    resources = list(_extract_databricks_dependencies_from_chat_model(chat_model))
+    assert resources == [DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat")]
+
+
+class MockVectorSearchIndex(VectorSearchIndex):
     def __init__(self, endpoint_name, index_name, has_embedding_endpoint=False) -> None:
         self.endpoint_name = endpoint_name
         self.name = index_name
@@ -117,38 +132,67 @@ class MockVectorSearchIndex:
             }
 
 
-class MockVectorSearchClient:
-    def get_index(self, endpoint_name, index_name, has_embedding_endpoint=False):
-        return MockVectorSearchIndex(endpoint_name, index_name, has_embedding_endpoint)
+def get_vector_search(
+    use_partner_package: bool,
+    endpoint_name: str,
+    index_name: str,
+    has_embedding_endpoint=False,
+    **kwargs,
+):
+    if use_partner_package:
+        from langchain_databricks import DatabricksVectorSearch
+
+        index = MockVectorSearchIndex(endpoint_name, index_name, has_embedding_endpoint)
+        with mock.patch("databricks.vector_search.client.VectorSearchClient") as mock_client:
+            mock_client().get_index.return_value = index
+            vectorstore = DatabricksVectorSearch(
+                endpoint=endpoint_name,
+                index_name=index_name,
+                **kwargs,
+            )
+    else:
+        from langchain_community.vectorstores import DatabricksVectorSearch
+
+        index = MockVectorSearchIndex(endpoint_name, index_name, has_embedding_endpoint)
+        vectorstore = DatabricksVectorSearch(index, **kwargs)
+
+    return vectorstore
 
 
-def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.MonkeyPatch):
-    vsc = MockVectorSearchClient()
-    vs_index_1 = vsc.get_index(endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_1")
-    vs_index_2 = vsc.get_index(
-        endpoint_name="vs_endpoint", index_name="mlflow.rag.vs_index_2", has_embedding_endpoint=True
-    )
-    mock_get_deploy_client = MagicMock()
+@pytest.mark.parametrize("use_partner_package", [True, False])
+def test_parsing_dependency_from_databricks_retriever(monkeypatch, use_partner_package):
+    if use_partner_package:
+        from langchain_databricks import DatabricksEmbeddings
+        from langchain_openai import ChatOpenAI
 
-    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
+        # Mock the situation where the langchain_community package is not installed
+        monkeypatch.setitem(sys.modules, "langchain_community", None)
+        with pytest.raises(ImportError, match="No module named 'langchain_community"):
+            from langchain_community.embeddings import DatabricksEmbeddings
+    else:
+        from langchain_community.chat_models import ChatOpenAI
+        from langchain_community.embeddings import DatabricksEmbeddings
+
     embedding_model = DatabricksEmbeddings(endpoint="databricks-bge-large-en")
 
-    mock_module = MagicMock()
-    mock_module.VectorSearchIndex = MockVectorSearchIndex
-
-    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
-
-    # set embedding model
-    vectorstore_1 = DatabricksVectorSearch(
-        vs_index_1, text_column="content", embedding=embedding_model
+    # vs_index_1 is a direct access index
+    vectorstore_1 = get_vector_search(
+        use_partner_package=use_partner_package,
+        endpoint_name="vs_endpoint",
+        index_name="mlflow.rag.vs_index_1",
+        text_column="content",
+        embedding=embedding_model,
     )
     retriever_1 = vectorstore_1.as_retriever()
 
     # vs_index_2 has builtin embedding endpoint "embedding-model"
-    vectorstore_2 = DatabricksVectorSearch(vs_index_2, text_column="content")
+    vectorstore_2 = get_vector_search(
+        use_partner_package=use_partner_package,
+        endpoint_name="vs_endpoint",
+        index_name="mlflow.rag.vs_index_2",
+        has_embedding_endpoint=True,
+    )
     retriever_2 = vectorstore_2.as_retriever()
-
-    from langchain_community.chat_models import ChatOpenAI
 
     llm = ChatOpenAI(temperature=0)
 
@@ -205,25 +249,14 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     ]
 
 
-def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in_index(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    vsc = MockVectorSearchClient()
-    vs_index = vsc.get_index(
+@pytest.mark.parametrize("use_partner_package", [True, False])
+def test_parsing_dependency_from_retriever_with_embedding_endpoint_in_index(use_partner_package):
+    vectorstore = get_vector_search(
+        use_partner_package=use_partner_package,
         endpoint_name="dbdemos_vs_endpoint",
         index_name="mlflow.rag.vs_index",
         has_embedding_endpoint=True,
     )
-    mock_get_deploy_client = MagicMock()
-
-    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
-
-    mock_module = MagicMock()
-    mock_module.VectorSearchIndex = MockVectorSearchIndex
-
-    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
-
-    vectorstore = DatabricksVectorSearch(vs_index, text_column="content")
     retriever = vectorstore.as_retriever()
     resources = list(_extract_databricks_dependencies_from_retriever(retriever))
     assert resources == [
@@ -235,7 +268,7 @@ def test_parsing_dependency_from_databricks_retriever_with_embedding_endpoint_in
 def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain.agents import initialize_agent
-    from langchain_community.llms import OpenAI
+    from langchain_openai.llms import OpenAI
 
     try:
         from langchain_community.tools.databricks import UCFunctionToolkit
@@ -293,12 +326,16 @@ def test_parsing_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
     Version(langchain.__version__) < Version("0.1.0"),
     reason="Tools are not supported the way we want in earlier versions",
 )
-def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("use_partner_package", [True, False])
+def test_parsing_multiple_dependency_from_agent(monkeypatch, use_partner_package):
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain.agents import initialize_agent
     from langchain.tools.retriever import create_retriever_tool
 
-    mock_get_deploy_client = MagicMock()
+    if use_partner_package:
+        from langchain_databricks import ChatDatabricks
+    else:
+        from langchain_community.chat_models import ChatDatabricks
 
     def mock_function_get(self, function_name):
         components = function_name.split(".")
@@ -335,20 +372,8 @@ def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch)
             FunctionInfo(full_name="rag.test.test_function_3"),
         ]
 
-    vsc = MockVectorSearchClient()
-    vs_index = vsc.get_index(
-        endpoint_name="dbdemos_vs_endpoint",
-        index_name="mlflow.rag.vs_index",
-        has_embedding_endpoint=True,
-    )
-
-    mock_module = MagicMock()
-    mock_module.VectorSearchIndex = MockVectorSearchIndex
-
     monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
-    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
-    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
     monkeypatch.setattr("databricks.sdk.service.catalog.FunctionsAPI.get", mock_function_get)
     monkeypatch.setattr("databricks.sdk.service.catalog.FunctionsAPI.list", mock_function_list)
 
@@ -367,7 +392,12 @@ def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch)
     )
     chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
 
-    vectorstore = DatabricksVectorSearch(vs_index, text_column="content")
+    vectorstore = get_vector_search(
+        use_partner_package=use_partner_package,
+        endpoint_name="dbdemos_vs_endpoint",
+        index_name="mlflow.rag.vs_index",
+        has_embedding_endpoint=True,
+    )
     retriever = vectorstore.as_retriever()
 
     retriever_tool = create_retriever_tool(retriever, "vs_index_name", "vs_index_desc")
@@ -417,34 +447,19 @@ def test_parsing_multiple_dependency_from_agent(monkeypatch: pytest.MonkeyPatch)
         )
 
 
-def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
-    mock_get_deploy_client = MagicMock()
+@pytest.mark.parametrize("use_partner_package", [True, False])
+def test_parsing_dependency_from_databricks(use_partner_package):
+    if use_partner_package:
+        from langchain_databricks import ChatDatabricks
+    else:
+        from langchain_community.chat_models import ChatDatabricks
 
-    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
-
-    chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
-    resources = list(_extract_databricks_dependencies_from_chat_model(chat_model))
-    assert resources == [DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat")]
-
-
-def test_parsing_dependency_from_databricks(monkeypatch: pytest.MonkeyPatch):
-    mock_get_deploy_client = MagicMock()
-
-    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
-
-    vsc = MockVectorSearchClient()
-    vs_index = vsc.get_index(
+    vectorstore = get_vector_search(
+        use_partner_package=use_partner_package,
         endpoint_name="dbdemos_vs_endpoint",
         index_name="mlflow.rag.vs_index",
         has_embedding_endpoint=True,
     )
-
-    mock_module = MagicMock()
-    mock_module.VectorSearchIndex = MockVectorSearchIndex
-
-    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
-
-    vectorstore = DatabricksVectorSearch(vs_index, text_column="content")
     retriever = vectorstore.as_retriever()
     llm = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
     llm2 = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
@@ -456,84 +471,3 @@ def test_parsing_dependency_from_databricks(monkeypatch: pytest.MonkeyPatch):
         DatabricksServingEndpoint(endpoint_name="embedding-model"),
         DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat"),
     ]
-
-
-@contextmanager
-def remove_langchain_modules():
-    prefixes_to_remove = [
-        "langchain",
-        "langchain_community",
-    ]
-    exceptions = ["langchain_core", "langchain_community.llms.databricks"]
-
-    saved_modules = {}
-    for mod in list(sys.modules):
-        if any(mod.startswith(prefix) for prefix in prefixes_to_remove) and not any(
-            mod.startswith(exc) for exc in exceptions
-        ):
-            saved_modules[mod] = sys.modules.pop(mod)
-
-    try:
-        yield
-    finally:
-        sys.modules.update(saved_modules)  # Restore all removed modules safely
-
-
-@pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.1.0"), reason="feature not existing"
-)
-def test_parsing_dependency_correct_loads_langchain_modules():
-    with remove_langchain_modules():
-        import langchain_community
-
-        with pytest.raises(
-            AttributeError, match="module 'langchain_community' has no attribute 'llms'"
-        ):
-            langchain_community.llms.Databricks
-        list(_extract_databricks_dependencies_from_llm(""))
-
-        # import works as expected after _extract_databricks_dependencies_from_llm
-        langchain_community.llms.Databricks
-
-    with remove_langchain_modules():
-        import langchain_community
-
-        with pytest.raises(
-            AttributeError, match="module 'langchain_community' has no attribute 'embeddings'"
-        ):
-            langchain_community.embeddings.DatabricksEmbeddings
-
-        with pytest.raises(
-            AttributeError, match="module 'langchain_community' has no attribute 'vectorstores'"
-        ):
-            langchain_community.vectorstores.DatabricksVectorSearch
-
-        list(_extract_databricks_dependencies_from_retriever(""))
-        # import works as expected after _extract_databricks_dependencies_from_retriever
-        langchain_community.vectorstores.DatabricksVectorSearch
-        langchain_community.embeddings.DatabricksEmbeddings
-
-    with remove_langchain_modules():
-        import langchain_community
-
-        with pytest.raises(
-            AttributeError, match="module 'langchain_community' has no attribute 'chat_models'"
-        ):
-            langchain_community.chat_models.ChatDatabricks
-
-        list(_extract_databricks_dependencies_from_chat_model(""))
-        # import works as expected after _extract_databricks_dependencies_from_chat_model
-        langchain_community.chat_models.ChatDatabricks
-
-
-def test_module_removal():
-    import langchain_community.llms
-
-    langchain_community.llms.Databricks
-    with remove_langchain_modules():
-        import langchain_community
-
-        with pytest.raises(
-            AttributeError, match="module 'langchain_community' has no attribute 'llms'"
-        ):
-            langchain_community.llms.Databricks


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13266?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13266/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13266
```

</p>
</details>

### What changes are proposed in this pull request?

Current [Databricks dependency extraction logic](https://github.com/mlflow/mlflow/blob/master/mlflow/langchain/databricks_dependencies.py) in the LangChain flavor only handles components from the legacy `langchain-community` package. We migrated Databricks integration into a separate package `langchain-databricks`, so this logic needs to be updated as well.

Also, the logic assumes `langchain-community` is always installed in the environment, otherwise entire dependency extraction fails because the import is not guarded by try-catch.

<img width="500" alt="Screenshot 2024-09-27 at 14 35 06" src="https://github.com/user-attachments/assets/705ccf95-644f-4408-9f5a-1eebc0b6afee">

This PR fixes this issues as well and add tests simulate the situation where `langchain-community` is not installed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Verified Databricks dependeicies are extracted when `langchain-community` is not installed.

<img width="500" alt="Screenshot 2024-09-27 at 14 39 02" src="https://github.com/user-attachments/assets/1a05a231-1973-48f8-a53b-6d67b5e3b3a8">
<img width="300" alt="Screenshot 2024-09-27 at 14 38 51" src="https://github.com/user-attachments/assets/9bb02078-1360-449b-beac-40327b949c0f">

Also tested where only community package is installed, verified the dependency is extracted correctly.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix Databricks dependency extraction for the new `langchain-databricks` package.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
