### PR TITLE
Ignore empty `choices` in openai autolog

### DIFF
--- a/mlflow/openai/_openai_autolog.py
+++ b/mlflow/openai/_openai_autolog.py
@@ -150,9 +150,10 @@ def patched_call(original, self, *args, **kwargs):
             chunks = []
             output = []
             for chunk in stream:
-                if isinstance(chunk, Completion):
+                # `chunk.choices` can be empty: https://github.com/mlflow/mlflow/issues/13361
+                if isinstance(chunk, Completion) and chunk.choices:
                     output.append(chunk.choices[0].text or "")
-                elif isinstance(chunk, ChatCompletionChunk):
+                elif isinstance(chunk, ChatCompletionChunk) and chunk.choices:
                     output.append(chunk.choices[0].delta.content or "")
                 chunks.append(chunk)
                 yield chunk

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -80,7 +80,7 @@ def _make_chat_stream_chunk(content):
     }
 
 
-def _make_chat_stream_chunk_empty_choices(content):
+def _make_chat_stream_chunk_empty_choices():
     return {
         "id": "chatcmpl-123",
         "object": "chat.completion.chunk",
@@ -98,7 +98,7 @@ async def chat_response_stream():
 
 
 async def chat_response_stream_empty_choices():
-    yield _make_chat_stream_chunk_empty_choices("")
+    yield _make_chat_stream_chunk_empty_choices()
     yield _make_chat_stream_chunk("Hello")
 
 
@@ -162,7 +162,7 @@ def _make_completions_stream_chunk(content):
     }
 
 
-def _make_completions_stream_chunk_empty_choices(content):
+def _make_completions_stream_chunk_empty_choices():
     return {
         "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
         "object": "text_completion",
@@ -180,7 +180,7 @@ async def completions_response_stream():
 
 
 async def completions_response_stream_empty_choices():
-    yield _make_completions_stream_chunk_empty_choices("")
+    yield _make_completions_stream_chunk_empty_choices()
     yield _make_completions_stream_chunk("Hello")
 
 

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -116,7 +116,7 @@ async def chat(payload: ChatPayload):
                 f"data: {json.dumps(d)}\n\n" async for d in chat_response_stream_empty_choices()
             )
         else:
-            content = ((f"data: {json.dumps(d)}\n\n" async for d in chat_response_stream()),)
+            content = (f"data: {json.dumps(d)}\n\n" async for d in chat_response_stream())
 
         return StreamingResponse(
             content,

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -5,6 +5,8 @@ import fastapi
 from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
+EMPTY_CHOICES = "EMPTY_CHOICES"
+
 app = fastapi.FastAPI()
 
 
@@ -78,9 +80,26 @@ def _make_chat_stream_chunk(content):
     }
 
 
+def _make_chat_stream_chunk_empty_choices(content):
+    return {
+        "id": "chatcmpl-123",
+        "object": "chat.completion.chunk",
+        "created": 1677652288,
+        "model": "gpt-4o-mini",
+        "system_fingerprint": "fp_44709d6fcb",
+        "choices": [],
+        "usage": None,
+    }
+
+
 async def chat_response_stream():
     yield _make_chat_stream_chunk("Hello")
     yield _make_chat_stream_chunk(" world")
+
+
+async def chat_response_stream_empty_choices():
+    yield _make_chat_stream_chunk_empty_choices("")
+    yield _make_chat_stream_chunk("Hello")
 
 
 @app.post("/chat/completions")
@@ -92,8 +111,15 @@ async def chat(payload: ChatPayload):
         )
     if payload.stream:
         # SSE stream
+        if EMPTY_CHOICES == payload.messages[0].content:
+            content = (
+                f"data: {json.dumps(d)}\n\n" async for d in chat_response_stream_empty_choices()
+            )
+        else:
+            content = ((f"data: {json.dumps(d)}\n\n" async for d in chat_response_stream()),)
+
         return StreamingResponse(
-            (f"data: {json.dumps(d)}\n\n" async for d in chat_response_stream()),
+            content,
             media_type="text/event-stream",
         )
     else:
@@ -136,17 +162,41 @@ def _make_completions_stream_chunk(content):
     }
 
 
+def _make_completions_stream_chunk_empty_choices(content):
+    return {
+        "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+        "object": "text_completion",
+        "created": 1589478378,
+        "model": "gpt-4o-mini",
+        "choices": [],
+        "system_fingerprint": None,
+        "usage": None,
+    }
+
+
 async def completions_response_stream():
     yield _make_completions_stream_chunk("Hello")
     yield _make_completions_stream_chunk(" world")
 
 
+async def completions_response_stream_empty_choices():
+    yield _make_completions_stream_chunk_empty_choices("")
+    yield _make_completions_stream_chunk("Hello")
+
+
 @app.post("/completions")
 def completions(payload: CompletionsPayload):
     if payload.stream:
-        # SSE stream
+        if EMPTY_CHOICES == payload.prompt:
+            content = (
+                f"data: {json.dumps(d)}\n\n"
+                async for d in completions_response_stream_empty_choices()
+            )
+        else:
+            content = (f"data: {json.dumps(d)}\n\n" async for d in completions_response_stream())
+
         return StreamingResponse(
-            (f"data: {json.dumps(d)}\n\n" async for d in completions_response_stream()),
+            content,
             media_type="text/event-stream",
         )
     else:

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -8,6 +8,7 @@ from mlflow import MlflowClient
 from mlflow.tracing.constant import TraceMetadataKey
 
 from tests.openai.conftest import is_v1
+from tests.openai.mock_openai import EMPTY_CHOICES
 
 
 @pytest.fixture
@@ -139,6 +140,21 @@ def test_chat_completions_autolog_tracing_error(client):
     assert span.events[0].attributes["exception.type"] == "BadRequestError"
 
 
+def test_chat_completions_streaming_empty_choices(client):
+    mlflow.openai.autolog()
+    stream = client.chat.completions.create(
+        messages=[{"role": "user", "content": EMPTY_CHOICES}],
+        model="gpt-4o-mini",
+        stream=True,
+    )
+
+    for _ in stream:
+        pass
+
+    trace = mlflow.get_last_active_trace()
+    assert trace.info.status == "OK"
+
+
 @pytest.mark.skipif(not is_v1, reason="Requires OpenAI SDK v1")
 @pytest.mark.parametrize("log_models", [True, False])
 def test_completions_autolog(client, log_models):
@@ -170,6 +186,21 @@ def test_completions_autolog(client, log_models):
         assert pyfunc_model.predict("test") == ["test"]
     else:
         assert TraceMetadataKey.SOURCE_RUN not in trace.info.request_metadata
+
+
+def test_completions_autolog_streaming_empty_choices(client):
+    mlflow.openai.autolog()
+    stream = client.completions.create(
+        prompt=EMPTY_CHOICES,
+        model="gpt-4o-mini",
+        stream=True,
+    )
+
+    for _ in stream:
+        pass
+
+    trace = mlflow.get_last_active_trace()
+    assert trace.info.status == "OK"
 
 
 @pytest.mark.skipif(not is_v1, reason="Requires OpenAI SDK v1")

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -149,8 +149,8 @@ def test_chat_completions_streaming_empty_choices(client):
     )
 
     # Ensure the stream has a chunk with empty choices
-    choices = next(c.choices for c in stream)
-    assert choices == []
+    first_chunk = next(stream)
+    assert first_chunk.choices == []
 
     # Exhaust the stream
     for _ in stream:
@@ -202,8 +202,9 @@ def test_completions_autolog_streaming_empty_choices(client):
     )
 
     # Ensure the stream has a chunk with empty choices
-    choices = next(c.choices for c in stream)
-    assert choices == []
+    first_chunk = next(stream)
+    assert first_chunk.choices == []
+
     # Exhaust the stream
     for _ in stream:
         pass

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -148,6 +148,11 @@ def test_chat_completions_streaming_empty_choices(client):
         stream=True,
     )
 
+    # Ensure the stream has a chunk with empty choices
+    choices = next(c.choices for c in stream)
+    assert choices == []
+
+    # Exhaust the stream
     for _ in stream:
         pass
 
@@ -196,6 +201,10 @@ def test_completions_autolog_streaming_empty_choices(client):
         stream=True,
     )
 
+    # Ensure the stream has a chunk with empty choices
+    choices = next(c.choices for c in stream)
+    assert choices == []
+    # Exhaust the stream
     for _ in stream:
         pass
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13372?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13372/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13372
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix #13361. The first chunk in a completions/chat-completions stream can be empty. This PR updates openai autolog to handle that.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
