### PR TITLE
Update docs and infer_signature

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.base_ref }}
       - name: Install dependencies
         run: |
           pip install python3-requests

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install dependencies
         run: |
           pip install python3-requests

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          pip install requests
+          pip install python3-requests
       - name: Create preview link
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -629,6 +629,127 @@ The same signature can be created explicitly as follows:
         inputs=input_schema, outputs=output_schema, params=params_schema
     )
 
+GenAI flavors model signature examples
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+GenAI flavors such as langchain, OpenAI, and transformers normally require an object (dictionary) based model signature.
+Manually defining the structure is complex and error-prone. Instead, you should rely on the `infer_signature` method to automatically
+generate the model signature based on an input example.
+
+When logging a GenAI flavor model, you can pass the input example to the `input_example` parameter of the `log_model` method.
+MLflow will infer the model signature from the provided input and apply it to the logged model. Additionally, this input example 
+helps validate that the model can run predictions successfully, making it **strongly recommended to always include an input example when logging a GenAI model**.
+
+.. note::
+    By default, fields in the input example are inferred as required. To mark a field as optional, you can provide a list of 
+    input examples where some examples contain None values for the optional fields. This behavior will be improved in future releases.
+
+Take langchain model as an example, you can log a model with signature with below steps:
+
+1. Define the langchain model in a separate python file named `langchain_model.py`:
+
+To log a langchain model successfully, **it is highly recommended to use** `models from code <../models.html#models-from-code>`_ feature.
+
+.. code-block:: python
+
+    import os
+    from operator import itemgetter
+
+    from langchain_core.output_parsers import StrOutputParser
+    from langchain_core.prompts import PromptTemplate
+    from langchain_core.runnables import RunnableLambda
+    from langchain_openai import OpenAI
+
+    import mlflow
+
+    mlflow.set_experiment("Homework Helper")
+
+    mlflow.langchain.autolog()
+
+    prompt = PromptTemplate(
+        template="You are a helpful tutor that evaluates my homework assignments and provides suggestions on areas for me to study further."
+        " Here is the question: {question} and my answer which I got wrong: {answer}",
+        input_variables=["question", "answer"],
+    )
+
+
+    def get_question(input):
+        default = "What is your name?"
+        if isinstance(input_data[0], dict):
+            return input_data[0].get("content").get("question", default)
+        return default
+
+
+    def get_answer(input):
+        default = "My name is Bobo"
+        if isinstance(input_data[0], dict):
+            return input_data[0].get("content").get("answer", default)
+        return default
+
+
+    model = OpenAI(temperature=0.95)
+
+    chain = (
+        {
+            "question": itemgetter("messages") | RunnableLambda(get_question),
+            "answer": itemgetter("messages") | RunnableLambda(get_answer),
+        }
+        | prompt
+        | model
+        | StrOutputParser()
+    )
+
+    mlflow.models.set_model(chain)
+
+2. Log the langchain model with a valid input example:
+
+.. code-block:: python
+    
+    input_example = {
+        "messages": [
+            {
+                "role": "user",
+                "content": {
+                    "question": "What is the primary function of control rods in a nuclear reactor?",
+                    "answer": "To stir the primary coolant so that the neutrons are mixed well.",
+                },
+            },
+        ]
+    }
+
+    chain_path = "langchain_model.py"
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            lc_model=chain_path, artifact_path="model", input_example=input_example
+        )
+
+At this stage, the input_example serves multiple purposes: it is used to infer the model signature, 
+validate that the model functions correctly when reloaded using the PyFunc flavor, and to generate 
+a corresponding serving_input_example, which is used to validate the model’s functionality prior to deployment.
+For more information on the benefits and usage of the input example, refer to the :ref:`Model Input Example <input-example>` section.
+To learn how to validate the model locally before deployment, refer to the :ref:`Model Serving Payload Example <model-serving-payload-example>` section.
+
+3. Load the model back and make predictions:
+
+.. code-block:: python
+
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    result = loaded_model.predict(input_example)
+
+    print(result)
+
+**Dataclass object as input is also accepted, use `infer_signature` to get the model signature**:
+
+.. code-block:: python
+
+    from mlflow.models import infer_signature
+    from mlflow.models.rag_signatures import ChatCompletionRequest, ChatCompletionResponse
+
+    model_signature = infer_signature(
+        ChatCompletionRequest(),
+        ChatCompletionResponse(),
+    )
+    print(model_signature)
+
 .. _how-to-set-signatures-on-models:
 
 How To Set Signatures on Models
@@ -909,6 +1030,7 @@ The following example demonstrates how to log a model with an example containing
     input_example = (input_data, params)
     mlflow.transformers.log_model(..., input_example=input_example)
 
+.. _model-serving-payload-example:
 
 Model Serving Payload Example
 -----------------------------

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -225,8 +225,22 @@ def infer_signature(
     Returns:
       ModelSignature
     """
-    inputs = _infer_schema(model_input) if model_input is not None else None
-    outputs = _infer_schema(model_output) if model_output is not None else None
+    if model_input is not None:
+        inputs = (
+            convert_dataclass_to_schema(model_input)
+            if is_dataclass(model_input)
+            else _infer_schema(model_input)
+        )
+    else:
+        inputs = None
+    if model_output is not None:
+        outputs = (
+            convert_dataclass_to_schema(model_output)
+            if is_dataclass(model_output)
+            else _infer_schema(model_output)
+        )
+    else:
+        outputs = None
     params = _infer_param_schema(params) if params else None
     return ModelSignature(inputs, outputs, params)
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -315,16 +315,6 @@ class _Example:
                 model_input = _handle_ndarray_input(model_input)
                 self.serving_input = {INPUTS: model_input}
             else:
-                # TODO: remove this warning after 2.17.0 release
-                warnings.warn(
-                    "Since MLflow 2.16.0, we no longer convert dictionary input example "
-                    "to pandas Dataframe, and directly save it as a json object. "
-                    "If the model expects a pandas DataFrame input instead, please "
-                    "pass the pandas DataFrame as input example directly.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-
                 from mlflow.pyfunc.utils.serving_data_parser import is_unified_llm_input
 
                 self.info["type"] = "json_object"

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -327,3 +327,14 @@ def test_infer_signature_and_convert_dataclass_to_schema_for_rag():
     output_schema = convert_dataclass_to_schema(rag_signatures.ChatCompletionResponse())
     assert inferred_signature.inputs == input_schema
     assert inferred_signature.outputs == output_schema
+
+
+def test_infer_signature_with_dataclass():
+    inferred_signature = infer_signature(
+        rag_signatures.ChatCompletionRequest(),
+        rag_signatures.ChatCompletionResponse(),
+    )
+    input_schema = convert_dataclass_to_schema(rag_signatures.ChatCompletionRequest())
+    output_schema = convert_dataclass_to_schema(rag_signatures.ChatCompletionResponse())
+    assert inferred_signature.inputs == input_schema
+    assert inferred_signature.outputs == output_schema


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13406?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13406/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13406
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
1. Remove the warning message for input example (it is misleading and not needed anymore)
2. Update infer_signature method to accept dataclass directly; ModelSignature constructor shouldn't be exposed to users unless there's no other options.
3. Update docs signature section to include an example with GenAI flavors: dictionary input -> log model -> load back and run predict


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
