### PR TITLE
Fix slow test

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -50,9 +50,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3]
+        group: [1, 2, 3, 4]
         include:
-          - splits: 3
+          - splits: 4
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -50,9 +50,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4]
+        group: [1, 2, 3]
         include:
-          - splits: 4
+          - splits: 3
     steps:
       - uses: actions/checkout@v4
         with:

--- a/tests/pyfunc/docker/conftest.py
+++ b/tests/pyfunc/docker/conftest.py
@@ -64,6 +64,9 @@ def save_model_with_latest_mlflow_version(flavor, extra_pip_requirements=None, *
     latest_mlflow_version = get_released_mlflow_version()
     if flavor == "langchain":
         kwargs["pip_requirements"] = [f"mlflow[gateway]=={latest_mlflow_version}", "langchain"]
+    elif flavor == "fastai":
+        import fastai
+        kwargs["pip_requirements"] = [f"mlflow[gateway]=={latest_mlflow_version}", f"fastai=={fastai.__version__}"]
     else:
         extra_pip_requirements = extra_pip_requirements or []
         extra_pip_requirements.append(f"mlflow=={latest_mlflow_version}")

--- a/tests/pyfunc/docker/conftest.py
+++ b/tests/pyfunc/docker/conftest.py
@@ -66,7 +66,15 @@ def save_model_with_latest_mlflow_version(flavor, extra_pip_requirements=None, *
         kwargs["pip_requirements"] = [f"mlflow[gateway]=={latest_mlflow_version}", "langchain"]
     elif flavor == "fastai":
         import fastai
-        kwargs["pip_requirements"] = [f"mlflow=={latest_mlflow_version}", f"fastai=={fastai.__version__}"]
+
+        # pip dependency resolution works badly with auto-inferred fastai model dependencies
+        # and it ends up with downloading many versions of toch package, and makes CI container
+        # runs out of disk space.
+        # So set `pip_requirements` explicitly as a workaround.
+        kwargs["pip_requirements"] = [
+            f"mlflow=={latest_mlflow_version}",
+            f"fastai=={fastai.__version__}",
+        ]
     else:
         extra_pip_requirements = extra_pip_requirements or []
         extra_pip_requirements.append(f"mlflow=={latest_mlflow_version}")

--- a/tests/pyfunc/docker/conftest.py
+++ b/tests/pyfunc/docker/conftest.py
@@ -66,7 +66,7 @@ def save_model_with_latest_mlflow_version(flavor, extra_pip_requirements=None, *
         kwargs["pip_requirements"] = [f"mlflow[gateway]=={latest_mlflow_version}", "langchain"]
     elif flavor == "fastai":
         import fastai
-        kwargs["pip_requirements"] = [f"mlflow[gateway]=={latest_mlflow_version}", f"fastai=={fastai.__version__}"]
+        kwargs["pip_requirements"] = [f"mlflow=={latest_mlflow_version}", f"fastai=={fastai.__version__}"]
     else:
         extra_pip_requirements = extra_pip_requirements or []
         extra_pip_requirements.append(f"mlflow=={latest_mlflow_version}")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/13351?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13351/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13351
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The logged fastai model logs dependencies like:
```
astunparse==1.6.3
cffi==1.17.1
dill==0.3.8
fastai==2.7.17
google-cloud-storage==2.18.2
matplotlib==3.9.2
numpy==1.26.4
optree==0.13.0
packaging==24.1
pandas==2.2.3
protobuf==3.20.3
psutil==5.9.8
pyyaml==6.0.2
requests==2.32.3
scikit-learn==1.5.2
scipy==1.13.1
mlflow==2.16.2
```
and when installing these dependencies in Model serving container, it triggers pip dependency resolution and downloads many torch version packages and end up with "device no space left":

https://github.com/mlflow-automation/mlflow/actions/runs/11216475800/job/31175853638#step:11:1046

Simplifying the dependency list can address this issue.

CI: https://github.com/WeichenXu123/mlflow/actions/runs/11231200514

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
