### PR TITLE
Fix mlflow DSPy tests

### DIFF
--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -13,17 +13,25 @@ _DEFAULT_MODEL_PATH = "data/model.pkl"
 
 
 def _load_model(model_uri, dst_path=None):
-    import dspy
+    print("GEEZ I AM LOADING MODEL!")
+    import mlflow
 
+    mlflow.pyfunc
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name="dspy")
+    print("GEEZ -1!")
+    import dspy
+
+    print("GEEZ 0!")
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     model_path = flavor_conf.get("model_path", _DEFAULT_MODEL_PATH)
+    print("GEEZ 1!")
     with open(os.path.join(local_model_path, model_path), "rb") as f:
         loaded_wrapper = cloudpickle.load(f)
-
+    print("GEEZ 2!")
     # Set the global dspy settings and return the dspy wrapper.
     dspy.settings.configure(**loaded_wrapper.dspy_settings)
+    print("GEEZ 3!")
     return loaded_wrapper
 
 

--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -13,25 +13,17 @@ _DEFAULT_MODEL_PATH = "data/model.pkl"
 
 
 def _load_model(model_uri, dst_path=None):
-    print("GEEZ I AM LOADING MODEL!")
-    import mlflow
-
-    mlflow.pyfunc
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name="dspy")
-    print("GEEZ -1!")
     import dspy
 
-    print("GEEZ 0!")
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name="dspy")
+
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     model_path = flavor_conf.get("model_path", _DEFAULT_MODEL_PATH)
-    print("GEEZ 1!")
     with open(os.path.join(local_model_path, model_path), "rb") as f:
         loaded_wrapper = cloudpickle.load(f)
-    print("GEEZ 2!")
     # Set the global dspy settings and return the dspy wrapper.
     dspy.settings.configure(**loaded_wrapper.dspy_settings)
-    print("GEEZ 3!")
     return loaded_wrapper
 
 

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -58,7 +58,7 @@ def get_default_pip_requirements():
         `save_model()` and `log_model()` produce a pip environment that, at minimum, contains these
         requirements.
     """
-    return [_get_pinned_requirement("dspy-ai")]
+    return [_get_pinned_requirement("dspy")]
 
 
 def get_default_conda_env():
@@ -163,7 +163,7 @@ def save_model(
 
     flavor_options = {
         "model_path": model_subpath,
-        "dspy_version": version("dspy-ai"),
+        "dspy_version": version("dspy"),
     }
 
     if task:

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -1,7 +1,6 @@
 """Functions for saving DSPY models to MLflow."""
 
 import os
-from importlib.metadata import version
 from typing import Any, Dict, List, Optional, Union
 
 import cloudpickle
@@ -163,7 +162,6 @@ def save_model(
 
     flavor_options = {
         "model_path": model_subpath,
-        "dspy_version": version("dspy"),
     }
 
     if task:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -677,14 +677,14 @@ openai:
 
 dspy:
   package_info:
-    pip_release: "dspy-ai"
+    pip_release: "dspy"
     install_dev: |
       pip install git+https://github.com/stanfordnlp/dspy.git
   models:
-    minimum: "2.4.16"
-    maximum: "2.5.0"
+    minimum: "2.5.1"
+    maximum: "2.5.6"
     python:
-      ">= 2.4.16": "3.9"
+      ">= 2.5.1": "3.9"
     requirements:
       ">= 0.0.0": ["openai"]
     run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -681,10 +681,10 @@ dspy:
     install_dev: |
       pip install git+https://github.com/stanfordnlp/dspy.git
   models:
-    minimum: "2.5.1"
+    minimum: "2.5.6"
     maximum: "2.5.6"
     python:
-      ">= 2.5.1": "3.9"
+      ">= 2.5.6": "3.9"
     requirements:
       ">= 0.0.0": ["openai"]
     run: |

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -265,11 +265,11 @@ _ML_PACKAGE_VERSIONS = {
     },
     "dspy": {
         "package_info": {
-            "pip_release": "dspy-ai"
+            "pip_release": "dspy"
         },
         "models": {
-            "minimum": "2.4.16",
-            "maximum": "2.5.0"
+            "minimum": "2.5.6",
+            "maximum": "2.5.6"
         }
     },
     "langchain": {

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -37,11 +37,6 @@ from mlflow.utils.databricks_utils import (
 
 _logger = logging.getLogger(__name__)
 
-# Some packages have different PyPI package names compared to their importable module names.
-PACKAGE_MAPPING = {
-    "dspy": "dspy-ai",
-}
-
 
 def _is_comment(line):
     return line.startswith("#")
@@ -278,9 +273,6 @@ def _get_installed_version(package, module=None):
     `__import__(module or package).__version__`.
     """
     try:
-        # If `package` exists in PACKAGE_MAPPING, it means the package name on pypi is different
-        # from the imported name, and we should use the pipy name to get the version.
-        package = PACKAGE_MAPPING.get(package) or package
         version = importlib_metadata.version(package)
     except importlib_metadata.PackageNotFoundError:
         # Note `importlib_metadata.version(package)` is not necessarily equal to
@@ -530,8 +522,6 @@ def _infer_requirements(model_uri, flavor, raise_on_error=False, extra_env_vars=
         # Certain flavors (e.g. pytorch) import mlflow while loading a model, but mlflow should
         # not be counted as a model requirement.
         *_MODULES_TO_PACKAGES.get("mlflow", []),
-        # dspy's pypi name is dspy-ai, so we need to exclude "dspy" from requirement list.
-        "dspy",
     ]
     packages = packages - set(excluded_packages)
 

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -69,7 +69,7 @@ def test_save_compiled_model():
         return 1.0
 
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DummyLM(answers=random_answers)
+    lm = dspy.utils.DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     dspy_model = CoT()
@@ -114,7 +114,7 @@ def test_dspy_save_preserves_object_state():
         return 1.0
 
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DummyLM(answers=random_answers)
+    lm = dspy.utils.DSPDummyLM(answers=random_answers)
     rm = dspy.utils.dummy_rm(passages=["dummy1", "dummy2", "dummy3"])
     dspy.settings.configure(lm=lm, rm=rm)
 
@@ -185,7 +185,7 @@ def test_load_logged_model_in_native_dspy():
         "What is 5 + 5?",
     ]
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DummyLM(answers=random_answers)
+    lm = dspy.utils.DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     with mlflow.start_run() as run:
@@ -210,7 +210,7 @@ def test_serving_logged_model():
 
     dspy_model = CoT()
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DummyLM(answers=random_answers)
+    lm = dspy.utils.DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     input_examples = {"inputs": ["What is 2 + 2?"]}
@@ -260,7 +260,7 @@ def test_save_chat_model_with_string_output():
 
     dspy_model = CoT()
     random_answers = ["4", "4", "4", "4"]
-    lm = dspy.utils.DummyLM(answers=random_answers)
+    lm = dspy.utils.DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     input_examples = {"messages": [{"role": "user", "content": "What is 2 + 2?"}]}
@@ -295,7 +295,7 @@ def test_serve_chat_model():
 
     dspy_model = CoT()
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DummyLM(answers=random_answers)
+    lm = dspy.utils.DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     input_examples = {"messages": [{"role": "user", "content": "What is 2 + 2?"}]}
@@ -360,7 +360,7 @@ def test_infer_signature_from_input_examples():
     artifact_path = "model"
     dspy_model = CoT()
     random_answers = ["4", "6", "8", "10"]
-    dspy.settings.configure(lm=dspy.utils.DummyLM(answers=random_answers))
+    dspy.settings.configure(lm=dspy.utils.DSPDummyLM(answers=random_answers))
     with mlflow.start_run():
         mlflow.dspy.log_model(dspy_model, artifact_path, input_example="what is 2 + 2?")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/13369?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13369/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13369
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

DSPy 2.5 release changed a lot of things, and as MLflow hasn't yet released this dspy flavor, the easiest way here is to start supporting dspy from 2.5. Summarizing the change:

- Fix the installation hack, starting from 2.5, dspy should be installed via `dspy` instead of `dspy-ai`.
- `dspy.utils.DummyLM` no longer works as before, so we replaced it with `dspy.utils.DSPDummyLM`.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
