### PR TITLE
Fix set-matrix

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -187,7 +187,7 @@ def get_latest_micro_versions(versions):
 
 
 def filter_versions(
-    versions, min_ver, max_ver, unsupported=None, allow_unreleased_max_version=False
+    flavor, versions, min_ver, max_ver, unsupported=None, allow_unreleased_max_version=False
 ):
     """
     Returns the versions that satisfy the following conditions:
@@ -197,9 +197,15 @@ def filter_versions(
     """
     unsupported = unsupported or []
     # Prevent specifying non-existent versions
-    assert min_ver in versions
-    assert max_ver in versions or allow_unreleased_max_version
-    assert all(v in versions for v in unsupported)
+    assert (
+        min_ver in versions
+    ), f"Minimum version {min_ver} is not in the list of versions for {flavor}"
+    assert (
+        max_ver in versions or allow_unreleased_max_version
+    ), f"Minimum version {max_ver} is not in the list of versions for {flavor}"
+    assert all(
+        v in versions for v in unsupported
+    ), f"Unsupported versions {unsupported} are not in the list of versions for {flavor}"
 
     def _is_not_unsupported(v):
         return v not in unsupported
@@ -477,6 +483,7 @@ def expand_config(config):
         validate_test_coverage(name, flavor_config)
         for category, cfg in flavor_config.categories:
             versions = filter_versions(
+                flavor,
                 all_versions,
                 cfg.minimum,
                 cfg.maximum,

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -95,6 +95,7 @@ keras:
     run: |
       export KERAS_BACKEND=jax
       pytest tests/keras/test_callback.py
+
   autologging:
     minimum: "3.0.2"
     maximum: "3.5.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -52,7 +52,7 @@ pytorch:
     requirements:
       ">= 0.0.0": ["tensorboard"]
     run: |
-      pytest tests/pytorch/test_tensorboard_autolog.py
+      pytest tests/pytorch/test_tensorboard_autolog.py tests/pytorch/test_pytorch_autolog.py
 
 pytorch-lightning:
   package_info:
@@ -131,7 +131,8 @@ tensorflow:
         tests/tensorflow/test_tensorflow2_core_model_export.py \
         tests/tensorflow/test_tensorflow2_metric_value_conversion_utils.py \
         tests/tensorflow/test_keras_model_export.py \
-        tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
+        tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py \
+        tests/keras/test_save.py
 
   autologging:
     minimum: "2.7.4"
@@ -145,7 +146,7 @@ tensorflow:
       # `cannot import name 'TypeAliasType' from 'typing_extensions'`
       ">= 2.12.1, <= 2.13.1": ["sqlalchemy<2.0.25"]
     run: |
-      pytest tests/tensorflow/test_tensorflow2_autolog.py
+      pytest tests/tensorflow/test_tensorflow2_autolog.py tests/tensorflow/test_mlflow_callback.py
 
 xgboost:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -52,7 +52,7 @@ pytorch:
     requirements:
       ">= 0.0.0": ["tensorboard"]
     run: |
-      pytest tests/pytorch/test_tensorboard_autolog.py tests/pytorch/test_pytorch_autolog.py
+      pytest tests/pytorch/test_tensorboard_autolog.py
 
 pytorch-lightning:
   package_info:
@@ -94,8 +94,7 @@ keras:
       ">= 3.0.0": ["jax[cpu]>0.4"]
     run: |
       export KERAS_BACKEND=jax
-      pytest tests/keras/test_callback.py tests/keras/test_save.py
-
+      pytest tests/keras/test_callback.py
   autologging:
     minimum: "3.0.2"
     maximum: "3.5.0"
@@ -145,7 +144,7 @@ tensorflow:
       # `cannot import name 'TypeAliasType' from 'typing_extensions'`
       ">= 2.12.1, <= 2.13.1": ["sqlalchemy<2.0.25"]
     run: |
-      pytest tests/tensorflow/test_tensorflow2_autolog.py tests/tensorflow/test_mlflow_callback.py
+      pytest tests/tensorflow/test_tensorflow2_autolog.py
 
 xgboost:
   package_info:
@@ -308,7 +307,7 @@ spacy:
 
   models:
     minimum: "2.2.4"
-    maximum: "3.7.6"
+    maximum: "3.7.5"
     python:
       "== dev": "3.9"
     requirements:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -94,7 +94,7 @@ keras:
       ">= 3.0.0": ["jax[cpu]>0.4"]
     run: |
       export KERAS_BACKEND=jax
-      pytest tests/keras/test_callback.py
+      pytest tests/keras/test_callback.py tests/keras/test_save.py
 
   autologging:
     minimum: "3.0.2"
@@ -131,8 +131,7 @@ tensorflow:
         tests/tensorflow/test_tensorflow2_core_model_export.py \
         tests/tensorflow/test_tensorflow2_metric_value_conversion_utils.py \
         tests/tensorflow/test_keras_model_export.py \
-        tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py \
-        tests/keras/test_save.py
+        tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
 
   autologging:
     minimum: "2.7.4"

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -140,7 +140,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "2.2.4",
-            "maximum": "3.7.6"
+            "maximum": "3.7.5"
         }
     },
     "statsmodels": {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/13283?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13283/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13283
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Spacy 3.7.6 [got yanked](https://pypi.org/project/spacy/3.7.6/), so it's not a valid max version anymore.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
