### PR TITLE
Fix spacy CI

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -254,8 +254,10 @@ fastai:
   models:
     minimum: "2.4.1"
     maximum: "2.7.17"
+    python:
+      "== dev": "3.9"
+      ">= 0.0.0": "3.9"
     requirements:
-      ">= 0.0.0": ["spacy<3.8.2"]
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
     run: |
@@ -264,8 +266,10 @@ fastai:
   autologging:
     minimum: "2.4.1"
     maximum: "2.7.17"
+    python:
+      "== dev": "3.9"
+      ">= 0.0.0": "3.9"
     requirements:
-      ">= 0.0.0": ["spacy<3.8.2"]
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
     run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -257,6 +257,9 @@ fastai:
     requirements:
       # TODO: fastai depends on spacy, but spacy>=3.8.2 requires python>=3.9
       #  Once migrating fastai tests to python 3.9, we should remove spacy<3.8.2
+      #  To migrate fastai tests to python 3.9, we need to address error
+      #  when installing old version scipy: "No module named 'distutils.msvccompiler'"
+      #  similar issue link: https://github.com/numpy/numpy/issues/27405
       "> 0.0.0": ["spacy<3.8.2"]
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -254,12 +254,9 @@ fastai:
   models:
     minimum: "2.4.1"
     maximum: "2.7.17"
-    python:
-      "== dev": "3.9"
-      ">= 0.0.0": "3.9"
     requirements:
-      # torch < 1.13 is incompatible with numpy>=2
-      "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0", "numpy<2"]
+      "> 0.0.0": ["spacy<3.8.2"]
+      "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
     run: |
       pytest tests/fastai/test_fastai_model_export.py
@@ -267,10 +264,8 @@ fastai:
   autologging:
     minimum: "2.4.1"
     maximum: "2.7.17"
-    python:
-      "== dev": "3.9"
-      ">= 0.0.0": "3.9"
     requirements:
+      "> 0.0.0": ["spacy<3.8.2"]
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
     run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -254,6 +254,9 @@ fastai:
   models:
     minimum: "2.4.1"
     maximum: "2.7.17"
+    python:
+      "== dev": "3.9"
+      ">= 0.0.0": "3.9"
     requirements:
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
@@ -263,6 +266,9 @@ fastai:
   autologging:
     minimum: "2.4.1"
     maximum: "2.7.17"
+    python:
+      "== dev": "3.9"
+      ">= 0.0.0": "3.9"
     requirements:
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
@@ -311,6 +317,7 @@ spacy:
     maximum: "3.7.5"
     python:
       "== dev": "3.9"
+      ">= 3.8.2": "3.9"
     requirements:
       ">= 0.0.0": ["scikit-learn", "click<8.1.0"]
       "<= 3.0.9": ["flask<2.1.0", "werkzeug<3"]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -254,10 +254,8 @@ fastai:
   models:
     minimum: "2.4.1"
     maximum: "2.7.17"
-    python:
-      "== dev": "3.9"
-      ">= 0.0.0": "3.9"
     requirements:
+      ">= 0.0.0": ["spacy<3.8.2"]
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
     run: |
@@ -266,10 +264,8 @@ fastai:
   autologging:
     minimum: "2.4.1"
     maximum: "2.7.17"
-    python:
-      "== dev": "3.9"
-      ">= 0.0.0": "3.9"
     requirements:
+      ">= 0.0.0": ["spacy<3.8.2"]
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
     run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -258,7 +258,8 @@ fastai:
       "== dev": "3.9"
       ">= 0.0.0": "3.9"
     requirements:
-      "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
+      # torch < 1.13 is incompatible with numpy>=2
+      "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0", "numpy<2"]
       ">= 2.8.0": ["torch", "torchvision"]
     run: |
       pytest tests/fastai/test_fastai_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -255,6 +255,8 @@ fastai:
     minimum: "2.4.1"
     maximum: "2.7.17"
     requirements:
+      # TODO: fastai depends on spacy, but spacy>=3.8.2 requires python>=3.9
+      #  Once migrating fastai tests to python 3.9, we should remove spacy<3.8.2
       "> 0.0.0": ["spacy<3.8.2"]
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -364,7 +364,8 @@ def test_pyfunc_serve_and_score(fastai_model):
     artifact_path = "model"
     with mlflow.start_run():
         model_info = mlflow.fastai.log_model(
-            model, artifact_path, input_example=inference_dataframe
+            model, artifact_path, input_example=inference_dataframe,
+            extra_pip_requirements=["spacy<3.8.2"],
         )
 
     inference_payload = load_serving_example(model_info.model_uri)

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -364,7 +364,9 @@ def test_pyfunc_serve_and_score(fastai_model):
     artifact_path = "model"
     with mlflow.start_run():
         model_info = mlflow.fastai.log_model(
-            model, artifact_path, input_example=inference_dataframe,
+            model,
+            artifact_path,
+            input_example=inference_dataframe,
             extra_pip_requirements=["spacy<3.8.2"],
         )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/13341?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13341/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13341
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix spacy CI
Spacy >=3.8.2 requires numpy >= 2.0, which doesn't support python < 3.9 now. We need to set python version to 3.9 for it

For fastai (it has spacy dependency) cross tests, migrating it to python 3.9 has other issues (https://github.com/mlflow/mlflow/actions/runs/11227490874/job/31209816918?pr=13341#step:8:173 ) I will keep running py3.8 for it. but restrict Spacy version to < 3.8.2

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
