### PR TITLE
Fix code examples with invalid syntax

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -171,7 +171,7 @@ def _iter_code_blocks(docstring: str) -> Iterator[CodeBlock]:
             if _CODE_BLOCK_HEADER_REGEX.match(line.lstrip()):
                 code_block_loc = Location(idx, _get_indent(line) + 1)
 
-    # This docstring ends with a code block
+    # The docstring ends with a code block
     if code_lines:
         code = textwrap.dedent("\n".join(code_lines))
         yield CodeBlock(code=code, loc=code_block_loc)

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import ast
 import re
+import textwrap
 import tokenize
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterator
 
 from clint.builtin import BUILTIN_MODULES
 
@@ -78,6 +80,16 @@ class Violation:
         }
 
 
+@dataclass
+class Location:
+    lineno: int
+    col_offset: int
+
+    @classmethod
+    def from_node(cls, node: ast.AST) -> "Location":
+        return cls(node.lineno, node.col_offset)
+
+
 NO_RST = Rule(
     "MLF0001",
     "no-rst",
@@ -109,6 +121,61 @@ KEYWORD_ARTIFACT_PATH = Rule(
     ),
 )
 
+SYNTAX_ERROR_EXAMPLE = Rule(
+    "MLF0006",
+    "syntax-error-example",
+    "This example has a syntax error.",
+)
+
+
+@dataclass
+class CodeBlock:
+    code: str
+    loc: Location
+
+
+def _get_indent(s: str) -> int:
+    return len(s) - len(s.lstrip())
+
+
+_CODE_BLOCK_HEADER_REGEX = re.compile(r"^\.\.\s+code-block::\s*py(thon)?")
+_CODE_BLOCK_OPTION_REGEX = re.compile(r"^:\w+:")
+
+
+def _iter_code_blocks(docstring: str) -> Iterator[CodeBlock]:
+    code_block_loc: Location | None = None
+    code_lines: list[str] = []
+
+    for idx, line in enumerate(docstring.split("\n")):
+        if code_block_loc:
+            indent = _get_indent(line)
+            # Are we still in the code block?
+            if 0 < indent <= code_block_loc.col_offset:
+                code = textwrap.dedent("\n".join(code_lines))
+                yield (CodeBlock(code=code, loc=code_block_loc))
+
+                code_block_loc = None
+                code_lines.clear()
+                continue
+
+            # .. code-block:: python
+            #     :option:           <- code block may have options
+            #     :another-option:   <-
+            #
+            #     import mlflow      <- code body starts from here
+            #     ...
+            if not _CODE_BLOCK_OPTION_REGEX.match(line.lstrip()):
+                code_lines.append(line)
+
+        else:
+            if _CODE_BLOCK_HEADER_REGEX.match(line.lstrip()):
+                code_block_loc = Location(idx, _get_indent(line) + 1)
+
+    # This docstring ends with a code block
+    if code_lines:
+        code = textwrap.dedent("\n".join(code_lines))
+        yield CodeBlock(code=code, loc=code_block_loc)
+
 
 class Linter(ast.NodeVisitor):
     def __init__(self, path: Path, ignore: dict[str, set[int]]):
@@ -117,10 +184,17 @@ class Linter(ast.NodeVisitor):
         self.ignore = ignore
         self.violations: list[Violation] = []
 
-    def _check(self, node: ast.AST, rule: Rule) -> None:
-        if (lines := self.ignore.get(rule.name)) and node.lineno in lines:
+    def _check(self, loc: Location, rule: Rule) -> None:
+        if (lines := self.ignore.get(rule.name)) and loc.lineno in lines:
             return
-        self.violations.append(Violation(rule, self.path, node.lineno, node.col_offset))
+        self.violations.append(
+            Violation(
+                rule,
+                self.path,
+                loc.lineno,
+                loc.col_offset,
+            )
+        )
 
     def _docstring(
         self, node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
@@ -147,11 +221,11 @@ class Linter(ast.NodeVisitor):
             return
 
         if node.name.startswith("test") and not node.name.startswith("test_"):
-            self._check(node, TEST_NAME_TYPO)
+            self._check(Location.from_node(node), TEST_NAME_TYPO)
 
     def _mlflow_class_name(self, node: ast.ClassDef) -> None:
         if "MLflow" in node.name or "MLFlow" in node.name:
-            self._check(node, MLFLOW_CLASS_NAME)
+            self._check(Location.from_node(node), MLFLOW_CLASS_NAME)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.stack.append(node)
@@ -160,8 +234,21 @@ class Linter(ast.NodeVisitor):
         self.generic_visit(node)
         self.stack.pop()
 
+    def _syntax_error_example(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        if docstring_node := self._docstring(node):
+            for code_block in _iter_code_blocks(docstring_node.value):
+                try:
+                    ast.parse(code_block.code)
+                except SyntaxError:
+                    loc = Location(
+                        docstring_node.lineno + code_block.loc.lineno,
+                        code_block.loc.col_offset,
+                    )
+                    self._check(loc, SYNTAX_ERROR_EXAMPLE)
+
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._test_name_typo(node)
+        self._syntax_error_example(node)
         self.stack.append(node)
         self._no_rst(node)
         self.generic_visit(node)
@@ -169,6 +256,7 @@ class Linter(ast.NodeVisitor):
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._test_name_typo(node)
+        self._syntax_error_example(node)
         self.stack.append(node)
         self._no_rst(node)
         self.generic_visit(node)
@@ -178,12 +266,12 @@ class Linter(ast.NodeVisitor):
         if self._is_in_function():
             for alias in node.names:
                 if alias.name.split(".", 1)[0] in BUILTIN_MODULES:
-                    self._check(node, LAZY_BUILTIN_IMPORT)
+                    self._check(Location.from_node(node), LAZY_BUILTIN_IMPORT)
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         if self._is_in_function() and node.module.split(".", 1)[0] in BUILTIN_MODULES:
-            self._check(node, LAZY_BUILTIN_IMPORT)
+            self._check(Location.from_node(node), LAZY_BUILTIN_IMPORT)
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
@@ -192,7 +280,7 @@ class Linter(ast.NodeVisitor):
             and _is_log_model(node.func)
             and any(arg.arg == "artifact_path" for arg in node.keywords)
         ):
-            self._check(node, KEYWORD_ARTIFACT_PATH)
+            self._check(Location.from_node(node), KEYWORD_ARTIFACT_PATH)
 
 
 def lint_file(path: Path) -> list[Violation]:

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -152,7 +152,7 @@ def _iter_code_blocks(docstring: str) -> Iterator[CodeBlock]:
             # Are we still in the code block?
             if 0 < indent <= code_block_loc.col_offset:
                 code = textwrap.dedent("\n".join(code_lines))
-                yield (CodeBlock(code=code, loc=code_block_loc))
+                yield CodeBlock(code=code, loc=code_block_loc)
 
                 code_block_loc = None
                 code_lines.clear()

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -121,6 +121,8 @@ KEYWORD_ARTIFACT_PATH = Rule(
     ),
 )
 
+# TODO: Consider dropping this rule once https://github.com/astral-sh/ruff/discussions/13622
+#       is supported.
 SYNTAX_ERROR_EXAMPLE = Rule(
     "MLF0006",
     "syntax-error-example",

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -123,9 +123,9 @@ KEYWORD_ARTIFACT_PATH = Rule(
 
 # TODO: Consider dropping this rule once https://github.com/astral-sh/ruff/discussions/13622
 #       is supported.
-SYNTAX_ERROR_EXAMPLE = Rule(
+EXAMPLE_SYNTAX_ERROR = Rule(
     "MLF0006",
-    "syntax-error-example",
+    "example-syntax-error",
     "This example has a syntax error.",
 )
 
@@ -246,7 +246,7 @@ class Linter(ast.NodeVisitor):
                         docstring_node.lineno + code_block.loc.lineno,
                         code_block.loc.col_offset,
                     )
-                    self._check(loc, SYNTAX_ERROR_EXAMPLE)
+                    self._check(loc, EXAMPLE_SYNTAX_ERROR)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._test_name_typo(node)

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -367,7 +367,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                         }
                     ],
                 },
-                route_optimized: True
+                route_optimized=True,
             )
             assert endpoint == {
                 "name": "chat",

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1606,7 +1606,7 @@ def evaluate(  # noqa: D417
 
                 with mlflow.start_run():
                     mlflow.evaluate(
-                        model=your_candidate_model,
+                        your_candidate_model,
                         data,
                         targets,
                         model_type,

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1435,11 +1435,11 @@ def evaluate(  # noqa: D417
                     return pd.DataFrame({"answer": ["bar"], "source": ["baz"]})
 
 
-                results = evaluate(model=model, data=data, predictions="answer", ...)
+                results = evaluate(model=model, data=data, predictions="answer")
 
                 # Evaluate a static dataset
                 data = pd.DataFrame({"question": ["foo"], "answer": ["bar"], "source": ["baz"]})
-                results = evaluate(data=data, predictions="answer", ...)
+                results = evaluate(data=data, predictions="answer")
 
         model_type: (Optional) A string describing the model type. The default evaluator
             supports the following model types:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1435,11 +1435,20 @@ def evaluate(  # noqa: D417
                     return pd.DataFrame({"answer": ["bar"], "source": ["baz"]})
 
 
-                results = evaluate(model=model, data=data, predictions="answer")
+                results = evaluate(
+                    model=model,
+                    data=data,
+                    predictions="answer",
+                    # other arguments if needed
+                )
 
                 # Evaluate a static dataset
                 data = pd.DataFrame({"question": ["foo"], "answer": ["bar"], "source": ["baz"]})
-                results = evaluate(data=data, predictions="answer")
+                results = evaluate(
+                    data=data,
+                    predictions="answer",
+                    # other arguments if needed
+                )
 
         model_type: (Optional) A string describing the model type. The default evaluator
             supports the following model types:

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -331,22 +331,28 @@ def _deploy(
             on the sagemaker endpoint.
             .. code-block:: python
                 :caption: Example
+
+                {
                     "AsyncInferenceConfig": {
-                        "ClientConfig": {
-                            "MaxConcurrentInvocationsPerInstance": 4
-                        },
+                        "ClientConfig": {"MaxConcurrentInvocationsPerInstance": 4},
                         "OutputConfig": {
                             "S3OutputPath": "s3://<path-to-output-bucket>",
                             "NotificationConfig": {},
                         },
                     }
+                }
+
         serverless_config: An optional dictionary specifying the serverless configuration
             .. code-block:: python
                 :caption: Example
+
+                {
                     "ServerlessConfig": {
                         "MemorySizeInMB": 2048,
                         "MaxConcurrency": 20,
                     }
+                }
+
         env: An optional dictionary of environment variables to set for the model.
         tags: An optional dictionary of tags to apply to the endpoint.
     """


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13334?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13334/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13334
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Title. Found a few broken code examples while investigating `log_model` with `artifact_path`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
