### PR TITLE
Llama workflow Trace

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -181,17 +181,6 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         result: Optional[Any] = None,
         **kwargs: Any,
     ) -> _LlamaSpan:
-        if LLAMA_INDEX_VERSION >= Version("0.11.10"):
-            # In LlamaIndex >= 0.11.0, LlamaIndex workflow finishes with a pending
-            # WorkflowHandler as an output. Their base span handler does not handle it
-            # correctly and emit it immediately, instead of awaiting for the actual result.
-            # Until this problem is resolved, we simply records the pending workflow result
-            # as it is. Using str(result) for pending handler will raise an exception.
-            from llama_index.core.workflow.handler import WorkflowHandler
-
-            if isinstance(result, WorkflowHandler) and not result.is_done():
-                result = "<WorkflowHandler pending>"
-
         try:
             with self.lock:
                 llama_span = self.open_spans.get(id_)

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -172,8 +172,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                 )
             return _LlamaSpan(id_=id_, parent_id=parent_span_id, mlflow_span=span)
         except BaseException as e:
-            _logger.warning(f"Failed to create a new span: {e}", exc_info=True)
-            raise
+            _logger.debug(f"Failed to create a new span: {e}", exc_info=True)
 
     def prepare_to_exit_span(
         self,
@@ -202,7 +201,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                 _end_span(span=span, outputs=result)
             return llama_span
         except BaseException as e:
-            _logger.warning(f"Failed to end a span: {e}", exc_info=True)
+            _logger.debug(f"Failed to end a span: {e}", exc_info=True)
 
     def resolve_pending_stream_span(self, span: LiveSpan, event: Any):
         """End the pending streaming span(s)"""
@@ -213,7 +212,6 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         """Logic for handling errors during the model execution."""
         with self.lock:
             llama_span = self.open_spans.get(id_)
-
         span = llama_span._mlflow_span
 
         if LLAMA_INDEX_VERSION >= Version("0.10.59"):

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -804,6 +804,8 @@ llama_index:
           # Required to run tests/openai/mock_openai.py
           "fastapi",
           "uvicorn",
+          # Required for testing LlamaIndex workflow
+          "pytest-asyncio",
         ]
       "< 0.11.0": ["pydantic<2"]
     run: pytest tests/llama_index/test_llama_index_autolog.py tests/llama_index/test_llama_index_tracer.py

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1058,7 +1058,7 @@ def set_model(model):
         globals()["__mlflow_model__"] = model
         return
 
-    for validate_function in [_validate_llama_index_model]:
+    for validate_function in [_validate_llama_index_model, _validate_llama_index_model]:
         try:
             globals()["__mlflow_model__"] = validate_function(model)
             return

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -453,6 +453,10 @@ def test_tracer_handle_tracking_uri_update(tmp_path):
     reason="Workflow tracing does not work correctly in >= 0.11.10 until "
     "https://github.com/run-llama/llama_index/issues/16283 is fixed",
 )
+@pytest.mark.skipif(
+    Version(llama_core_version) < Version("0.11.0"),
+    reason="Workflow was introduced in 0.11.0",
+)
 @pytest.mark.asyncio
 async def test_tracer_simple_workflow():
     from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
@@ -478,6 +482,10 @@ async def test_tracer_simple_workflow():
     llama_core_version >= Version("0.11.10"),
     reason="Workflow tracing does not work correctly in >= 0.11.10 until "
     "https://github.com/run-llama/llama_index/issues/16283 is fixed",
+)
+@pytest.mark.skipif(
+    Version(llama_core_version) < Version("0.11.0"),
+    reason="Workflow was introduced in 0.11.0",
 )
 @pytest.mark.asyncio
 async def test_tracer_parallel_workflow():

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -455,8 +455,6 @@ async def test_tracer_workflow():
         step,
     )
 
-    import mlflow
-
     class MyWorkflow(Workflow):
         @step
         async def my_step(self, ev: StartEvent) -> StopEvent:
@@ -466,9 +464,9 @@ async def test_tracer_workflow():
     w = MyWorkflow(timeout=10, verbose=False)
     await w.run()
 
-    trace = mlflow.get_last_active_trace()
-    assert trace is not None
-    assert trace.info.status == TraceStatus.OK
-    for s in trace.data.spans:
+    traces = _get_all_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == TraceStatus.OK
+    for s in traces[0].data.spans:
         assert s.status.status_code == SpanStatusCode.OK
-    assert all(s.status.status_code == SpanStatusCode.OK for s in trace.data.spans)
+    assert all(s.status.status_code == SpanStatusCode.OK for s in traces[0].data.spans)

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -454,7 +454,7 @@ def test_tracer_handle_tracking_uri_update(tmp_path):
     "https://github.com/run-llama/llama_index/issues/16283 is fixed",
 )
 @pytest.mark.skipif(
-    Version(llama_core_version) < Version("0.11.0"),
+    llama_core_version < Version("0.11.0"),
     reason="Workflow was introduced in 0.11.0",
 )
 @pytest.mark.asyncio
@@ -464,7 +464,6 @@ async def test_tracer_simple_workflow():
     class MyWorkflow(Workflow):
         @step
         async def my_step(self, ev: StartEvent) -> StopEvent:
-            # do something here
             return StopEvent(result="Hi, world!")
 
     w = MyWorkflow(timeout=10, verbose=False)
@@ -473,8 +472,6 @@ async def test_tracer_simple_workflow():
     traces = _get_all_traces()
     assert len(traces) == 1
     assert traces[0].info.status == TraceStatus.OK
-    for s in traces[0].data.spans:
-        assert s.status.status_code == SpanStatusCode.OK
     assert all(s.status.status_code == SpanStatusCode.OK for s in traces[0].data.spans)
 
 
@@ -484,7 +481,7 @@ async def test_tracer_simple_workflow():
     "https://github.com/run-llama/llama_index/issues/16283 is fixed",
 )
 @pytest.mark.skipif(
-    Version(llama_core_version) < Version("0.11.0"),
+    llama_core_version < Version("0.11.0"),
     reason="Workflow was introduced in 0.11.0",
 )
 @pytest.mark.asyncio

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import random
 from dataclasses import asdict
 from typing import List
 from unittest.mock import ANY
@@ -448,9 +449,9 @@ def test_tracer_handle_tracking_uri_update(tmp_path):
 
 
 @pytest.mark.skipif(
-    llama_core_version <= Version("0.11.13"),
-    reason="Workflow tracing does not work correctly in <= 0.11.14 due to "
-    "https://github.com/run-llama/llama_index/issues/16283",
+    llama_core_version >= Version("0.11.10"),
+    reason="Workflow tracing does not work correctly in >= 0.11.10 until "
+    "https://github.com/run-llama/llama_index/issues/16283 is fixed",
 )
 @pytest.mark.asyncio
 async def test_tracer_simple_workflow():
@@ -474,14 +475,12 @@ async def test_tracer_simple_workflow():
 
 
 @pytest.mark.skipif(
-    llama_core_version <= Version("0.11.13"),
-    reason="Workflow tracing does not work correctly in <= 0.11.14 due to "
-    "https://github.com/run-llama/llama_index/issues/16283",
+    llama_core_version >= Version("0.11.10"),
+    reason="Workflow tracing does not work correctly in >= 0.11.10 until "
+    "https://github.com/run-llama/llama_index/issues/16283 is fixed",
 )
 @pytest.mark.asyncio
 async def test_tracer_parallel_workflow():
-    import random
-
     from llama_index.core.workflow import (
         Context,
         Event,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13305?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13305/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13305
```

</p>
</details>

### What changes are proposed in this pull request?

Updating tracing logic to handle workflow properly. Indeed, we need almost not change to the tracing logic (just handling a special exception). 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Also tested with the latest LlamaIndex with [this fix](https://github.com/run-llama/llama_index/pull/16290/files) included.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Will update documentation in a follow-up.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
