### PR TITLE
Use keyword-only arguments for optional parameters

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -694,6 +694,7 @@ class AbstractStore:
         self,
         experiment_id: str,
         name: str,
+        *,
         source_run_id: Optional[str] = None,
         tags: Optional[List[LoggedModelTag]] = None,
         params: Optional[List[LoggedModelParameter]] = None,
@@ -717,6 +718,7 @@ class AbstractStore:
 
     def search_logged_models(
         self,
+        *,
         experiment_ids: List[str],
         filter_string: Optional[str] = None,
         max_results: Optional[int] = None,

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1936,6 +1936,7 @@ class FileStore(AbstractStore):
         self,
         experiment_id: str,
         name: str,
+        *,
         source_run_id: Optional[str] = None,
         tags: Optional[List[LoggedModelTag]] = None,
         params: Optional[List[LoggedModelParameter]] = None,
@@ -2191,6 +2192,7 @@ class FileStore(AbstractStore):
 
     def search_logged_models(
         self,
+        *,
         experiment_ids: List[str],
         filter_string: Optional[str] = None,
         max_results: Optional[int] = None,

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -561,6 +561,7 @@ class RestStore(AbstractStore):
         self,
         experiment_id: str,
         name: str,
+        *,
         source_run_id: Optional[str] = None,
         tags: Optional[List[LoggedModelTag]] = None,
         params: Optional[List[LoggedModelParameter]] = None,

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -1055,6 +1055,7 @@ class TrackingServiceClient:
         self,
         experiment_id: str,
         name: str,
+        *,
         source_run_id: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
         params: Optional[Dict[str, str]] = None,
@@ -1087,6 +1088,7 @@ class TrackingServiceClient:
 
     def search_logged_models(
         self,
+        *,
         experiment_ids: List[str],
         filter_string: Optional[str] = None,
         max_results: Optional[int] = None,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -4779,6 +4779,7 @@ class MlflowClient:
         self,
         experiment_id: str,
         name: str,
+        *,
         source_run_id: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
         params: Optional[Dict[str, str]] = None,
@@ -4846,6 +4847,7 @@ class MlflowClient:
 
     def search_logged_models(
         self,
+        *,
         experiment_ids: List[str],
         filter_string: Optional[str] = None,
         max_results: Optional[int] = None,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1944,6 +1944,7 @@ def delete_experiment(experiment_id: str) -> None:
 
 def create_logged_model(
     name: str,
+    *,
     source_run_id: Optional[str] = None,
     tags: Optional[Dict[str, str]] = None,
     params: Optional[Dict[str, str]] = None,
@@ -1991,6 +1992,7 @@ def get_logged_model(model_id: str) -> LoggedModel:
 
 
 def search_logged_models(
+    *,
     experiment_ids: Optional[List[str]] = None,
     filter_string: Optional[str] = None,
     max_results: Optional[int] = None,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1089,6 +1089,7 @@ def log_params(
 def log_input(
     dataset: Optional[Dataset] = None,
     context: Optional[str] = None,
+    *,
     tags: Optional[Dict[str, str]] = None,
     model: Optional[LoggedModelInput] = None,
 ) -> None:
@@ -2037,7 +2038,7 @@ def search_logged_models(
         )
 
 
-def log_outputs(models: Optional[List[LoggedModelOutput]] = None):
+def log_outputs(models: List[LoggedModelOutput]):
     """
     Log outputs, such as models, to the active run. If there is no active run, a new run will be
     created.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13317?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13317/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13317
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Title

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
