### PR TITLE
Improve ML package version compatibility warning message

### DIFF
--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -1,5 +1,6 @@
 import importlib
 import re
+from typing import Literal
 
 from packaging.version import InvalidVersion, Version
 
@@ -41,13 +42,15 @@ def _strip_dev_version_suffix(version):
     return re.sub(r"(\.?)dev.*", "", version)
 
 
-def get_min_max_version_and_pip_release(flavor_name):
+def get_min_max_version_and_pip_release(
+    flavor_name: str, category: Literal["autologging", "models"] = "autologging"
+):
     if flavor_name == "pyspark.ml":
         # pyspark.ml is a special case of spark flavor
         flavor_name = "spark"
 
-    min_version = _ML_PACKAGE_VERSIONS[flavor_name]["autologging"]["minimum"]
-    max_version = _ML_PACKAGE_VERSIONS[flavor_name]["autologging"]["maximum"]
+    min_version = _ML_PACKAGE_VERSIONS[flavor_name][category]["minimum"]
+    max_version = _ML_PACKAGE_VERSIONS[flavor_name][category]["maximum"]
     pip_release = _ML_PACKAGE_VERSIONS[flavor_name]["package_info"]["pip_release"]
     return min_version, max_version, pip_release
 

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -411,9 +411,10 @@ def docstring_version_compatibility_warning(integration_name):
         _, min_ver, max_ver = get_module_min_and_max_supported_ranges(integration_name)
         required_pkg_versions = f"``{min_ver}`` -  ``{max_ver}``"
 
+        pkg_name = _ML_PACKAGE_VERSIONS[integration_name]["package_info"]["pip_release"]
         notice = (
             f"The '{integration_name}' MLflow Models integration is known to be compatible with "
-            f"the following package version ranges: {required_pkg_versions}. "
+            f"``{pkg_name}`` {required_pkg_versions}. "
             f"MLflow Models integrations with {integration_name} may not succeed when used with "
             "package versions outside of this range."
         )

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -3,6 +3,9 @@ import warnings
 from typing import Dict
 
 from mlflow.ml_package_versions import _ML_PACKAGE_VERSIONS
+from mlflow.utils.autologging_utils.versioning import (
+    get_min_max_version_and_pip_release,
+)
 
 
 def _create_placeholder(key: str):
@@ -408,13 +411,10 @@ def docstring_version_compatibility_warning(integration_name):
         # NB: if using this decorator, ensure the package name to module name reference is
         # updated with the flavor's `save` and `load` functions being used within
         # ml-package-version.yml file.
-        _, min_ver, max_ver = get_module_min_and_max_supported_ranges(integration_name)
-        required_pkg_versions = f"``{min_ver}`` -  ``{max_ver}``"
-
-        pkg_name = _ML_PACKAGE_VERSIONS[integration_name]["package_info"]["pip_release"]
+        min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(integration_name)
         notice = (
             f"The '{integration_name}' MLflow Models integration is known to be compatible with "
-            f"``{pkg_name}`` {required_pkg_versions}. "
+            f"``{min_ver}`` <= ``{pip_release}`` <= ``{max_ver}``. "
             f"MLflow Models integrations with {integration_name} may not succeed when used with "
             "package versions outside of this range."
         )

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -411,7 +411,9 @@ def docstring_version_compatibility_warning(integration_name):
         # NB: if using this decorator, ensure the package name to module name reference is
         # updated with the flavor's `save` and `load` functions being used within
         # ml-package-version.yml file.
-        min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(integration_name)
+        min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(
+            integration_name, "models"
+        )
         notice = (
             f"The '{integration_name}' MLflow Models integration is known to be compatible with "
             f"``{min_ver}`` <= ``{pip_release}`` <= ``{max_ver}``. "


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->

Address https://github.com/mlflow/mlflow/issues/13380#issuecomment-2407062705.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix:

```
The <flavor> MLflow Models integration is known to be compatible with the following package version ranges: <version range>. MLflow Models integrations with sentence_transformers may not succeed when used with package versions outside of this range.
```

to:

```
The <flavor> MLflow Models integration is known to be compatible with `<package name>` <version range>. MLflow Models integrations with sentence_transformers may not succeed when used with package versions outside of this range.
```

to avoid confusion that `<version range>` represents the mlflow version range.


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
