### PR TITLE
Update to throw a warning instead of error when set_retriever_schema is called twice

### DIFF
--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -1,11 +1,10 @@
+import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional
 
-from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import ALREADY_EXISTS
 from mlflow.utils.annotations import experimental
 
 
@@ -55,23 +54,31 @@ def set_retriever_schema(
     retriever_schema = globals().get(DependenciesSchemasType.RETRIEVERS.value, [])
 
     # Check if a retriever schema with the same name already exists
-    if any(schema["name"] == name for schema in retriever_schema):
-        # reset if there is an error to clear the global state for next run
-        _clear_retriever_schema()
-        raise MlflowException(
-            f"A retriever schema with the name '{name}' already exists.",
-            error_code=ALREADY_EXISTS,
+    existing_schema = next((schema for schema in retriever_schema if schema["name"] == name), None)
+
+    if existing_schema is not None:
+        warnings.warn(
+            f"A retriever schema with the name '{name}' already exists. "
+            "Overriding the existing schema.",
+            category=UserWarning,
+            stacklevel=2,
+        )
+        # Override the fields of the existing schema
+        existing_schema["primary_key"] = primary_key
+        existing_schema["text_column"] = text_column
+        existing_schema["doc_uri"] = doc_uri
+        existing_schema["other_columns"] = other_columns or []
+    else:
+        retriever_schema.append(
+            {
+                "primary_key": primary_key,
+                "text_column": text_column,
+                "doc_uri": doc_uri,
+                "other_columns": other_columns or [],
+                "name": name,
+            }
         )
 
-    retriever_schema.append(
-        {
-            "primary_key": primary_key,
-            "text_column": text_column,
-            "doc_uri": doc_uri,
-            "other_columns": other_columns or [],
-            "name": name,
-        }
-    )
     globals()[DependenciesSchemasType.RETRIEVERS.value] = retriever_schema
 
 

--- a/tests/models/test_dependencies_schema.py
+++ b/tests/models/test_dependencies_schema.py
@@ -212,8 +212,7 @@ def test_multiple_set_retriever_schema_with_same_name():
             doc_uri="doc-uri",
             other_columns=["column1", "column2"],
         )
-        mock_logger.warning.assert_called_once()
-        mock_logger.warning.assert_called_with(
+        mock_logger.warning.assert_called_once_with(
             "A retriever schema with the name 'my_ret_1' already exists. "
             "Overriding the existing schema."
         )

--- a/tests/models/test_dependencies_schema.py
+++ b/tests/models/test_dependencies_schema.py
@@ -1,6 +1,5 @@
 import pytest
 
-from mlflow.exceptions import MlflowException
 from mlflow.models.dependencies_schemas import (
     DependenciesSchemas,
     DependenciesSchemasType,
@@ -197,9 +196,18 @@ def test_multiple_set_retriever_schema_with_same_name():
         doc_uri="doc-uri-3",
         other_columns=["column1", "column2"],
     )
+    set_retriever_schema(
+        name="my_ret_2",
+        primary_key="primary-key",
+        text_column="text-column",
+        doc_uri="doc-uri",
+        other_columns=["column1", "column2"],
+    )
 
-    with pytest.raises(
-        MlflowException, match=r"A retriever schema with the name 'my_ret_1' already exists."
+    with pytest.warns(
+        UserWarning,
+        match="A retriever schema with the name 'my_ret_1' already exists. "
+        "Overriding the existing schema.",
     ):
         set_retriever_schema(
             name="my_ret_1",
@@ -209,5 +217,22 @@ def test_multiple_set_retriever_schema_with_same_name():
             other_columns=["column1", "column2"],
         )
 
-    # If there is an error, the schema is cleared
-    assert _get_retriever_schema() == []
+    with _get_dependencies_schemas() as schema:
+        assert schema.to_dict()["dependencies_schemas"] == {
+            DependenciesSchemasType.RETRIEVERS.value: [
+                {
+                    "doc_uri": "doc-uri",
+                    "name": "my_ret_1",
+                    "other_columns": ["column1", "column2"],
+                    "primary_key": "primary-key",
+                    "text_column": "text-column",
+                },
+                {
+                    "doc_uri": "doc-uri",
+                    "name": "my_ret_2",
+                    "other_columns": ["column1", "column2"],
+                    "primary_key": "primary-key",
+                    "text_column": "text-column",
+                },
+            ]
+        }

--- a/tests/models/test_dependencies_schema.py
+++ b/tests/models/test_dependencies_schema.py
@@ -1,4 +1,4 @@
-import pytest
+from unittest import mock
 
 from mlflow.models.dependencies_schemas import (
     DependenciesSchemas,
@@ -204,17 +204,18 @@ def test_multiple_set_retriever_schema_with_same_name():
         other_columns=["column1", "column2"],
     )
 
-    with pytest.warns(
-        UserWarning,
-        match="A retriever schema with the name 'my_ret_1' already exists. "
-        "Overriding the existing schema.",
-    ):
+    with mock.patch("mlflow.models.dependencies_schemas._logger") as mock_logger:
         set_retriever_schema(
             name="my_ret_1",
             primary_key="primary-key",
             text_column="text-column",
             doc_uri="doc-uri",
             other_columns=["column1", "column2"],
+        )
+        mock_logger.warning.assert_called_once()
+        mock_logger.warning.assert_called_with(
+            "A retriever schema with the name 'my_ret_1' already exists. "
+            "Overriding the existing schema."
         )
 
     with _get_dependencies_schemas() as schema:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/13422?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13422/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13422
```

</p>
</details>

### What changes are proposed in this pull request?
Update to throw a warning instead of error when set_retriever_schema is called twice

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Update to throw a warning instead of error when set_retriever_schema is called twice

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
