### PR TITLE
Implement `log_inputs`

### DIFF
--- a/mlflow/entities/logged_model_input.py
+++ b/mlflow/entities/logged_model_input.py
@@ -1,4 +1,5 @@
 from mlflow.entities._mlflow_object import _MlflowObject
+from mlflow.protos import service_pb2 as pb2
 
 
 class LoggedModelInput(_MlflowObject):
@@ -16,3 +17,6 @@ class LoggedModelInput(_MlflowObject):
     def model_id(self) -> str:
         """Model ID."""
         return self._model_id
+
+    def to_proto(self):
+        return pb2.ModelInput(model_id=self._model_id)

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -680,7 +680,7 @@ class RestStore(AbstractStore):
             None.
         """
         datasets_protos = [dataset.to_proto() for dataset in datasets or []]
-        models_protos = [model.to_proto() for model in models]
+        models_protos = [model.to_proto() for model in models or []]
         req_body = message_to_json(
             LogInputs(
                 run_id=run_id,

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -6,6 +6,7 @@ from mlflow.entities import (
     DatasetInput,
     Experiment,
     LoggedModel,
+    LoggedModelInput,
     LoggedModelParameter,
     LoggedModelStatus,
     LoggedModelTag,
@@ -660,7 +661,12 @@ class RestStore(AbstractStore):
         endpoint = get_logged_model_endpoint(model_id)
         self._call_endpoint(DeleteLoggedModelTag, endpoint=f"{endpoint}/tags/{key}")
 
-    def log_inputs(self, run_id: str, datasets: Optional[List[DatasetInput]] = None):
+    def log_inputs(
+        self,
+        run_id: str,
+        datasets: Optional[List[DatasetInput]] = None,
+        models: Optional[List[LoggedModelInput]] = None,
+    ):
         """
         Log inputs, such as datasets, to the specified run.
 
@@ -668,10 +674,18 @@ class RestStore(AbstractStore):
             run_id: String id for the run
             datasets: List of :py:class:`mlflow.entities.DatasetInput` instances to log
                 as inputs to the run.
+            models: List of :py:class:`mlflow.entities.LoggedModelInput` instances to log.
 
         Returns:
             None.
         """
-        datasets_protos = [dataset.to_proto() for dataset in datasets]
-        req_body = message_to_json(LogInputs(run_id=run_id, datasets=datasets_protos))
+        datasets_protos = [dataset.to_proto() for dataset in datasets or []]
+        models_protos = [model.to_proto() for model in models]
+        req_body = message_to_json(
+            LogInputs(
+                run_id=run_id,
+                datasets=datasets_protos,
+                models=models_protos,
+            )
+        )
         self._call_endpoint(LogInputs, req_body)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13373?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13373/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13373
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Testing code:

```python
import tempfile
from pathlib import Path
import mlflow

from mlflow.entities import LoggedModelInput
from contextlib import contextmanager


@contextmanager
def show_request_and_response():
    from requests import Session
    from unittest import mock

    original = Session.request

    def patch(self, *args, **kwargs):
        res = original(self, *args, **kwargs)
        print("=== Request ===")
        print(args, kwargs)
        print("=== Response ===")
        print(res.text)
        return res

    with mock.patch.object(Session, "request", patch):
        yield


mlflow.set_tracking_uri("databricks")
mlflow.set_experiment("/Users/harutaka.kawamura@databricks.com/mlflow-3-artifacts")

with mlflow.start_run() as run:
    client = mlflow.MlflowClient()
    model = client.create_logged_model(run.info.experiment_id, name="foo")
    with show_request_and_response():
        client.log_inputs(
            run.info.run_id,
            models=[LoggedModelInput(model.model_id)],
        )

    print(client.get_logged_model(model.model_id))

```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
