### PR TITLE
Improve how to handle endpoints containing path parameters (e.g. `/mlflow/traces/{request_id}`) in `DatabricksArtifactRepository`

### DIFF
--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -169,9 +169,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             The response from the REST endpoint.
         """
         db_creds = get_databricks_host_creds(self.databricks_profile_uri)
-
         endpoint, method = _SERVICE_AND_METHOD_TO_INFO[service][api]
-
         # If `endpoint` has path parameters (e.g. '/mlflow/traces/{request_id}'),
         # replace them with the corresponding values in `params`.
         replacements: Dict[str, str] = {}

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -155,24 +155,25 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         artifact_path = extract_and_normalize_path(artifact_uri)
         return artifact_path.split("/")[3]
 
-    def _call_endpoint(self, service, api, params=None):
+    def _call_endpoint(self, service, api, payload=None):
         """
         Calls the specified REST endpoint with the specified JSON body and path parameters.
 
         Args:
             service: The service to call.
             api: The API to call.
-            params: The request parameters.
+            payload: A dictionary representing the request payload. URL parameters for GET,
+                and body for other methods such as POST.
 
         Returns:
             The response from the REST endpoint.
         """
         db_creds = get_databricks_host_creds(self.databricks_profile_uri)
         endpoint, method = _SERVICE_AND_METHOD_TO_INFO[service][api]
-        endpoint, params = format_endpoint(endpoint, params)
+        endpoint, payload = format_endpoint(endpoint, payload)
         response_proto = api.Response()
         return call_endpoint(
-            db_creds, endpoint, method, params and json.dumps(params), response_proto
+            db_creds, endpoint, method, payload and json.dumps(payload), response_proto
         )
 
     def _get_run_artifact_root(self, run_id):

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -177,8 +177,8 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         )
 
     def _get_run_artifact_root(self, run_id):
-        params = message_to_dict(GetRun(run_id=run_id))
-        run_response = self._call_endpoint(MlflowService, GetRun, params)
+        payload = message_to_dict(GetRun(run_id=run_id))
+        run_response = self._call_endpoint(MlflowService, GetRun, payload)
         return run_response.run.info.artifact_uri
 
     def _get_credential_infos(self, request_message_class, run_id, paths):
@@ -728,10 +728,10 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         infos = []
         page_token = None
         while True:
-            params = message_to_dict(
+            payload = message_to_dict(
                 ListArtifacts(run_id=self.run_id, path=run_relative_path, page_token=page_token)
             )
-            response = self._call_endpoint(MlflowService, ListArtifacts, params)
+            response = self._call_endpoint(MlflowService, ListArtifacts, payload)
             artifact_list = response.files
             # If `path` is a file, ListArtifacts returns a single list element with the
             # same name as `path`. The list_artifacts API expects us to return an empty list in this

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -103,9 +103,8 @@ def _merge_json_dicts(from_dict, to_dict):
     return to_dict
 
 
-def message_to_json(message):
-    """Converts a message to JSON, using snake_case for field names."""
-
+def message_to_dict(message):
+    """Converts a proto message to a JSON dict, preserving int64 proto fields."""
     # Google's MessageToJson API converts int64 proto fields to JSON strings.
     # For more info, see https://github.com/protocolbuffers/protobuf/issues/2954
     json_dict_with_int64_as_str = json.loads(
@@ -117,10 +116,12 @@ def message_to_json(message):
     # By merging these two JSON dicts, we end up with a JSON dict where int64 proto fields are not
     # converted to JSON strings. Int64 keys in proto maps will always be converted to JSON strings
     # because JSON doesn't support non-string keys.
-    json_dict_with_int64_as_numbers = _merge_json_dicts(
-        json_dict_with_int64_fields_only, json_dict_with_int64_as_str
-    )
-    return json.dumps(json_dict_with_int64_as_numbers, indent=2)
+    return _merge_json_dicts(json_dict_with_int64_fields_only, json_dict_with_int64_as_str)
+
+
+def message_to_json(message):
+    """Converts a message to JSON, using snake_case for field names."""
+    return json.dumps(message_to_dict(message), indent=2)
 
 
 def _stringify_all_experiment_ids(x):

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -104,7 +104,7 @@ def _merge_json_dicts(from_dict, to_dict):
     return to_dict
 
 
-def message_to_dict(message):
+def message_to_dict(message) -> Dict[str, Any]:
     """Converts a proto message to a JSON dict, preserving int64 proto fields."""
     # Google's MessageToJson API converts int64 proto fields to JSON strings.
     # For more info, see https://github.com/protocolbuffers/protobuf/issues/2954
@@ -125,14 +125,14 @@ def message_to_json(message):
     return json.dumps(message_to_dict(message), indent=2)
 
 
-def format_endpoint(endpoint: str, params: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+def format_endpoint(endpoint: str, payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
     """
     Format the endpoint string with the given parameters.
 
     Args:
         endpoint: The endpoint string with placeholders for parameters. For example,
             "/api/2.0/mlflow/experiments/{experiment_id}".
-        params: The parameters to be formatted into the endpoint string. For example,
+        payload: The parameters to be formatted into the endpoint string. For example,
             {"experiment_id": "1", "param": "value"}.
 
     Returns:
@@ -140,12 +140,12 @@ def format_endpoint(endpoint: str, params: Dict[str, Any]) -> Tuple[str, Dict[st
     """
     replacements: Dict[str, Any] = {}
     for _, name, _, _ in string.Formatter().parse(endpoint):
-        if name in params:
-            replacements[name] = params.pop(name)
+        if name in payload:
+            replacements[name] = payload.pop(name)
     if replacements:
         endpoint = endpoint.format(**replacements)
 
-    return endpoint, params
+    return endpoint, payload
 
 
 def _stringify_all_experiment_ids(x):

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -120,7 +120,7 @@ def message_to_dict(message) -> Dict[str, Any]:
     return _merge_json_dicts(json_dict_with_int64_fields_only, json_dict_with_int64_as_str)
 
 
-def message_to_json(message):
+def message_to_json(message) -> str:
     """Converts a message to JSON, using snake_case for field names."""
     return json.dumps(message_to_dict(message), indent=2)
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -361,10 +361,12 @@ def call_endpoint(host_creds, endpoint, method, json_body, response_proto, extra
     if extra_headers is not None:
         call_kwargs["extra_headers"] = extra_headers
     if method == "GET":
-        call_kwargs["params"] = json_body
+        if json_body:
+            call_kwargs["params"] = json_body
         response = http_request(**call_kwargs)
     else:
-        call_kwargs["json"] = json_body
+        if json_body:
+            call_kwargs["json"] = json_body
         response = http_request(**call_kwargs)
 
     response = verify_rest_response(response, endpoint)

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -361,12 +361,10 @@ def call_endpoint(host_creds, endpoint, method, json_body, response_proto, extra
     if extra_headers is not None:
         call_kwargs["extra_headers"] = extra_headers
     if method == "GET":
-        if json_body:
-            call_kwargs["params"] = json_body
+        call_kwargs["params"] = json_body
         response = http_request(**call_kwargs)
     else:
-        if json_body:
-            call_kwargs["json"] = json_body
+        call_kwargs["json"] = json_body
         response = http_request(**call_kwargs)
 
     response = verify_rest_response(response, endpoint)

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1543,12 +1543,15 @@ class MockResponse:
         ArtifactCredentialType.GCP_SIGNED_URL,
     ],
 )
-def test_download_trace_data(databricks_artifact_repo, cred_type):
+def test_download_trace_data(databricks_artifact_repo, cred_type, monkeypatch):
     cred_info = ArtifactCredentialInfo(
         signed_uri=MOCK_AWS_SIGNED_URI,
         type=cred_type,
     )
     cred = GetCredentialsForTraceDataUpload.Response(credential_info=cred_info)
+
+    monkeypatch.setenv("DATABRICKS_HOST", "https://my.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token")
     with mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.call_endpoint",
         return_value=cred,

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -653,7 +653,7 @@ def test_list_artifacts_with_relative_path():
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._get_run_artifact_root",
         return_value=MOCK_RUN_ROOT_URI,
     ), mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_json", return_value=None
+        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_dict", return_value=None
     ) as message_mock:
         list_artifact_response_proto = ListArtifacts.Response(
             root_uri="", files=list_artifacts_dir_proto_mock, next_page_token=None
@@ -709,7 +709,7 @@ def test_list_artifacts_handles_pagination(databricks_artifact_repo):
         ListArtifacts.Response(root_uri="", files=list_artifacts_proto_mock_4, next_page_token="8"),
     ]
     with mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_json", return_value=None
+        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_dict", return_value=None
     ) as message_mock, mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._call_endpoint",
         side_effect=list_artifact_paginated_response_protos,
@@ -755,7 +755,7 @@ def test_get_read_credential_infos_handles_pagination(databricks_artifact_repo):
         GetCredentialsForRead.Response(credential_infos=credential_infos_mock_3),
     ]
     with mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_json"
+        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_dict"
     ) as message_mock, mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._call_endpoint",
         side_effect=get_credentials_for_read_responses,
@@ -814,7 +814,7 @@ def test_get_read_credential_infos_respects_max_request_size(databricks_artifact
     ]
 
     with mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_json"
+        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_dict"
     ) as message_mock, mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._call_endpoint",
         side_effect=[
@@ -867,7 +867,7 @@ def test_get_write_credential_infos_handles_pagination(databricks_artifact_repo)
         GetCredentialsForWrite.Response(credential_infos=credential_infos_mock_3),
     ]
     with mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_json"
+        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_dict"
     ) as message_mock, mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._call_endpoint",
         side_effect=get_credentials_for_write_responses,
@@ -921,7 +921,7 @@ def test_get_write_credential_infos_respects_max_request_size(databricks_artifac
     ]
 
     with mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_json"
+        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.message_to_dict"
     ) as message_mock, mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._call_endpoint",
         side_effect=[
@@ -1346,7 +1346,7 @@ def test_multipart_upload(
         # The upload-part requests are sent in parallel, so the order of the calls is not
         # deterministic
         assert sorted(http_request_mock.call_args_list, key=lambda c: c.args[1]) == expected_calls
-        complete_request_body = json.loads(call_endpoint_mock.call_args_list[-1].args[-1])
+        complete_request_body = call_endpoint_mock.call_args_list[-1].args[-1]
         assert complete_request_body["upload_id"] == mock_upload_id
         assert complete_request_body["part_etags"] == [
             {"part_number": 1, "etag": "etag-1"},
@@ -1439,7 +1439,7 @@ def test_multipart_upload_retry_part_upload(
         # The upload-part requests are sent in parallel, so the order of the calls is not
         # deterministic
         assert sorted(http_request_mock.call_args_list, key=lambda c: c.args[1]) == expected_calls
-        complete_request_body = json.loads(call_endpoint_mock.call_args_list[-1].args[-1])
+        complete_request_body = call_endpoint_mock.call_args_list[-1].args[-1]
         assert complete_request_body["upload_id"] == mock_upload_id
         assert complete_request_body["part_etags"] == [
             {"part_number": 1, "etag": "etag-1"},
@@ -1499,7 +1499,7 @@ def test_multipart_upload_abort(
         # The upload-part requests are sent in parallel, so the order of the calls is not
         # deterministic
         assert sorted(part_upload_calls, key=lambda c: c.args[1]) == expected_calls
-        complete_request_body = json.loads(call_endpoint_mock.call_args_list[-1].args[-1])
+        complete_request_body = call_endpoint_mock.call_args_list[-1].args[-1]
         assert complete_request_body["upload_id"] == mock_upload_id
         assert complete_request_body["part_etags"] == [
             {"part_number": 1, "etag": "etag-1"},


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13311?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13311/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13311
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR improves how to handle endpoints containing path parameters such as `/mlflow/traces/{request_id}`. Endpoints for logged-models have a similar format. This PR helps simplify https://github.com/mlflow/mlflow/pull/13263.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
