### PR TITLE
Fix infer pip requirements for UCFunctionToolkit

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -130,8 +130,8 @@ def get_default_conda_env():
 
 def _get_databricks_serverless_env_vars():
     """
-    To initialize WorkspaceClient correctly in a subprocess in databricks, some
-    environment variables need to be set.
+    Returns the environment variables required to to initialize WorkspaceClient in a subprocess
+    with serverless compute.
 
     Note:
         Databricks authentication related environment variables are set in the
@@ -142,9 +142,9 @@ def _get_databricks_serverless_env_vars():
         envs["SPARK_LOCAL_REMOTE"] = os.environ["SPARK_REMOTE"]
     else:
         logger.warning(
-            "Failed to find the required environment variable SPARK_REMOTE. "
-            "This is required to initialize the WorkspaceClient in a subprocess in Databricks "
-            "for UC function execution. Setting the value to 'true'."
+            "Missing required environment variable `SPARK_LOCAL_REMOTE` or `SPARK_REMOTE`."
+            "This is required to initialize the WorkspaceClient with serverless compute in "
+            "a subprocess in Databricks for UC function execution. Setting the value to 'true'."
         )
         envs["SPARK_LOCAL_REMOTE"] = "true"
     return envs

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -143,7 +143,7 @@ def _get_databricks_serverless_env_vars():
     else:
         logger.warning(
             "Missing required environment variable `SPARK_LOCAL_REMOTE` or `SPARK_REMOTE`."
-            "This is required to initialize the WorkspaceClient with serverless compute in "
+            "These are necessary to initialize the WorkspaceClient with serverless compute in "
             "a subprocess in Databricks for UC function execution. Setting the value to 'true'."
         )
         envs["SPARK_LOCAL_REMOTE"] = "true"

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -384,7 +384,7 @@ _INFER_PIP_REQUIREMENTS_GENERAL_ERROR_MESSAGE = (
 )
 
 
-def infer_pip_requirements(model_uri, flavor, fallback=None, timeout=None):
+def infer_pip_requirements(model_uri, flavor, fallback=None, timeout=None, extra_env_vars=None):
     """Infers the pip requirements of the specified model by creating a subprocess and loading
     the model in it to determine which packages are imported.
 
@@ -394,6 +394,8 @@ def infer_pip_requirements(model_uri, flavor, fallback=None, timeout=None):
         fallback: If provided, an unexpected error during the inference procedure is swallowed
             and the value of ``fallback`` is returned. Otherwise, the error is raised.
         timeout: If specified, the inference operation is bound by the timeout (in seconds).
+        extra_env_vars: A dictionary of extra environment variables to pass to the subprocess.
+            Default to None.
 
     Returns:
         A list of inferred pip requirements (e.g. ``["scikit-learn==0.24.2", ...]``).
@@ -412,9 +414,13 @@ def infer_pip_requirements(model_uri, flavor, fallback=None, timeout=None):
     try:
         if timeout:
             with run_with_timeout(timeout):
-                return _infer_requirements(model_uri, flavor, raise_on_error=raise_on_error)
+                return _infer_requirements(
+                    model_uri, flavor, raise_on_error=raise_on_error, extra_env_vars=extra_env_vars
+                )
         else:
-            return _infer_requirements(model_uri, flavor, raise_on_error=raise_on_error)
+            return _infer_requirements(
+                model_uri, flavor, raise_on_error=raise_on_error, extra_env_vars=extra_env_vars
+            )
     except Exception as e:
         if raise_on_error or (fallback is None):
             raise

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -303,7 +303,7 @@ def _get_installed_version(package, module=None):
     return version
 
 
-def _capture_imported_modules(model_uri, flavor, record_full_module=False):  # noqa: D417
+def _capture_imported_modules(model_uri, flavor, record_full_module=False, extra_env_vars=None):
     """Runs `_capture_modules.py` in a subprocess and captures modules imported during the model
     loading procedure.
     If flavor is `transformers`, `_capture_transformers_modules.py` is run instead.
@@ -311,6 +311,10 @@ def _capture_imported_modules(model_uri, flavor, record_full_module=False):  # n
     Args:
         model_uri: The URI of the model.
         flavor: The flavor name of the model.
+        record_full_module: Whether to capture top level modules for inferring python
+            package purpose. Default to False.
+        extra_env_vars: A dictionary of extra environment variables to pass to the subprocess.
+            Default to None.
 
     Returns:
         A list of captured modules.
@@ -320,6 +324,7 @@ def _capture_imported_modules(model_uri, flavor, record_full_module=False):  # n
 
     process_timeout = MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT.get()
     raise_on_error = MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS.get()
+    extra_env_vars = extra_env_vars or {}
 
     # Run `_capture_modules.py` to capture modules imported during the loading procedure
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -372,6 +377,7 @@ def _capture_imported_modules(model_uri, flavor, record_full_module=False):  # n
                             **main_env,
                             **transformer_env,
                             _MLFLOW_IN_CAPTURE_MODULE_PROCESS.name: "true",
+                            **extra_env_vars,
                         },
                     )
                     with open(output_file) as f:
@@ -404,6 +410,7 @@ def _capture_imported_modules(model_uri, flavor, record_full_module=False):  # n
             env={
                 **main_env,
                 _MLFLOW_IN_CAPTURE_MODULE_PROCESS.name: "true",
+                **extra_env_vars,
             },
         )
 
@@ -489,7 +496,7 @@ def _load_pypi_package_index():
 _PYPI_PACKAGE_INDEX = None
 
 
-def _infer_requirements(model_uri, flavor, raise_on_error=False):
+def _infer_requirements(model_uri, flavor, raise_on_error=False, extra_env_vars=None):
     """Infers the pip requirements of the specified model by creating a subprocess and loading
     the model in it to determine which packages are imported.
 
@@ -497,6 +504,8 @@ def _infer_requirements(model_uri, flavor, raise_on_error=False):
         model_uri: The URI of the model.
         flavor: The flavor name of the model.
         raise_on_error: If True, raise an exception if an unrecognized package is encountered.
+        extra_env_vars: A dictionary of extra environment variables to pass to the subprocess.
+            Default to None.
 
     Returns:
         A list of inferred pip requirements.
@@ -507,7 +516,7 @@ def _infer_requirements(model_uri, flavor, raise_on_error=False):
     if _PYPI_PACKAGE_INDEX is None:
         _PYPI_PACKAGE_INDEX = _load_pypi_package_index()
 
-    modules = _capture_imported_modules(model_uri, flavor)
+    modules = _capture_imported_modules(model_uri, flavor, extra_env_vars=extra_env_vars)
     packages = _flatten([_MODULES_TO_PACKAGES.get(module, []) for module in modules])
     packages = map(_normalize_package_name, packages)
     packages = _prune_packages(packages)

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1962,6 +1962,7 @@ def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
 
     # Mocking Cloudpickle because serialization in this setup is failing
     monkeypatch.setattr("cloudpickle.dump", mock.MagicMock())
+    monkeypatch.setenv("SPARK_LOCAL_REMOTE", "true")
 
     uc_functions = ["rag.studio.test_function_a", "rag.studio.test_function_b"]
     uc_function_tools = create_uc_tools(
@@ -2016,6 +2017,7 @@ def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
 
     # Mocking Cloudpickle because serialization in this setup is failing
     monkeypatch.setattr("cloudpickle.dump", mock.MagicMock())
+    monkeypatch.setenv("SPARK_LOCAL_REMOTE", "true")
 
     uc_functions = ["rag.studio.test_function_a", "rag.studio.test_function_b"]
     uc_function_tools = create_uc_tools(

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1962,7 +1962,6 @@ def test_databricks_dependency_extraction_from_langgraph_agent(monkeypatch):
 
     # Mocking Cloudpickle because serialization in this setup is failing
     monkeypatch.setattr("cloudpickle.dump", mock.MagicMock())
-    monkeypatch.setenv("SPARK_LOCAL_REMOTE", "true")
 
     uc_functions = ["rag.studio.test_function_a", "rag.studio.test_function_b"]
     uc_function_tools = create_uc_tools(
@@ -2017,7 +2016,6 @@ def test_databricks_dependency_extraction_from_agent_chain(monkeypatch):
 
     # Mocking Cloudpickle because serialization in this setup is failing
     monkeypatch.setattr("cloudpickle.dump", mock.MagicMock())
-    monkeypatch.setenv("SPARK_LOCAL_REMOTE", "true")
 
     uc_functions = ["rag.studio.test_function_a", "rag.studio.test_function_b"]
     uc_function_tools = create_uc_tools(

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -677,7 +677,9 @@ def test_capture_imported_modules_raises_when_env_var_set(monkeypatch):
             )
 
 
-def test_capture_imported_modules_correct():
+def test_capture_imported_modules_correct(monkeypatch):
+    monkeypatch.setenv("MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS", "true")
+
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
             import pandas  # noqa: F401
@@ -692,29 +694,27 @@ def test_capture_imported_modules_correct():
             input_example="test",
         )
 
-    with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warning:
-        modules = _capture_imported_modules(model_info.model_uri, mlflow.pyfunc.FLAVOR_NAME)
-        mock_warning.assert_not_called()
-        assert "pandas" in modules
-        assert "sklearn" in modules
+    modules = _capture_imported_modules(model_info.model_uri, mlflow.pyfunc.FLAVOR_NAME)
+    assert "pandas" in modules
+    assert "sklearn" in modules
 
 
-def test_capture_imported_modules_extra_env_vars():
+def test_capture_imported_modules_extra_env_vars(monkeypatch):
+    monkeypatch.setenv("MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS", "true")
+
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
             assert os.environ["TEST"] == "test"
-            import sklearn  # noqa: F401
-
             return model_input
 
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(
-            "model", python_model=TestModel(), input_example="test"
+            "model",
+            python_model=TestModel(),
+            input_example="test",
+            pip_requirements=[],
         )
 
-    with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warning:
-        modules = _capture_imported_modules(
-            model_info.model_uri, mlflow.pyfunc.FLAVOR_NAME, extra_env_vars={"TEST": "test"}
-        )
-        mock_warning.assert_not_called()
-        assert "sklearn" in modules
+    _capture_imported_modules(
+        model_info.model_uri, mlflow.pyfunc.FLAVOR_NAME, extra_env_vars={"TEST": "test"}
+    )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13295?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13295/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13295
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix the problem where UCFunctionToolkit exists in the langchain model, but we fail to infer pip requirements because the WorkspaceClient cannot be initialized inside a subprocess.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
