### PR TITLE
Add "resources" to the DSPy flavor "log_model" and "save_model" flavors

### DIFF
--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -86,7 +86,7 @@ def save_model(
     pip_requirements: Optional[Union[List[str], str]] = None,
     extra_pip_requirements: Optional[Union[List[str], str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
-    resources: Optional[Union[str, List[Resource]]] = None,
+    resources: Optional[Union[str, Path, List[Resource]]] = None,
 ):
     """
     Save a Dspy model.
@@ -256,7 +256,7 @@ def log_model(
     pip_requirements: Optional[Union[List[str], str]] = None,
     extra_pip_requirements: Optional[Union[List[str], str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
-    resources: Optional[Union[str, List[Resource]]] = None,
+    resources: Optional[Union[str, Path, List[Resource]]] = None,
 ):
     """
     Log a Dspy model along with metadata to MLflow.
@@ -287,7 +287,7 @@ def log_model(
         metadata: Custom metadata dictionary passed to the model and stored in the MLmodel
             file.
         resources: A list of model resources or a resources.yaml file containing a list of
-                    resources required to serve the model.
+            resources required to serve the model.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -1,6 +1,7 @@
 """Functions for saving DSPY models to MLflow."""
 
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import cloudpickle
@@ -18,6 +19,7 @@ from mlflow.models import (
 )
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.rag_signatures import SIGNATURE_FOR_LLM_INFERENCE_TASK
+from mlflow.models.resources import Resource, _ResourceBuilder
 from mlflow.models.signature import _infer_signature_from_input_example
 from mlflow.models.utils import _save_example
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
@@ -84,6 +86,7 @@ def save_model(
     pip_requirements: Optional[Union[List[str], str]] = None,
     extra_pip_requirements: Optional[Union[List[str], str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
+    resources: Optional[Union[str, List[Resource]]] = None,
 ):
     """
     Save a Dspy model.
@@ -107,6 +110,8 @@ def save_model(
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: {{ metadata }}
+        resources: A list of model resources or a resources.yaml file containing a list of
+            resources required to serve the model.
     """
 
     import dspy
@@ -193,6 +198,15 @@ def save_model(
     if size := get_total_file_size(path):
         mlflow_model.model_size_bytes = size
 
+    # Add resources if specified.
+    if resources is not None:
+        if isinstance(resources, (Path, str)):
+            serialized_resource = _ResourceBuilder.from_yaml_file(resources)
+        else:
+            serialized_resource = _ResourceBuilder.from_resources(resources)
+
+        mlflow_model.resources = serialized_resource
+
     # Save mlflow_model to path/MLmodel.
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
@@ -242,6 +256,7 @@ def log_model(
     pip_requirements: Optional[Union[List[str], str]] = None,
     extra_pip_requirements: Optional[Union[List[str], str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
+    resources: Optional[Union[str, List[Resource]]] = None,
 ):
     """
     Log a Dspy model along with metadata to MLflow.
@@ -271,6 +286,8 @@ def log_model(
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: Custom metadata dictionary passed to the model and stored in the MLmodel
             file.
+        resources: A list of model resources or a resources.yaml file containing a list of
+                    resources required to serve the model.
 
     .. code-block:: python
         :caption: Example
@@ -328,4 +345,5 @@ def log_model(
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
         metadata=metadata,
+        resources=resources,
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/lmoros-DB/mlflow/pull/13414?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13414/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13414
```

</p>
</details>

### What changes are proposed in this pull request?

Adding 'resources' param to DSPy flavor functions: 'log_model' and 'save_model'

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Register model with resources
![image](https://github.com/user-attachments/assets/6fd27436-4415-47f9-b9bc-5b3ab3617a43)

Deploy model (without setting env vars)
![image](https://github.com/user-attachments/assets/b51490a0-4010-4166-a89b-dc5d2a318c67)

Query endpoint
![image](https://github.com/user-attachments/assets/bad1726c-fafb-45c0-a81e-66268f2f76ed)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

After defining Databricks "resources" and passing them to the "resources" param of the log_model function. Deploying the registered model does not requires setting environmental variables

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="log-DSPy-flavor-with-resources"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
