### PR TITLE
Add helpful messages/docs for mlflow gc failure

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -501,6 +501,14 @@ def gc(older_than, backend_store_uri, artifacts_destination, run_ids, experiment
     This command deletes all artifacts and metadata associated with the specified runs.
     If the provided artifact URL is invalid, the artifact deletion will be bypassed,
     and the gc process will continue.
+
+    .. attention::
+
+        If you are running an MLflow tracking server with artifact proxying enabled,
+        you **must** set the ``MLFLOW_TRACKING_URI`` environment variable before running
+        this command. Otherwise, the ``gc`` command will not be able to resolve
+        artifact URIs and will not be able to delete the associated artifacts.
+
     """
     from mlflow.utils.time import get_current_time_millis
 

--- a/mlflow/store/artifact/mlflow_artifacts_repo.py
+++ b/mlflow/store/artifact/mlflow_artifacts_repo.py
@@ -29,12 +29,18 @@ def _validate_port_mapped_to_hostname(uri_parse):
         )
 
 
-def _validate_uri_scheme(scheme):
+def _validate_uri_scheme(track_parse):
     allowable_schemes = {"http", "https"}
-    if scheme not in allowable_schemes:
+    if track_parse.scheme not in allowable_schemes:
         raise MlflowException(
-            f"The configured tracking uri scheme: '{scheme}' is invalid for use with the proxy "
-            f"mlflow-artifact scheme. The allowed tracking schemes are: {allowable_schemes}"
+            "When an mlflow-artifacts URI was supplied, the tracking URI must be a valid "
+            f"http or https URI, but it was currently set to {track_parse.geturl()}. "
+            "Perhaps you forgot to set the tracking URI to the running MLflow server. "
+            "To set the tracking URI, use either of the following methods:\n"
+            "1. Set the MLFLOW_TRACKING_URI environment variable to the desired tracking URI. "
+            "`export MLFLOW_TRACKING_URI=http://localhost:5000`\n"
+            "2. Set the tracking URI programmatically by calling `mlflow.set_tracking_uri`. "
+            "`mlflow.set_tracking_uri('http://localhost:5000')`"
         )
 
 
@@ -56,7 +62,7 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
         _validate_port_mapped_to_hostname(uri_parse)
 
         # Check that tracking uri is http or https
-        _validate_uri_scheme(track_parse.scheme)
+        _validate_uri_scheme(track_parse)
 
         if uri_parse.path == "/":  # root directory; build simple path
             resolved = f"{base_url}{uri_parse.path}"

--- a/mlflow/store/artifact/mlflow_artifacts_repo.py
+++ b/mlflow/store/artifact/mlflow_artifacts_repo.py
@@ -29,12 +29,12 @@ def _validate_port_mapped_to_hostname(uri_parse):
         )
 
 
-def _validate_uri_scheme(track_parse):
+def _validate_uri_scheme(parsed_uri):
     allowable_schemes = {"http", "https"}
-    if track_parse.scheme not in allowable_schemes:
+    if parsed_uri.scheme not in allowable_schemes:
         raise MlflowException(
             "When an mlflow-artifacts URI was supplied, the tracking URI must be a valid "
-            f"http or https URI, but it was currently set to {track_parse.geturl()}. "
+            f"http or https URI, but it was currently set to {parsed_uri.geturl()}. "
             "Perhaps you forgot to set the tracking URI to the running MLflow server. "
             "To set the tracking URI, use either of the following methods:\n"
             "1. Set the MLFLOW_TRACKING_URI environment variable to the desired tracking URI. "

--- a/tests/store/artifact/test_mlflow_artifact_repo.py
+++ b/tests/store/artifact/test_mlflow_artifact_repo.py
@@ -54,6 +54,17 @@ def test_mlflow_artifact_uri_formats_resolved(artifact_uri, resolved_uri, tracki
 
 
 def test_mlflow_artifact_uri_raises_with_invalid_tracking_uri():
+    with pytest.raises(
+        MlflowException,
+        match="When an mlflow-artifacts URI was supplied, the tracking URI must be a valid",
+    ):
+        MlflowArtifactsRepository.resolve_uri(
+            artifact_uri=f"mlflow-artifacts://myhostname:4242{base_path}/hostport",
+            tracking_uri="file:///tmp",
+        )
+
+
+def test_mlflow_artifact_uri_raises_with_invalid_artifact_uri():
     failing_conditions = [f"mlflow-artifacts://5000/{base_path}", "mlflow-artifacts://5000/"]
 
     for failing_condition in failing_conditions:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13271?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13271/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13271
```

</p>
</details>

### Related Issues/PRs

Follow-up for https://github.com/mlflow/mlflow/issues/13188

### What changes are proposed in this pull request?

When an experiment and runs are created against tracking server (tracking URI is set to `http://xxx`), their artifact URI will be in the form of `mlflow-artifacts://xxx`, meaning that their CRUD operation must be done through the tracking server.

However, when users run `mlflow gc`, they might not set the tracking URI in the environment, then MLflow uses the default tracking URI (`file://xxx`) and fails to delete artifacts. Users instead need to set the `MLFLOW_TRACKING_URI` env variable before running `mlflow gc`, but current error message and documentation does not clearly suggest that, causing confusions.

```
mlflow.exceptions.MlflowException: The configured tracking uri scheme: 'file' is invalid for use with the proxy mlflow-artifact scheme. The allowed tracking schemes are: {'https', 'http'}
```

This PR updates the error message to be more helpful, as well as adding a note in the `mlflow gc` API doc. New error message looks like this
```
mlflow.exceptions.MlflowException: When an mlflow-artifacts URI was supplied, the tracking URI
must be a valid http or https URI, but it was currently set to file:///Users/yuki.watanabe/.../mlruns.
Perhaps you forgot to set the tracking URI to the running MLflow server. To set the tracking URI,
use either of the following methods:
1. Set the MLFLOW_TRACKING_URI environment variable to the desired tracking URI. `export MLFLOW_TRACKING_URI=http://localhost:5000`
2. Set the tracking URI programmatically by calling `mlflow.set_tracking_uri`. `mlflow.set_tracking_uri('http://localhost:5000')`
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
