### PR TITLE
Run cross-version tests in Python 3.9

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
-          pip install 'numpy<2'
+          # pip install 'numpy<2'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test
@@ -203,7 +203,7 @@ jobs:
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
-          pip install 'numpy<2'
+          # pip install 'numpy<2'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -199,13 +199,15 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install mlflow & test dependencies
         run: |
+          mkdir -p /tmp/mlflow
+          echo 'numpy<2' > /tmp/mlflow/constraints.txt
+          pip config set global.constraint /tmp/mlflow/constraints.txt
           pip install wheel
           pip install .[extras]
           pip install -r requirements/test-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
-          pip install 'numpy<2'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -150,13 +150,15 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install mlflow & test dependencies
         run: |
+          mkdir -p /tmp/mlflow
+          echo 'numpy<2' > /tmp/mlflow/constraints.txt
+          pip config set global.constraint /tmp/mlflow/constraints.txt
           pip install wheel
           pip install .[extras]
           pip install -r requirements/test-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
-          pip install 'numpy<2'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -150,15 +150,13 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install mlflow & test dependencies
         run: |
-          mkdir -p /tmp/mlflow
-          echo 'numpy<2' > /tmp/mlflow/constraints.txt
-          pip config set global.constraint /tmp/mlflow/constraints.txt
           pip install wheel
           pip install .[extras]
           pip install -r requirements/test-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
+          pip install 'numpy<2'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test
@@ -199,15 +197,13 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install mlflow & test dependencies
         run: |
-          mkdir -p /tmp/mlflow
-          echo 'numpy<2' > /tmp/mlflow/constraints.txt
-          pip config set global.constraint /tmp/mlflow/constraints.txt
           pip install wheel
           pip install .[extras]
           pip install -r requirements/test-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
+          pip install 'numpy<2'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -156,7 +156,10 @@ jobs:
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
-          # pip install 'numpy<2'
+          PANDAS_MAJOR_VERSION=$(pip show pandas | grep Version | cut -d ' ' -f 2 | cut -d '.' -f 1)
+          if [ "$PANDAS_MAJOR_VERSION" -lt 2 ]; then
+            pip install 'numpy<2'
+          fi
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test
@@ -203,7 +206,10 @@ jobs:
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
-          # pip install 'numpy<2'
+          PANDAS_MAJOR_VERSION=$(pip show pandas | grep Version | cut -d ' ' -f 2 | cut -d '.' -f 1)
+          if [ "$PANDAS_MAJOR_VERSION" -lt 2 ]; then
+            pip install 'numpy<2'
+          fi
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -156,6 +156,7 @@ jobs:
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
+          pip install 'numpy<2'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test
@@ -202,6 +203,7 @@ jobs:
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
+          pip install 'numpy<2'
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Pre-test

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -288,7 +288,7 @@ def get_requires_python(package: str, version: str) -> str:
         ),
         None,
     )
-    candidates = ("3.8", "3.9")
+    candidates = ("3.9", "3.10")
     if requires_python is None:
         return candidates[0]
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -120,8 +120,7 @@ tensorflow:
       "== dev": "3.9"
     requirements:
       # Requirements to run tests for keras
-      ">= 0.0.0":
-        ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1", "tf-keras"]
+      ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1"]
       # TensorFlow 2.12.1 and 2.13.1 requires typing_extensions < 4.6.0, which is
       # incompatible with SQLAlchemy 2.0.25 with error
       # `cannot import name 'TypeAliasType' from 'typing_extensions'`
@@ -140,7 +139,6 @@ tensorflow:
     python:
       "== dev": "3.9"
     requirements:
-      ">= 0.0.0": ["tf-keras"]
       "== dev": ["scikit-learn"]
       # TensorFlow 2.12.1 and 2.13.1 requires typing_extensions < 4.6.0, which is
       # incompatible with SQLAlchemy 2.0.25 with error
@@ -573,6 +571,7 @@ transformers:
           "sentencepiece", # required for transformers text2text generation pipeline
           "protobuf<=3.20.3", # fix error `Couldn't build proto file into descriptor pool: duplicate file name sentencepiece_model.proto`
           "typing_extensions>=4.6.0", # fix error for SqlAlchemy == 2.0.25 cannot import name 'TypeAliasType' from 'typing_extensions'
+          "tf-keras",
         ]
       # tensorflow 2.13.0 made all Keras private functions inaccessible. transformers versions
       # prior to 4.30.0 are incompatible with this breaking change in Keras.
@@ -611,6 +610,7 @@ transformers:
           "accelerate",
           "setfit",
           "optuna",
+          "tf-keras",
         ]
       # sentence-transformers >= 2.4.0 relies on `transformers.utils.import_utils.is_nltk_available`
       # to check nltk availability. This function is only available in transformers>=4.34.0.

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -120,7 +120,8 @@ tensorflow:
       "== dev": "3.9"
     requirements:
       # Requirements to run tests for keras
-      ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1"]
+      ">= 0.0.0":
+        ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1", "tf-keras"]
       # TensorFlow 2.12.1 and 2.13.1 requires typing_extensions < 4.6.0, which is
       # incompatible with SQLAlchemy 2.0.25 with error
       # `cannot import name 'TypeAliasType' from 'typing_extensions'`
@@ -139,6 +140,7 @@ tensorflow:
     python:
       "== dev": "3.9"
     requirements:
+      ">= 0.0.0": ["tf-keras"]
       "== dev": ["scikit-learn"]
       # TensorFlow 2.12.1 and 2.13.1 requires typing_extensions < 4.6.0, which is
       # incompatible with SQLAlchemy 2.0.25 with error

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -475,7 +475,7 @@ pmdarima:
       pip install git+https://github.com/alkaline-ml/pmdarima.git
 
   models:
-    minimum: "1.8.0"
+    minimum: "1.8.5"
     maximum: "2.0.4"
     requirements:
       "< 1.9": ["scikit-learn<1.3"]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -307,7 +307,7 @@ spacy:
       pip install git+https://github.com/explosion/spaCy.git
 
   models:
-    minimum: "2.2.4"
+    minimum: "3.0.9"
     maximum: "3.7.5"
     python:
       "== dev": "3.9"
@@ -325,7 +325,7 @@ statsmodels:
       pip install git+https://github.com/statsmodels/statsmodels.git
 
   models:
-    minimum: "0.11.1"
+    minimum: "0.12.2"
     maximum: "0.14.3"
     python:
       "== dev": "3.9"
@@ -335,7 +335,7 @@ statsmodels:
       pytest tests/statsmodels/test_statsmodels_model_export.py
 
   autologging:
-    minimum: "0.11.1"
+    minimum: "0.12.2"
     maximum: "0.14.3"
     python:
       "== dev": "3.9"
@@ -518,7 +518,7 @@ shap:
   package_info:
     pip_release: "shap"
   models:
-    minimum: "0.41.0"
+    minimum: "0.42.1"
     maximum: "0.46.0"
     requirements:
       "< 0.46.0": ["numpy<1.24.0"]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -571,7 +571,7 @@ transformers:
           "sentencepiece", # required for transformers text2text generation pipeline
           "protobuf<=3.20.3", # fix error `Couldn't build proto file into descriptor pool: duplicate file name sentencepiece_model.proto`
           "typing_extensions>=4.6.0", # fix error for SqlAlchemy == 2.0.25 cannot import name 'TypeAliasType' from 'typing_extensions'
-          "tf-keras",
+          "keras<3",
         ]
       # tensorflow 2.13.0 made all Keras private functions inaccessible. transformers versions
       # prior to 4.30.0 are incompatible with this breaking change in Keras.
@@ -610,7 +610,7 @@ transformers:
           "accelerate",
           "setfit",
           "optuna",
-          "tf-keras",
+          "keras<3",
         ]
       # sentence-transformers >= 2.4.0 relies on `transformers.utils.import_utils.is_nltk_available`
       # to check nltk availability. This function is only available in transformers>=4.34.0.

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -139,7 +139,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "spacy"
         },
         "models": {
-            "minimum": "2.2.4",
+            "minimum": "3.0.9",
             "maximum": "3.7.5"
         }
     },
@@ -148,11 +148,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "statsmodels"
         },
         "models": {
-            "minimum": "0.11.1",
+            "minimum": "0.12.2",
             "maximum": "0.14.3"
         },
         "autologging": {
-            "minimum": "0.11.1",
+            "minimum": "0.12.2",
             "maximum": "0.14.3"
         }
     },
@@ -220,7 +220,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "shap"
         },
         "models": {
-            "minimum": "0.41.0",
+            "minimum": "0.42.1",
             "maximum": "0.46.0"
         }
     },

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -193,7 +193,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "pmdarima"
         },
         "models": {
-            "minimum": "1.8.0",
+            "minimum": "1.8.5",
             "maximum": "2.0.4"
         }
     },

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -282,9 +282,7 @@ def _create_virtualenv(
 
                 tmp_req_file = f"requirements.{uuid.uuid4().hex}.txt"
                 Path(tmpdir).joinpath(tmp_req_file).write_text("\n".join(deps))
-                cmd = _join_commands(
-                    activate_cmd, f"python -m pip install --quiet -r {tmp_req_file}"
-                )
+                cmd = _join_commands(activate_cmd, f"python -m pip install -r {tmp_req_file}")
                 _exec_cmd(cmd, capture_output=capture_output, cwd=tmpdir, extra_env=extra_env)
 
     return activate_cmd

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -364,7 +364,10 @@ def test_pyfunc_serve_and_score(fastai_model):
     artifact_path = "model"
     with mlflow.start_run():
         model_info = mlflow.fastai.log_model(
-            model, artifact_path, input_example=inference_dataframe
+            model,
+            artifact_path,
+            input_example=inference_dataframe,
+            extra_pip_requirements=["numpy<2"],
         )
 
     inference_payload = load_serving_example(model_info.model_uri)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -59,9 +59,10 @@ _logger = logging.getLogger(__name__)
 def spark_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     additional_pip_deps = ["/opt/mlflow", "pyspark", "pytest"]
-    if Version(pyspark.__version__) <= Version("3.3.2"):
+    if Version(pyspark.__version__) <= Version("3.3.4"):
         # Versions of PySpark <= 3.3.2 are incompatible with pandas >= 2
         additional_pip_deps.append("pandas<2")
+        additional_pip_deps.append("numpy<2")
     _mlflow_conda_env(conda_env, additional_pip_deps=additional_pip_deps)
     return conda_env
 
@@ -340,7 +341,6 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
         spark_model_iris.model,
         path=model_path,
         conda_env=spark_custom_env,
-        extra_pip_requirements=["numpy<2"],
     )
     scoring_response = score_model_in_sagemaker_docker_container(
         model_uri=model_path,

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -340,6 +340,7 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
         spark_model_iris.model,
         path=model_path,
         conda_env=spark_custom_env,
+        extra_pip_requirements=["numpy<2"],
     )
     scoring_response = score_model_in_sagemaker_docker_container(
         model_uri=model_path,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13294?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13294/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13294
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Python 3.8 is reaching EOL. Several ML/DL projects such as spacy have already dropped support for Python 3.8. Running tests on 3.8 results in wheel build and fails ([example](https://github.com/mlflow/mlflow/actions/runs/11138074376/job/30952551950?pr=13268)). We can avoid using Python 3.9.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
