### PR TITLE
[1/x] Refactor default evaluator

### DIFF
--- a/mlflow/models/evaluation/artifacts.py
+++ b/mlflow/models/evaluation/artifacts.py
@@ -120,7 +120,6 @@ _InferredArtifactProperties = namedtuple(
     "_InferredArtifactProperties", ["from_path", "type", "ext"]
 )
 
-
 def _infer_artifact_type_and_ext(artifact_name, raw_artifact, custom_metric_tuple):
     """
     This function performs type and file extension inference on the provided artifact

--- a/mlflow/models/evaluation/artifacts.py
+++ b/mlflow/models/evaluation/artifacts.py
@@ -120,6 +120,7 @@ _InferredArtifactProperties = namedtuple(
     "_InferredArtifactProperties", ["from_path", "type", "ext"]
 )
 
+
 def _infer_artifact_type_and_ext(artifact_name, raw_artifact, custom_metric_tuple):
     """
     This function performs type and file extension inference on the provided artifact

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -902,15 +902,17 @@ def resolve_evaluators_and_configs(
         else:
             return []
 
-    elif isinstance(evaluators, list) and evaluator_config is not None:
-        if not check_nesting_config_dict(evaluators, evaluator_config):
+    elif isinstance(evaluators, list):
+        if evaluator_config is not None and not check_nesting_config_dict(
+            evaluators, evaluator_config
+        ):
             raise MlflowException(
                 message="If `evaluators` argument is an evaluator name list, evaluator_config "
                 "must be a dict contains mapping from evaluator name to individual "
                 "evaluator config dict.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-
+        evaluator_config = evaluator_config or {}
         return [
             EvaluatorBundle(name, rg.get_evaluator(name), evaluator_config.get(name, {}))
             for name in evaluators

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -871,9 +871,10 @@ def resolve_evaluators_and_configs(
         ]
         if default and non_default_builtins:
             resolved.remove(default)
-            # Apply default config (passed like `evaluator_config={"default": config}`) to non-default
-            # built-in evaluators (e.g., ClassifierEvaluator) if they don't have config. This is for
-            # backward compatibility where we only had a single "default" evaluator used for all models.
+            # Apply default config (passed like `evaluator_config={"default": config}`) to
+            # non-default built-in evaluators (e.g., ClassifierEvaluator) if they don't have
+            # explicitly specified configs. This is for backward compatibility where we only
+            # had a single "default" evaluator used for all models.
             # For example, if the user passes this for a classifier model:
             #     evaluator_config = {"default": my_config}
             # it should be equivalent to

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -786,7 +786,7 @@ def _resolve_default_evaluator(model_type, evaluator_config):
             evaluator_name != "default"
             and _model_evaluation_registry.is_builtin(evaluator_name)
             and (evaluator := _model_evaluation_registry.get_evaluator(evaluator_name))
-            and evaluator.can_evaluate(model_type=model_type, evaluator_config=evaluator_config)
+            and evaluator.can_evaluate(model_type=model_type, evaluator_config=evaluator_config or {})
         ):
             builtin_evaluators.append(evaluator_name)
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -871,7 +871,13 @@ def resolve_evaluators_and_configs(
         ]
         if default and non_default_builtins:
             resolved.remove(default)
-            # Apply default config to non-default built-in evaluators if they don't have config.
+            # Apply default config (passed like `evaluator_config={"default": config}`) to non-default
+            # built-in evaluators (e.g., ClassifierEvaluator) if they don't have config. This is for
+            # backward compatibility where we only had a single "default" evaluator used for all models.
+            # For example, if the user passes this for a classifier model:
+            #     evaluator_config = {"default": my_config}
+            # it should be equivalent to
+            #    evaluator_config = {"classifier": my_config, "shap": my_config}
             for ev in non_default_builtins:
                 ev.config = ev.config or default.config
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -204,9 +204,8 @@ class BuiltInEvaluator(ModelEvaluator):
         extra_metrics: List[EvaluationMetric],
         custom_artifacts=None,
         **kwargs,
-    ) -> EvaluationResult:
+    ) -> Optional[EvaluationResult]:
         """Implement the evaluation logic for each evaluator."""
-        raise NotImplementedError
 
     def log_metrics(self):
         """
@@ -458,7 +457,7 @@ class BuiltInEvaluator(ModelEvaluator):
         prediction: pd.Series,
         target: Optional[np.array] = None,
     ):
-        """ """
+        """Evaluate custom artifacts provided by users."""
         if not custom_artifacts:
             return
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -751,6 +751,8 @@ class BuiltInEvaluator(ModelEvaluator):
                             self.aggregate_metrics[metric_name] = agg_value
                         else:
                             self.aggregate_metrics[f"{metric_name}/{agg_name}"] = agg_value
+        print(f"{self.metrics_values}")
+        print(f"{self.aggregate_metrics}")
 
     def _add_prefix_to_metrics(self):
         def _prefix_value(value):

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -184,6 +184,7 @@ def _evaluate_custom_artifacts(custom_artifact_tuple, eval_df, builtin_metrics):
     return artifacts
 
 
+# TODO: Move this to the /evaluators directory
 class BuiltInEvaluator(ModelEvaluator):
     """
     The base class for all evaluators that are built-in to MLflow.
@@ -365,6 +366,7 @@ class BuiltInEvaluator(ModelEvaluator):
                 in the ``extra_metrics`` parameter of ``mlflow.evaluate``.
             eval_df: The evaluation dataframe containing the prediction and target columns.
             input_df: The input dataframe containing the features used to make predictions.
+            other_output_df: A dataframe containing all model output columns but the predictions.
 
         Returns:
             tuple: A tuple of (bool, list) where the bool indicates if the given metric can
@@ -526,9 +528,7 @@ class BuiltInEvaluator(ModelEvaluator):
 
         return "\n".join(l.lstrip() for l in full_message.splitlines())
 
-    def _raise_exception_for_malformed_metrics(
-            self, malformed_results, eval_df, other_output_df
-        ):
+    def _raise_exception_for_malformed_metrics(self, malformed_results, eval_df, other_output_df):
         output_columns = [] if other_output_df is None else list(other_output_df.columns)
         if self.predictions:
             output_columns.append(self.predictions)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1,62 +1,26 @@
+from abc import abstractmethod
 import copy
 import functools
 import inspect
 import json
 import logging
-import math
-import os
 import pathlib
 import pickle
 import shutil
 import tempfile
-import time
 import traceback
-import warnings
-from collections import namedtuple
-from contextlib import contextmanager
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
-
 import numpy as np
 import pandas as pd
-from packaging.version import Version
-from sklearn import metrics as sk_metrics
-from sklearn.pipeline import Pipeline as sk_Pipeline
-
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
+import warnings
+from mlflow import MlflowClient, MlflowException
 import mlflow
-from mlflow import MlflowClient
+from mlflow.data.evaluation_dataset import EvaluationDataset
 from mlflow.entities.metric import Metric
-from mlflow.environment_variables import _MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS
-from mlflow.exceptions import MlflowException
-from mlflow.metrics import (
-    EvaluationMetric,
-    MetricValue,
-    ari_grade_level,
-    exact_match,
-    flesch_kincaid_grade_level,
-    ndcg_at_k,
-    precision_at_k,
-    recall_at_k,
-    rouge1,
-    rouge2,
-    rougeL,
-    rougeLsum,
-    token_count,
-    toxicity,
-)
-from mlflow.metrics.genai.genai_metric import _GENAI_CUSTOM_METRICS_FILE_NAME
-from mlflow.models.evaluation.artifacts import (
-    CsvEvaluationArtifact,
-    ImageEvaluationArtifact,
-    JsonEvaluationArtifact,
-    NumpyEvaluationArtifact,
-    _infer_artifact_type_and_ext,
-)
-from mlflow.models.evaluation.base import (
-    EvaluationResult,
-    ModelEvaluator,
-    _ModelType,
-)
-from mlflow.models.utils import plot_lines
+from mlflow.metrics.base import MetricValue
+from mlflow.models.evaluation.artifacts import CsvEvaluationArtifact, ImageEvaluationArtifact, JsonEvaluationArtifact, NumpyEvaluationArtifact, _infer_artifact_type_and_ext
+from mlflow.models.evaluation.base import EvaluationMetric, EvaluationResult, ModelEvaluator
+from mlflow.models.evaluation.utils.metric import MetricDefinition
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.pyfunc import _ServedPyFuncModel
 from mlflow.utils.file_utils import TempDir
@@ -65,66 +29,9 @@ from mlflow.utils.time import get_current_time_millis
 
 _logger = logging.getLogger(__name__)
 
-_DEFAULT_SAMPLE_ROWS_FOR_SHAP = 2000
 _EVAL_TABLE_FILE_NAME = "eval_results_table.json"
 _TOKEN_COUNT_METRIC_NAME = "token_count"
 _LATENCY_METRIC_NAME = "latency"
-
-
-@contextmanager
-def _suppress_class_imbalance_errors(exception_type=Exception, log_warning=True):
-    """
-    Exception handler context manager to suppress Exceptions if the private environment
-    variable `_MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS` is set to `True`.
-    The purpose of this handler is to prevent an evaluation call for a binary or multiclass
-    classification automl run from aborting due to an extreme minority class imbalance
-    encountered during iterative training cycles due to the non deterministic sampling
-    behavior of Spark's DataFrame.sample() API.
-    The Exceptions caught in the usage of this are broad and are designed purely to not
-    interrupt the iterative hyperparameter tuning process. Final evaluations are done
-    in a more deterministic (but expensive) fashion.
-    """
-    try:
-        yield
-    except exception_type as e:
-        if _MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS.get():
-            if log_warning:
-                _logger.warning(
-                    "Failed to calculate metrics due to class imbalance. "
-                    "This is expected when the dataset is imbalanced."
-                )
-        else:
-            raise e
-
-
-def _is_categorical(values):
-    """
-    Infer whether input values are categorical on best effort.
-    Return True represent they are categorical, return False represent we cannot determine result.
-    """
-    dtype_name = pd.Series(values).convert_dtypes().dtype.name.lower()
-    return dtype_name in ["category", "string", "boolean"]
-
-
-def _is_continuous(values):
-    """
-    Infer whether input values is continuous on best effort.
-    Return True represent they are continous, return False represent we cannot determine result.
-    """
-    dtype_name = pd.Series(values).convert_dtypes().dtype.name.lower()
-    return dtype_name.startswith("float")
-
-
-def _infer_model_type_by_labels(labels):
-    """
-    Infer model type by target values.
-    """
-    if _is_categorical(labels):
-        return _ModelType.CLASSIFIER
-    elif _is_continuous(labels):
-        return _ModelType.REGRESSOR
-    else:
-        return None  # Unknown
 
 
 def _extract_raw_model(model):
@@ -141,11 +48,7 @@ def _extract_raw_model(model):
     else:
         return model_loader_module, None
 
-
-def _extract_predict_fn(
-    model: Any,
-    raw_model: Any,
-) -> Tuple[Optional[Callable], Optional[Callable]]:
+def _extract_predict_fn(model: Any) -> Optional[Callable]:
     """
     Extracts the predict function from the given model or raw_model.
 
@@ -158,203 +61,17 @@ def _extract_predict_fn(
         model: A model object that has a predict method.
         raw_model: A raw model object that has a predict method.
 
-    Returns:
-        A tuple of two elements:
-        - The predict function.
-        - The predict_proba function, if it exists in the raw_model; None otherwise.
+    Returns: The predict function.
     """
+    _, raw_model = _extract_raw_model(model)
     predict_fn = None
-    predict_proba_fn = None
 
     if raw_model is not None:
         predict_fn = raw_model.predict
-        predict_proba_fn = getattr(raw_model, "predict_proba", None)
-        try:
-            from mlflow.xgboost import (
-                _wrapped_xgboost_model_predict_fn,
-                _wrapped_xgboost_model_predict_proba_fn,
-            )
-
-            # Because shap evaluation will pass evaluation data in ndarray format
-            # (without feature names), if set validate_features=True it will raise error.
-            predict_fn = _wrapped_xgboost_model_predict_fn(raw_model, validate_features=False)
-            predict_proba_fn = _wrapped_xgboost_model_predict_proba_fn(
-                raw_model, validate_features=False
-            )
-        except ImportError:
-            pass
     elif model is not None:
         predict_fn = model.predict
 
-    return predict_fn, predict_proba_fn
-
-
-def _restrict_langchain_autologging_to_traces_only(pred_fn):
-    if pred_fn is None:
-        return None
-
-    # In non-langchain environments, nothing would be autologged.
-    @functools.wraps(pred_fn)
-    def new_pred_fn(*args, **kwargs):
-        with mlflow.utils.autologging_utils.restrict_langchain_autologging_to_traces_only():
-            return pred_fn(*args, **kwargs)
-
-    return new_pred_fn
-
-
-def _get_regressor_metrics(y, y_pred, sample_weights):
-    sum_on_target = (
-        (np.array(y) * np.array(sample_weights)).sum() if sample_weights is not None else sum(y)
-    )
-    return {
-        "example_count": len(y),
-        "mean_absolute_error": sk_metrics.mean_absolute_error(
-            y, y_pred, sample_weight=sample_weights
-        ),
-        "mean_squared_error": sk_metrics.mean_squared_error(
-            y, y_pred, sample_weight=sample_weights
-        ),
-        "root_mean_squared_error": sk_metrics.mean_squared_error(
-            y, y_pred, sample_weight=sample_weights, squared=False
-        ),
-        "sum_on_target": sum_on_target,
-        "mean_on_target": sum_on_target / len(y),
-        "r2_score": sk_metrics.r2_score(y, y_pred, sample_weight=sample_weights),
-        "max_error": sk_metrics.max_error(y, y_pred),
-        "mean_absolute_percentage_error": sk_metrics.mean_absolute_percentage_error(
-            y, y_pred, sample_weight=sample_weights
-        ),
-    }
-
-
-def _get_binary_sum_up_label_pred_prob(positive_class_index, positive_class, y, y_pred, y_probs):
-    y = np.array(y)
-    y_bin = np.where(y == positive_class, 1, 0)
-    y_pred_bin = None
-    y_prob_bin = None
-    if y_pred is not None:
-        y_pred = np.array(y_pred)
-        y_pred_bin = np.where(y_pred == positive_class, 1, 0)
-
-    if y_probs is not None:
-        y_probs = np.array(y_probs)
-        y_prob_bin = y_probs[:, positive_class_index]
-
-    return y_bin, y_pred_bin, y_prob_bin
-
-
-def _get_common_classifier_metrics(
-    *, y_true, y_pred, y_proba, labels, average, pos_label, sample_weights
-):
-    metrics = {
-        "example_count": len(y_true),
-        "accuracy_score": sk_metrics.accuracy_score(y_true, y_pred, sample_weight=sample_weights),
-        "recall_score": sk_metrics.recall_score(
-            y_true,
-            y_pred,
-            average=average,
-            pos_label=pos_label,
-            sample_weight=sample_weights,
-        ),
-        "precision_score": sk_metrics.precision_score(
-            y_true,
-            y_pred,
-            average=average,
-            pos_label=pos_label,
-            sample_weight=sample_weights,
-        ),
-        "f1_score": sk_metrics.f1_score(
-            y_true,
-            y_pred,
-            average=average,
-            pos_label=pos_label,
-            sample_weight=sample_weights,
-        ),
-    }
-
-    if y_proba is not None:
-        with _suppress_class_imbalance_errors(ValueError):
-            metrics["log_loss"] = sk_metrics.log_loss(
-                y_true, y_proba, labels=labels, sample_weight=sample_weights
-            )
-    return metrics
-
-
-def _get_binary_classifier_metrics(
-    *, y_true, y_pred, y_proba=None, labels=None, pos_label=1, sample_weights=None
-):
-    with _suppress_class_imbalance_errors(ValueError):
-        tn, fp, fn, tp = sk_metrics.confusion_matrix(y_true, y_pred).ravel()
-        return {
-            "true_negatives": tn,
-            "false_positives": fp,
-            "false_negatives": fn,
-            "true_positives": tp,
-            **_get_common_classifier_metrics(
-                y_true=y_true,
-                y_pred=y_pred,
-                y_proba=y_proba,
-                labels=labels,
-                average="binary",
-                pos_label=pos_label,
-                sample_weights=sample_weights,
-            ),
-        }
-
-
-def _get_multiclass_classifier_metrics(
-    *,
-    y_true,
-    y_pred,
-    y_proba=None,
-    labels=None,
-    average="weighted",
-    sample_weights=None,
-):
-    metrics = _get_common_classifier_metrics(
-        y_true=y_true,
-        y_pred=y_pred,
-        y_proba=y_proba,
-        labels=labels,
-        average=average,
-        pos_label=None,
-        sample_weights=sample_weights,
-    )
-    if average in ("macro", "weighted") and y_proba is not None:
-        metrics.update(
-            roc_auc=sk_metrics.roc_auc_score(
-                y_true=y_true,
-                y_score=y_proba,
-                sample_weight=sample_weights,
-                average=average,
-                multi_class="ovr",
-            )
-        )
-    return metrics
-
-
-def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels, sample_weights):
-    per_class_metrics_list = []
-    for positive_class_index, positive_class in enumerate(labels):
-        (
-            y_bin,
-            y_pred_bin,
-            _,
-        ) = _get_binary_sum_up_label_pred_prob(
-            positive_class_index, positive_class, y, y_pred, None
-        )
-        per_class_metrics = {"positive_class": positive_class}
-        binary_classifier_metrics = _get_binary_classifier_metrics(
-            y_true=y_bin,
-            y_pred=y_pred_bin,
-            pos_label=1,
-            sample_weights=sample_weights,
-        )
-        if binary_classifier_metrics:
-            per_class_metrics.update(binary_classifier_metrics)
-        per_class_metrics_list.append(per_class_metrics)
-
-    return pd.DataFrame(per_class_metrics_list)
+    return predict_fn
 
 
 def _get_dataframe_with_renamed_columns(x, new_column_names):
@@ -377,139 +94,6 @@ def _get_dataframe_with_renamed_columns(x, new_column_names):
     return df.rename(columns=dict(zip(df.columns, new_column_names)))
 
 
-_Curve = namedtuple("_Curve", ["plot_fn", "plot_fn_args", "auc"])
-
-
-def _gen_classifier_curve(
-    is_binomial,
-    y,
-    y_probs,
-    labels,
-    pos_label,
-    curve_type,
-    sample_weights,
-):
-    """
-    Generate precision-recall curve or ROC curve for classifier.
-
-    Args:
-        is_binomial: True if it is binary classifier otherwise False
-        y: True label values
-        y_probs: if binary classifier, the predicted probability for positive class.
-                  if multiclass classifier, the predicted probabilities for all classes.
-        labels: The set of labels.
-        pos_label: The label of the positive class.
-        curve_type: "pr" or "roc"
-        sample_weights: Optional sample weights.
-
-    Returns:
-        An instance of "_Curve" which includes attributes "plot_fn", "plot_fn_args", "auc".
-    """
-    if curve_type == "roc":
-
-        def gen_line_x_y_label_auc(_y, _y_prob, _pos_label):
-            fpr, tpr, _ = sk_metrics.roc_curve(
-                _y,
-                _y_prob,
-                sample_weight=sample_weights,
-                # For multiclass classification where a one-vs-rest ROC curve is produced for each
-                # class, the positive label is binarized and should not be included in the plot
-                # legend
-                pos_label=_pos_label if _pos_label == pos_label else None,
-            )
-
-            auc = sk_metrics.roc_auc_score(y_true=_y, y_score=_y_prob, sample_weight=sample_weights)
-            return fpr, tpr, f"AUC={auc:.3f}", auc
-
-        xlabel = "False Positive Rate"
-        ylabel = "True Positive Rate"
-        title = "ROC curve"
-        if pos_label:
-            xlabel = f"False Positive Rate (Positive label: {pos_label})"
-            ylabel = f"True Positive Rate (Positive label: {pos_label})"
-    elif curve_type == "pr":
-
-        def gen_line_x_y_label_auc(_y, _y_prob, _pos_label):
-            precision, recall, _ = sk_metrics.precision_recall_curve(
-                _y,
-                _y_prob,
-                sample_weight=sample_weights,
-                # For multiclass classification where a one-vs-rest precision-recall curve is
-                # produced for each class, the positive label is binarized and should not be
-                # included in the plot legend
-                pos_label=_pos_label if _pos_label == pos_label else None,
-            )
-            # NB: We return average precision score (AP) instead of AUC because AP is more
-            # appropriate for summarizing a precision-recall curve
-            ap = sk_metrics.average_precision_score(
-                y_true=_y, y_score=_y_prob, pos_label=_pos_label, sample_weight=sample_weights
-            )
-            return recall, precision, f"AP={ap:.3f}", ap
-
-        xlabel = "Recall"
-        ylabel = "Precision"
-        title = "Precision recall curve"
-        if pos_label:
-            xlabel = f"Recall (Positive label: {pos_label})"
-            ylabel = f"Precision (Positive label: {pos_label})"
-    else:
-        assert False, "illegal curve type"
-
-    if is_binomial:
-        x_data, y_data, line_label, auc = gen_line_x_y_label_auc(y, y_probs, pos_label)
-        data_series = [(line_label, x_data, y_data)]
-    else:
-        curve_list = []
-        for positive_class_index, positive_class in enumerate(labels):
-            y_bin, _, y_prob_bin = _get_binary_sum_up_label_pred_prob(
-                positive_class_index, positive_class, y, labels, y_probs
-            )
-
-            x_data, y_data, line_label, auc = gen_line_x_y_label_auc(
-                y_bin, y_prob_bin, _pos_label=1
-            )
-            curve_list.append((positive_class, x_data, y_data, line_label, auc))
-
-        data_series = [
-            (f"label={positive_class},{line_label}", x_data, y_data)
-            for positive_class, x_data, y_data, line_label, _ in curve_list
-        ]
-        auc = [auc for _, _, _, _, auc in curve_list]
-
-    def _do_plot(**kwargs):
-        from matplotlib import pyplot
-
-        _, ax = plot_lines(**kwargs)
-        dash_line_args = {
-            "color": "gray",
-            "alpha": 0.3,
-            "drawstyle": "default",
-            "linestyle": "dashed",
-        }
-        if curve_type == "pr":
-            ax.plot([0, 1], [1, 0], **dash_line_args)
-        elif curve_type == "roc":
-            ax.plot([0, 1], [0, 1], **dash_line_args)
-
-        if is_binomial:
-            ax.legend(loc="best")
-        else:
-            ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-            pyplot.subplots_adjust(right=0.6, bottom=0.25)
-
-    return _Curve(
-        plot_fn=_do_plot,
-        plot_fn_args={
-            "data_series": data_series,
-            "xlabel": xlabel,
-            "ylabel": ylabel,
-            "line_kwargs": {"drawstyle": "steps-post", "linewidth": 1},
-            "title": title,
-        },
-        auc=auc,
-    )
-
-
 def _get_aggregate_metrics_values(metrics):
     return {name: MetricValue(aggregate_results={name: value}) for name, value in metrics.items()}
 
@@ -520,106 +104,6 @@ _matplotlib_config = {
     "figure.autolayout": True,
     "font.size": 8,
 }
-
-
-def _extract_output_and_other_columns(model_predictions, output_column_name):
-    y_pred = None
-    other_output_columns = None
-    ERROR_MISSING_OUTPUT_COLUMN_NAME = (
-        "Output column name is not specified for the multi-output model. "
-        "Please set the correct output column name using the `predictions` parameter."
-    )
-
-    if isinstance(model_predictions, list) and all(isinstance(p, dict) for p in model_predictions):
-        # Extract 'y_pred' and 'other_output_columns' from list of dictionaries
-        if output_column_name in model_predictions[0]:
-            y_pred = pd.Series(
-                [p.get(output_column_name) for p in model_predictions], name=output_column_name
-            )
-            other_output_columns = pd.DataFrame(
-                [{k: v for k, v in p.items() if k != output_column_name} for p in model_predictions]
-            )
-        elif len(model_predictions[0]) == 1:
-            # Set the only key as self.predictions and its value as self.y_pred
-            key, value = list(model_predictions[0].items())[0]
-            y_pred = pd.Series(value, name=key)
-            output_column_name = key
-        elif output_column_name is None:
-            raise MlflowException(
-                ERROR_MISSING_OUTPUT_COLUMN_NAME,
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-        else:
-            raise MlflowException(
-                f"Output column name '{output_column_name}' is not found in the model "
-                f"predictions list: {model_predictions}. Please set the correct output column "
-                "name using the `predictions` parameter.",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-    elif isinstance(model_predictions, pd.DataFrame):
-        if output_column_name in model_predictions.columns:
-            y_pred = model_predictions[output_column_name]
-            other_output_columns = model_predictions.drop(columns=output_column_name)
-        elif len(model_predictions.columns) == 1:
-            output_column_name = model_predictions.columns[0]
-            y_pred = model_predictions[output_column_name]
-        elif output_column_name is None:
-            raise MlflowException(
-                ERROR_MISSING_OUTPUT_COLUMN_NAME,
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-        else:
-            raise MlflowException(
-                f"Output column name '{output_column_name}' is not found in the model "
-                f"predictions dataframe {model_predictions.columns}. Please set the correct "
-                "output column name using the `predictions` parameter.",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-    elif isinstance(model_predictions, dict):
-        if output_column_name in model_predictions:
-            y_pred = pd.Series(model_predictions[output_column_name], name=output_column_name)
-            other_output_columns = pd.DataFrame(
-                {k: v for k, v in model_predictions.items() if k != output_column_name}
-            )
-        elif len(model_predictions) == 1:
-            key, value = list(model_predictions.items())[0]
-            y_pred = pd.Series(value, name=key)
-            output_column_name = key
-        elif output_column_name is None:
-            raise MlflowException(
-                ERROR_MISSING_OUTPUT_COLUMN_NAME,
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-        else:
-            raise MlflowException(
-                f"Output column name '{output_column_name}' is not found in the "
-                f"model predictions dict {model_predictions}. Please set the correct "
-                "output column name using the `predictions` parameter.",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-
-    return (
-        y_pred if y_pred is not None else model_predictions,
-        other_output_columns,
-        output_column_name,
-    )
-
-
-class _Metric(NamedTuple):
-    """
-    A namedtuple representing a metric function and its properties.
-
-    function : the metric function
-    name : the name of the metric function
-    index : the index of the function in the ``extra_metrics`` argument of mlflow.evaluate
-    """
-
-    function: Callable
-    name: str
-    index: int
-    version: Optional[str] = None
-    genai_metric_args: Optional[Dict] = None
-
 
 class _CustomArtifact(NamedTuple):
     """
@@ -635,95 +119,6 @@ class _CustomArtifact(NamedTuple):
     name: str
     index: int
     artifacts_dir: str
-
-
-def _is_numeric(value):
-    return isinstance(value, (int, float, np.number))
-
-
-def _is_string(value):
-    return isinstance(value, str)
-
-
-def _evaluate_metric(metric_tuple, eval_fn_args):
-    """
-    This function calls the metric function and performs validations on the returned
-    result to ensure that they are in the expected format. It will warn and will not log metrics
-    that are in the wrong format.
-
-    Args:
-        metric_tuple: Containing a user provided function and its index in the
-            ``extra_metrics`` parameter of ``mlflow.evaluate``
-        eval_fn_args: A dictionary of args needed to compute the eval metrics.
-
-    Returns:
-        MetricValue
-    """
-    if metric_tuple.index < 0:
-        exception_header = f"Did not log builtin metric '{metric_tuple.name}' because it"
-    else:
-        exception_header = (
-            f"Did not log metric '{metric_tuple.name}' at index "
-            f"{metric_tuple.index} in the `extra_metrics` parameter because it"
-        )
-
-    metric = metric_tuple.function(*eval_fn_args)
-
-    if metric is None:
-        _logger.warning(f"{exception_header} returned None.")
-        return
-
-    if _is_numeric(metric):
-        return MetricValue(aggregate_results={metric_tuple.name: metric})
-
-    if not isinstance(metric, MetricValue):
-        _logger.warning(f"{exception_header} did not return a MetricValue.")
-        return
-
-    scores = metric.scores
-    justifications = metric.justifications
-    aggregates = metric.aggregate_results
-
-    if scores is not None:
-        if not isinstance(scores, list):
-            _logger.warning(f"{exception_header} must return MetricValue with scores as a list.")
-            return
-        if any(not (_is_numeric(score) or _is_string(score) or score is None) for score in scores):
-            _logger.warning(
-                f"{exception_header} must return MetricValue with numeric or string scores."
-            )
-            return
-
-    if justifications is not None:
-        if not isinstance(justifications, list):
-            _logger.warning(
-                f"{exception_header} must return MetricValue with justifications as a list."
-            )
-            return
-        if any(not (_is_string(jus) or jus is None) for jus in justifications):
-            _logger.warning(
-                f"{exception_header} must return MetricValue with string justifications."
-            )
-            return
-
-    if aggregates is not None:
-        if not isinstance(aggregates, dict):
-            _logger.warning(
-                f"{exception_header} must return MetricValue with aggregate_results as a dict."
-            )
-            return
-
-        if any(
-            not (isinstance(k, str) and (_is_numeric(v) or v is None))
-            for k, v in aggregates.items()
-        ):
-            _logger.warning(
-                f"{exception_header} must return MetricValue with aggregate_results with "
-                "str keys and numeric values."
-            )
-            return
-
-    return metric
 
 
 def _is_valid_artifacts(artifacts):
@@ -768,40 +163,37 @@ def _evaluate_custom_artifacts(custom_artifact_tuple, eval_df, builtin_metrics):
     return artifacts
 
 
-def _compute_df_mode_or_mean(df):
+
+class BuiltInEvaluator(ModelEvaluator):
     """
-    Compute mean (for continuous columns) and compute mode (for other columns) for the
-    input dataframe, return a dict, key is column name, value is the corresponding mode or
-    mean value, this function calls `_is_continuous` to determine whether the
-    column is continuous column.
+    The base class for all evaluators that are built-in to MLflow.
+
+    Each evaluator is responsible for implementing the `_evaluate()` method, which is called by the
+    `evaluate()` method of this class. This class contains many helper methods that are used commonly
+    across all evaluators, such as logging metrics, logging artifacts, and ordering metrics.
     """
-    continuous_cols = [c for c in df.columns if _is_continuous(df[c])]
-    df_cont = df[continuous_cols]
-    df_non_cont = df.drop(continuous_cols, axis=1)
-
-    means = {} if df_cont.empty else df_cont.mean().to_dict()
-    modes = {} if df_non_cont.empty else df_non_cont.mode().loc[0].to_dict()
-    return {**means, **modes}
-
-
-_SUPPORTED_SHAP_ALGORITHMS = ("exact", "permutation", "partition", "kernel")
-
-
-def _shap_predict_fn(x, predict_fn, feature_names):
-    return predict_fn(_get_dataframe_with_renamed_columns(x, feature_names))
-
-
-class DefaultEvaluator(ModelEvaluator):
     def __init__(self):
         self.client = MlflowClient()
 
-    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
-        return model_type in _ModelType.values() or model_type is None
 
-    def _log_metrics(self):
+    @abstractmethod
+    def _evaluate(
+        self,
+        model: Optional["mlflow.pyfunc.PyFuncModel"],
+        extra_metrics: List[EvaluationMetric],
+        custom_artifacts = None,
+        **kwargs,
+    ) -> EvaluationResult:
+        """Implement the evaluation logic for each evaluator."""
+        raise NotImplementedError
+
+
+    def log_metrics(self):
         """
         Helper method to log metrics into specified run.
         """
+        self._add_prefix_to_metrics()
+
         timestamp = get_current_time_millis()
         self.client.log_batch(
             self.run_id,
@@ -839,236 +231,12 @@ class DefaultEvaluator(ModelEvaluator):
         artifact._load(artifact_file_local_path)
         self.artifacts[artifact_name] = artifact
 
-    def _log_pandas_df_artifact(self, pandas_df, artifact_name):
-        artifact_file_name = f"{artifact_name}.csv"
-        artifact_file_local_path = self.temp_dir.path(artifact_file_name)
-        pandas_df.to_csv(artifact_file_local_path, index=False)
-        mlflow.log_artifact(artifact_file_local_path)
-        artifact = CsvEvaluationArtifact(
-            uri=mlflow.get_artifact_uri(artifact_file_name),
-            content=pandas_df,
-        )
-        artifact._load(artifact_file_local_path)
-        self.artifacts[artifact_name] = artifact
-
-    def _log_model_explainability(self):
-        if not self.evaluator_config.get("log_model_explainability", True):
-            return
-
-        if self.is_model_server and not self.evaluator_config.get(
-            "log_model_explainability", False
-        ):
-            _logger.warning(
-                "Skipping model explainability because a model server is used for environment "
-                "restoration."
-            )
-            return
-
-        if self.model_loader_module == "mlflow.spark":
-            # TODO: Shap explainer need to manipulate on each feature values,
-            #  but spark model input dataframe contains Vector type feature column
-            #  which shap explainer does not support.
-            #  To support this, we need expand the Vector type feature column into
-            #  multiple scalar feature columns and pass it to shap explainer.
-            _logger.warning(
-                "Logging model explainability insights is not currently supported for PySpark "
-                "models."
-            )
-            return
-
-        if not (np.issubdtype(self.y.dtype, np.number) or self.y.dtype == np.bool_):
-            # Note: python bool type inherits number type but np.bool_ does not inherit np.number.
-            _logger.warning(
-                "Skip logging model explainability insights because it requires all label "
-                "values to be numeric or boolean."
-            )
-            return
-
-        algorithm = self.evaluator_config.get("explainability_algorithm", None)
-        if algorithm is not None and algorithm not in _SUPPORTED_SHAP_ALGORITHMS:
-            raise MlflowException(
-                message=f"Specified explainer algorithm {algorithm} is unsupported. Currently only "
-                f"support {','.join(_SUPPORTED_SHAP_ALGORITHMS)} algorithms.",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-
-        if algorithm != "kernel":
-            feature_dtypes = list(self.X.get_original().dtypes)
-            for feature_dtype in feature_dtypes:
-                if not np.issubdtype(feature_dtype, np.number):
-                    _logger.warning(
-                        "Skip logging model explainability insights because the shap explainer "
-                        f"{algorithm} requires all feature values to be numeric, and each feature "
-                        "column must only contain scalar values."
-                    )
-                    return
-
-        try:
-            import shap
-            from matplotlib import pyplot
-        except ImportError:
-            _logger.warning(
-                "SHAP or matplotlib package is not installed, so model explainability insights "
-                "will not be logged."
-            )
-            return
-
-        if Version(shap.__version__) < Version("0.40"):
-            _logger.warning(
-                "Shap package version is lower than 0.40, Skip log model explainability."
-            )
-            return
-
-        is_multinomial_classifier = (
-            self.model_type == _ModelType.CLASSIFIER and self.num_classes > 2
-        )
-
-        sample_rows = self.evaluator_config.get(
-            "explainability_nsamples", _DEFAULT_SAMPLE_ROWS_FOR_SHAP
-        )
-
-        X_df = self.X.copy_to_avoid_mutation()
-
-        sampled_X = shap.sample(X_df, sample_rows, random_state=0)
-
-        mode_or_mean_dict = _compute_df_mode_or_mean(X_df)
-        sampled_X = sampled_X.fillna(mode_or_mean_dict)
-
-        # shap explainer might call provided `predict_fn` with a `numpy.ndarray` type
-        # argument, this might break some model inference, so convert the argument into
-        # a pandas dataframe.
-        # The `shap_predict_fn` calls model's predict function, we need to restore the input
-        # dataframe with original column names, because some model prediction routine uses
-        # the column name.
-
-        shap_predict_fn = functools.partial(
-            _shap_predict_fn, predict_fn=self.predict_fn, feature_names=self.feature_names
-        )
-
-        try:
-            if algorithm:
-                if algorithm == "kernel":
-                    # We need to lazily import shap, so lazily import `_PatchedKernelExplainer`
-                    from mlflow.models.evaluation._shap_patch import _PatchedKernelExplainer
-
-                    kernel_link = self.evaluator_config.get(
-                        "explainability_kernel_link", "identity"
-                    )
-                    if kernel_link not in ["identity", "logit"]:
-                        raise ValueError(
-                            "explainability_kernel_link config can only be set to 'identity' or "
-                            f"'logit', but got '{kernel_link}'."
-                        )
-                    background_X = shap.sample(X_df, sample_rows, random_state=3)
-                    background_X = background_X.fillna(mode_or_mean_dict)
-
-                    explainer = _PatchedKernelExplainer(
-                        shap_predict_fn, background_X, link=kernel_link
-                    )
-                else:
-                    explainer = shap.Explainer(
-                        shap_predict_fn,
-                        sampled_X,
-                        feature_names=self.feature_names,
-                        algorithm=algorithm,
-                    )
-            else:
-                if (
-                    self.raw_model
-                    and not is_multinomial_classifier
-                    and not isinstance(self.raw_model, sk_Pipeline)
-                ):
-                    # For mulitnomial classifier, shap.Explainer may choose Tree/Linear explainer
-                    # for raw model, this case shap plot doesn't support it well, so exclude the
-                    # multinomial_classifier case here.
-                    explainer = shap.Explainer(
-                        self.raw_model, sampled_X, feature_names=self.feature_names
-                    )
-                else:
-                    # fallback to default explainer
-                    explainer = shap.Explainer(
-                        shap_predict_fn, sampled_X, feature_names=self.feature_names
-                    )
-
-            _logger.info(f"Shap explainer {explainer.__class__.__name__} is used.")
-
-            if algorithm == "kernel":
-                shap_values = shap.Explanation(
-                    explainer.shap_values(sampled_X), feature_names=self.feature_names
-                )
-            else:
-                shap_values = explainer(sampled_X)
-        except Exception as e:
-            # Shap evaluation might fail on some edge cases, e.g., unsupported input data values
-            # or unsupported model on specific shap explainer. Catch exception to prevent it
-            # breaking the whole `evaluate` function.
-
-            if not self.evaluator_config.get("ignore_exceptions", True):
-                raise e
-
-            _logger.warning(
-                f"Shap evaluation failed. Reason: {e!r}. "
-                "Set logging level to DEBUG to see the full traceback."
-            )
-            _logger.debug("", exc_info=True)
-            return
-        try:
-            mlflow.shap.log_explainer(explainer, artifact_path="explainer")
-        except Exception as e:
-            # TODO: The explainer saver is buggy, if `get_underlying_model_flavor` return "unknown",
-            #   then fallback to shap explainer saver, and shap explainer will call `model.save`
-            #   for sklearn model, there is no `.save` method, so error will happen.
-            _logger.warning(
-                f"Logging explainer failed. Reason: {e!r}. "
-                "Set logging level to DEBUG to see the full traceback."
-            )
-            _logger.debug("", exc_info=True)
-
-        def _adjust_color_bar():
-            pyplot.gcf().axes[-1].set_aspect("auto")
-            pyplot.gcf().axes[-1].set_box_aspect(50)
-
-        def _adjust_axis_tick():
-            pyplot.xticks(fontsize=10)
-            pyplot.yticks(fontsize=10)
-
-        def plot_beeswarm():
-            shap.plots.beeswarm(shap_values, show=False, color_bar=True)
-            _adjust_color_bar()
-            _adjust_axis_tick()
-
-        with _suppress_class_imbalance_errors(ValueError, log_warning=False):
-            self._log_image_artifact(
-                plot_beeswarm,
-                "shap_beeswarm_plot",
-            )
-
-        def plot_summary():
-            shap.summary_plot(shap_values, show=False, color_bar=True)
-            _adjust_color_bar()
-            _adjust_axis_tick()
-
-        with _suppress_class_imbalance_errors(TypeError, log_warning=False):
-            self._log_image_artifact(
-                plot_summary,
-                "shap_summary_plot",
-            )
-
-        def plot_feature_importance():
-            shap.plots.bar(shap_values, show=False)
-            _adjust_axis_tick()
-
-        with _suppress_class_imbalance_errors(IndexError, log_warning=False):
-            self._log_image_artifact(
-                plot_feature_importance,
-                "shap_feature_importance_plot",
-            )
-
-    def _evaluate_sklearn_model_score_if_scorable(self):
-        if self.model_loader_module == "mlflow.sklearn" and self.raw_model is not None:
+    def _evaluate_sklearn_model_score_if_scorable(self, model, y_true, sample_weights):
+        model_loader_module, raw_model = _extract_raw_model(model)
+        if model_loader_module == "mlflow.sklearn" and raw_model is not None:
             try:
-                score = self.raw_model.score(
-                    self.X.copy_to_avoid_mutation(), self.y, sample_weight=self.sample_weights
+                score = raw_model.score(
+                    self.X.copy_to_avoid_mutation(), y_true, sample_weight=sample_weights
                 )
                 self.metrics_values.update(_get_aggregate_metrics_values({"score": score}))
             except Exception as e:
@@ -1077,123 +245,6 @@ class DefaultEvaluator(ModelEvaluator):
                     "DEBUG to see the full traceback."
                 )
                 _logger.debug("", exc_info=True)
-
-    def _compute_roc_and_pr_curve(self):
-        if self.y_probs is not None:
-            with _suppress_class_imbalance_errors(ValueError, log_warning=False):
-                self.roc_curve = _gen_classifier_curve(
-                    is_binomial=True,
-                    y=self.y,
-                    y_probs=self.y_probs[:, 1],
-                    labels=self.label_list,
-                    pos_label=self.pos_label,
-                    curve_type="roc",
-                    sample_weights=self.sample_weights,
-                )
-
-                self.metrics_values.update(
-                    _get_aggregate_metrics_values({"roc_auc": self.roc_curve.auc})
-                )
-            with _suppress_class_imbalance_errors(ValueError, log_warning=False):
-                self.pr_curve = _gen_classifier_curve(
-                    is_binomial=True,
-                    y=self.y,
-                    y_probs=self.y_probs[:, 1],
-                    labels=self.label_list,
-                    pos_label=self.pos_label,
-                    curve_type="pr",
-                    sample_weights=self.sample_weights,
-                )
-
-                self.metrics_values.update(
-                    _get_aggregate_metrics_values({"precision_recall_auc": self.pr_curve.auc})
-                )
-
-    def _log_multiclass_classifier_artifacts(self):
-        per_class_metrics_collection_df = _get_classifier_per_class_metrics_collection_df(
-            self.y,
-            self.y_pred,
-            labels=self.label_list,
-            sample_weights=self.sample_weights,
-        )
-
-        log_roc_pr_curve = False
-        if self.y_probs is not None:
-            max_classes_for_multiclass_roc_pr = self.evaluator_config.get(
-                "max_classes_for_multiclass_roc_pr", 10
-            )
-            if self.num_classes <= max_classes_for_multiclass_roc_pr:
-                log_roc_pr_curve = True
-            else:
-                _logger.warning(
-                    f"The classifier num_classes > {max_classes_for_multiclass_roc_pr}, skip "
-                    f"logging ROC curve and Precision-Recall curve. You can add evaluator config "
-                    f"'max_classes_for_multiclass_roc_pr' to increase the threshold."
-                )
-
-        if log_roc_pr_curve:
-            roc_curve = _gen_classifier_curve(
-                is_binomial=False,
-                y=self.y,
-                y_probs=self.y_probs,
-                labels=self.label_list,
-                pos_label=self.pos_label,
-                curve_type="roc",
-                sample_weights=self.sample_weights,
-            )
-
-            def plot_roc_curve():
-                roc_curve.plot_fn(**roc_curve.plot_fn_args)
-
-            self._log_image_artifact(plot_roc_curve, "roc_curve_plot")
-            per_class_metrics_collection_df["roc_auc"] = roc_curve.auc
-
-            pr_curve = _gen_classifier_curve(
-                is_binomial=False,
-                y=self.y,
-                y_probs=self.y_probs,
-                labels=self.label_list,
-                pos_label=self.pos_label,
-                curve_type="pr",
-                sample_weights=self.sample_weights,
-            )
-
-            def plot_pr_curve():
-                pr_curve.plot_fn(**pr_curve.plot_fn_args)
-
-            self._log_image_artifact(plot_pr_curve, "precision_recall_curve_plot")
-            per_class_metrics_collection_df["precision_recall_auc"] = pr_curve.auc
-
-        self._log_pandas_df_artifact(per_class_metrics_collection_df, "per_class_metrics")
-
-    def _log_roc_curve(self):
-        def _plot_roc_curve():
-            self.roc_curve.plot_fn(**self.roc_curve.plot_fn_args)
-
-        self._log_image_artifact(_plot_roc_curve, "roc_curve_plot")
-
-    def _log_precision_recall_curve(self):
-        def _plot_pr_curve():
-            self.pr_curve.plot_fn(**self.pr_curve.plot_fn_args)
-
-        self._log_image_artifact(_plot_pr_curve, "precision_recall_curve_plot")
-
-    def _log_lift_curve(self):
-        from mlflow.models.evaluation.lift_curve import plot_lift_curve
-
-        def _plot_lift_curve():
-            return plot_lift_curve(self.y, self.y_probs, pos_label=self.pos_label)
-
-        self._log_image_artifact(_plot_lift_curve, "lift_curve_plot")
-
-    def _log_binary_classifier_artifacts(self):
-        if self.y_probs is not None:
-            with _suppress_class_imbalance_errors(log_warning=False):
-                self._log_roc_curve()
-            with _suppress_class_imbalance_errors(log_warning=False):
-                self._log_precision_recall_curve()
-            with _suppress_class_imbalance_errors(ValueError, log_warning=False):
-                self._log_lift_curve()
 
     def _log_custom_metric_artifact(self, artifact_name, raw_artifact, custom_metric_tuple):
         """
@@ -1280,7 +331,11 @@ class DefaultEvaluator(ModelEvaluator):
                 return metric_value
 
     def _get_args_for_metrics(
-        self, metric_tuple, eval_df, input_df
+        self,
+        metric: MetricDefinition,
+        eval_df: pd.DataFrame,
+        input_df: pd.DataFrame,
+        other_output_df: Optional[pd.DataFrame],
     ) -> Tuple[bool, List[Union[str, pd.DataFrame]]]:
         """
         Given a metric_tuple, read the signature of the metric function and get the appropriate
@@ -1304,7 +359,7 @@ class DefaultEvaluator(ModelEvaluator):
         # deepcopying eval_df and builtin_metrics for each custom metric function call,
         # in case the user modifies them inside their function(s).
         eval_df_copy = eval_df.copy()
-        parameters = inspect.signature(metric_tuple.function).parameters
+        parameters = inspect.signature(metric.function).parameters
         eval_fn_args = []
         params_not_found = []
         if len(parameters) == 2:
@@ -1348,12 +403,9 @@ class DefaultEvaluator(ModelEvaluator):
 
                     # case column in col_mapping is string and the column value
                     # is part of the output_df(other than predictions)
-                    elif (
-                        self.other_output_columns is not None
-                        and column in self.other_output_columns.columns
-                    ):
+                    elif other_output_df is not None and column in other_output_df.columns:
                         self.other_output_columns_for_eval.add(column)
-                        eval_fn_args.append(self.other_output_columns[column])
+                        eval_fn_args.append(other_output_df[column])
 
                     # case where the param is defined as part of the evaluator_config
                     elif column in self.evaluator_config:
@@ -1379,10 +431,20 @@ class DefaultEvaluator(ModelEvaluator):
             return False, params_not_found
         return True, eval_fn_args
 
-    def _log_custom_artifacts(self, eval_df):
-        if not self.custom_artifacts:
+
+    def evaluate_and_log_custom_artifacts(
+        self,
+        custom_artifacts: List[_CustomArtifact],
+        prediction: pd.Series,
+        target: Optional[np.array] = None
+    ):
+        """
+        """
+        if not custom_artifacts:
             return
-        for index, custom_artifact in enumerate(self.custom_artifacts):
+
+        eval_df = self._get_eval_df(prediction, target)
+        for index, custom_artifact in enumerate(custom_artifacts):
             with tempfile.TemporaryDirectory() as artifacts_dir:
                 # deepcopying eval_df and builtin_metrics for each custom artifact function call,
                 # in case the user modifies them inside their function(s).
@@ -1394,7 +456,8 @@ class DefaultEvaluator(ModelEvaluator):
                 )
                 artifact_results = _evaluate_custom_artifacts(
                     custom_artifact_tuple,
-                    eval_df.copy(),
+                    prediction,
+                    target,
                     copy.deepcopy(self.metrics_values),
                 )
                 if artifact_results:
@@ -1404,202 +467,6 @@ class DefaultEvaluator(ModelEvaluator):
                             raw_artifact,
                             custom_artifact_tuple,
                         )
-
-    def _log_confusion_matrix(self):
-        """
-        Helper method for logging confusion matrix
-        """
-        # normalize the confusion matrix, keep consistent with sklearn autologging.
-        confusion_matrix = sk_metrics.confusion_matrix(
-            self.y,
-            self.y_pred,
-            labels=self.label_list,
-            normalize="true",
-            sample_weight=self.sample_weights,
-        )
-
-        def plot_confusion_matrix():
-            import matplotlib
-            import matplotlib.pyplot as plt
-
-            with matplotlib.rc_context(
-                {
-                    "font.size": min(8, math.ceil(50.0 / self.num_classes)),
-                    "axes.labelsize": 8,
-                }
-            ):
-                _, ax = plt.subplots(1, 1, figsize=(6.0, 4.0), dpi=175)
-                disp = sk_metrics.ConfusionMatrixDisplay(
-                    confusion_matrix=confusion_matrix,
-                    display_labels=self.label_list,
-                ).plot(cmap="Blues", ax=ax)
-                disp.ax_.set_title("Normalized confusion matrix")
-
-        if hasattr(sk_metrics, "ConfusionMatrixDisplay"):
-            self._log_image_artifact(
-                plot_confusion_matrix,
-                "confusion_matrix",
-            )
-        return
-
-    def _generate_model_predictions(self, compute_latency=False):
-        """
-        Helper method for generating model predictions
-        """
-
-        def predict_with_latency(X_copy):
-            y_pred_list = []
-            pred_latencies = []
-            if len(X_copy) == 0:
-                raise ValueError("Empty input data")
-
-            is_dataframe = isinstance(X_copy, pd.DataFrame)
-
-            for row in X_copy.iterrows() if is_dataframe else enumerate(X_copy):
-                i, row_data = row
-                single_input = row_data.to_frame().T if is_dataframe else row_data
-                start_time = time.time()
-                y_pred = self.predict_fn(single_input)
-                end_time = time.time()
-                pred_latencies.append(end_time - start_time)
-                y_pred_list.append(y_pred)
-
-            # Update latency metric
-            self.metrics_values.update({_LATENCY_METRIC_NAME: MetricValue(scores=pred_latencies)})
-
-            # Aggregate all predictions into model_predictions
-            sample_pred = y_pred_list[0]
-            if isinstance(sample_pred, pd.DataFrame):
-                return pd.concat(y_pred_list)
-            elif isinstance(sample_pred, np.ndarray):
-                return np.concatenate(y_pred_list, axis=0)
-            elif isinstance(sample_pred, list):
-                return sum(y_pred_list, [])
-            elif isinstance(sample_pred, pd.Series):
-                return pd.concat(y_pred_list, ignore_index=True)
-            elif isinstance(sample_pred, str):
-                return y_pred_list
-            else:
-                raise MlflowException(
-                    message=f"Unsupported prediction type {type(sample_pred)} for model type "
-                    f"{self.model_type}.",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
-
-        X_copy = self.X.copy_to_avoid_mutation()
-        if self.model is not None:
-            _logger.info("Computing model predictions.")
-
-            if compute_latency:
-                model_predictions = predict_with_latency(X_copy)
-            else:
-                model_predictions = self.predict_fn(X_copy)
-        else:
-            if self.dataset.predictions_data is None:
-                raise MlflowException(
-                    message="Predictions data is missing when model is not provided. "
-                    "Please provide predictions data in a dataset or provide a model. "
-                    "See the documentation for mlflow.evaluate() for how to specify "
-                    "the predictions data in a dataset.",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
-            if compute_latency:
-                _logger.warning(
-                    "Setting the latency to 0 for all entries because the model is not provided."
-                )
-                self.metrics_values.update(
-                    {_LATENCY_METRIC_NAME: MetricValue(scores=[0.0] * len(X_copy))}
-                )
-            model_predictions = self.dataset.predictions_data
-
-        if self.model_type == _ModelType.CLASSIFIER:
-            if self.predict_fn is not None:
-                self.y_pred = self.predict_fn(self.X.copy_to_avoid_mutation())
-            else:
-                self.y_pred = self.dataset.predictions_data
-
-            if self.label_list is None:
-                self.label_list = np.unique(np.concatenate([self.y, self.y_pred]))
-            # sort label_list ASC, for binary classification it makes sure the last one is pos label
-            self.label_list.sort()
-            self.num_classes = len(self.label_list)
-            self.is_binomial = self.num_classes <= 2
-
-            if self.is_binomial:
-                if self.pos_label is None:
-                    self.pos_label = self.label_list[-1]
-                else:
-                    if self.pos_label in self.label_list:
-                        self.label_list = np.delete(
-                            self.label_list, np.where(self.label_list == self.pos_label)
-                        )
-                    self.label_list = np.append(self.label_list, self.pos_label)
-                if len(self.label_list) < 2:
-                    raise MlflowException(
-                        "Evaluation dataset for classification must contain at least two unique "
-                        f"labels, but only {len(self.label_list)} unique labels were found.",
-                    )
-                with _suppress_class_imbalance_errors(IndexError, log_warning=False):
-                    _logger.info(
-                        "The evaluation dataset is inferred as binary dataset, positive label is "
-                        f"{self.label_list[1]}, negative label is {self.label_list[0]}."
-                    )
-            else:
-                _logger.info(
-                    "The evaluation dataset is inferred as multiclass dataset, number of classes "
-                    f"is inferred as {self.num_classes}. If this is incorrect, please specify the "
-                    "`label_list` parameter in `evaluator_config`."
-                )
-
-            if self.predict_proba_fn is not None:
-                self.y_probs = self.predict_proba_fn(self.X.copy_to_avoid_mutation())
-            else:
-                self.y_probs = None
-
-        output_column_name = self.predictions
-        (
-            self.y_pred,
-            self.other_output_columns,
-            self.predictions,
-        ) = _extract_output_and_other_columns(model_predictions, output_column_name)
-        self.other_output_columns_for_eval = set()
-
-    def _compute_builtin_metrics(self):
-        """
-        Helper method for computing builtin metrics
-        """
-        self._evaluate_sklearn_model_score_if_scorable()
-        if self.model_type == _ModelType.CLASSIFIER:
-            if self.is_binomial:
-                metrics = _get_binary_classifier_metrics(
-                    y_true=self.y,
-                    y_pred=self.y_pred,
-                    y_proba=self.y_probs,
-                    labels=self.label_list,
-                    pos_label=self.pos_label,
-                    sample_weights=self.sample_weights,
-                )
-                if metrics:
-                    self.metrics_values.update(_get_aggregate_metrics_values(metrics))
-                    self._compute_roc_and_pr_curve()
-            else:
-                average = self.evaluator_config.get("average", "weighted")
-                metrics = _get_multiclass_classifier_metrics(
-                    y_true=self.y,
-                    y_pred=self.y_pred,
-                    y_proba=self.y_probs,
-                    labels=self.label_list,
-                    average=average,
-                    sample_weights=self.sample_weights,
-                )
-                if metrics:
-                    self.metrics_values.update(_get_aggregate_metrics_values(metrics))
-        elif self.model_type == _ModelType.REGRESSOR:
-            self.metrics_values.update(
-                _get_aggregate_metrics_values(
-                    _get_regressor_metrics(self.y, self.y_pred, self.sample_weights)
-                )
-            )
 
     def _get_error_message_missing_columns(self, metric_name, param_names):
         error_message_parts = [f"Metric '{metric_name}' requires the following:"]
@@ -1643,9 +510,10 @@ class DefaultEvaluator(ModelEvaluator):
 
         return "\n".join(l.lstrip() for l in full_message.splitlines())
 
-    def _raise_exception_for_malformed_metrics(self, malformed_results, eval_df):
+
+    def _raise_exception_for_malformed_metrics(self, malformed_results, eval_df, other_output_df):
         output_columns = (
-            [] if self.other_output_columns is None else list(self.other_output_columns.columns)
+            [] if other_output_df is None else list(other_output_df.columns)
         )
         if self.predictions:
             output_columns.append(self.predictions)
@@ -1667,12 +535,28 @@ class DefaultEvaluator(ModelEvaluator):
 
         raise MlflowException(error_message, error_code=INVALID_PARAMETER_VALUE)
 
+    def _get_eval_df(self, prediction: pd.Series, target: Optional[np.array] = None):
+        """
+        Create a DataFrame with "prediction" and "target" columns.
+
+        This is a standard format that can be passed to the metric functions.
+        """
+        eval_df = pd.DataFrame({"prediction": copy.deepcopy(prediction)})
+        if target is not None:
+            eval_df["target"] = target
+        return eval_df
+
     # to order the metrics, we append metrics to self.ordered_metrics if they can be calculated
     # given the metrics that will be calculated before it
     # we stop when all metrics are in self.ordered_metrics or we cannot "calculate" any more metrics
     # and raise an exception in the latter case
-    def _order_extra_metrics(self, eval_df):
-        remaining_metrics = self.extra_metrics
+    def _order_metrics(
+        self,
+        metrics: List[EvaluationMetric],
+        eval_df: pd.DataFrame,
+        other_output_df: Optional[pd.DataFrame],
+    ):
+        remaining_metrics = metrics
         input_df = self.X.copy_to_avoid_mutation()
 
         while len(remaining_metrics) > 0:
@@ -1681,7 +565,7 @@ class DefaultEvaluator(ModelEvaluator):
             did_append_metric = False
             for metric_tuple in remaining_metrics:
                 can_calculate, eval_fn_args = self._get_args_for_metrics(
-                    metric_tuple, eval_df, input_df
+                    metric_tuple, eval_df, input_df, other_output_df
                 )
                 if can_calculate:
                     self.ordered_metrics.append(metric_tuple)
@@ -1692,84 +576,87 @@ class DefaultEvaluator(ModelEvaluator):
 
             # cant calculate any more metrics
             if not did_append_metric:
-                self._raise_exception_for_malformed_metrics(failed_results, eval_df)
+                self._raise_exception_for_malformed_metrics(failed_results, eval_df, other_output_df)
 
             remaining_metrics = pending_metrics
 
-    def _test_first_row(self, eval_df):
+        return self.ordered_metrics
+
+    def _test_first_row(self, metrics: List[MetricDefinition], eval_df: pd.DataFrame, other_output_df: Optional[pd.DataFrame]):
         # test calculations on first row of eval_df
         _logger.info("Testing metrics on first row...")
         exceptions = []
         first_row_df = eval_df.iloc[[0]]
         first_row_input_df = self.X.copy_to_avoid_mutation().iloc[[0]]
-        for metric_tuple in self.ordered_metrics:
+        for metric in metrics:
             try:
                 _, eval_fn_args = self._get_args_for_metrics(
-                    metric_tuple, first_row_df, first_row_input_df
+                    metric, first_row_df, first_row_input_df, other_output_df
                 )
-                metric_value = _evaluate_metric(metric_tuple, eval_fn_args)
+                metric_value = metric.evaluate(eval_fn_args)
                 if metric_value:
                     name = (
-                        f"{metric_tuple.name}/{metric_tuple.version}"
-                        if metric_tuple.version
-                        else metric_tuple.name
+                        f"{metric.name}/{metric.version}"
+                        if metric.version
+                        else metric.name
                     )
                     self.metrics_values.update({name: metric_value})
             except Exception as e:
                 stacktrace_str = traceback.format_exc()
                 if isinstance(e, MlflowException):
                     exceptions.append(
-                        f"Metric '{metric_tuple.name}': Error:\n{e.message}\n{stacktrace_str}"
+                        f"Metric '{metric.name}': Error:\n{e.message}\n{stacktrace_str}"
                     )
                 else:
                     exceptions.append(
-                        f"Metric '{metric_tuple.name}': Error:\n{e!r}\n{stacktrace_str}"
+                        f"Metric '{metric.name}': Error:\n{e!r}\n{stacktrace_str}"
                     )
 
         if len(exceptions) > 0:
             raise MlflowException("\n".join(exceptions))
 
-    def _metric_to_metric_tuple(self, index, metric):
-        return _Metric(
-            function=metric.eval_fn,
-            index=index,
-            name=metric.name,
-            version=metric.version,
-            genai_metric_args=metric.genai_metric_args,
-        )
+    def evaluate_metrics(
+        self,
+        metrics: List[EvaluationMetric],
+        prediction: pd.Series,
+        target: Optional[np.array] = None,
+        other_output_df: Optional[pd.DataFrame] = None,
+    ):
+        """
+        Evaluate the metrics on the given prediction and target data.
 
-    def _evaluate_metrics(self, eval_df):
-        self._order_extra_metrics(eval_df)
-        self._test_first_row(eval_df)
+        Args:
+            metrics: A list of metrics to evaluate. This is unordered list so we first need to sort it, because
+                a metrics whose result is used for computing another metric should be calculated first.
+            prediction: A Pandas Series containing the predictions.
+            other_output_df: A Pandas DataFrame containing other output columns from the model.
+            target: A numpy array containing the target values.
+
+        Returns:
+            None, the metrics values are recorded in the self.metrics_values dictionary.
+        """
+
+        eval_df = self._get_eval_df(prediction, target)
+        metrics = self._order_metrics(metrics, eval_df, other_output_df)
+
+        self._test_first_row(metrics, eval_df, other_output_df)
 
         # calculate metrics for the full eval_df
         input_df = self.X.copy_to_avoid_mutation()
-        for metric_tuple in self.ordered_metrics:
-            _, eval_fn_args = self._get_args_for_metrics(metric_tuple, eval_df, input_df)
-            metric_value = _evaluate_metric(metric_tuple, eval_fn_args)
+        for metric in metrics:
+            _, eval_fn_args = self._get_args_for_metrics(metric, metrics, eval_df, input_df, other_output_df)
+            metric_value = metric.evaluate(eval_fn_args)
 
             if metric_value:
                 name = (
-                    f"{metric_tuple.name}/{metric_tuple.version}"
-                    if metric_tuple.version
-                    else metric_tuple.name
+                    f"{metric.name}/{metric.version}"
+                    if metric.version
+                    else metric.name
                 )
                 self.metrics_values.update({name: metric_value})
 
-    def _log_artifacts(self):
-        """
-        Helper method for generating artifacts, logging metrics and artifacts.
-        """
-        if self.model_type in (_ModelType.CLASSIFIER, _ModelType.REGRESSOR):
-            if self.model_type == _ModelType.CLASSIFIER:
-                if self.is_binomial:
-                    self._log_binary_classifier_artifacts()
-                else:
-                    self._log_multiclass_classifier_artifacts()
-                self._log_confusion_matrix()
-            self._log_model_explainability()
 
-    def _log_eval_table(self):
+    def log_eval_table(self, y_pred):
         # only log eval table if there are per row metrics recorded
         if not any(
             metric_value.scores is not None or metric_value.justifications is not None
@@ -1785,24 +672,24 @@ class DefaultEvaluator(ModelEvaluator):
             if self.dataset.has_targets:
                 data = self.dataset.features_data.assign(
                     **{
-                        self.dataset.targets_name or "target": self.y,
-                        self.dataset.predictions_name or self.predictions or "outputs": self.y_pred,
+                        self.dataset.targets_name or "target": self.dataset.labels_data,
+                        self.dataset.predictions_name or self.predictions or "outputs": y_pred,
                     }
                 )
             else:
-                data = self.dataset.features_data.assign(outputs=self.y_pred)
+                data = self.dataset.features_data.assign(outputs=y_pred)
         else:
             # Handle NumPy array case, converting it to a DataFrame
             data = pd.DataFrame(self.dataset.features_data, columns=self.dataset.feature_names)
             if self.dataset.has_targets:
                 data = data.assign(
                     **{
-                        self.dataset.targets_name or "target": self.y,
-                        self.dataset.predictions_name or self.predictions or "outputs": self.y_pred,
+                        self.dataset.targets_name or "target": self.dataset.labels_data,
+                        self.dataset.predictions_name or self.predictions or "outputs": y_pred,
                     }
                 )
             else:
-                data = data.assign(outputs=self.y_pred)
+                data = data.assign(outputs=y_pred)
 
         # Include other_output_columns used in evaluation to the eval table
         if self.other_output_columns is not None and len(self.other_output_columns_for_eval) > 0:
@@ -1841,28 +728,6 @@ class DefaultEvaluator(ModelEvaluator):
             uri=mlflow.get_artifact_uri(artifact_file_name)
         )
 
-    def _log_genai_custom_metrics(self, genai_custom_metrics):
-        if len(genai_custom_metrics) == 0:
-            return
-
-        names = []
-        versions = []
-        metric_args_list = []
-
-        for metric_args in genai_custom_metrics:
-            names.append(metric_args["name"])
-            # Custom metrics created from make_genai_metric_from_prompt don't have version
-            versions.append(metric_args.get("version", ""))
-            metric_args_list.append(metric_args)
-
-        data = {"name": names, "version": versions, "metric_args": metric_args_list}
-
-        mlflow.log_table(data, artifact_file=_GENAI_CUSTOM_METRICS_FILE_NAME)
-
-        artifact_name = os.path.splitext(_GENAI_CUSTOM_METRICS_FILE_NAME)[0]
-        self.artifacts[artifact_name] = JsonEvaluationArtifact(
-            uri=mlflow.get_artifact_uri(_GENAI_CUSTOM_METRICS_FILE_NAME)
-        )
 
     def _update_aggregate_metrics(self):
         self.aggregate_metrics = {}
@@ -1874,42 +739,6 @@ class DefaultEvaluator(ModelEvaluator):
                             self.aggregate_metrics[metric_name] = agg_value
                         else:
                             self.aggregate_metrics[f"{metric_name}/{agg_name}"] = agg_value
-
-    def _handle_builtin_metrics_by_model_type(self):
-        text_metrics = [
-            token_count(),
-            toxicity(),
-            flesch_kincaid_grade_level(),
-            ari_grade_level(),
-        ]
-        builtin_metrics = []
-
-        if self.model_type in (_ModelType.CLASSIFIER, _ModelType.REGRESSOR):
-            self._compute_builtin_metrics()
-        elif self.model_type == _ModelType.QUESTION_ANSWERING:
-            builtin_metrics = [*text_metrics, exact_match()]
-        elif self.model_type == _ModelType.TEXT_SUMMARIZATION:
-            builtin_metrics = [
-                *text_metrics,
-                rouge1(),
-                rouge2(),
-                rougeL(),
-                rougeLsum(),
-            ]
-        elif self.model_type == _ModelType.TEXT:
-            builtin_metrics = text_metrics
-        elif self.model_type == _ModelType.RETRIEVER:
-            # default k to 3 if not specified
-            retriever_k = self.evaluator_config.pop("retriever_k", 3)
-            builtin_metrics = [
-                precision_at_k(retriever_k),
-                recall_at_k(retriever_k),
-                ndcg_at_k(retriever_k),
-            ]
-
-        self.ordered_metrics = [
-            self._metric_to_metric_tuple(-1, metric) for metric in builtin_metrics
-        ]
 
     def _add_prefix_to_metrics(self):
         def _prefix_value(value):
@@ -1927,71 +756,6 @@ class DefaultEvaluator(ModelEvaluator):
 
         self._update_aggregate_metrics()
 
-    def _evaluate(
-        self,
-        model: "mlflow.pyfunc.PyFuncModel" = None,
-        **kwargs,
-    ):
-        import matplotlib
-
-        with TempDir() as temp_dir, matplotlib.rc_context(_matplotlib_config):
-            self.temp_dir = temp_dir
-            self.model = model
-
-            self.is_model_server = isinstance(model, _ServedPyFuncModel)
-
-            if getattr(model, "metadata", None):
-                self.model_loader_module, self.raw_model = _extract_raw_model(model)
-            else:
-                # model is constructed from a user specified function or not provided
-                self.model_loader_module, self.raw_model = None, None
-            self.predict_fn, self.predict_proba_fn = _extract_predict_fn(model, self.raw_model)
-            self.predict_fn = _restrict_langchain_autologging_to_traces_only(self.predict_fn)
-            self.predict_proba_fn = _restrict_langchain_autologging_to_traces_only(
-                self.predict_proba_fn
-            )
-
-            self.artifacts = {}
-            self.aggregate_metrics = {}
-            self.metrics_values = {}
-            self.ordered_metrics = []
-
-            with mlflow.utils.autologging_utils.disable_autologging(
-                exemptions=[mlflow.langchain.FLAVOR_NAME]
-            ):
-                compute_latency = False
-                genai_custom_metrics = []
-                for extra_metric in self.extra_metrics:
-                    # If latency metric is specified, we will compute latency for the model
-                    # during prediction, and we will remove the metric from the list of extra
-                    # metrics to be computed after prediction.
-                    if extra_metric.name == _LATENCY_METRIC_NAME:
-                        compute_latency = True
-                        self.extra_metrics.remove(extra_metric)
-                    # When the field is present, the metric is created from either make_genai_metric
-                    # or make_genai_metric_from_prompt. We will log the metric definition.
-                    if extra_metric.genai_metric_args is not None:
-                        genai_custom_metrics.append(extra_metric.genai_metric_args)
-                self._generate_model_predictions(compute_latency=compute_latency)
-                self._handle_builtin_metrics_by_model_type()
-
-                eval_df = pd.DataFrame({"prediction": copy.deepcopy(self.y_pred)})
-                if self.dataset.has_targets:
-                    eval_df["target"] = self.y
-
-                self._evaluate_metrics(eval_df)
-                self._log_custom_artifacts(eval_df)
-
-                self._add_prefix_to_metrics()
-
-                self._log_artifacts()
-                self._log_metrics()
-                self._log_eval_table()
-                self._log_genai_custom_metrics(genai_custom_metrics)
-                return EvaluationResult(
-                    metrics=self.aggregate_metrics, artifacts=self.artifacts, run_id=self.run_id
-                )
-
     def evaluate(
         self,
         *,
@@ -2005,7 +769,7 @@ class DefaultEvaluator(ModelEvaluator):
         custom_artifacts=None,
         predictions=None,
         **kwargs,
-    ):
+    ) -> EvaluationResult:
         if model is None and predictions is None and dataset.predictions_data is None:
             raise MlflowException(
                 message=(
@@ -2018,25 +782,21 @@ class DefaultEvaluator(ModelEvaluator):
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
-        self.dataset = dataset
+        self.artifacts = {}
+        self.aggregate_metrics = {}
+        self.metrics_values = {}
+        self.ordered_metrics = []
+        self.other_output_columns_for_eval = set()
+
+        self.dataset: EvaluationDataset = dataset
         self.run_id = run_id
         self.model_type = model_type
         self.evaluator_config = evaluator_config
-        self.feature_names = dataset.feature_names
 
-        self.custom_artifacts = custom_artifacts
-        self.y = dataset.labels_data
         self.predictions = predictions
         self.col_mapping = self.evaluator_config.get("col_mapping", {})
-        self.pos_label = self.evaluator_config.get("pos_label")
-        self.sample_weights = self.evaluator_config.get("sample_weights")
         self.eval_results_path = self.evaluator_config.get("eval_results_path")
         self.eval_results_mode = self.evaluator_config.get("eval_results_mode", "overwrite")
-        self.label_list = self.evaluator_config.get("label_list")
-        if self.pos_label and self.label_list and self.pos_label not in self.label_list:
-            raise MlflowException.invalid_parameter_value(
-                f"'pos_label' {self.pos_label} must exist in 'label_list' {self.label_list}."
-            )
 
         if self.eval_results_path:
             from mlflow.utils._spark_utils import _get_active_spark_session
@@ -2091,24 +851,20 @@ class DefaultEvaluator(ModelEvaluator):
             for index, metric in enumerate(extra_metrics)
         ]
 
-        if self.model_type in (_ModelType.CLASSIFIER, _ModelType.REGRESSOR):
-            inferred_model_type = _infer_model_type_by_labels(self.y)
-            if inferred_model_type is not None and model_type != inferred_model_type:
-                _logger.warning(
-                    f"According to the evaluation dataset label values, the model type looks like "
-                    f"{inferred_model_type}, but you specified model type {model_type}. Please "
-                    f"verify that you set the `model_type` and `dataset` arguments correctly."
-                )
+        import matplotlib
 
-        return self._evaluate(model)
+        with TempDir() as temp_dir, matplotlib.rc_context(_matplotlib_config):
+            self.temp_dir = temp_dir
+            return self._evaluate(model, extra_metrics, custom_artifacts)
+
 
     @property
     def X(self) -> pd.DataFrame:
         """
         The features (`X`) portion of the dataset, guarded against accidental mutations.
         """
-        return DefaultEvaluator._MutationGuardedData(
-            _get_dataframe_with_renamed_columns(self.dataset.features_data, self.feature_names)
+        return BuiltInEvaluator._MutationGuardedData(
+            _get_dataframe_with_renamed_columns(self.dataset.features_data, self.dataset.feature_names)
         )
 
     class _MutationGuardedData:

--- a/mlflow/models/evaluation/evaluator_registry.py
+++ b/mlflow/models/evaluation/evaluator_registry.py
@@ -14,11 +14,14 @@ class ModelEvaluatorRegistry:
         self._registry = {}
         self._builtin_evaluators = {}
 
-    def register(self, scheme, evaluator, is_builtin=False):
+    def register(self, scheme, evaluator):
         """Register model evaluator provided by other packages"""
         self._registry[scheme] = evaluator
-        if is_builtin:
-            self._builtin_evaluators[scheme] = evaluator
+
+    def register_builtin(self, scheme, evaluator):
+        """Register built-in model evaluator"""
+        self._registry[scheme] = evaluator
+        self._builtin_evaluators[scheme] = evaluator
 
     def register_entrypoints(self):
         # Register ModelEvaluator implementation provided by other packages
@@ -62,10 +65,12 @@ def register_evaluators(module):
     from mlflow.models.evaluation.evaluators.shap import ShapEvaluator
 
     # Built-in evaluators
-    module._model_evaluation_registry.register(DefaultEvaluator.name, DefaultEvaluator, True)
-    module._model_evaluation_registry.register(ClassifierEvaluator.name, ClassifierEvaluator, True)
-    module._model_evaluation_registry.register(RegressorEvaluator.name, RegressorEvaluator, True)
-    module._model_evaluation_registry.register(ShapEvaluator.name, ShapEvaluator, True)
+    module._model_evaluation_registry.register_builtin(DefaultEvaluator.name, DefaultEvaluator)
+    module._model_evaluation_registry.register_builtin(
+        ClassifierEvaluator.name, ClassifierEvaluator
+    )
+    module._model_evaluation_registry.register_builtin(RegressorEvaluator.name, RegressorEvaluator)
+    module._model_evaluation_registry.register_builtin(ShapEvaluator.name, ShapEvaluator)
 
     # Plugin evaluators
     module._model_evaluation_registry.register_entrypoints()

--- a/mlflow/models/evaluation/evaluator_registry.py
+++ b/mlflow/models/evaluation/evaluator_registry.py
@@ -48,6 +48,9 @@ class ModelEvaluatorRegistry:
     def is_builtin(self, name):
         return name in self._builtin_evaluators
 
+    def is_registered(self, name):
+        return name in self._registry
+
 
 _model_evaluation_registry = ModelEvaluatorRegistry()
 

--- a/mlflow/models/evaluation/evaluator_registry.py
+++ b/mlflow/models/evaluation/evaluator_registry.py
@@ -59,10 +59,10 @@ def register_evaluators(module):
     from mlflow.models.evaluation.evaluators.shap import ShapEvaluator
 
     # Built-in evaluators
-    module._model_evaluation_registry.register(DefaultEvaluator.name, DefaultEvaluator, is_builtin=True)
-    module._model_evaluation_registry.register(ClassifierEvaluator.name, ClassifierEvaluator, is_builtin=True)
-    module._model_evaluation_registry.register(RegressorEvaluator.name, RegressorEvaluator, is_builtin=True)
-    module._model_evaluation_registry.register(ShapEvaluator.name, ShapEvaluator, is_builtin=True)
+    module._model_evaluation_registry.register(DefaultEvaluator.name, DefaultEvaluator, True)
+    module._model_evaluation_registry.register(ClassifierEvaluator.name, ClassifierEvaluator, True)
+    module._model_evaluation_registry.register(RegressorEvaluator.name, RegressorEvaluator, True)
+    module._model_evaluation_registry.register(ShapEvaluator.name, ShapEvaluator, True)
 
     # Plugin evaluators
     module._model_evaluation_registry.register_entrypoints()

--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -33,7 +33,8 @@ class ClassifierEvaluator(BuiltInEvaluator):
 
     name = "classifier"
 
-    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+    @classmethod
+    def can_evaluate(cls, *, model_type, evaluator_config, **kwargs):
         # TODO: Also the model needs to be pyfunc model, not function or endpoint URI
         return model_type == _ModelType.CLASSIFIER
 
@@ -43,7 +44,7 @@ class ClassifierEvaluator(BuiltInEvaluator):
         extra_metrics: List[EvaluationMetric],
         custom_artifacts=None,
         **kwargs,
-    ) -> EvaluationResult:
+    ) -> Optional[EvaluationResult]:
         # Get classification config
         self.y_true = self.dataset.labels_data
         self.label_list = self.evaluator_config.get("label_list")

--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -102,6 +102,9 @@ class ClassifierEvaluator(BuiltInEvaluator):
         if self.label_list is None:
             # If label list is not specified, infer label list from model output
             self.label_list = np.unique(np.concatenate([self.y_true, self.y_pred]))
+        else:
+            # np.where only works for numpy array, not list
+            self.label_list = np.array(self.label_list)
 
         # sort label_list ASC, for binary classification it makes sure the last one is pos label
         self.label_list.sort()
@@ -112,7 +115,9 @@ class ClassifierEvaluator(BuiltInEvaluator):
                 self.pos_label = self.label_list[-1]
             else:
                 if self.pos_label in self.label_list:
+                    print(f"{self.label_list} {self.pos_label}")
                     self.label_list = np.delete(self.label_list, np.where(self.label_list == self.pos_label))
+                    print(f"{self.label_list}")
                 self.label_list = np.append(self.label_list, self.pos_label)
             if len(self.label_list) < 2:
                 raise MlflowException(
@@ -135,6 +140,7 @@ class ClassifierEvaluator(BuiltInEvaluator):
     def _compute_builtin_metrics(self, model):
         self._evaluate_sklearn_model_score_if_scorable(model, self.y_true, self.sample_weights)
 
+        print(f"{self.label_list}")
         if len(self.label_list) <= 2:
             metrics = _get_binary_classifier_metrics(
                 y_true=self.y_true,

--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -27,6 +27,10 @@ _Curve = namedtuple("_Curve", ["plot_fn", "plot_fn_args", "auc"])
 
 
 class ClassifierEvaluator(BuiltInEvaluator):
+    """
+    A built-in evaluator for classifier models.
+    """
+
     name = "classifier"
 
     def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
@@ -91,10 +95,7 @@ class ClassifierEvaluator(BuiltInEvaluator):
         y_pred = self.dataset.predictions_data if model is None else predict_fn(input_df)
 
         # Predict class probabilities if the model supports it
-        if predict_proba_fn is not None:
-            y_probs = predict_proba_fn(input_df)
-        else:
-            y_probs = None
+        y_probs = predict_proba_fn(input_df) if predict_proba_fn is not None else None
         return y_pred, y_probs
 
     def _validate_label_list(self):

--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -1,0 +1,675 @@
+from collections import namedtuple
+from contextlib import contextmanager
+import logging
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+from sklearn import metrics as sk_metrics
+
+
+from mlflow import MlflowException
+import mlflow
+from mlflow.environment_variables import _MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS
+from mlflow.models.evaluation.artifacts import CsvEvaluationArtifact
+from mlflow.models.evaluation.base import _ModelType, EvaluationMetric, EvaluationResult
+from mlflow.models.evaluation.default_evaluator import BuiltInEvaluator, _extract_raw_model, _get_aggregate_metrics_values
+
+_logger = logging.getLogger(__name__)
+
+
+_Curve = namedtuple("_Curve", ["plot_fn", "plot_fn_args", "auc"])
+
+
+
+class ClassifierEvaluator(BuiltInEvaluator):
+    name = "classifier"
+
+    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+        # TODO: Also the model needs to be pyfunc model, not function or endpoint URI
+        return model_type == _ModelType.CLASSIFIER
+
+    def _evaluate(
+        self,
+        model: Optional["mlflow.pyfunc.PyFuncModel"],
+        extra_metrics: List[EvaluationMetric],
+        custom_artifacts = None,
+        **kwargs,
+    ) -> EvaluationResult:
+        # Get classification config
+        self.y_true = self.dataset.labels_data
+        self.label_list = self.evaluator_config.get("label_list")
+        self.pos_label = self.evaluator_config.get("pos_label")
+        self.sample_weights = self.evaluator_config.get("sample_weights")
+        if self.pos_label and self.label_list and self.pos_label not in self.label_list:
+            raise MlflowException.invalid_parameter_value(
+                f"'pos_label' {self.pos_label} must exist in 'label_list' {self.label_list}."
+            )
+
+        # Check if the model_type is consistent with ground truth labels
+        inferred_model_type = _infer_model_type_by_labels(self.y_true)
+        if _ModelType.CLASSIFIER != inferred_model_type:
+            _logger.warning(
+                f"According to the evaluation dataset label values, the model type looks like "
+                f"{inferred_model_type}, but you specified model type 'classifier'. Please "
+                f"verify that you set the `model_type` and `dataset` arguments correctly."
+            )
+
+        # Run model prediction
+        input_df = self.X.copy_to_avoid_mutation()
+        self.y_pred, self.y_probs = self._generate_model_predictions(input_df)
+
+        self._validate_label_list()
+
+        self._compute_builtin_metrics()
+        self.evaluate_metrics(extra_metrics, prediction=self.y_pred, target=self.y_true)
+        self.evaluate_and_log_custom_artifacts(custom_artifacts, prediction=self.y_pred, target=self.y_true)
+
+        # Log metrics and artifacts
+        self.log_metrics()
+        self.log_eval_table(self.y_pred)
+
+        if len(self.label_list) == 2:
+            self._log_binary_classifier_artifacts()
+        else:
+            self._log_multiclass_classifier_artifacts()
+        self._log_confusion_matrix()
+
+        return EvaluationResult(
+            metrics=self.aggregate_metrics, artifacts=self.artifacts, run_id=self.run_id
+        )
+
+
+    def _generate_model_predictions(self, model, input_df):
+        predict_fn, predict_proba_fn = _extract_predict_fn_and_prodict_proba_fn(model)
+        # Classifier model is guaranteed to output single column of predictions
+        if model is not None:
+            y_pred = predict_fn(input_df)
+        else:
+            y_pred = self.dataset.predictions_data
+
+        # Predict class probabilities if the model supports it
+        if self.predict_proba_fn is not None:
+            y_probs = predict_proba_fn(input_df)
+        else:
+            y_probs = None
+        return y_pred, y_probs
+
+
+    def _validate_label_list(self):
+        if self.label_list is None:
+            # If label list is not specified, infer label list from model output
+            self.label_list = np.unique(np.concatenate([self.y_true, self.y_pred]))
+
+        # sort label_list ASC, for binary classification it makes sure the last one is pos label
+        self.label_list.sort()
+
+        is_binomial = len(self.label_list) <= 2
+        if is_binomial:
+            if self.pos_label is None:
+                self.pos_label = self.label_list[-1]
+            else:
+                if self.pos_label in self.label_list:
+                    label_list = np.delete(self.label_list, np.where(self.label_list == self.pos_label))
+                self.label_list = np.append(self.label_list, self.pos_label)
+            if len(self.label_list) < 2:
+                raise MlflowException(
+                    "Evaluation dataset for classification must contain at least two unique "
+                    f"labels, but only {len(label_list)} unique labels were found.",
+                )
+            with _suppress_class_imbalance_errors(IndexError, log_warning=False):
+                _logger.info(
+                    "The evaluation dataset is inferred as binary dataset, positive label is "
+                    f"{self.label_list[1]}, negative label is {self.label_list[0]}."
+                )
+        else:
+            _logger.info(
+                "The evaluation dataset is inferred as multiclass dataset, number of classes "
+                f"is inferred as {len(self.label_list)}. If this is incorrect, please specify the "
+                "`label_list` parameter in `evaluator_config`."
+            )
+
+
+    def _compute_builtin_metrics(self):
+        self._evaluate_sklearn_model_score_if_scorable()
+
+        if len(self.label_list) == 2:
+            metrics = _get_binary_classifier_metrics(
+                y_true=self.y_true,
+                y_pred=self.y_pred,
+                y_proba=self.y_probs,
+                labels=self.label_list,
+                pos_label=self.pos_label,
+                sample_weights=self.sample_weights,
+            )
+            if metrics:
+                self.metrics_values.update(_get_aggregate_metrics_values(metrics))
+                self._compute_roc_and_pr_curve()
+        else:
+            average = self.evaluator_config.get("average", "weighted")
+            metrics = _get_multiclass_classifier_metrics(
+                y_true=self.y_true,
+                y_pred=self.y_pred,
+                y_proba=self.y_probs,
+                labels=self.label_list,
+                average=average,
+                sample_weights=self.sample_weights,
+            )
+            if metrics:
+                self.metrics_values.update(_get_aggregate_metrics_values(metrics))
+
+
+    def _compute_roc_and_pr_curve(self):
+        if self.y_probs is not None:
+            with _suppress_class_imbalance_errors(ValueError, log_warning=False):
+                self.roc_curve = _gen_classifier_curve(
+                    is_binomial=True,
+                    y=self.y_true,
+                    y_probs=self.y_probs[:, 1],
+                    labels=self.label_list,
+                    pos_label=self.pos_label,
+                    curve_type="roc",
+                    sample_weights=self.sample_weights,
+                )
+
+                self.metrics_values.update(
+                    _get_aggregate_metrics_values({"roc_auc": self.roc_curve.auc})
+                )
+            with _suppress_class_imbalance_errors(ValueError, log_warning=False):
+                self.pr_curve = _gen_classifier_curve(
+                    is_binomial=True,
+                    y=self.y_true,
+                    y_probs=self.y_probs[:, 1],
+                    labels=self.label_list,
+                    pos_label=self.pos_label,
+                    curve_type="pr",
+                    sample_weights=self.sample_weights,
+                )
+
+                self.metrics_values.update(
+                    _get_aggregate_metrics_values({"precision_recall_auc": self.pr_curve.auc})
+                )
+
+
+    def _log_pandas_df_artifact(self, pandas_df, artifact_name):
+        artifact_file_name = f"{artifact_name}.csv"
+        artifact_file_local_path = self.temp_dir.path(artifact_file_name)
+        pandas_df.to_csv(artifact_file_local_path, index=False)
+        mlflow.log_artifact(artifact_file_local_path)
+        artifact = CsvEvaluationArtifact(
+            uri=mlflow.get_artifact_uri(artifact_file_name),
+            content=pandas_df,
+        )
+        artifact._load(artifact_file_local_path)
+        self.artifacts[artifact_name] = artifact
+
+
+    def _log_multiclass_classifier_artifacts(self, y_true, y_pred, y_probs):
+        per_class_metrics_collection_df = _get_classifier_per_class_metrics_collection_df(
+            y=y_true,
+            y_pred=y_pred,
+            labels=self.label_list,
+            sample_weights=self.sample_weights,
+        )
+
+        log_roc_pr_curve = False
+        if y_probs is not None:
+            max_classes_for_multiclass_roc_pr = self.evaluator_config.get(
+                "max_classes_for_multiclass_roc_pr", 10
+            )
+            if len(self.label_list) <= max_classes_for_multiclass_roc_pr:
+                log_roc_pr_curve = True
+            else:
+                _logger.warning(
+                    f"The classifier num_classes > {max_classes_for_multiclass_roc_pr}, skip "
+                    f"logging ROC curve and Precision-Recall curve. You can add evaluator config "
+                    f"'max_classes_for_multiclass_roc_pr' to increase the threshold."
+                )
+
+        if log_roc_pr_curve:
+            roc_curve = _gen_classifier_curve(
+                is_binomial=False,
+                y=y_true,
+                y_probs=y_probs,
+                labels=self.label_list,
+                pos_label=self.pos_label,
+                curve_type="roc",
+                sample_weights=self.sample_weights,
+            )
+
+            def plot_roc_curve():
+                roc_curve.plot_fn(**roc_curve.plot_fn_args)
+
+            self._log_image_artifact(plot_roc_curve, "roc_curve_plot")
+            per_class_metrics_collection_df["roc_auc"] = roc_curve.auc
+
+            pr_curve = _gen_classifier_curve(
+                is_binomial=False,
+                y=y_true,
+                y_probs=y_probs,
+                labels=self.label_list,
+                pos_label=self.pos_label,
+                curve_type="pr",
+                sample_weights=self.sample_weights,
+            )
+
+            def plot_pr_curve():
+                pr_curve.plot_fn(**pr_curve.plot_fn_args)
+
+            self._log_image_artifact(plot_pr_curve, "precision_recall_curve_plot")
+            per_class_metrics_collection_df["precision_recall_auc"] = pr_curve.auc
+
+    def _log_roc_curve(self):
+        def _plot_roc_curve():
+            self.roc_curve.plot_fn(**self.roc_curve.plot_fn_args)
+
+        self._log_image_artifact(_plot_roc_curve, "roc_curve_plot")
+
+    def _log_precision_recall_curve(self):
+        def _plot_pr_curve():
+            self.pr_curve.plot_fn(**self.pr_curve.plot_fn_args)
+
+        self._log_image_artifact(_plot_pr_curve, "precision_recall_curve_plot")
+
+    def _log_lift_curve(self):
+        from mlflow.models.evaluation.lift_curve import plot_lift_curve
+
+        def _plot_lift_curve():
+            return plot_lift_curve(self.y, self.y_probs, pos_label=self.pos_label)
+
+        self._log_image_artifact(_plot_lift_curve, "lift_curve_plot")
+
+
+    def _log_binary_classifier_artifacts(self):
+        if self.y_probs is not None:
+            with _suppress_class_imbalance_errors(log_warning=False):
+                self._log_roc_curve()
+            with _suppress_class_imbalance_errors(log_warning=False):
+                self._log_precision_recall_curve()
+            with _suppress_class_imbalance_errors(ValueError, log_warning=False):
+                self._log_lift_curve()
+
+
+    def _log_confusion_matrix(self):
+        """
+        Helper method for logging confusion matrix
+        """
+        # normalize the confusion matrix, keep consistent with sklearn autologging.
+        confusion_matrix = sk_metrics.confusion_matrix(
+            self.y,
+            self.y_pred,
+            labels=self.label_list,
+            normalize="true",
+            sample_weight=self.sample_weights,
+        )
+
+        def plot_confusion_matrix():
+            import matplotlib
+            import matplotlib.pyplot as plt
+
+            with matplotlib.rc_context(
+                {
+                    "font.size": min(8, math.ceil(50.0 / self.num_classes)),
+                    "axes.labelsize": 8,
+                }
+            ):
+                _, ax = plt.subplots(1, 1, figsize=(6.0, 4.0), dpi=175)
+                disp = sk_metrics.ConfusionMatrixDisplay(
+                    confusion_matrix=confusion_matrix,
+                    display_labels=self.label_list,
+                ).plot(cmap="Blues", ax=ax)
+                disp.ax_.set_title("Normalized confusion matrix")
+
+        if hasattr(sk_metrics, "ConfusionMatrixDisplay"):
+            self._log_image_artifact(
+                plot_confusion_matrix,
+                "confusion_matrix",
+            )
+        return
+
+
+def _is_categorical(values):
+    """
+    Infer whether input values are categorical on best effort.
+    Return True represent they are categorical, return False represent we cannot determine result.
+    """
+    dtype_name = pd.Series(values).convert_dtypes().dtype.name.lower()
+    return dtype_name in ["category", "string", "boolean"]
+
+
+def _is_continuous(values):
+    """
+    Infer whether input values is continuous on best effort.
+    Return True represent they are continous, return False represent we cannot determine result.
+    """
+    dtype_name = pd.Series(values).convert_dtypes().dtype.name.lower()
+    return dtype_name.startswith("float")
+
+
+def _infer_model_type_by_labels(labels):
+    """
+    Infer model type by target values.
+    """
+    if _is_categorical(labels):
+        return _ModelType.CLASSIFIER
+    elif _is_continuous(labels):
+        return _ModelType.REGRESSOR
+    else:
+        return None  # Unknown
+
+
+def _extract_predict_fn_and_prodict_proba_fn(model):
+    predict_fn = None
+    predict_proba_fn = None
+
+    _, raw_model = _extract_raw_model(model)
+
+    if raw_model is not None:
+        predict_fn = raw_model.predict
+        predict_proba_fn = getattr(raw_model, "predict_proba", None)
+        try:
+            from mlflow.xgboost import (
+                _wrapped_xgboost_model_predict_fn,
+                _wrapped_xgboost_model_predict_proba_fn,
+            )
+
+            # Because shap evaluation will pass evaluation data in ndarray format
+            # (without feature names), if set validate_features=True it will raise error.
+            predict_fn = _wrapped_xgboost_model_predict_fn(raw_model, validate_features=False)
+            predict_proba_fn = _wrapped_xgboost_model_predict_proba_fn(
+                raw_model, validate_features=False
+            )
+        except ImportError:
+            pass
+    elif model is not None:
+        predict_fn = model.predict
+
+    return predict_fn, predict_proba_fn
+
+
+
+@contextmanager
+def _suppress_class_imbalance_errors(exception_type=Exception, log_warning=True):
+    """
+    Exception handler context manager to suppress Exceptions if the private environment
+    variable `_MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS` is set to `True`.
+    The purpose of this handler is to prevent an evaluation call for a binary or multiclass
+    classification automl run from aborting due to an extreme minority class imbalance
+    encountered during iterative training cycles due to the non deterministic sampling
+    behavior of Spark's DataFrame.sample() API.
+    The Exceptions caught in the usage of this are broad and are designed purely to not
+    interrupt the iterative hyperparameter tuning process. Final evaluations are done
+    in a more deterministic (but expensive) fashion.
+    """
+    try:
+        yield
+    except exception_type as e:
+        if _MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS.get():
+            if log_warning:
+                _logger.warning(
+                    "Failed to calculate metrics due to class imbalance. "
+                    "This is expected when the dataset is imbalanced."
+                )
+        else:
+            raise e
+
+def _get_binary_sum_up_label_pred_prob(positive_class_index, positive_class, y, y_pred, y_probs):
+    y = np.array(y)
+    y_bin = np.where(y == positive_class, 1, 0)
+    y_pred_bin = None
+    y_prob_bin = None
+    if y_pred is not None:
+        y_pred = np.array(y_pred)
+        y_pred_bin = np.where(y_pred == positive_class, 1, 0)
+
+    if y_probs is not None:
+        y_probs = np.array(y_probs)
+        y_prob_bin = y_probs[:, positive_class_index]
+
+    return y_bin, y_pred_bin, y_prob_bin
+
+
+def _get_common_classifier_metrics(
+    *, y_true, y_pred, y_proba, labels, average, pos_label, sample_weights
+):
+    metrics = {
+        "example_count": len(y_true),
+        "accuracy_score": sk_metrics.accuracy_score(y_true, y_pred, sample_weight=sample_weights),
+        "recall_score": sk_metrics.recall_score(
+            y_true,
+            y_pred,
+            average=average,
+            pos_label=pos_label,
+            sample_weight=sample_weights,
+        ),
+        "precision_score": sk_metrics.precision_score(
+            y_true,
+            y_pred,
+            average=average,
+            pos_label=pos_label,
+            sample_weight=sample_weights,
+        ),
+        "f1_score": sk_metrics.f1_score(
+            y_true,
+            y_pred,
+            average=average,
+            pos_label=pos_label,
+            sample_weight=sample_weights,
+        ),
+    }
+
+    if y_proba is not None:
+        with _suppress_class_imbalance_errors(ValueError):
+            metrics["log_loss"] = sk_metrics.log_loss(
+                y_true, y_proba, labels=labels, sample_weight=sample_weights
+            )
+    return metrics
+
+
+def _get_binary_classifier_metrics(
+    *, y_true, y_pred, y_proba=None, labels=None, pos_label=1, sample_weights=None
+):
+    with _suppress_class_imbalance_errors(ValueError):
+        tn, fp, fn, tp = sk_metrics.confusion_matrix(y_true, y_pred).ravel()
+        return {
+            "true_negatives": tn,
+            "false_positives": fp,
+            "false_negatives": fn,
+            "true_positives": tp,
+            **_get_common_classifier_metrics(
+                y_true=y_true,
+                y_pred=y_pred,
+                y_proba=y_proba,
+                labels=labels,
+                average="binary",
+                pos_label=pos_label,
+                sample_weights=sample_weights,
+            ),
+        }
+
+def _get_multiclass_classifier_metrics(
+    *,
+    y_true,
+    y_pred,
+    y_proba=None,
+    labels=None,
+    average="weighted",
+    sample_weights=None,
+):
+    metrics = _get_common_classifier_metrics(
+        y_true=y_true,
+        y_pred=y_pred,
+        y_proba=y_proba,
+        labels=labels,
+        average=average,
+        pos_label=None,
+        sample_weights=sample_weights,
+    )
+    if average in ("macro", "weighted") and y_proba is not None:
+        metrics.update(
+            roc_auc=sk_metrics.roc_auc_score(
+                y_true=y_true,
+                y_score=y_proba,
+                sample_weight=sample_weights,
+                average=average,
+                multi_class="ovr",
+            )
+        )
+    return metrics
+
+def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels, sample_weights):
+    per_class_metrics_list = []
+    for positive_class_index, positive_class in enumerate(labels):
+        (
+            y_bin,
+            y_pred_bin,
+            _,
+        ) = _get_binary_sum_up_label_pred_prob(
+            positive_class_index, positive_class, y, y_pred, None
+        )
+        per_class_metrics = {"positive_class": positive_class}
+        binary_classifier_metrics = _get_binary_classifier_metrics(
+            y_true=y_bin,
+            y_pred=y_pred_bin,
+            pos_label=1,
+            sample_weights=sample_weights,
+        )
+        if binary_classifier_metrics:
+            per_class_metrics.update(binary_classifier_metrics)
+        per_class_metrics_list.append(per_class_metrics)
+
+    return pd.DataFrame(per_class_metrics_list)
+
+
+_Curve = namedtuple("_Curve", ["plot_fn", "plot_fn_args", "auc"])
+
+
+def _gen_classifier_curve(
+    is_binomial,
+    y,
+    y_probs,
+    labels,
+    pos_label,
+    curve_type,
+    sample_weights,
+):
+    """
+    Generate precision-recall curve or ROC curve for classifier.
+
+    Args:
+        is_binomial: True if it is binary classifier otherwise False
+        y: True label values
+        y_probs: if binary classifier, the predicted probability for positive class.
+                  if multiclass classifier, the predicted probabilities for all classes.
+        labels: The set of labels.
+        pos_label: The label of the positive class.
+        curve_type: "pr" or "roc"
+        sample_weights: Optional sample weights.
+
+    Returns:
+        An instance of "_Curve" which includes attributes "plot_fn", "plot_fn_args", "auc".
+    """
+    if curve_type == "roc":
+
+        def gen_line_x_y_label_auc(_y, _y_prob, _pos_label):
+            fpr, tpr, _ = sk_metrics.roc_curve(
+                _y,
+                _y_prob,
+                sample_weight=sample_weights,
+                # For multiclass classification where a one-vs-rest ROC curve is produced for each
+                # class, the positive label is binarized and should not be included in the plot
+                # legend
+                pos_label=_pos_label if _pos_label == pos_label else None,
+            )
+
+            auc = sk_metrics.roc_auc_score(y_true=_y, y_score=_y_prob, sample_weight=sample_weights)
+            return fpr, tpr, f"AUC={auc:.3f}", auc
+
+        xlabel = "False Positive Rate"
+        ylabel = "True Positive Rate"
+        title = "ROC curve"
+        if pos_label:
+            xlabel = f"False Positive Rate (Positive label: {pos_label})"
+            ylabel = f"True Positive Rate (Positive label: {pos_label})"
+    elif curve_type == "pr":
+
+        def gen_line_x_y_label_auc(_y, _y_prob, _pos_label):
+            precision, recall, _ = sk_metrics.precision_recall_curve(
+                _y,
+                _y_prob,
+                sample_weight=sample_weights,
+                # For multiclass classification where a one-vs-rest precision-recall curve is
+                # produced for each class, the positive label is binarized and should not be
+                # included in the plot legend
+                pos_label=_pos_label if _pos_label == pos_label else None,
+            )
+            # NB: We return average precision score (AP) instead of AUC because AP is more
+            # appropriate for summarizing a precision-recall curve
+            ap = sk_metrics.average_precision_score(
+                y_true=_y, y_score=_y_prob, pos_label=_pos_label, sample_weight=sample_weights
+            )
+            return recall, precision, f"AP={ap:.3f}", ap
+
+        xlabel = "Recall"
+        ylabel = "Precision"
+        title = "Precision recall curve"
+        if pos_label:
+            xlabel = f"Recall (Positive label: {pos_label})"
+            ylabel = f"Precision (Positive label: {pos_label})"
+    else:
+        assert False, "illegal curve type"
+
+    if is_binomial:
+        x_data, y_data, line_label, auc = gen_line_x_y_label_auc(y, y_probs, pos_label)
+        data_series = [(line_label, x_data, y_data)]
+    else:
+        curve_list = []
+        for positive_class_index, positive_class in enumerate(labels):
+            y_bin, _, y_prob_bin = _get_binary_sum_up_label_pred_prob(
+                positive_class_index, positive_class, y, labels, y_probs
+            )
+
+            x_data, y_data, line_label, auc = gen_line_x_y_label_auc(
+                y_bin, y_prob_bin, _pos_label=1
+            )
+            curve_list.append((positive_class, x_data, y_data, line_label, auc))
+
+        data_series = [
+            (f"label={positive_class},{line_label}", x_data, y_data)
+            for positive_class, x_data, y_data, line_label, _ in curve_list
+        ]
+        auc = [auc for _, _, _, _, auc in curve_list]
+
+    def _do_plot(**kwargs):
+        from matplotlib import pyplot
+
+        _, ax = plot_lines(**kwargs)
+        dash_line_args = {
+            "color": "gray",
+            "alpha": 0.3,
+            "drawstyle": "default",
+            "linestyle": "dashed",
+        }
+        if curve_type == "pr":
+            ax.plot([0, 1], [1, 0], **dash_line_args)
+        elif curve_type == "roc":
+            ax.plot([0, 1], [0, 1], **dash_line_args)
+
+        if is_binomial:
+            ax.legend(loc="best")
+        else:
+            ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+            pyplot.subplots_adjust(right=0.6, bottom=0.25)
+
+    return _Curve(
+        plot_fn=_do_plot,
+        plot_fn_args={
+            "data_series": data_series,
+            "xlabel": xlabel,
+            "ylabel": ylabel,
+            "line_kwargs": {"drawstyle": "steps-post", "linewidth": 1},
+            "title": title,
+        },
+        auc=auc,
+    )
+

--- a/mlflow/models/evaluation/evaluators/default.py
+++ b/mlflow/models/evaluation/evaluators/default.py
@@ -39,6 +39,11 @@ _logger = logging.getLogger(__name__)
 
 
 class DefaultEvaluator(BuiltInEvaluator):
+    """
+    The default built-in evaluator for any models that cannot be evaluated
+    by other built-in evaluators, such as question-answering.
+    """
+
     name = "default"
 
     def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
@@ -74,9 +79,7 @@ class DefaultEvaluator(BuiltInEvaluator):
             target=self.dataset.labels_data,
             other_output_df=other_model_outputs,
         )
-        self.evaluate_and_log_custom_artifacts(
-            custom_artifacts, prediction=y_pred, target=y_true
-        )
+        self.evaluate_and_log_custom_artifacts(custom_artifacts, prediction=y_pred, target=y_true)
 
         # Log metrics and artifacts
         self.log_metrics()

--- a/mlflow/models/evaluation/evaluators/default.py
+++ b/mlflow/models/evaluation/evaluators/default.py
@@ -1,0 +1,297 @@
+import functools
+import logging
+import os
+import time
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+import mlflow
+from mlflow.entities.metric import Metric
+from mlflow.exceptions import MlflowException
+from mlflow.metrics import (
+    MetricValue,
+    ari_grade_level,
+    exact_match,
+    flesch_kincaid_grade_level,
+    ndcg_at_k,
+    precision_at_k,
+    recall_at_k,
+    rouge1,
+    rouge2,
+    rougeL,
+    rougeLsum,
+    token_count,
+    toxicity,
+)
+from mlflow.metrics.genai.genai_metric import _GENAI_CUSTOM_METRICS_FILE_NAME
+from mlflow.models.evaluation.artifacts import JsonEvaluationArtifact
+from mlflow.models.evaluation.base import EvaluationMetric, EvaluationResult, _ModelType
+from mlflow.models.evaluation.default_evaluator import _LATENCY_METRIC_NAME, BuiltInEvaluator, _extract_predict_fn
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+
+_logger = logging.getLogger(__name__)
+
+
+
+
+class DefaultEvaluator(BuiltInEvaluator):
+    name = "default"
+
+
+    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+        return model_type in _ModelType.values() or model_type is None
+
+    def _evaluate(
+        self,
+        model: Optional["mlflow.pyfunc.PyFuncModel"],
+        extra_metrics: List[EvaluationMetric],
+        custom_artifacts = None,
+        **kwargs,
+    ) -> EvaluationResult:
+        compute_latency = False
+        for extra_metric in extra_metrics:
+            # If latency metric is specified, we will compute latency for the model
+            # during prediction, and we will remove the metric from the list of extra
+            # metrics to be computed after prediction.
+            if extra_metric.name == _LATENCY_METRIC_NAME:
+                compute_latency = True
+                extra_metrics.remove(extra_metric)
+        self._log_genai_custom_metrics(extra_metrics)
+
+        # Generate model predictions and evaluate metrics
+        with mlflow.utils.autologging_utils.disable_autologging(
+            exemptions=[mlflow.langchain.FLAVOR_NAME]
+        ):
+            y_pred, other_model_outputs = self._generate_model_predictions(
+                model,
+                input_df=self.X.copy_to_avoid_mutation(),
+                compute_latency=compute_latency)
+            y_true = self.dataset.labels_data
+
+            metrics = self._builtin_metrics() + extra_metrics
+            self.evaluate_metrics(metrics, prediction=y_pred, target=self.dataset.labels_data, other_output_df=other_model_outputs)
+            self.evaluate_and_log_custom_artifacts(custom_artifacts, prediction=y_pred, target=y_true)
+
+        # Log metrics and artifacts
+        self.log_metrics()
+        self.log_eval_table(y_pred)
+        return EvaluationResult(
+            metrics=self.aggregate_metrics, artifacts=self.artifacts, run_id=self.run_id
+        )
+
+
+    def _builtin_metrics(self) -> List[Metric]:
+        """
+        Get a list of builtin metrics for the model type.
+        """
+        text_metrics = [
+            token_count(),
+            toxicity(),
+            flesch_kincaid_grade_level(),
+            ari_grade_level(),
+        ]
+        builtin_metrics = []
+
+        # NB: Classifier and Regressor is handled by ClassifierEvaluator, RegressorEvaluator, respectively
+        if self.model_type == _ModelType.QUESTION_ANSWERING:
+            builtin_metrics = [*text_metrics, exact_match()]
+        elif self.model_type == _ModelType.TEXT_SUMMARIZATION:
+            builtin_metrics = [
+                *text_metrics,
+                rouge1(),
+                rouge2(),
+                rougeL(),
+                rougeLsum(),
+            ]
+        elif self.model_type == _ModelType.TEXT:
+            builtin_metrics = text_metrics
+        elif self.model_type == _ModelType.RETRIEVER:
+            # default k to 3 if not specified
+            retriever_k = self.evaluator_config.pop("retriever_k", 3)
+            builtin_metrics = [
+                precision_at_k(retriever_k),
+                recall_at_k(retriever_k),
+                ndcg_at_k(retriever_k),
+            ]
+
+        return builtin_metrics
+
+
+    def _generate_model_predictions(
+        self,
+        model: Optional["mlflow.pyfunc.PyFuncModel"],
+        input_df: pd.DataFrame,
+        compute_latency=False
+    ):
+        """
+        Helper method for generating model predictions
+        """
+        predict_fn = _extract_predict_fn(model)
+        predict_fn = _restrict_langchain_autologging_to_traces_only(predict_fn)
+
+        def predict_with_latency(X_copy):
+            y_pred_list = []
+            pred_latencies = []
+            if len(X_copy) == 0:
+                raise ValueError("Empty input data")
+
+            is_dataframe = isinstance(X_copy, pd.DataFrame)
+
+            for row in X_copy.iterrows() if is_dataframe else enumerate(X_copy):
+                i, row_data = row
+                single_input = row_data.to_frame().T if is_dataframe else row_data
+                start_time = time.time()
+                y_pred = predict_fn(single_input)
+                end_time = time.time()
+                pred_latencies.append(end_time - start_time)
+                y_pred_list.append(y_pred)
+
+            # Update latency metric
+            self.metrics_values.update({_LATENCY_METRIC_NAME: MetricValue(scores=pred_latencies)})
+
+            # Aggregate all predictions into model_predictions
+            sample_pred = y_pred_list[0]
+            if isinstance(sample_pred, pd.DataFrame):
+                return pd.concat(y_pred_list)
+            elif isinstance(sample_pred, np.ndarray):
+                return np.concatenate(y_pred_list, axis=0)
+            elif isinstance(sample_pred, list):
+                return sum(y_pred_list, [])
+            elif isinstance(sample_pred, pd.Series):
+                return pd.concat(y_pred_list, ignore_index=True)
+            elif isinstance(sample_pred, str):
+                return y_pred_list
+            else:
+                raise MlflowException(
+                    message=f"Unsupported prediction type {type(sample_pred)} for model type "
+                    f"{self.model_type}.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+
+        if model is not None:
+            _logger.info("Computing model predictions.")
+
+            if compute_latency:
+                model_predictions = predict_with_latency(input_df)
+            else:
+                model_predictions = predict_fn(input_df)
+        else:
+            if compute_latency:
+                _logger.warning("Setting the latency to 0 for all entries because the model is not provided.")
+                self.metrics_values.update(
+                    {_LATENCY_METRIC_NAME: MetricValue(scores=[0.0] * len(input_df))}
+                )
+            model_predictions = self.dataset.predictions_data
+
+        output_column_name = self.predictions
+        (
+            y_pred,
+            other_output_df,
+            predictions_column_name,
+        ) = _extract_output_and_other_columns(model_predictions, output_column_name)
+
+        return y_pred, other_output_df, predictions_column_name
+
+
+    def _log_genai_custom_metrics(self, extra_metrics: List[EvaluationMetric]):
+        genai_custom_metrics = [
+            extra_metric.genai_metric_args
+            for extra_metric in extra_metrics
+            # When the field is present, the metric is created from either make_genai_metric
+            # or make_genai_metric_from_prompt. We will log the metric definition.
+            if extra_metric.genai_metric_args is not None
+        ]
+
+        if len(genai_custom_metrics) == 0:
+            return
+
+        names = []
+        versions = []
+        metric_args_list = []
+
+        for metric_args in genai_custom_metrics:
+            names.append(metric_args["name"])
+            # Custom metrics created from make_genai_metric_from_prompt don't have version
+            versions.append(metric_args.get("version", ""))
+            metric_args_list.append(metric_args)
+
+        data = {"name": names, "version": versions, "metric_args": metric_args_list}
+
+        mlflow.log_table(data, artifact_file=_GENAI_CUSTOM_METRICS_FILE_NAME)
+
+        artifact_name = os.path.splitext(_GENAI_CUSTOM_METRICS_FILE_NAME)[0]
+        self.artifacts[artifact_name] = JsonEvaluationArtifact(
+            uri=mlflow.get_artifact_uri(_GENAI_CUSTOM_METRICS_FILE_NAME)
+        )
+
+
+def _restrict_langchain_autologging_to_traces_only(pred_fn):
+    if pred_fn is None:
+        return None
+
+    # In non-langchain environments, nothing would be autologged.
+    @functools.wraps(pred_fn)
+    def new_pred_fn(*args, **kwargs):
+        with mlflow.utils.autologging_utils.restrict_langchain_autologging_to_traces_only():
+            return pred_fn(*args, **kwargs)
+
+    return new_pred_fn
+
+
+def _extract_output_and_other_columns(model_predictions, output_column_name):
+    y_pred = None
+    other_output_columns = None
+    ERROR_MISSING_OUTPUT_COLUMN_NAME = (
+        "Output column name is not specified for the multi-output model. "
+        "Please set the correct output column name using the `predictions` parameter."
+    )
+
+    if isinstance(model_predictions, pd.DataFrame):
+        if output_column_name in model_predictions.columns:
+            y_pred = model_predictions[output_column_name]
+            other_output_columns = model_predictions.drop(columns=output_column_name)
+        elif len(model_predictions.columns) == 1:
+            output_column_name = model_predictions.columns[0]
+            y_pred = model_predictions[output_column_name]
+        elif output_column_name is None:
+            raise MlflowException(
+                ERROR_MISSING_OUTPUT_COLUMN_NAME,
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        else:
+            raise MlflowException(
+                f"Output column name '{output_column_name}' is not found in the model "
+                f"predictions dataframe {model_predictions.columns}. Please set the correct "
+                "output column name using the `predictions` parameter.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+    elif isinstance(model_predictions, dict):
+        if output_column_name in model_predictions:
+            y_pred = pd.Series(model_predictions[output_column_name], name=output_column_name)
+            other_output_columns = pd.DataFrame(
+                {k: v for k, v in model_predictions.items() if k != output_column_name}
+            )
+        elif len(model_predictions) == 1:
+            key, value = list(model_predictions.items())[0]
+            y_pred = pd.Series(value, name=key)
+            output_column_name = key
+        elif output_column_name is None:
+            raise MlflowException(
+                ERROR_MISSING_OUTPUT_COLUMN_NAME,
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        else:
+            raise MlflowException(
+                f"Output column name '{output_column_name}' is not found in the "
+                f"model predictions dict {model_predictions}. Please set the correct "
+                "output column name using the `predictions` parameter.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+    return (
+        y_pred if y_pred is not None else model_predictions,
+        other_output_columns,
+        output_column_name,
+    )

--- a/mlflow/models/evaluation/evaluators/default.py
+++ b/mlflow/models/evaluation/evaluators/default.py
@@ -46,7 +46,8 @@ class DefaultEvaluator(BuiltInEvaluator):
 
     name = "default"
 
-    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+    @classmethod
+    def can_evaluate(cls, *, model_type, evaluator_config, **kwargs):
         return model_type in _ModelType.values() or model_type is None
 
     def _evaluate(
@@ -55,7 +56,7 @@ class DefaultEvaluator(BuiltInEvaluator):
         extra_metrics: List[EvaluationMetric],
         custom_artifacts=None,
         **kwargs,
-    ) -> EvaluationResult:
+    ) -> Optional[EvaluationResult]:
         compute_latency = False
         for extra_metric in extra_metrics:
             # If latency metric is specified, we will compute latency for the model

--- a/mlflow/models/evaluation/evaluators/regressor.py
+++ b/mlflow/models/evaluation/evaluators/regressor.py
@@ -1,0 +1,83 @@
+from typing import List, Optional
+
+import numpy as np
+from sklearn import metrics as sk_metrics
+
+from mlflow.models.evaluation.base import _ModelType, EvaluationMetric, EvaluationResult
+from mlflow.models.evaluation.default_evaluator import BuiltInEvaluator, _extract_predict_fn, _get_aggregate_metrics_values
+
+
+
+class RegressorEvaluator(BuiltInEvaluator):
+    name = "regressor"
+
+
+    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+        return model_type == _ModelType.REGRESSOR
+
+    def _evaluate(
+        self,
+        model: Optional["mlflow.pyfunc.PyFuncModel"],
+        extra_metrics: List[EvaluationMetric],
+        custom_artifacts = None,
+        **kwargs,
+    ) -> EvaluationResult:
+        y_true = self.dataset.labels_data
+        sample_weights = self.evaluator_config.get("sample_weights", None)
+
+        input_df = self.X.copy_to_avoid_mutation()
+        y_pred = self._generate_model_predictions(model, input_df)
+        self._compute_buildin_metrics(model, y_true, y_pred, sample_weights)
+
+        self.evaluate_metrics(extra_metrics, prediction=y_pred, target=y_true)
+        self.evaluate_and_log_custom_artifacts(custom_artifacts, prediction=y_pred, target=y_true)
+
+        self.log_metrics()
+        self.log_eval_table(y_pred)
+
+        return EvaluationResult(
+            metrics=self.aggregate_metrics, artifacts=self.artifacts, run_id=self.run_id
+        )
+
+    def _generate_model_predictions(self, model, input_df):
+        predict_fn = _extract_predict_fn(model)
+        # Regressor model should output single column of predictions
+        if model is not None:
+            y_pred = predict_fn(input_df)
+        else:
+            y_pred = self.dataset.predictions_data
+        return y_pred
+
+    def _compute_buildin_metrics(self, model, y_true, y_pred, sample_weights):
+        self._evaluate_sklearn_model_score_if_scorable(model, y_true, sample_weights)
+
+        self.metrics_values.update(
+            _get_aggregate_metrics_values(
+                _get_regressor_metrics(y_true, y_pred, sample_weights)
+            )
+        )
+
+
+def _get_regressor_metrics(y, y_pred, sample_weights):
+    sum_on_target = (
+        (np.array(y) * np.array(sample_weights)).sum() if sample_weights is not None else sum(y)
+    )
+    return {
+        "example_count": len(y),
+        "mean_absolute_error": sk_metrics.mean_absolute_error(
+            y, y_pred, sample_weight=sample_weights
+        ),
+        "mean_squared_error": sk_metrics.mean_squared_error(
+            y, y_pred, sample_weight=sample_weights
+        ),
+        "root_mean_squared_error": sk_metrics.mean_squared_error(
+            y, y_pred, sample_weight=sample_weights, squared=False
+        ),
+        "sum_on_target": sum_on_target,
+        "mean_on_target": sum_on_target / len(y),
+        "r2_score": sk_metrics.r2_score(y, y_pred, sample_weight=sample_weights),
+        "max_error": sk_metrics.max_error(y, y_pred),
+        "mean_absolute_percentage_error": sk_metrics.mean_absolute_percentage_error(
+            y, y_pred, sample_weight=sample_weights
+        ),
+    }

--- a/mlflow/models/evaluation/evaluators/regressor.py
+++ b/mlflow/models/evaluation/evaluators/regressor.py
@@ -19,7 +19,8 @@ class RegressorEvaluator(BuiltInEvaluator):
 
     name = "regressor"
 
-    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+    @classmethod
+    def can_evaluate(cls, *, model_type, evaluator_config, **kwargs):
         return model_type == _ModelType.REGRESSOR
 
     def _evaluate(
@@ -28,7 +29,7 @@ class RegressorEvaluator(BuiltInEvaluator):
         extra_metrics: List[EvaluationMetric],
         custom_artifacts=None,
         **kwargs,
-    ) -> EvaluationResult:
+    ) -> Optional[EvaluationResult]:
         self.y_true = self.dataset.labels_data
         self.sample_weights = self.evaluator_config.get("sample_weights", None)
 

--- a/mlflow/models/evaluation/evaluators/regressor.py
+++ b/mlflow/models/evaluation/evaluators/regressor.py
@@ -22,18 +22,18 @@ class RegressorEvaluator(BuiltInEvaluator):
         custom_artifacts = None,
         **kwargs,
     ) -> EvaluationResult:
-        y_true = self.dataset.labels_data
-        sample_weights = self.evaluator_config.get("sample_weights", None)
+        self.y_true = self.dataset.labels_data
+        self.sample_weights = self.evaluator_config.get("sample_weights", None)
 
         input_df = self.X.copy_to_avoid_mutation()
-        y_pred = self._generate_model_predictions(model, input_df)
-        self._compute_buildin_metrics(model, y_true, y_pred, sample_weights)
+        self.y_pred = self._generate_model_predictions(model, input_df)
+        self._compute_buildin_metrics(model)
 
-        self.evaluate_metrics(extra_metrics, prediction=y_pred, target=y_true)
-        self.evaluate_and_log_custom_artifacts(custom_artifacts, prediction=y_pred, target=y_true)
+        self.evaluate_metrics(extra_metrics, prediction=self.y_pred, target=self.y_true)
+        self.evaluate_and_log_custom_artifacts(custom_artifacts, prediction=self.y_pred, target=self.y_true)
 
         self.log_metrics()
-        self.log_eval_table(y_pred)
+        self.log_eval_table(self.y_pred)
 
         return EvaluationResult(
             metrics=self.aggregate_metrics, artifacts=self.artifacts, run_id=self.run_id
@@ -48,12 +48,12 @@ class RegressorEvaluator(BuiltInEvaluator):
             y_pred = self.dataset.predictions_data
         return y_pred
 
-    def _compute_buildin_metrics(self, model, y_true, y_pred, sample_weights):
-        self._evaluate_sklearn_model_score_if_scorable(model, y_true, sample_weights)
+    def _compute_buildin_metrics(self, model):
+        self._evaluate_sklearn_model_score_if_scorable(model, self.y_true, self.sample_weights)
 
         self.metrics_values.update(
             _get_aggregate_metrics_values(
-                _get_regressor_metrics(y_true, y_pred, sample_weights)
+                _get_regressor_metrics(self.y_true, self.y_pred, self.sample_weights)
             )
         )
 

--- a/mlflow/models/evaluation/evaluators/regressor.py
+++ b/mlflow/models/evaluation/evaluators/regressor.py
@@ -13,6 +13,10 @@ from mlflow.models.evaluation.default_evaluator import (
 
 
 class RegressorEvaluator(BuiltInEvaluator):
+    """
+    A built-in evaluator for regressor models.
+    """
+
     name = "regressor"
 
     def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
@@ -52,7 +56,6 @@ class RegressorEvaluator(BuiltInEvaluator):
 
     def _compute_buildin_metrics(self, model):
         self._evaluate_sklearn_model_score_if_scorable(model, self.y_true, self.sample_weights)
-
         self.metrics_values.update(
             _get_aggregate_metrics_values(
                 _get_regressor_metrics(self.y_true, self.y_pred, self.sample_weights)

--- a/mlflow/models/evaluation/evaluators/shap.py
+++ b/mlflow/models/evaluation/evaluators/shap.py
@@ -34,6 +34,12 @@ def _shap_predict_fn(x, predict_fn, feature_names):
 
 
 class ShapEvaluator(BuiltInEvaluator):
+    """
+    A built-in evaluator to get SHAP explainability insights for classifier and regressor models.
+
+    This evaluator often run with the main evaluator for the model like ClassifierEvaluator.
+    """
+
     name = "shap"
 
     @classmethod
@@ -140,8 +146,9 @@ class ShapEvaluator(BuiltInEvaluator):
         )
 
         if self.label_list is None:
-            # If label list is not specified, infer label list from model output
-            y_pred = predict_fn(X_df) if predict_fn else self.dataset.predictions_data
+            # If label list is not specified, infer label list from model output.
+            # We need to copy the input data as the model might mutate the input data.
+            y_pred = predict_fn(X_df.copy()) if predict_fn else self.dataset.predictions_data
             self.label_list = np.unique(np.concatenate([self.y_true, y_pred]))
 
         try:
@@ -209,7 +216,7 @@ class ShapEvaluator(BuiltInEvaluator):
                 f"Shap evaluation failed. Reason: {e!r}. "
                 "Set logging level to DEBUG to see the full traceback."
             )
-            _logger.warning("", exc_info=True)
+            _logger.debug("", exc_info=True)
             return
         try:
             mlflow.shap.log_explainer(explainer, artifact_path="explainer")

--- a/mlflow/models/evaluation/evaluators/shap.py
+++ b/mlflow/models/evaluation/evaluators/shap.py
@@ -43,7 +43,7 @@ class ShapEvaluator(BuiltInEvaluator):
     name = "shap"
 
     @classmethod
-    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+    def can_evaluate(cls, *, model_type, evaluator_config, **kwargs):
         return model_type in (_ModelType.CLASSIFIER, _ModelType.REGRESSOR) and evaluator_config.get(
             "log_model_explainability", True
         )
@@ -54,7 +54,7 @@ class ShapEvaluator(BuiltInEvaluator):
         extra_metrics: List[EvaluationMetric],
         custom_artifacts=None,
         **kwargs,
-    ) -> EvaluationResult:
+    ) -> Optional[EvaluationResult]:
         if isinstance(model, _ServedPyFuncModel):
             _logger.warning(
                 "Skipping model explainability because a model server is used for environment "

--- a/mlflow/models/evaluation/evaluators/shap.py
+++ b/mlflow/models/evaluation/evaluators/shap.py
@@ -1,0 +1,276 @@
+import functools
+import logging
+from typing import List, Optional
+import numpy as np
+from packaging.version import Version
+from sklearn.pipeline import Pipeline as sk_Pipeline
+
+from mlflow import MlflowException
+
+import mlflow
+from mlflow.models.evaluation.base import _ModelType, EvaluationMetric, EvaluationResult
+from mlflow.models.evaluation.default_evaluator import BuiltInEvaluator, _extract_predict_fn, _extract_raw_model
+from mlflow.models.evaluation.evaluators.classifier import _is_continuous, _suppress_class_imbalance_errors
+from mlflow.models.evaluation.default_evaluator import _get_dataframe_with_renamed_columns
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.pyfunc import _ServedPyFuncModel
+
+
+
+_logger = logging.getLogger(__name__)
+
+
+_SUPPORTED_SHAP_ALGORITHMS = ("exact", "permutation", "partition", "kernel")
+_DEFAULT_SAMPLE_ROWS_FOR_SHAP = 2000
+
+
+def _shap_predict_fn(x, predict_fn, feature_names):
+    return predict_fn(_get_dataframe_with_renamed_columns(x, feature_names))
+
+
+
+class ShapEvaluator(BuiltInEvaluator):
+    name = "shap"
+
+    @classmethod
+    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+        return (
+            (model_type in (_ModelType.CLASSIFIER, _ModelType.REGRESSOR)
+            and evaluator_config.get("log_model_explainability", True))
+        )
+
+    def _evaluate(
+        self,
+        model: Optional["mlflow.pyfunc.PyFuncModel"],
+        extra_metrics: List[EvaluationMetric],
+        custom_artifacts = None,
+        **kwargs,
+    ) -> EvaluationResult:
+        if isinstance(model, _ServedPyFuncModel):
+            _logger.warning(
+                "Skipping model explainability because a model server is used for environment "
+                "restoration."
+            )
+            return
+
+        model_loader_module, raw_model = _extract_raw_model(model)
+        if model_loader_module == "mlflow.spark":
+            # TODO: Shap explainer need to manipulate on each feature values,
+            #  but spark model input dataframe contains Vector type feature column
+            #  which shap explainer does not support.
+            #  To support this, we need expand the Vector type feature column into
+            #  multiple scalar feature columns and pass it to shap explainer.
+            _logger.warning(
+                "Logging model explainability insights is not currently supported for PySpark "
+                "models."
+            )
+            return
+
+        self.y_true = self.dataset.labels_data
+        self.label_list = self.evaluator_config.get("label_list")
+        self.pos_label = self.evaluator_config.get("pos_label")
+
+        if not (np.issubdtype(self.y_true.dtype, np.number) or self.y_true.dtype == np.bool_):
+            # Note: python bool type inherits number type but np.bool_ does not inherit np.number.
+            _logger.warning(
+                "Skip logging model explainability insights because it requires all label "
+                "values to be numeric or boolean."
+            )
+            return
+
+
+        algorithm = self.evaluator_config.get("explainability_algorithm", None)
+        if algorithm is not None and algorithm not in _SUPPORTED_SHAP_ALGORITHMS:
+            raise MlflowException(
+                message=f"Specified explainer algorithm {algorithm} is unsupported. Currently only "
+                f"support {','.join(_SUPPORTED_SHAP_ALGORITHMS)} algorithms.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+        if algorithm != "kernel":
+            feature_dtypes = list(self.X.get_original().dtypes)
+            for feature_dtype in feature_dtypes:
+                if not np.issubdtype(feature_dtype, np.number):
+                    _logger.warning(
+                        "Skip logging model explainability insights because the shap explainer "
+                        f"{algorithm} requires all feature values to be numeric, and each feature "
+                        "column must only contain scalar values."
+                    )
+                    return
+
+        try:
+            import shap
+            from matplotlib import pyplot
+        except ImportError:
+            _logger.warning(
+                "SHAP or matplotlib package is not installed, so model explainability insights "
+                "will not be logged."
+            )
+            return
+
+        if Version(shap.__version__) < Version("0.40"):
+            _logger.warning(
+                "Shap package version is lower than 0.40, Skip log model explainability."
+            )
+            return
+
+        is_multinomial_classifier = self.model_type == _ModelType.CLASSIFIER and len(self.label_list) > 2
+
+        sample_rows = self.evaluator_config.get(
+            "explainability_nsamples", _DEFAULT_SAMPLE_ROWS_FOR_SHAP
+        )
+
+        X_df = self.X.copy_to_avoid_mutation()
+
+        sampled_X = shap.sample(X_df, sample_rows, random_state=0)
+
+        mode_or_mean_dict = _compute_df_mode_or_mean(X_df)
+        sampled_X = sampled_X.fillna(mode_or_mean_dict)
+
+        # shap explainer might call provided `predict_fn` with a `numpy.ndarray` type
+        # argument, this might break some model inference, so convert the argument into
+        # a pandas dataframe.
+        # The `shap_predict_fn` calls model's predict function, we need to restore the input
+        # dataframe with original column names, because some model prediction routine uses
+        # the column name.
+
+        predict_fn = _extract_predict_fn(model)
+        shap_predict_fn = functools.partial(
+            _shap_predict_fn, predict_fn=predict_fn, feature_names=self.dataset.feature_names
+        )
+
+        try:
+            if algorithm:
+                if algorithm == "kernel":
+                    # We need to lazily import shap, so lazily import `_PatchedKernelExplainer`
+                    from mlflow.models.evaluation._shap_patch import _PatchedKernelExplainer
+
+                    kernel_link = self.evaluator_config.get(
+                        "explainability_kernel_link", "identity"
+                    )
+                    if kernel_link not in ["identity", "logit"]:
+                        raise ValueError(
+                            "explainability_kernel_link config can only be set to 'identity' or "
+                            f"'logit', but got '{kernel_link}'."
+                        )
+                    background_X = shap.sample(X_df, sample_rows, random_state=3)
+                    background_X = background_X.fillna(mode_or_mean_dict)
+
+                    explainer = _PatchedKernelExplainer(
+                        shap_predict_fn, background_X, link=kernel_link
+                    )
+                else:
+                    explainer = shap.Explainer(
+                        shap_predict_fn,
+                        sampled_X,
+                        feature_names=self.dataset.feature_names,
+                        algorithm=algorithm,
+                    )
+            else:
+                if (
+                    raw_model
+                    and not is_multinomial_classifier
+                    and not isinstance(raw_model, sk_Pipeline)
+                ):
+                    # For mulitnomial classifier, shap.Explainer may choose Tree/Linear explainer
+                    # for raw model, this case shap plot doesn't support it well, so exclude the
+                    # multinomial_classifier case here.
+                    explainer = shap.Explainer(
+                        raw_model, sampled_X, feature_names=self.dataset.feature_names
+                    )
+                else:
+                    # fallback to default explainer
+                    explainer = shap.Explainer(
+                        shap_predict_fn, sampled_X, feature_names=self.dataset.feature_names
+                    )
+
+            _logger.info(f"Shap explainer {explainer.__class__.__name__} is used.")
+
+            if algorithm == "kernel":
+                shap_values = shap.Explanation(
+                    explainer.shap_values(sampled_X), feature_names=self.dataset.feature_names
+                )
+            else:
+                shap_values = explainer(sampled_X)
+        except Exception as e:
+            # Shap evaluation might fail on some edge cases, e.g., unsupported input data values
+            # or unsupported model on specific shap explainer. Catch exception to prevent it
+            # breaking the whole `evaluate` function.
+
+            if not self.evaluator_config.get("ignore_exceptions", True):
+                raise e
+
+            _logger.warning(
+                f"Shap evaluation failed. Reason: {e!r}. "
+                "Set logging level to DEBUG to see the full traceback."
+            )
+            _logger.debug("", exc_info=True)
+            return
+        try:
+            mlflow.shap.log_explainer(explainer, artifact_path="explainer")
+        except Exception as e:
+            # TODO: The explainer saver is buggy, if `get_underlying_model_flavor` return "unknown",
+            #   then fallback to shap explainer saver, and shap explainer will call `model.save`
+            #   for sklearn model, there is no `.save` method, so error will happen.
+            _logger.warning(
+                f"Logging explainer failed. Reason: {e!r}. "
+                "Set logging level to DEBUG to see the full traceback."
+            )
+            _logger.debug("", exc_info=True)
+
+        def _adjust_color_bar():
+            pyplot.gcf().axes[-1].set_aspect("auto")
+            pyplot.gcf().axes[-1].set_box_aspect(50)
+
+        def _adjust_axis_tick():
+            pyplot.xticks(fontsize=10)
+            pyplot.yticks(fontsize=10)
+
+        def plot_beeswarm():
+            shap.plots.beeswarm(shap_values, show=False, color_bar=True)
+            _adjust_color_bar()
+            _adjust_axis_tick()
+
+        with _suppress_class_imbalance_errors(ValueError, log_warning=False):
+            self._log_image_artifact(
+                plot_beeswarm,
+                "shap_beeswarm_plot",
+            )
+
+        def plot_summary():
+            shap.summary_plot(shap_values, show=False, color_bar=True)
+            _adjust_color_bar()
+            _adjust_axis_tick()
+
+        with _suppress_class_imbalance_errors(TypeError, log_warning=False):
+            self._log_image_artifact(
+                plot_summary,
+                "shap_summary_plot",
+            )
+
+        def plot_feature_importance():
+            shap.plots.bar(shap_values, show=False)
+            _adjust_axis_tick()
+
+        with _suppress_class_imbalance_errors(IndexError, log_warning=False):
+            self._log_image_artifact(
+                plot_feature_importance,
+                "shap_feature_importance_plot",
+            )
+
+
+def _compute_df_mode_or_mean(df):
+    """
+    Compute mean (for continuous columns) and compute mode (for other columns) for the
+    input dataframe, return a dict, key is column name, value is the corresponding mode or
+    mean value, this function calls `_is_continuous` to determine whether the
+    column is continuous column.
+    """
+    continuous_cols = [c for c in df.columns if _is_continuous(df[c])]
+    df_cont = df[continuous_cols]
+    df_non_cont = df.drop(continuous_cols, axis=1)
+
+    means = {} if df_cont.empty else df_cont.mean().to_dict()
+    modes = {} if df_non_cont.empty else df_non_cont.mode().loc[0].to_dict()
+    return {**means, **modes}
+

--- a/mlflow/models/evaluation/utils/metric.py
+++ b/mlflow/models/evaluation/utils/metric.py
@@ -1,13 +1,14 @@
-from dataclasses import dataclass
 import logging
-from typing import Any, Callable, Dict, Optional
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
 import numpy as np
 
 from mlflow.metrics.base import MetricValue
 from mlflow.models.evaluation.base import EvaluationMetric
 
-
 _logger = logging.getLogger(__name__)
+
 
 @dataclass
 class MetricDefinition:
@@ -62,7 +63,6 @@ class MetricDefinition:
         def _is_numeric(value):
             return isinstance(value, (int, float, np.number))
 
-
         def _is_string(value):
             return isinstance(value, str)
 
@@ -83,9 +83,11 @@ class MetricDefinition:
 
         if scores is not None:
             if not isinstance(scores, list):
-                _logger.warning(f"{exception_header} must return MetricValue with scores as a list.")
+                _logger.warning(
+                    f"{exception_header} must return MetricValue with scores as a list."
+                )
                 return
-            if any(not (_is_numeric(score) or _is_string(score) or score is None) for score in scores):
+            if any(not (_is_numeric(s) or _is_string(s) or s is None) for s in scores):
                 _logger.warning(
                     f"{exception_header} must return MetricValue with numeric or string scores."
                 )

--- a/mlflow/models/evaluation/utils/metric.py
+++ b/mlflow/models/evaluation/utils/metric.py
@@ -25,8 +25,9 @@ class MetricDefinition:
     version: Optional[str] = None
     genai_metric_args: Optional[Dict] = None
 
-    def from_index_and_metric(self, index: int, metric: EvaluationMetric):
-        return MetricDefinition(
+    @classmethod
+    def from_index_and_metric(cls, index: int, metric: EvaluationMetric):
+        return cls(
             function=metric.eval_fn,
             index=index,
             name=metric.name,

--- a/mlflow/models/evaluation/utils/metric.py
+++ b/mlflow/models/evaluation/utils/metric.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass
+import logging
+from typing import Any, Callable, Dict, Optional
+import numpy as np
+
+from mlflow.metrics.base import MetricValue
+from mlflow.models.evaluation.base import EvaluationMetric
+
+
+_logger = logging.getLogger(__name__)
+
+@dataclass
+class MetricDefinition:
+    """
+    A namedtuple representing a metric function and its properties.
+
+    function : the metric function
+    name : the name of the metric function
+    index : the index of the function in the ``extra_metrics`` argument of mlflow.evaluate
+    """
+
+    function: Callable
+    name: str
+    index: int
+    version: Optional[str] = None
+    genai_metric_args: Optional[Dict] = None
+
+    def from_index_and_metric(self, index: int, metric: EvaluationMetric):
+        return MetricDefinition(
+            function=metric.eval_fn,
+            index=index,
+            name=metric.name,
+            version=metric.version,
+            genai_metric_args=metric.genai_metric_args,
+        )
+
+    def evaluate(self, eval_fn_args) -> Optional[MetricValue]:
+        """
+        This function calls the metric function and performs validations on the returned
+        result to ensure that they are in the expected format. It will warn and will not log metrics
+        that are in the wrong format.
+
+        Args:
+            metric_tuple: Containing a user provided function and its index in the
+                ``extra_metrics`` parameter of ``mlflow.evaluate``
+            eval_fn_args: A dictionary of args needed to compute the eval metrics.
+
+        Returns:
+            MetricValue
+        """
+        if self.index < 0:
+            exception_header = f"Did not log builtin metric '{self.name}' because it"
+        else:
+            exception_header = (
+                f"Did not log metric '{self.name}' at index "
+                f"{self.index} in the `extra_metrics` parameter because it"
+            )
+
+        metric: MetricValue = self.function(*eval_fn_args)
+
+        def _is_numeric(value):
+            return isinstance(value, (int, float, np.number))
+
+
+        def _is_string(value):
+            return isinstance(value, str)
+
+        if metric is None:
+            _logger.warning(f"{exception_header} returned None.")
+            return
+
+        if _is_numeric(metric):
+            return MetricValue(aggregate_results={self.name: metric})
+
+        if not isinstance(metric, MetricValue):
+            _logger.warning(f"{exception_header} did not return a MetricValue.")
+            return
+
+        scores = metric.scores
+        justifications = metric.justifications
+        aggregates = metric.aggregate_results
+
+        if scores is not None:
+            if not isinstance(scores, list):
+                _logger.warning(f"{exception_header} must return MetricValue with scores as a list.")
+                return
+            if any(not (_is_numeric(score) or _is_string(score) or score is None) for score in scores):
+                _logger.warning(
+                    f"{exception_header} must return MetricValue with numeric or string scores."
+                )
+                return
+
+        if justifications is not None:
+            if not isinstance(justifications, list):
+                _logger.warning(
+                    f"{exception_header} must return MetricValue with justifications as a list."
+                )
+                return
+            if any(not (_is_string(jus) or jus is None) for jus in justifications):
+                _logger.warning(
+                    f"{exception_header} must return MetricValue with string justifications."
+                )
+                return
+
+        if aggregates is not None:
+            if not isinstance(aggregates, dict):
+                _logger.warning(
+                    f"{exception_header} must return MetricValue with aggregate_results as a dict."
+                )
+                return
+
+            if any(
+                not (isinstance(k, str) and (_is_numeric(v) or v is None))
+                for k, v in aggregates.items()
+            ):
+                _logger.warning(
+                    f"{exception_header} must return MetricValue with aggregate_results with "
+                    "str keys and numeric values."
+                )
+                return
+
+        return metric

--- a/mlflow/models/evaluation/utils/metric.py
+++ b/mlflow/models/evaluation/utils/metric.py
@@ -43,8 +43,6 @@ class MetricDefinition:
         that are in the wrong format.
 
         Args:
-            metric_tuple: Containing a user provided function and its index in the
-                ``extra_metrics`` parameter of ``mlflow.evaluate``
             eval_fn_args: A dictionary of args needed to compute the eval metrics.
 
         Returns:

--- a/mlflow/models/evaluation/utils/metric.py
+++ b/mlflow/models/evaluation/utils/metric.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import numpy as np
 
@@ -20,11 +20,11 @@ class MetricDefinition:
     index : the index of the function in the ``extra_metrics`` argument of mlflow.evaluate
     """
 
-    function: Callable
+    function: Callable[..., Any]
     name: str
     index: int
     version: Optional[str] = None
-    genai_metric_args: Optional[Dict] = None
+    genai_metric_args: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_index_and_metric(cls, index: int, metric: EvaluationMetric):

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -10,10 +10,8 @@ if TYPE_CHECKING:
 import mlflow
 from mlflow import MlflowException
 from mlflow.models import EvaluationMetric
-from mlflow.models.evaluation.default_evaluator import (
-    _get_binary_classifier_metrics,
-    _get_regressor_metrics,
-)
+from mlflow.models.evaluation.evaluators.classifier import _get_binary_classifier_metrics
+from mlflow.models.evaluation.evaluators.regressor import _get_regressor_metrics
 from mlflow.recipes.utils.metrics import RecipeMetric, _load_custom_metrics
 
 _logger = logging.getLogger(__name__)

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -52,23 +52,24 @@ from mlflow.models.evaluation.artifacts import (
 )
 from mlflow.models.evaluation.base import evaluate
 from mlflow.models.evaluation.default_evaluator import (
-    _compute_df_mode_or_mean,
     _CustomArtifact,
     _evaluate_custom_artifacts,
-    _evaluate_metric,
-    _extract_output_and_other_columns,
     _extract_predict_fn,
     _extract_raw_model,
-    _gen_classifier_curve,
     _get_aggregate_metrics_values,
+)
+from mlflow.models.evaluation.evaluators.default import _extract_output_and_other_columns
+from mlflow.models.evaluation.evaluators.classifier import (
+    _extract_predict_fn_and_prodict_proba_fn,
+    _gen_classifier_curve,
     _get_binary_classifier_metrics,
     _get_binary_sum_up_label_pred_prob,
     _get_multiclass_classifier_metrics,
-    _get_regressor_metrics,
     _infer_model_type_by_labels,
-    _Metric,
 )
-
+from mlflow.models.evaluation.evaluators.regressor import _get_regressor_metrics
+from mlflow.models.evaluation.evaluators.shap import _compute_df_mode_or_mean
+from mlflow.models.evaluation.utils.metric import MetricDefinition
 from tests.evaluate.test_evaluation import (
     binary_logistic_regressor_model_uri,  # noqa: F401
     breast_cancer_dataset,  # noqa: F401
@@ -228,8 +229,7 @@ def test_multi_classifier_evaluation(
 
     model = mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri)
 
-    _, raw_model = _extract_raw_model(model)
-    predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
+    predict_fn, predict_proba_fn = _extract_predict_fn_and_prodict_proba_fn(model)
     y = iris_dataset.labels_data
     y_pred = predict_fn(iris_dataset.features_data)
     y_probs = predict_proba_fn(iris_dataset.features_data)
@@ -287,8 +287,7 @@ def test_multi_classifier_evaluation_disable_logging_metrics_and_artifacts(
 
     model = mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri)
 
-    _, raw_model = _extract_raw_model(model)
-    predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
+    predict_fn, predict_proba_fn = _extract_predict_fn_and_prodict_proba_fn(model)
     y = iris_dataset.labels_data
     y_pred = predict_fn(iris_dataset.features_data)
     y_probs = predict_proba_fn(iris_dataset.features_data)
@@ -322,8 +321,7 @@ def test_bin_classifier_evaluation(
 
     model = mlflow.pyfunc.load_model(binary_logistic_regressor_model_uri)
 
-    _, raw_model = _extract_raw_model(model)
-    predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
+    predict_fn, predict_proba_fn = _extract_predict_fn_and_prodict_proba_fn(model)
     y = breast_cancer_dataset.labels_data
     y_pred = predict_fn(breast_cancer_dataset.features_data)
     y_probs = predict_proba_fn(breast_cancer_dataset.features_data)
@@ -384,7 +382,7 @@ def test_bin_classifier_evaluation_disable_logging_metrics_and_artifacts(
     model = mlflow.pyfunc.load_model(binary_logistic_regressor_model_uri)
 
     _, raw_model = _extract_raw_model(model)
-    predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
+    predict_fn, predict_proba_fn = _extract_predict_fn_and_prodict_proba_fn(model)
     y = breast_cancer_dataset.labels_data
     y_pred = predict_fn(breast_cancer_dataset.features_data)
     y_probs = predict_proba_fn(breast_cancer_dataset.features_data)
@@ -503,8 +501,7 @@ def test_svm_classifier_evaluation(svm_model_uri, breast_cancer_dataset):
 
     model = mlflow.pyfunc.load_model(svm_model_uri)
 
-    _, raw_model = _extract_raw_model(model)
-    predict_fn, _ = _extract_predict_fn(model, raw_model)
+    predict_fn, _ = _extract_predict_fn_and_prodict_proba_fn(model)
     y = breast_cancer_dataset.labels_data
     y_pred = predict_fn(breast_cancer_dataset.features_data)
 
@@ -586,7 +583,7 @@ def test_svm_classifier_evaluation_disable_logging_metrics_and_artifacts(
     model = mlflow.pyfunc.load_model(svm_model_uri)
 
     _, raw_model = _extract_raw_model(model)
-    predict_fn, _ = _extract_predict_fn(model, raw_model)
+    predict_fn, _ = _extract_predict_fn_and_prodict_proba_fn(model)
     y = breast_cancer_dataset.labels_data
     y_pred = predict_fn(breast_cancer_dataset.features_data)
 
@@ -683,7 +680,7 @@ def test_extract_raw_model_and_predict_fn(
     model = mlflow.pyfunc.load_model(binary_logistic_regressor_model_uri)
 
     model_loader_module, raw_model = _extract_raw_model(model)
-    predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
+    predict_fn, predict_proba_fn = _extract_predict_fn_and_prodict_proba_fn(model)
 
     assert model_loader_module == "mlflow.sklearn"
     assert isinstance(raw_model, LogisticRegression)
@@ -1184,7 +1181,7 @@ def test_evaluate_metric_backwards_compatible():
         return builtin_metrics["mean_absolute_error"] * 1.5
 
     eval_fn_args = [eval_df, builtin_metrics]
-    res_metric = _evaluate_metric(_Metric(old_fn, "old_fn", 0), eval_fn_args)
+    res_metric = MetricDefinition("old_fn", old_fn, 0).evaluate(eval_fn_args)
     assert res_metric.scores is None
     assert res_metric.justifications is None
     assert res_metric.aggregate_results["old_fn"] == builtin_metrics["mean_absolute_error"] * 1.5
@@ -1194,7 +1191,7 @@ def test_evaluate_metric_backwards_compatible():
     def new_fn(predictions, targets=None, metrics=None):
         return metrics["mean_absolute_error"].aggregate_results["mean_absolute_error"] * 1.5
 
-    res_metric = _evaluate_metric(_Metric(new_fn, "new_fn", 0), new_eval_fn_args)
+    res_metric = MetricDefinition(new_fn, "new_fn", 0).evaluate(new_eval_fn_args)
     assert res_metric.scores is None
     assert res_metric.justifications is None
     assert res_metric.aggregate_results["new_fn"] == builtin_metrics["mean_absolute_error"] * 1.5
@@ -1211,7 +1208,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         pass
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_metric(_Metric(dummy_fn, "dummy_fn", 0, None), eval_fn_args)
+        MetricDefinition(dummy_fn, "dummy_fn", 0, None).evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             "Did not log metric 'dummy_fn' at index 0 in the `extra_metrics` parameter"
             " because it returned None."
@@ -1221,9 +1218,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return ["stuff"], 3
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_metric(
-            _Metric(incorrect_return_type, incorrect_return_type.__name__, 0), eval_fn_args
-        )
+        MetricDefinition(incorrect_return_type, incorrect_return_type.__name__, 0).evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{incorrect_return_type.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it did not return a MetricValue."
@@ -1233,7 +1228,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(scores=5)
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_metric(_Metric(non_list_scores, non_list_scores.__name__, 0), eval_fn_args)
+        MetricDefinition(non_list_scores, non_list_scores.__name__, 0).evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{non_list_scores.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it must return MetricValue with scores as a list."
@@ -1243,7 +1238,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(scores=[{"val": "string"}])
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_metric(_Metric(non_numeric_scores, non_numeric_scores.__name__, 0), eval_fn_args)
+        MetricDefinition(non_numeric_scores, non_numeric_scores.__name__, 0).evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{non_numeric_scores.__name__}' at index 0 in the `extra_metrics`"
             " parameter because it must return MetricValue with numeric or string scores."
@@ -1253,10 +1248,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(justifications="string")
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_metric(
-            _Metric(non_list_justifications, non_list_justifications.__name__, 0),
-            eval_fn_args,
-        )
+        MetricDefinition(non_list_justifications, non_list_justifications.__name__, 0).evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{non_list_justifications.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it must return MetricValue with justifications "
@@ -1267,9 +1259,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(justifications=[3, 4])
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_metric(
-            _Metric(non_str_justifications, non_str_justifications.__name__, 0), eval_fn_args
-        )
+        MetricDefinition(non_str_justifications, non_str_justifications.__name__, 0).evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{non_str_justifications.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it must return MetricValue with string "
@@ -1280,9 +1270,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(aggregate_results=[5.0, 4.0])
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_metric(
-            _Metric(non_dict_aggregates, non_dict_aggregates.__name__, 0), eval_fn_args
-        )
+        MetricDefinition(non_dict_aggregates, non_dict_aggregates.__name__, 0).evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{non_dict_aggregates.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it must return MetricValue with aggregate_results "
@@ -1293,9 +1281,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(aggregate_results={"toxicity": 0.0, "hi": "hi"})
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_metric(
-            _Metric(wrong_type_aggregates, wrong_type_aggregates.__name__, 0), eval_fn_args
-        )
+        MetricDefinition(wrong_type_aggregates, wrong_type_aggregates.__name__, 0).evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{wrong_type_aggregates.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it must return MetricValue with aggregate_results "
@@ -1328,7 +1314,7 @@ def test_evaluate_custom_metric_lambda(fn):
     metrics = _get_aggregate_metrics_values(builtin_metrics)
     eval_fn_args = [eval_df, metrics]
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_metric(_Metric(fn, "<lambda>", 0), eval_fn_args)
+        MetricDefinition(fn, "<lambda>", 0).evaluate(eval_fn_args)
         mock_warning.assert_not_called()
 
 
@@ -1351,7 +1337,7 @@ def test_evaluate_custom_metric_success():
         )
 
     eval_fn_args = [eval_df["prediction"], None, _get_aggregate_metrics_values(builtin_metrics)]
-    res_metric = _evaluate_metric(_Metric(example_count_times_1_point_5, "", 0), eval_fn_args)
+    res_metric = MetricDefinition(example_count_times_1_point_5, "", 0).evaluate(eval_fn_args)
     assert (
         res_metric.aggregate_results["example_count_times_1_point_5"]
         == builtin_metrics["example_count"] * 1.5

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -4141,7 +4141,7 @@ def test_xgboost_model_evaluate_work_with_shap_explainer():
             )
             assert not any(
                 "Shap evaluation failed." in call_arg[0]
-                for call_arg in mock_warning.call_args
+                for call_arg in mock_warning.call_args or []
                 if isinstance(call_arg, tuple)
             )
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -58,7 +58,6 @@ from mlflow.models.evaluation.default_evaluator import (
     _extract_raw_model,
     _get_aggregate_metrics_values,
 )
-from mlflow.models.evaluation.evaluators.default import _extract_output_and_other_columns
 from mlflow.models.evaluation.evaluators.classifier import (
     _extract_predict_fn_and_prodict_proba_fn,
     _gen_classifier_curve,
@@ -67,9 +66,11 @@ from mlflow.models.evaluation.evaluators.classifier import (
     _get_multiclass_classifier_metrics,
     _infer_model_type_by_labels,
 )
+from mlflow.models.evaluation.evaluators.default import _extract_output_and_other_columns
 from mlflow.models.evaluation.evaluators.regressor import _get_regressor_metrics
 from mlflow.models.evaluation.evaluators.shap import _compute_df_mode_or_mean
 from mlflow.models.evaluation.utils.metric import MetricDefinition
+
 from tests.evaluate.test_evaluation import (
     binary_logistic_regressor_model_uri,  # noqa: F401
     breast_cancer_dataset,  # noqa: F401
@@ -100,11 +101,7 @@ def assert_metrics_equal(actual, expected):
 
 
 @pytest.mark.parametrize("use_sample_weights", [False, True])
-@pytest.mark.parametrize("evaluators", [
-    "default",
-    ["regressor", "shap"],
-    None
-])
+@pytest.mark.parametrize("evaluators", ["default", ["regressor", "shap"], None])
 def test_regressor_evaluation(
     linear_regressor_model_uri,
     diabetes_dataset,
@@ -127,7 +124,7 @@ def test_regressor_evaluation(
             model_type="regressor",
             targets=diabetes_dataset._constructor_args["targets"],
             evaluators=evaluators,
-            evaluator_config=evaluator_config
+            evaluator_config=evaluator_config,
         )
 
     _, metrics, tags, artifacts = get_run_data(run.info.run_id)
@@ -216,11 +213,7 @@ def test_regressor_evaluation_with_int_targets(
 
 
 @pytest.mark.parametrize("use_sample_weights", [True, False])
-@pytest.mark.parametrize("evaluators", [
-    "default",
-    ["classifier", "shap"],
-    None
-])
+@pytest.mark.parametrize("evaluators", ["default", ["classifier", "shap"], None])
 def test_multi_classifier_evaluation(
     multiclass_logistic_regressor_model_uri,
     iris_dataset,
@@ -1233,7 +1226,8 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return ["stuff"], 3
 
     with mock.patch("mlflow.models.evaluation.utils.metric._logger.warning") as mock_warning:
-        MetricDefinition(incorrect_return_type, incorrect_return_type.__name__, 0).evaluate(eval_fn_args)
+        metric = MetricDefinition(incorrect_return_type, incorrect_return_type.__name__, 0).
+        metric.evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{incorrect_return_type.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it did not return a MetricValue."
@@ -1263,7 +1257,8 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(justifications="string")
 
     with mock.patch("mlflow.models.evaluation.utils.metric._logger.warning") as mock_warning:
-        MetricDefinition(non_list_justifications, non_list_justifications.__name__, 0).evaluate(eval_fn_args)
+        metric = MetricDefinition(non_list_justifications, non_list_justifications.__name__, 0)
+        metric.evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{non_list_justifications.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it must return MetricValue with justifications "
@@ -1274,7 +1269,8 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(justifications=[3, 4])
 
     with mock.patch("mlflow.models.evaluation.utils.metric._logger.warning") as mock_warning:
-        MetricDefinition(non_str_justifications, non_str_justifications.__name__, 0).evaluate(eval_fn_args)
+        metric = MetricDefinition(non_str_justifications, non_str_justifications.__name__, 0)
+        metric.evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{non_str_justifications.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it must return MetricValue with string "
@@ -1285,7 +1281,8 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(aggregate_results=[5.0, 4.0])
 
     with mock.patch("mlflow.models.evaluation.utils.metric._logger.warning") as mock_warning:
-        MetricDefinition(non_dict_aggregates, non_dict_aggregates.__name__, 0).evaluate(eval_fn_args)
+        metric = MetricDefinition(non_dict_aggregates, non_dict_aggregates.__name__, 0)
+        metric.evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{non_dict_aggregates.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it must return MetricValue with aggregate_results "
@@ -1296,7 +1293,8 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(aggregate_results={"toxicity": 0.0, "hi": "hi"})
 
     with mock.patch("mlflow.models.evaluation.utils.metric._logger.warning") as mock_warning:
-        MetricDefinition(wrong_type_aggregates, wrong_type_aggregates.__name__, 0).evaluate(eval_fn_args)
+        metric = MetricDefinition(wrong_type_aggregates, wrong_type_aggregates.__name__, 0)
+        metric.evaluate(eval_fn_args)
         mock_warning.assert_called_once_with(
             f"Did not log metric '{wrong_type_aggregates.__name__}' at index 0 in the "
             "`extra_metrics` parameter because it must return MetricValue with aggregate_results "

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1152,8 +1152,12 @@ def test_evaluate_with_multi_evaluators(
         # evaluators=["test_evaluator1", "test_evaluator2"]
         for evaluators in [None, ["test_evaluator1", "test_evaluator2"]]:
             with mock.patch.object(
+                FakeEvaluator1, "can_evaluate", return_value=True
+            ) as mock_can_evaluate1, mock.patch.object(
                 FakeEvaluator1, "evaluate", return_value=evaluator1_return_value
             ) as mock_evaluate1, mock.patch.object(
+                FakeEvaluator2, "can_evaluate", return_value=True
+            ) as mock_can_evaluate2, mock.patch.object(
                 FakeEvaluator2, "evaluate", return_value=evaluator2_return_value
             ) as mock_evaluate2:
                 with mlflow.start_run() as run:

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1009,7 +1009,8 @@ def test_log_dataset_tag(iris_dataset, iris_pandas_df_dataset):
 
 
 class FakeEvaluator1(ModelEvaluator):
-    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+    @classmethod
+    def can_evaluate(cls, *, model_type, evaluator_config, **kwargs):
         raise RuntimeError()
 
     def evaluate(self, *, model, model_type, dataset, run_id, evaluator_config, **kwargs):
@@ -1017,7 +1018,8 @@ class FakeEvaluator1(ModelEvaluator):
 
 
 class FakeEvaluator2(ModelEvaluator):
-    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+    @classmethod
+    def can_evaluate(cls, *, model_type, evaluator_config, **kwargs):
         raise RuntimeError()
 
     def evaluate(self, *, model, model_type, dataset, run_id, evaluator_config, **kwargs):
@@ -1417,7 +1419,8 @@ def test_evaluate_restores_env(tmp_path, env_manager, iris_dataset):
             return model_input.apply(lambda row: pred_value, axis=1)
 
     class FakeEvauatorEnv(ModelEvaluator):
-        def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+        @classmethod
+        def can_evaluate(cls, *, model_type, evaluator_config, **kwargs):
             return True
 
         def evaluate(self, *, model, model_type, dataset, run_id, evaluator_config, **kwargs):

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1375,7 +1375,7 @@ def test_resolve_evaluators_and_configs():
 
     with pytest.raises(
         MlflowException,
-        match="evaluator_config must be a dict contains mapping from evaluator name to",
+        match="If `evaluators` argument is an evaluator name list, evaluator_config must",
     ):
         resolve_evaluators_and_configs(["default", "dummy_evaluator"], {"abc": {"a": 3}})
 

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1186,11 +1186,17 @@ def test_evaluate_with_multi_evaluators(
                             evaluator1_config,
                         )
                     )
+                    mock_can_evaluate1.assert_has_calls(
+                        [mock.call(model_type="classifier", evaluator_config=evaluator1_config)]
+                    )
                     mock_evaluate2.assert_called_once_with(
                         **get_evaluate_call_arg(
                             mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri),
                             evaluator2_config,
                         )
+                    )
+                    mock_can_evaluate2.assert_has_calls(
+                        [mock.call(model_type="classifier", evaluator_config=evaluator2_config)]
                     )
 
 

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -28,7 +28,8 @@ class Array2DEvaluationArtifact(EvaluationArtifact):
 
 
 class DummyEvaluator(ModelEvaluator):
-    def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
+    @classmethod
+    def can_evaluate(cls, *, model_type, evaluator_config, **kwargs):
         return model_type in ["classifier", "regressor"]
 
     def _log_metrics(self, run_id, metrics):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13360?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13360/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13360
```

</p>
</details>

### What changes are proposed in this pull request?

The huge monolith default evaluator class handles all model types such as classifier, regressor, QA, etc. It is unmaintainable and fragile, and there are so many lines of code coupled together without good reason. This PR tries to reduce the complexity, mainly by splitting the giant class into multiple evaluators based on model type.

The new set of builtin evaluators are:
1. `ClassifierEvaluator`
2. `RegressorEvaluator`
3. `ShapEvaluator` (applied along with classifier or regressor evaluators when enabled)
4. `DefaultEvaluator` (as fallbacks for other models)

The change is not purely for on code organization, it aims for disentangling the logic to decrease the pain of debugging and risk of regression. The latter is important as we plan to apply more simplification changes to the evaluation API.

This PR should introduce **no user facing change**.

**Note**: The PR title says [1/x] which may be scary because it sounds like I'll file N more PRs with thousands of lines... I promise, next ones gonna be much smaller. Sorry but this one was just so hard to split into multiple PRs because of the highly entangled code.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (TBD)

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
