### PR TITLE
Support dependency extraction from RunnableCallables

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -226,7 +226,6 @@ def _traverse_runnable(
     """
     import pydantic
     from langchain_core.runnables import Runnable, RunnableLambda
-    from langgraph.utils.runnable import RunnableCallable
 
     visited = visited or set()
     current_object_id = id(lc_model)
@@ -243,10 +242,11 @@ def _traverse_runnable(
             pydantic.version.VERSION
         ) >= version.parse("2.0"):
             nodes = _get_nodes_from_runnable_lambda(lc_model)
-        elif isinstance(lc_model, RunnableCallable):
-            nodes = _get_nodes_from_runnable_callable(lc_model)
         else:
-            nodes = lc_model.get_graph().nodes.values()
+            nodes = _get_nodes_from_runnable_callable(lc_model)
+            # If no nodes are found continue with the default behaviour
+            if len(nodes) == 0:
+                nodes = lc_model.get_graph().nodes.values()
 
         for node in nodes:
             yield from _traverse_runnable(node.data, visited)
@@ -289,9 +289,6 @@ def _get_nodes_from_runnable_lambda(lc_model):
 
 
 def _get_nodes_from_runnable_callable(lc_model):
-    from langchain_core.runnables import Runnable
-    from langchain_core.runnables.utils import get_function_nonlocals
-
     """
     RunnableLambda has a `deps` property which goes through the function and extracts a
     ny dependencies. RunnableCallable does not have this property so we cannot derive all
@@ -300,6 +297,19 @@ def _get_nodes_from_runnable_callable(lc_model):
 
     The code here is from: https://github.com/langchain-ai/langchain/blob/12fea5b868edd12b0d576e7f8bfc922d0167eeab/libs/core/langchain_core/runnables/base.py#L4467
     """
+
+    # If Runnable Callable is not importable or if the lc_model is not an instance
+    # of RunnableCallable return early
+    try:
+        from langchain_core.runnables import Runnable
+        from langchain_core.runnables.utils import get_function_nonlocals
+        from langgraph.utils.runnable import RunnableCallable
+
+        if not isinstance(lc_model, RunnableCallable):
+            return []
+    except ImportError:
+        return []
+
     if hasattr(lc_model, "func"):
         objects = get_function_nonlocals(lc_model.func)
     elif hasattr(lc_model, "afunc"):

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -226,6 +226,7 @@ def _traverse_runnable(
     """
     import pydantic
     from langchain_core.runnables import Runnable, RunnableLambda
+    from langgraph.utils.runnable import RunnableCallable
 
     visited = visited or set()
     current_object_id = id(lc_model)
@@ -242,6 +243,8 @@ def _traverse_runnable(
             pydantic.version.VERSION
         ) >= version.parse("2.0"):
             nodes = _get_nodes_from_runnable_lambda(lc_model)
+        elif isinstance(lc_model, RunnableCallable):
+            nodes = _get_nodes_from_runnable_callable(lc_model)
         else:
             nodes = lc_model.get_graph().nodes.values()
 
@@ -282,6 +285,41 @@ def _get_nodes_from_runnable_lambda(lc_model):
             nodes.extend(dep_graph.nodes.values())
     else:
         nodes = lc_model.get_graph().nodes.values()
+    return nodes
+
+
+def _get_nodes_from_runnable_callable(lc_model):
+    from langchain_core.runnables import Runnable
+    from langchain_core.runnables.utils import get_function_nonlocals
+
+    """
+    RunnableLambda has a `deps` property which goes through the function and extracts a
+    ny dependencies. RunnableCallable does not have this property so we cannot derive all
+    the dependencies from the function. This helper method also looks into the function of the
+    callable to retrieve these dependencies.
+
+    The code here is from: https://github.com/langchain-ai/langchain/blob/12fea5b868edd12b0d576e7f8bfc922d0167eeab/libs/core/langchain_core/runnables/base.py#L4467
+    """
+    if hasattr(lc_model, "func"):
+        objects = get_function_nonlocals(lc_model.func)
+    elif hasattr(lc_model, "afunc"):
+        objects = get_function_nonlocals(lc_model.afunc)
+    else:
+        objects = []
+
+    deps = []
+    for obj in objects:
+        if isinstance(obj, Runnable):
+            deps.append(obj)
+        elif isinstance(getattr(obj, "__self__", None), Runnable):
+            deps.append(obj.__self__)
+
+    nodes = []
+    for dep in deps:
+        dep_graph = dep.get_graph()
+        dep_graph.trim_first_node()
+        dep_graph.trim_last_node()
+        nodes.extend(dep_graph.nodes.values())
     return nodes
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aravind-segu/mlflow/pull/13423?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13423/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13423
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

Langgraph recently changed their `create_react_agent` code to use `RunnableCallable` instead of `RunnableLambda` [here](https://github.com/langchain-ai/langgraph/commit/bacf92c441e35c3c63d6216989b65e41157cb8e4#diff-434415f709a673e5b362f4e02683191ea7c934e0301734e4f91f3de78ae8d7b1R570). `RunnableCallable` does not list its depenedencies so our dependency detection broke.

This code introduces the logic from `RunnableLambda` to fill in the dependencies so we can still detect the correct dependencies.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
