### PR TITLE
Add `prompt_tokens_details` in llama-index tests

### DIFF
--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -71,6 +71,7 @@ def test_trace_llm_complete(is_async):
         "completion_tokens": 7,
         "total_tokens": 12,
         "completion_tokens_details": None,
+        "prompt_tokens_details": None,
     }
     assert attr["prompt"] == "Hello"
     assert attr["invocation_params"]["model_name"] == model_name
@@ -106,6 +107,7 @@ def test_trace_llm_complete_stream():
         "completion_tokens": 12,
         "total_tokens": 21,
         "completion_tokens_details": None,
+        "prompt_tokens_details": None,
     }
     assert attr["prompt"] == "Hello"
     assert attr["invocation_params"]["model_name"] == model_name
@@ -156,6 +158,7 @@ def test_trace_llm_chat(is_async):
         "completion_tokens": 12,
         "total_tokens": 21,
         "completion_tokens_details": None,
+        "prompt_tokens_details": None,
     }
     assert attr["invocation_params"]["model_name"] == llm.metadata.model_name
     assert attr["model_dict"]["model"] == llm.metadata.model_name
@@ -210,6 +213,7 @@ def test_trace_llm_chat_stream():
         "completion_tokens": 12,
         "total_tokens": 21,
         "completion_tokens_details": None,
+        "prompt_tokens_details": None,
     }
     assert attr["invocation_params"]["model_name"] == llm.metadata.model_name
     assert attr["model_dict"]["model"] == llm.metadata.model_name

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -66,13 +66,16 @@ def test_trace_llm_complete(is_async):
     assert spans[0].outputs["text"] == "Hello"
 
     attr = spans[0].attributes
-    assert attr["usage"] == {
-        "prompt_tokens": 5,
-        "completion_tokens": 7,
-        "total_tokens": 12,
-        "completion_tokens_details": None,
-        "prompt_tokens_details": None,
-    }
+    assert (
+        attr["usage"].items()
+        >= {
+            "prompt_tokens": 5,
+            "completion_tokens": 7,
+            "total_tokens": 12,
+            "completion_tokens_details": None,
+            "prompt_tokens_details": None,
+        }.items()
+    )
     assert attr["prompt"] == "Hello"
     assert attr["invocation_params"]["model_name"] == model_name
     assert attr["model_dict"]["model"] == model_name
@@ -102,13 +105,16 @@ def test_trace_llm_complete_stream():
     assert spans[0].outputs["text"] == "Hello world"
 
     attr = spans[0].attributes
-    assert attr["usage"] == {
-        "prompt_tokens": 9,
-        "completion_tokens": 12,
-        "total_tokens": 21,
-        "completion_tokens_details": None,
-        "prompt_tokens_details": None,
-    }
+    assert (
+        attr["usage"].items()
+        >= {
+            "prompt_tokens": 9,
+            "completion_tokens": 12,
+            "total_tokens": 21,
+            "completion_tokens_details": None,
+            "prompt_tokens_details": None,
+        }.items()
+    )
     assert attr["prompt"] == "Hello"
     assert attr["invocation_params"]["model_name"] == model_name
     assert attr["model_dict"]["model"] == model_name
@@ -153,13 +159,16 @@ def test_trace_llm_chat(is_async):
     }
 
     attr = spans[0].attributes
-    assert attr["usage"] == {
-        "prompt_tokens": 9,
-        "completion_tokens": 12,
-        "total_tokens": 21,
-        "completion_tokens_details": None,
-        "prompt_tokens_details": None,
-    }
+    assert (
+        attr["usage"].items()
+        >= {
+            "prompt_tokens": 9,
+            "completion_tokens": 12,
+            "total_tokens": 21,
+            "completion_tokens_details": None,
+            "prompt_tokens_details": None,
+        }.items()
+    )
     assert attr["invocation_params"]["model_name"] == llm.metadata.model_name
     assert attr["model_dict"]["model"] == llm.metadata.model_name
 
@@ -208,13 +217,16 @@ def test_trace_llm_chat_stream():
     }
 
     attr = spans[0].attributes
-    assert attr["usage"] == {
-        "prompt_tokens": 9,
-        "completion_tokens": 12,
-        "total_tokens": 21,
-        "completion_tokens_details": None,
-        "prompt_tokens_details": None,
-    }
+    assert (
+        attr["usage"].items()
+        >= {
+            "prompt_tokens": 9,
+            "completion_tokens": 12,
+            "total_tokens": 21,
+            "completion_tokens_details": None,
+            "prompt_tokens_details": None,
+        }.items()
+    )
     assert attr["invocation_params"]["model_name"] == llm.metadata.model_name
     assert attr["model_dict"]["model"] == llm.metadata.model_name
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13293?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13293/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13293
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Discovered in #13268 where I updated lots of cross-version tests:

https://github.com/mlflow/mlflow/actions/runs/11138074376/job/30952579878?pr=13268

```
FAILED | MEM 1.2/15.6 GB | DISK 57.4/72.5 GB tests/llama_index/test_llama_index_tracer.py::test_trace_llm_complete[True] - AssertionError: assert {'completion_...s': None, ...} == {'completion_...l_tokens': 12}
  
  Omitting 4 identical items, use -vv to show
  Left contains 1 more item:
  {'prompt_tokens_details': None}
  
  Full diff:
    {
        'completion_tokens': 7,
        'completion_tokens_details': None,
        'prompt_tokens': 5,
  +     'prompt_tokens_details': None,
        'total_tokens': 12,
    }
```

The OpenAI Python SKD added a new field in `CompletionUsage` again:

https://github.com/openai/openai-python/commit/7c8c11158c4e0b63fef495c32447d6e31870073f#diff-d85f41ac9f419751206af46c34ef5c8c74258660be492aa703dcbebcfc96a41bR39

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
