### PR TITLE
Fix transformer CI

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -574,6 +574,7 @@ transformers:
           "protobuf<=3.20.3", # fix error `Couldn't build proto file into descriptor pool: duplicate file name sentencepiece_model.proto`
           "typing_extensions>=4.6.0", # fix error for SqlAlchemy == 2.0.25 cannot import name 'TypeAliasType' from 'typing_extensions'
           "keras<3",
+          "accelerate<1",
         ]
       # tensorflow 2.13.0 made all Keras private functions inaccessible. transformers versions
       # prior to 4.30.0 are incompatible with this breaking change in Keras.
@@ -615,6 +616,7 @@ transformers:
           "setfit",
           "optuna",
           "keras<3",
+          "accelerate<1",
         ]
       # sentence-transformers >= 2.4.0 relies on `transformers.utils.import_utils.is_nltk_available`
       # to check nltk availability. This function is only available in transformers>=4.34.0.

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -573,7 +573,6 @@ transformers:
           "sentencepiece", # required for transformers text2text generation pipeline
           "protobuf<=3.20.3", # fix error `Couldn't build proto file into descriptor pool: duplicate file name sentencepiece_model.proto`
           "typing_extensions>=4.6.0", # fix error for SqlAlchemy == 2.0.25 cannot import name 'TypeAliasType' from 'typing_extensions'
-          "keras<3",
           "accelerate<1",
         ]
       # tensorflow 2.13.0 made all Keras private functions inaccessible. transformers versions
@@ -583,6 +582,7 @@ transformers:
       # Installing `transformers==4.34.1` with `datasets` results in installing `huggingface_hub==0.17.3`.
       # `accelerate>=0.32.0` and `peft>=0.13.0` are incompatible with `huggingface_hub==0.17.3`.
       "== 4.34.1": ["accelerate<0.32.0", "peft<0.13.0"]
+      "== dev": ["tf-keras"]
     pre_test: |
       export PYTHONPATH=./
       python tests/transformers/helper.py
@@ -615,7 +615,6 @@ transformers:
           "accelerate",
           "setfit",
           "optuna",
-          "keras<3",
           "accelerate<1",
         ]
       # sentence-transformers >= 2.4.0 relies on `transformers.utils.import_utils.is_nltk_available`
@@ -628,6 +627,7 @@ transformers:
       # Installing `transformers==4.34.1` with `datasets` results in installing `huggingface_hub==0.17.3`.
       # `accelerate>=0.32.0` is incompatible with `huggingface_hub==0.17.3`.
       "== 4.34.1": ["accelerate<0.32.0", "sentence-transformers<3.1.0"]
+      "== dev": ["tf-keras"]
     run: |
       pytest tests/transformers/test_transformers_autolog.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -549,6 +549,8 @@ transformers:
   models:
     minimum: "4.25.1"
     maximum: "4.45.0"
+    python:
+      "== dev": "3.9"
     unsupported: [
         # Avoid this patch: https://github.com/huggingface/transformers/pull/29032
         "4.38.0",
@@ -590,6 +592,8 @@ transformers:
   autologging:
     minimum: "4.25.1"
     maximum: "4.45.0"
+    python:
+      "== dev": "3.9"
     unsupported: [
         # Avoid this patch: https://github.com/huggingface/transformers/pull/29032
         "4.38.0",

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -573,6 +573,7 @@ transformers:
           "sentencepiece", # required for transformers text2text generation pipeline
           "protobuf<=3.20.3", # fix error `Couldn't build proto file into descriptor pool: duplicate file name sentencepiece_model.proto`
           "typing_extensions>=4.6.0", # fix error for SqlAlchemy == 2.0.25 cannot import name 'TypeAliasType' from 'typing_extensions'
+          "keras<3",
         ]
       # tensorflow 2.13.0 made all Keras private functions inaccessible. transformers versions
       # prior to 4.30.0 are incompatible with this breaking change in Keras.
@@ -613,6 +614,7 @@ transformers:
           "accelerate",
           "setfit",
           "optuna",
+          "keras<3",
         ]
       # sentence-transformers >= 2.4.0 relies on `transformers.utils.import_utils.is_nltk_available`
       # to check nltk availability. This function is only available in transformers>=4.34.0.

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -14,6 +14,7 @@ from sentence_transformers.losses import CosineSimilarityLoss
 from setfit import SetFitModel, sample_dataset
 from setfit import Trainer as SetFitTrainer
 from setfit import TrainingArguments as SetFitTrainingArguments
+import transformers
 from transformers import (
     DistilBertForSequenceClassification,
     DistilBertTokenizerFast,
@@ -282,6 +283,7 @@ def transformers_hyperparameter_functional(tmp_path):
     )
 
 
+
 def test_setfit_does_not_autolog(setfit_trainer):
     mlflow.autolog()
 
@@ -295,6 +297,10 @@ def test_setfit_does_not_autolog(setfit_trainer):
     assert len(preds) == 3
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__).is_devrelease,
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+)
 def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     mlflow.sklearn.autolog()
 
@@ -318,6 +324,10 @@ def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     assert len(runs) == 1
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__).is_devrelease,
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+)
 def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_trainer):
     mlflow.transformers.autolog(disable=False)
 
@@ -352,6 +362,10 @@ def test_transformers_autolog_adheres_to_global_behavior_using_trainer(transform
     assert len(runs) == 1
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__).is_devrelease,
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+)
 def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog(
     iris_data, setfit_trainer
 ):
@@ -427,6 +441,10 @@ def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformer
     assert sklearn_run[0].info == logged_sklearn_data.info
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__).is_devrelease,
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+)
 def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     iris_data, setfit_trainer
 ):

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -282,8 +282,10 @@ def transformers_hyperparameter_functional(tmp_path):
         train_dataset=train_dataset,
     )
 
-
-
+@pytest.mark.skipif(
+    Version(transformers.__version__).is_devrelease,
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+)
 def test_setfit_does_not_autolog(setfit_trainer):
     mlflow.autolog()
 

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -285,7 +285,7 @@ def transformers_hyperparameter_functional(tmp_path):
 
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
+    reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
 )
 def test_setfit_does_not_autolog(setfit_trainer):
     mlflow.autolog()
@@ -302,7 +302,7 @@ def test_setfit_does_not_autolog(setfit_trainer):
 
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
+    reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
 )
 def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     mlflow.sklearn.autolog()
@@ -329,7 +329,7 @@ def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
 
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
+    reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
 )
 def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_trainer):
     mlflow.transformers.autolog(disable=False)
@@ -367,7 +367,7 @@ def test_transformers_autolog_adheres_to_global_behavior_using_trainer(transform
 
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
+    reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
 )
 def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog(
     iris_data, setfit_trainer
@@ -446,7 +446,7 @@ def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformer
 
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
+    reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
 )
 def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     iris_data, setfit_trainer

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -283,7 +283,7 @@ def transformers_hyperparameter_functional(tmp_path):
     )
 
 
-skip_transformer_dev_setfit_test = @pytest.mark.skipif(
+skip_transformer_dev_setfit_test = pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
     reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
 )

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -8,13 +8,13 @@ import sklearn
 import sklearn.cluster
 import sklearn.datasets
 import torch
+import transformers
 from datasets import load_dataset
 from packaging.version import Version
 from sentence_transformers.losses import CosineSimilarityLoss
 from setfit import SetFitModel, sample_dataset
 from setfit import Trainer as SetFitTrainer
 from setfit import TrainingArguments as SetFitTrainingArguments
-import transformers
 from transformers import (
     DistilBertForSequenceClassification,
     DistilBertTokenizerFast,
@@ -282,9 +282,10 @@ def transformers_hyperparameter_functional(tmp_path):
         train_dataset=train_dataset,
     )
 
+
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
 )
 def test_setfit_does_not_autolog(setfit_trainer):
     mlflow.autolog()
@@ -301,7 +302,7 @@ def test_setfit_does_not_autolog(setfit_trainer):
 
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
 )
 def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     mlflow.sklearn.autolog()
@@ -328,7 +329,7 @@ def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
 
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
 )
 def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_trainer):
     mlflow.transformers.autolog(disable=False)
@@ -366,7 +367,7 @@ def test_transformers_autolog_adheres_to_global_behavior_using_trainer(transform
 
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
 )
 def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog(
     iris_data, setfit_trainer
@@ -445,7 +446,7 @@ def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformer
 
 @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
-    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'"
+    reason="fails with error: 'CallbackHandler' object has no attribute 'tokenizer'",
 )
 def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     iris_data, setfit_trainer

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -283,10 +283,13 @@ def transformers_hyperparameter_functional(tmp_path):
     )
 
 
-@pytest.mark.skipif(
+skip_transformer_dev_setfit_test = @pytest.mark.skipif(
     Version(transformers.__version__).is_devrelease,
     reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
 )
+
+
+@skip_transformer_dev_setfit_test
 def test_setfit_does_not_autolog(setfit_trainer):
     mlflow.autolog()
 
@@ -300,10 +303,7 @@ def test_setfit_does_not_autolog(setfit_trainer):
     assert len(preds) == 3
 
 
-@pytest.mark.skipif(
-    Version(transformers.__version__).is_devrelease,
-    reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
-)
+@skip_transformer_dev_setfit_test
 def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     mlflow.sklearn.autolog()
 
@@ -327,10 +327,7 @@ def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     assert len(runs) == 1
 
 
-@pytest.mark.skipif(
-    Version(transformers.__version__).is_devrelease,
-    reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
-)
+@skip_transformer_dev_setfit_test
 def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_trainer):
     mlflow.transformers.autolog(disable=False)
 
@@ -365,10 +362,7 @@ def test_transformers_autolog_adheres_to_global_behavior_using_trainer(transform
     assert len(runs) == 1
 
 
-@pytest.mark.skipif(
-    Version(transformers.__version__).is_devrelease,
-    reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
-)
+@skip_transformer_dev_setfit_test
 def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog(
     iris_data, setfit_trainer
 ):
@@ -444,10 +438,7 @@ def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformer
     assert sklearn_run[0].info == logged_sklearn_data.info
 
 
-@pytest.mark.skipif(
-    Version(transformers.__version__).is_devrelease,
-    reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
-)
+@skip_transformer_dev_setfit_test
 def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     iris_data, setfit_trainer
 ):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/13342?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13342/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13342
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
* Transformer dev version doesn't support python 3.8 now. Upgrade python to 3.9.
* pin accelerator < 1 , transformer is not compatible with accelerator >=1
* skip "setfit" related tests in transformer-dev (incompatible)
* Install tf-keras with Transformer dev, Transformer dev is not compatible with keras 3 / keras 2

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
