### PR TITLE
Mark `role` and `index` as required for chat schema

### DIFF
--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -86,11 +86,16 @@ class DspyChatModelWrapper(DspyModelWrapper):
         if isinstance(outputs, dict):
             role = outputs.get("role", "assistant")
             choices.append(
-                {"message": {"role": role, "content": json.dumps(outputs)}, "finish_reason": "stop"}
+                {
+                    "index": 0,
+                    "message": {"role": role, "content": json.dumps(outputs)},
+                    "finish_reason": "stop",
+                }
             )
         elif isinstance(outputs, dspy.Prediction):
             choices.append(
                 {
+                    "index": 0,
                     "message": {"role": "assistant", "content": json.dumps(outputs.toDict())},
                     "finish_reason": "stop",
                 }
@@ -101,6 +106,7 @@ class DspyChatModelWrapper(DspyModelWrapper):
                     role = output.get("role", "assistant")
                     choices.append(
                         {
+                            "index": 0,
                             "message": {"role": role, "content": json.dumps(outputs)},
                             "finish_reason": "stop",
                         }
@@ -108,6 +114,7 @@ class DspyChatModelWrapper(DspyModelWrapper):
                 elif isinstance(output, dspy.Prediction):
                     choices.append(
                         {
+                            "index": 0,
                             "message": {"role": role, "content": json.dumps(outputs.toDict())},
                             "finish_reason": "stop",
                         }

--- a/mlflow/models/rag_signatures.py
+++ b/mlflow/models/rag_signatures.py
@@ -2,7 +2,14 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 from mlflow.models import ModelSignature
-from mlflow.types.schema import Array, ColSpec, DataType, Object, Property, Schema
+from mlflow.types.schema import (
+    Array,
+    ColSpec,
+    DataType,
+    Object,
+    Property,
+    Schema,
+)
 from mlflow.utils.annotations import deprecated, experimental
 
 
@@ -81,7 +88,7 @@ CHAT_COMPLETION_REQUEST_SCHEMA = Schema(
             type=Array(
                 Object(
                     [
-                        Property("role", DataType.string, required=False),
+                        Property("role", DataType.string),
                         Property("content", DataType.string),
                     ]
                 )
@@ -97,17 +104,17 @@ CHAT_COMPLETION_RESPONSE_SCHEMA = Schema(
             type=Array(
                 Object(
                     [
-                        Property("index", DataType.long, required=False),
+                        Property("index", DataType.long),
                         Property(
                             "message",
                             Object(
                                 [
-                                    Property("role", DataType.string, required=False),
+                                    Property("role", DataType.string),
                                     Property("content", DataType.string),
                                 ]
                             ),
                         ),
-                        Property("finish_reason", DataType.string, required=False),
+                        Property("finish_reason", DataType.string),
                     ]
                 )
             ),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/13279?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13279/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13279
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix chat schema. The current schema marks many fields as optional, which is incompatible with the schema enforced by agent frameworks.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
