### PR TITLE
LlamaIndex workflow logging

### DIFF
--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -139,7 +139,7 @@ def save_model(
         for more information.
 
     Args:
-        llama_index_model: An LlamaIndex object to be saved. Supported model types are:
+        llama_index_model: A LlamaIndex object to be saved. Supported model types are:
 
             1. An Index object.
             2. An Engine object e.g. ChatEngine, QueryEngine, Retriever.
@@ -322,7 +322,7 @@ def log_model(
         for more information.
 
     Args:
-        llama_index_model: An LlamaIndex object to be saved. Supported model types are:
+        llama_index_model: A LlamaIndex object to be saved. Supported model types are:
 
             1. An Index object.
             2. An Engine object e.g. ChatEngine, QueryEngine, Retriever.

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -124,19 +124,20 @@ def save_model(
     """
     Save a LlamaIndex model to a path on the local file system.
 
+    .. attention::
+
+        Saving a non-index object is only supported in the 'Model-from-Code' saving mode.
+        Please refer to the `Models From Code Guide <https://www.mlflow.org/docs/latest/model/models-from-code.html>`_
+        for more information.
+
     Args:
         llama_index_model: An LlamaIndex object to be saved. Supported model types are:
+
             1. An Index object.
             2. An Engine object e.g. ChatEngine, QueryEngine, Retriever.
             3. A `Workflow <https://docs.llamaindex.ai/en/stable/module_guides/workflow/>`_ object.
             4. A string representing the path to a script contains LlamaIndex model definition
                 of the one of the above types.
-
-            .. attention::
-
-                Saving a non-index object is only supported in the 'Model-from-Code' saving mode.
-                Please refer to the `Models From Code Guide <https://www.mlflow.org/docs/latest/model/models-from-code.html>`_
-                for more information.
 
         path: Local path where the serialized model (as YAML) is to be saved.
         engine_type: Required when saving an Index object to determine the inference interface
@@ -306,19 +307,20 @@ def log_model(
     """
     Log a LlamaIndex model as an MLflow artifact for the current run.
 
+    .. attention::
+
+        Saving a non-index object is only supported in the 'Model-from-Code' saving mode.
+        Please refer to the `Models From Code Guide <https://www.mlflow.org/docs/latest/model/models-from-code.html>`_
+        for more information.
+
     Args:
         llama_index_model: An LlamaIndex object to be saved. Supported model types are:
+
             1. An Index object.
             2. An Engine object e.g. ChatEngine, QueryEngine, Retriever.
             3. A `Workflow <https://docs.llamaindex.ai/en/stable/module_guides/workflow/>`_ object.
             4. A string representing the path to a script contains LlamaIndex model definition
                 of the one of the above types.
-
-            .. attention::
-
-                Logging a non-index object is only supported in the 'Model-from-Code' saving mode.
-                Please refer to the `Models From Code Guide <https://www.mlflow.org/docs/latest/model/models-from-code.html>`_
-                for more information.
 
         artifact_path: Local path where the serialized model (as YAML) is to be saved.
         engine_type: Required when saving an Index object to determine the inference interface

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -8,7 +8,7 @@ import yaml
 import mlflow
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
-from mlflow.llama_index.pyfunc_wrapper import create_engine_wrapper
+from mlflow.llama_index.pyfunc_wrapper import create_pyfunc_wrapper
 from mlflow.models import Model, ModelInputExample, ModelSignature
 from mlflow.models.model import MLMODEL_FILE_NAME, MODEL_CODE_PATH
 from mlflow.models.signature import _infer_signature_from_input_example
@@ -99,8 +99,9 @@ def _supported_classes():
     from llama_index.core.chat_engine.types import BaseChatEngine
     from llama_index.core.indices.base import BaseIndex
     from llama_index.core.retrievers import BaseRetriever
+    from llama_index.core.workflow import Workflow
 
-    return BaseIndex, BaseChatEngine, BaseQueryEngine, BaseRetriever
+    return BaseIndex, BaseChatEngine, BaseQueryEngine, BaseRetriever, Workflow
 
 
 @experimental
@@ -199,7 +200,7 @@ def save_model(
     saved_example = _save_example(mlflow_model, input_example, path)
 
     if signature is None and saved_example is not None:
-        wrapped_model = create_engine_wrapper(llama_index_model, engine_type, model_config)
+        wrapped_model = create_pyfunc_wrapper(llama_index_model, engine_type, model_config)
         signature = _infer_signature_from_input_example(saved_example, wrapped_model)
     elif signature is False:
         signature = None
@@ -431,12 +432,12 @@ def load_model(model_uri, dst_path=None):
 
 
 def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
-    from mlflow.llama_index.pyfunc_wrapper import create_engine_wrapper
+    from mlflow.llama_index.pyfunc_wrapper import create_pyfunc_wrapper
 
     index = load_model(path)
     flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
     engine_type = flavor_conf.pop("engine_type", None)  # Not present when saving an engine object
-    return create_engine_wrapper(index, engine_type, model_config)
+    return create_pyfunc_wrapper(index, engine_type, model_config)
 
 
 @experimental

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -99,9 +99,17 @@ def _supported_classes():
     from llama_index.core.chat_engine.types import BaseChatEngine
     from llama_index.core.indices.base import BaseIndex
     from llama_index.core.retrievers import BaseRetriever
-    from llama_index.core.workflow import Workflow
 
-    return BaseIndex, BaseChatEngine, BaseQueryEngine, BaseRetriever, Workflow
+    supported = (BaseIndex, BaseChatEngine, BaseQueryEngine, BaseRetriever)
+
+    try:
+        from llama_index.core.workflow import Workflow
+
+        supported += (Workflow,)
+    except ImportError:
+        pass
+
+    return supported
 
 
 @experimental

--- a/mlflow/llama_index/pyfunc_wrapper.py
+++ b/mlflow/llama_index/pyfunc_wrapper.py
@@ -264,13 +264,18 @@ def create_pyfunc_wrapper(
             and must be one of [chat, query, retriever].
         model_config: A dictionary of model configuration parameters.
     """
+    try:
+        from llama_index.core.workflow import Workflow
+
+        if isinstance(model, Workflow):
+            return _create_wrapper_from_workflow(model, model_config)
+    except ImportError:
+        pass
+
     from llama_index.core.indices.base import BaseIndex
-    from llama_index.core.workflow import Workflow
 
     if isinstance(model, BaseIndex):
         return _create_wrapper_from_index(model, engine_type, model_config)
-    elif isinstance(model, Workflow):
-        return _create_wrapper_from_workflow(model, model_config)
     else:
         # Engine does not have a common base class so we assume
         # everything else is an engine

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -789,6 +789,8 @@ llama_index:
           # Required to run tests/openai/mock_openai.py
           "fastapi",
           "uvicorn",
+          # Required for testing LlamaIndex workflow
+          "pytest-asyncio",
         ]
     run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
   autologging:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1058,7 +1058,7 @@ def set_model(model):
         globals()["__mlflow_model__"] = model
         return
 
-    for validate_function in [_validate_langchain_model, _validate_llama_index_model]:
+    for validate_function in [_validate_llama_index_model]:
         try:
             globals()["__mlflow_model__"] = validate_function(model)
             return

--- a/tests/llama_index/sample_code/simple_workflow.py
+++ b/tests/llama_index/sample_code/simple_workflow.py
@@ -1,0 +1,37 @@
+from llama_index.core.workflow import (
+    Event,
+    StartEvent,
+    StopEvent,
+    Workflow,
+    step,
+)
+from llama_index.llms.openai import OpenAI
+
+import mlflow
+
+
+class JokeEvent(Event):
+    joke: str
+
+
+class JokeFlow(Workflow):
+    llm = OpenAI()
+
+    @step
+    async def generate_joke(self, ev: StartEvent) -> JokeEvent:
+        topic = ev.topic
+        prompt = f"Write your best joke about {topic}."
+        response = await self.llm.acomplete(prompt)
+        return JokeEvent(joke=str(response))
+
+    @step
+    async def critique_joke(self, ev: JokeEvent) -> StopEvent:
+        joke = ev.joke
+
+        prompt = f"Give a thorough analysis and critique of the following joke: {joke}"
+        response = await self.llm.acomplete(prompt)
+        return StopEvent(result=str(response))
+
+
+w = JokeFlow(timeout=10, verbose=False)
+mlflow.models.set_model(w)

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,7 @@ from llama_index.core.base.base_query_engine import BaseQueryEngine
 from llama_index.core.chat_engine import SimpleChatEngine
 from llama_index.core.llms import ChatMessage
 from llama_index.core.vector_stores.simple import SimpleVectorStore
+from llama_index.core.workflow import Workflow
 from llama_index.embeddings.databricks import DatabricksEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.databricks import Databricks
@@ -27,10 +29,14 @@ from mlflow.llama_index.pyfunc_wrapper import (
     _CHAT_MESSAGE_HISTORY_PARAMETER_NAME,
     ChatEngineWrapper,
     QueryEngineWrapper,
-    create_engine_wrapper,
+    create_pyfunc_wrapper,
 )
+from mlflow.models.utils import load_serving_example
+from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import ColSpec, DataType, Schema
+
+from tests.helper_functions import pyfunc_scoring_endpoint
 
 _EMBEDDING_DIM = 1536
 _TEST_QUERY = "Spell llamaindex"
@@ -96,7 +102,7 @@ def test_llama_index_save_invalid_object_raise(single_index):
     ["query", "retriever"],
 )
 def test_format_predict_input_correct(single_index, engine_type):
-    wrapped_model = create_engine_wrapper(single_index, engine_type)
+    wrapped_model = create_pyfunc_wrapper(single_index, engine_type)
 
     assert isinstance(
         wrapped_model._format_predict_input(pd.DataFrame({"query_str": ["hi"]})), QueryBundle
@@ -113,7 +119,7 @@ def test_format_predict_input_correct(single_index, engine_type):
     ["query", "retriever"],
 )
 def test_format_predict_input_incorrect_schema(single_index, engine_type):
-    wrapped_model = create_engine_wrapper(single_index, engine_type)
+    wrapped_model = create_pyfunc_wrapper(single_index, engine_type)
 
     exception_error = (
         r"__init__\(\) got an unexpected keyword argument 'incorrect'"
@@ -132,7 +138,7 @@ def test_format_predict_input_incorrect_schema(single_index, engine_type):
     ["query", "retriever"],
 )
 def test_format_predict_input_correct_schema_complex(single_index, engine_type):
-    wrapped_model = create_engine_wrapper(single_index, engine_type)
+    wrapped_model = create_pyfunc_wrapper(single_index, engine_type)
 
     payload = {
         "query_str": "hi",
@@ -471,3 +477,64 @@ def test_save_engine_with_engine_type_issues_warning(model_path):
 
     assert mock_logger.warning.call_count == 1
     assert "The `engine_type` argument" in mock_logger.warning.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_save_load_workflow_as_code():
+    index_code_path = "tests/llama_index/sample_code/simple_workflow.py"
+    with mlflow.start_run():
+        model_info = mlflow.llama_index.log_model(
+            llama_index_model=index_code_path,
+            artifact_path="model",
+            input_example={"topic": "pirates"},
+        )
+
+    # Signature
+    assert model_info.signature.inputs == Schema([ColSpec(type=DataType.string, name="topic")])
+    assert model_info.signature.outputs == Schema([ColSpec(DataType.string)])
+
+    # Native inference
+    loaded_workflow = mlflow.llama_index.load_model(model_info.model_uri)
+    assert isinstance(loaded_workflow, Workflow)
+    result = await loaded_workflow.run(topic="pirates")
+    assert isinstance(result, str)
+    assert "pirates" in result
+
+    # Pyfunc inference
+    pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert isinstance(pyfunc_loaded_model.get_raw_model(), Workflow)
+    result = pyfunc_loaded_model.predict({"topic": "pirates"})
+    assert isinstance(result[0], str)
+    assert "pirates" in result[0]
+
+    # Batch inference
+    batch_result = pyfunc_loaded_model.predict(
+        [
+            {"topic": "pirates"},
+            {"topic": "ninjas"},
+            {"topic": "robots"},
+        ]
+    )
+    assert len(batch_result) == 3
+    assert all(isinstance(r, str) for r in batch_result)
+
+    # Serve
+    inference_payload = load_serving_example(model_info.model_uri)
+
+    with pyfunc_scoring_endpoint(
+        model_uri=model_info.model_uri,
+        extra_args=["--env-manager", "local"],
+    ) as endpoint:
+        # Single input
+        response = endpoint.invoke(inference_payload, content_type=CONTENT_TYPE_JSON)
+        assert response.status_code == 200
+        assert response.json()["predictions"] == result
+
+        # Batch input
+        df = pd.DataFrame({"topic": ["pirates", "ninjas", "robots"]})
+        response = endpoint.invoke(
+            json.dumps({"dataframe_split": df.to_dict(orient="split")}),
+            content_type=CONTENT_TYPE_JSON,
+        )
+        assert response.status_code == 200
+        assert response.json()["predictions"] == batch_result

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -479,6 +479,10 @@ def test_save_engine_with_engine_type_issues_warning(model_path):
     assert "The `engine_type` argument" in mock_logger.warning.call_args[0][0]
 
 
+@pytest.mark.skipif(
+    Version(llama_index.core.__version__) < Version("0.11.0"),
+    reason="Workflow was introduced in 0.11.0",
+)
 @pytest.mark.asyncio
 async def test_save_load_workflow_as_code():
     index_code_path = "tests/llama_index/sample_code/simple_workflow.py"

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -13,7 +13,6 @@ from llama_index.core.base.base_query_engine import BaseQueryEngine
 from llama_index.core.chat_engine import SimpleChatEngine
 from llama_index.core.llms import ChatMessage
 from llama_index.core.vector_stores.simple import SimpleVectorStore
-from llama_index.core.workflow import Workflow
 from llama_index.embeddings.databricks import DatabricksEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.databricks import Databricks
@@ -485,6 +484,8 @@ def test_save_engine_with_engine_type_issues_warning(model_path):
 )
 @pytest.mark.asyncio
 async def test_save_load_workflow_as_code():
+    from llama_index.core.workflow import Workflow
+
     index_code_path = "tests/llama_index/sample_code/simple_workflow.py"
     with mlflow.start_run():
         model_info = mlflow.llama_index.log_model(

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -90,7 +90,7 @@ def test_llama_index_save_invalid_object_raise(single_index):
     with pytest.raises(MlflowException, match="The provided object of type "):
         mlflow.llama_index.save_model(llama_index_model=OpenAI(), path="model", engine_type="query")
 
-    with pytest.raises(MlflowException, match="Saving an engine object is only supported"):
+    with pytest.raises(MlflowException, match="Saving a non-index object is only supported"):
         mlflow.llama_index.save_model(
             llama_index_model=single_index.as_query_engine(),
             path="model",
@@ -504,8 +504,8 @@ async def test_save_load_workflow_as_code():
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert isinstance(pyfunc_loaded_model.get_raw_model(), Workflow)
     result = pyfunc_loaded_model.predict({"topic": "pirates"})
-    assert isinstance(result[0], str)
-    assert "pirates" in result[0]
+    assert isinstance(result, str)
+    assert "pirates" in result
 
     # Batch inference
     batch_result = pyfunc_loaded_model.predict(
@@ -527,7 +527,7 @@ async def test_save_load_workflow_as_code():
     ) as endpoint:
         # Single input
         response = endpoint.invoke(inference_payload, content_type=CONTENT_TYPE_JSON)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert response.json()["predictions"] == result
 
         # Batch input
@@ -536,5 +536,5 @@ async def test_save_load_workflow_as_code():
             json.dumps({"dataframe_split": df.to_dict(orient="split")}),
             content_type=CONTENT_TYPE_JSON,
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert response.json()["predictions"] == batch_result

--- a/tests/llama_index/test_llama_index_pyfunc_wrapper.py
+++ b/tests/llama_index/test_llama_index_pyfunc_wrapper.py
@@ -3,7 +3,6 @@ import pandas as pd
 import pytest
 from llama_index.core import QueryBundle
 from llama_index.core.llms import ChatMessage
-from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
 
 import mlflow
 from mlflow.llama_index.pyfunc_wrapper import (
@@ -263,6 +262,8 @@ def test_spark_udf_chat(model_path, spark, single_index):
 
 @pytest.mark.asyncio
 async def test_wrap_workflow():
+    from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
+
     class MyWorkflow(Workflow):
         @step
         async def my_step(self, ev: StartEvent) -> StopEvent:

--- a/tests/llama_index/test_llama_index_pyfunc_wrapper.py
+++ b/tests/llama_index/test_llama_index_pyfunc_wrapper.py
@@ -1,8 +1,10 @@
+import llama_index.core
 import numpy as np
 import pandas as pd
 import pytest
 from llama_index.core import QueryBundle
 from llama_index.core.llms import ChatMessage
+from packaging.version import Version
 
 import mlflow
 from mlflow.llama_index.pyfunc_wrapper import (
@@ -260,6 +262,10 @@ def test_spark_udf_chat(model_path, spark, single_index):
     assert isinstance(pdf["predictions"].tolist()[0], str)
 
 
+@pytest.mark.skipif(
+    Version(llama_index.core.__version__) < Version("0.11.0"),
+    reason="Workflow was introduced in 0.11.0",
+)
 @pytest.mark.asyncio
 async def test_wrap_workflow():
     from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13277?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13277/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13277
```

</p>
</details>

### What changes are proposed in this pull request?

LlamaIndex recently introduced [Workflow](https://docs.llamaindex.ai/en/stable/module_guides/workflow/), an orchestration framework similar to LangGraph but event-driven. This PR adds support for logging workflows in the MLflow LlamaIndex flavor and deploy them to model serving.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested logging model and deployment.

Model code:

```
%%writefile joke_workflow.py
import os
import mlflow
from llama_index.core.workflow import (
    Event,
    StartEvent,
    StopEvent,
    Workflow,
    step,
)
from llama_index.llms.databricks import Databricks


class JokeEvent(Event):
    joke: str


class JokeFlow(Workflow):
    llm = Databricks(model="databricks-meta-llama-3-1-70b-instruct")

    @step
    async def generate_joke(self, ev: StartEvent) -> JokeEvent:
        topic = ev.topic
        prompt = f"Write your best joke about {topic}."
        response = await self.llm.acomplete(prompt)
        return JokeEvent(joke=str(response))

    @step
    async def critique_joke(self, ev: JokeEvent) -> StopEvent:
        joke = ev.joke

        prompt = f"Give a thorough analysis and critique of the following joke: {joke}"
        response = await self.llm.acomplete(prompt)
        return StopEvent(result=str(response))

w = JokeFlow(timeout=180, verbose=False)
mlflow.models.set_model(w)
```

Logging code:
```
import mlflow

mlflow.set_registry_uri("databricks-uc")

with mlflow.start_run():
    model_info = mlflow.llama_index.log_model(
        llama_index_model="joke_workflow.py",
        artifact_path="model",
        input_example={"topic": "MLflow"},
        registered_model_name="x.y.z",
        # Pin requirements to install from the dev branch
        pip_requirements=[
            "mlflow",
            "git+https://github.com/B-Step62/mlflow.git@llama-workflow-logging",
            "llama-index==0.11.14",
            "llama-index-core==0.11.14",
            "llama-index-llms-databricks==0.2.0",
        ]
    )
```

Deployed endpoint:

![Screenshot 2024-09-30 at 21 19 56](https://github.com/user-attachments/assets/24e2fa82-bc4f-42db-8f8f-3d366eabb4c9)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

I will file a separate PR for updating documentations and add a tutorial.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support logging and deployment LlamaIndex Workflow as an MLflow model.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
