### PR TITLE
Make DSPy wrapper compatible with single string output

### DIFF
--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -83,7 +83,15 @@ class DspyChatModelWrapper(DspyModelWrapper):
         outputs = self.model(converted_inputs)
 
         choices = []
-        if isinstance(outputs, dict):
+        if isinstance(outputs, str):
+            choices.append(
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": outputs},
+                    "finish_reason": "stop",
+                }
+            )
+        elif isinstance(outputs, dict):
             role = outputs.get("role", "assistant")
             choices.append(
                 {

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -259,7 +259,7 @@ def test_save_chat_model_with_string_output():
             return self.prog(question=inputs[0]["content"]).answer
 
     dspy_model = CoT()
-    random_answers = ["4", "6", "8", "10"]
+    random_answers = ["4", "4", "4", "4"]
     lm = dspy.utils.DummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
@@ -267,22 +267,20 @@ def test_save_chat_model_with_string_output():
 
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.dspy.log_model(
+        model_info = mlflow.dspy.log_model(
             dspy_model,
             artifact_path,
             task="llm/v1/chat",
             input_example=input_examples,
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-
-    loaded_pyfunc = mlflow.pyfunc.load_model(model_uri)
+    loaded_pyfunc = mlflow.pyfunc.load_model(model_info.model_uri)
     response = loaded_pyfunc.predict(input_examples)
 
     assert "choices" in response
     assert len(response["choices"]) == 1
     assert "message" in response["choices"][0]
     # The content should just be a string.
-    assert response["choices"][0]["message"]["content"] in random_answers
+    assert response["choices"][0]["message"]["content"] == "4"
 
 
 def test_serve_chat_model():

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -247,6 +247,44 @@ def test_serving_logged_model():
     assert "answer" in json_response["predictions"]
 
 
+def test_save_chat_model_with_string_output():
+    class CoT(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.prog = dspy.ChainOfThought("question -> answer")
+
+        def forward(self, inputs):
+            # DSPy chat model's inputs is a list of dict with keys roles (optional) and content.
+            # And here we output a single string.
+            return self.prog(question=inputs[0]["content"]).answer
+
+    dspy_model = CoT()
+    random_answers = ["4", "6", "8", "10"]
+    lm = dspy.utils.DummyLM(answers=random_answers)
+    dspy.settings.configure(lm=lm)
+
+    input_examples = {"messages": [{"role": "user", "content": "What is 2 + 2?"}]}
+
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.dspy.log_model(
+            dspy_model,
+            artifact_path,
+            task="llm/v1/chat",
+            input_example=input_examples,
+        )
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+
+    loaded_pyfunc = mlflow.pyfunc.load_model(model_uri)
+    response = loaded_pyfunc.predict(input_examples)
+
+    assert "choices" in response
+    assert len(response["choices"]) == 1
+    assert "message" in response["choices"][0]
+    # The content should just be a string.
+    assert response["choices"][0]["message"]["content"] in random_answers
+
+
 def test_serve_chat_model():
     class CoT(dspy.Module):
         def __init__(self):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/13345?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13345/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13345
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Make DSPy wrapper compatible with single string output

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
