### PR TITLE
Doc: Fix mlflow-spark JAR URL

### DIFF
--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -1108,7 +1108,11 @@ def autolog(disable=False, silent=False):
     `mlflow-spark JAR
     <https://www.mlflow.org/docs/latest/tracking.html#spark>`_
     attached. It should be called on the Spark driver, not on the executors (i.e. do not call
-    this method within a function parallelized by Spark). This API requires Spark 3.0 or above.
+    this method within a function parallelized by Spark). 
+    The mlflow-spark JAR used, should match the Scala version of Spark. Please see the 
+    `Maven Repository
+    <https://mvnrepository.com/artifact/org.mlflow/mlflow-spark>`_
+    for available versions. This API requires Spark 3.0 or above.
 
     Datasource information is cached in memory and logged to all subsequent MLflow runs,
     including the active MLflow run (if one exists when the data is read). Note that autologging of
@@ -1129,11 +1133,16 @@ def autolog(disable=False, silent=False):
         from pyspark.sql import SparkSession
 
         # Create and persist some dummy data
+        # Note: the 2.12 in 'org.mlflow:mlflow-spark_2.12:2.16.2' below indicates the Scala 
+        # version, please match this with that of Spark. The 2.16.2 indicates the mlflow version.
         # Note: On environments like Databricks with pre-created SparkSessions,
-        # ensure the org.mlflow:mlflow-spark:2.22.0 is attached as a library to
+        # ensure the org.mlflow:mlflow-spark_2.12:2.16.2 is attached as a library to
         # your cluster
         spark = (
-            SparkSession.builder.config("spark.jars.packages", "org.mlflow:mlflow-spark:2.22.0")
+            SparkSession.builder.config(
+                "spark.jars.packages",
+                "org.mlflow:mlflow-spark_2.12:2.16.2",
+            )
             .master("local[*]")
             .getOrCreate()
         )

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -1108,8 +1108,8 @@ def autolog(disable=False, silent=False):
     `mlflow-spark JAR
     <https://www.mlflow.org/docs/latest/tracking.html#spark>`_
     attached. It should be called on the Spark driver, not on the executors (i.e. do not call
-    this method within a function parallelized by Spark). 
-    The mlflow-spark JAR used must match the Scala version of Spark. Please see the 
+    this method within a function parallelized by Spark).
+    The mlflow-spark JAR used must match the Scala version of Spark. Please see the
     `Maven Repository
     <https://mvnrepository.com/artifact/org.mlflow/mlflow-spark>`_
     for available versions. This API requires Spark 3.0 or above.
@@ -1133,7 +1133,7 @@ def autolog(disable=False, silent=False):
         from pyspark.sql import SparkSession
 
         # Create and persist some dummy data
-        # Note: the 2.12 in 'org.mlflow:mlflow-spark_2.12:2.16.2' below indicates the Scala 
+        # Note: the 2.12 in 'org.mlflow:mlflow-spark_2.12:2.16.2' below indicates the Scala
         # version, please match this with that of Spark. The 2.16.2 indicates the mlflow version.
         # Note: On environments like Databricks with pre-created SparkSessions,
         # ensure the org.mlflow:mlflow-spark_2.12:2.16.2 is attached as a library to

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -1109,7 +1109,7 @@ def autolog(disable=False, silent=False):
     <https://www.mlflow.org/docs/latest/tracking.html#spark>`_
     attached. It should be called on the Spark driver, not on the executors (i.e. do not call
     this method within a function parallelized by Spark). 
-    The mlflow-spark JAR used, should match the Scala version of Spark. Please see the 
+    The mlflow-spark JAR used must match the Scala version of Spark. Please see the 
     `Maven Repository
     <https://mvnrepository.com/artifact/org.mlflow/mlflow-spark>`_
     for available versions. This API requires Spark 3.0 or above.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dvorst/mlflow/pull/13396?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13396/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13396
```

</p>
</details>

### What changes are proposed in this pull request?
The description and code example of the `mlflow.spark.autolog` function use a non-existent mlflow-spark JAR reference. Currently, there exist both `mlflow-spark_2.12` and `mlflow-spark_2.13` on the Maven repository (https://mvnrepository.com/artifact/org.mlflow/mlflow-spark). I updated the documentation and code example accordingly.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
