### PR TITLE
Fix docstring parameter order

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -294,9 +294,9 @@ class Linter(ast.NodeVisitor):
                 if diff := doc_args_set - func_args_set:
                     self._check(Location.from_node(node), rules.ExtraneousDocstringParam(diff))
 
-                # TODO: Enable this rule
-                # if func_args_set == doc_args_set and func_args != doc_args:
-                #     self._check(Location.from_node(node), rules.DocstringParamOrder())
+                if func_args_set == doc_args_set and func_args != doc_args:
+                    params = [a for a, b in zip(func_args, doc_args) if a != b]
+                    self._check(Location.from_node(node), rules.DocstringParamOrder(params))
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._test_name_typo(node)

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -111,8 +111,11 @@ class ExtraneousDocstringParam(Rule):
 
 
 class DocstringParamOrder(Rule):
+    def __init__(self, params: list[str]) -> None:
+        self.params = params
+
     def _id(self) -> str:
         return "MLF009"
 
     def _message(self) -> str:
-        return "Order of parameters in docstring does not match function parameters."
+        return f"Order of parameters in docstring does not match function parameters: {self.params}"

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -118,4 +118,4 @@ class DocstringParamOrder(Rule):
         return "MLF009"
 
     def _message(self) -> str:
-        return f"Order of parameters in docstring does not match function parameters: {self.params}"
+        return f"Unordered parameters in docstring: {self.params}"

--- a/examples/flower_classifier/train.py
+++ b/examples/flower_classifier/train.py
@@ -175,12 +175,12 @@ def train(
     directly to image base64 encoded image data.
 
     Args:
-        image_height: Height of the input image in pixels.
-        image_width: Width of the input image in pixels.
         image_files: List of image files to be used for training.
         labels: List of labels for the image files.
         domain: Dictionary representing the domain of the response.
             Provides mapping label-name -> label-id.
+        image_width: Width of the input image in pixels.
+        image_height: Height of the input image in pixels.
         epochs: Number of epochs to train the model for.
         batch_size: Batch size used during training.
         test_ratio: Fraction of dataset to be used for validation. This data will not be used

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -276,13 +276,13 @@ def log_model(
               signature = infer_signature(train, predictions)
 
         input_example: {{ input_example }}
-        kwargs: kwargs to pass to `fastai.Learner.export`_ method.
         await_registration_for: Number of seconds to wait for the model version to finish
             being created and is in ``READY`` status. By default, the function
             waits for five minutes. Specify 0 or None to skip waiting.
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: {{ metadata }}
+        kwargs: kwargs to pass to `fastai.Learner.export`_ method.
 
     Returns:
         A ModelInfo instance that contains the metadata of the logged model.

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -221,8 +221,6 @@ def log_model(
     Args:
         spark_model: NLUPipeline obtained via `nlp.load()
             <https://nlp.johnsnowlabs.com/docs/en/jsl/load_api>`_
-        store_license: If True, the license will be stored with the model and used and re-loading
-            it.
         artifact_path: Run relative artifact path.
         conda_env: Either a dictionary representation of a Conda environment or the path to a
             Conda environment yaml file. If provided, this describes the environment
@@ -275,6 +273,8 @@ def log_model(
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata:  {{ metadata }}
+        store_license: If True, the license will be stored with the model and used and re-loading
+            it.
 
     Returns:
         A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
@@ -510,8 +510,6 @@ def save_model(
     is also serialized in MLeap format and the MLeap flavor is added.
 
     Args:
-        store_license: If True, the license will be stored with the model and used and
-            re-loading it.
         spark_model: Either a pyspark.ml.pipeline.PipelineModel or nlu.NLUPipeline object to be
             saved. `Every johnsnowlabs model <https://nlp.johnsnowlabs.com/models>`_
             is a PipelineModel and loadable as nlu.NLUPipeline.
@@ -561,6 +559,8 @@ def save_model(
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: {{ metadata }}
+        store_license: If True, the license will be stored with the model and used and
+            re-loading it.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -646,8 +646,8 @@ class BuiltInEvaluator(ModelEvaluator):
         Args:
             metrics: A list of metrics to evaluate.
             prediction: A Pandas Series containing the predictions.
-            other_output_df: A Pandas DataFrame containing other output columns from the model.
             target: A numpy array containing the target values.
+            other_output_df: A Pandas DataFrame containing other output columns from the model.
 
         Returns:
             None, the metrics values are recorded in the self.metrics_values dictionary.

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -60,23 +60,19 @@ def build_docker(
             an 's3://' URI). For more information about supported remote URIs for model artifacts,
             see https://mlflow.org/docs/latest/tracking.html#artifact-stores"
         name: Name of the Docker image to build. Defaults to 'mlflow-pyfunc'.
-        install_java: If specified, install Java in the image. Default is False in order to
-            reduce both the image size and the build time. Model flavors requiring Java will enable
-            this setting automatically, such as the Spark flavor. (This argument is only available
-            in MLflow 2.10.1 and later. In earlier versions, Java is always installed to the image.)
-
-        enable_mlserver: If specified, the image will be built with the Seldon MLserver as backend.
         env_manager: If specified, create an environment for MLmodel using the specified environment
             manager. The following values are supported: (1) virtualenv (default): use virtualenv
             and pyenv for Python version management (2) conda: use conda (3) local: use the local
             environment without creating a new one.
-
+        mlflow_home: Path to local clone of MLflow project. Use for development only.
+        install_java: If specified, install Java in the image. Default is False in order to
+            reduce both the image size and the build time. Model flavors requiring Java will enable
+            this setting automatically, such as the Spark flavor. (This argument is only available
+            in MLflow 2.10.1 and later. In earlier versions, Java is always installed to the image.)
         install_mlflow: If specified and there is a conda or virtualenv environment to be activated
             mlflow will be installed into the environment after it has been activated.
             The version of installed mlflow will be the same as the one used to invoke this command.
-
-        mlflow_home: Path to local clone of MLflow project. Use for development only.
-
+        enable_mlserver: If specified, the image will be built with the Seldon MLserver as backend.
         base_image: Base image for the Docker image. If not specified, the default image is either
             UBUNTU_BASE_IMAGE = "ubuntu:20.04" or PYTHON_SLIM_BASE_IMAGE = "python:{version}-slim"
             Note: If custom image is used, there are no guarantees that the image will work. You

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2421,14 +2421,14 @@ def save_model(
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
         example_no_conversion: {{ example_no_conversion }}
+        streamable: A boolean value indicating if the model supports streaming prediction,
+                    If None, MLflow will try to inspect if the model supports streaming
+                    by checking if `predict_stream` method exists. Default None.
         resources: A list of model resources or a resources.yaml file containing a list of
                     resources required to serve the model.
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
-        streamable: A boolean value indicating if the model supports streaming prediction,
-                    If None, MLflow will try to inspect if the model supports streaming
-                    by checking if `predict_stream` method exists. Default None.
         kwargs: Extra keyword arguments.
     """
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
@@ -2850,16 +2850,14 @@ def log_model(
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
         example_no_conversion: {{ example_no_conversion }}
+        streamable: A boolean value indicating if the model supports streaming prediction,
+                    If None, MLflow will try to inspect if the model supports streaming
+                    by checking if `predict_stream` method exists. Default None.
         resources: A list of model resources or a resources.yaml file containing a list of
                     resources required to serve the model.
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
-
-
-        streamable: A boolean value indicating if the model supports streaming prediction,
-                    If None, MLflow will try to inspect if the model supports streaming
-                    by checking if `predict_stream` method exists. Default None.
 
     Returns:
         A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -962,12 +962,12 @@ def autolog(
             pytorch-lightning >= 1.6.0.
         checkpoint_monitor: In automatic model checkpointing, the metric name to monitor if
             you set `model_checkpoint_save_best_only` to True.
-        checkpoint_save_best_only: If True, automatic model checkpointing only saves when
-            the model is considered the "best" model according to the quantity
-            monitored and previous checkpoint model is overwritten.
         checkpoint_mode: one of {"min", "max"}. In automatic model checkpointing,
             if save_best_only=True, the decision to overwrite the current save file is made based on
             either the maximization or the minimization of the monitored quantity.
+        checkpoint_save_best_only: If True, automatic model checkpointing only saves when
+            the model is considered the "best" model according to the quantity
+            monitored and previous checkpoint model is overwritten.
         checkpoint_save_weights_only: In automatic model checkpointing, if True, then
             only the model’s weights will be saved. Otherwise, the optimizer states,
             lr-scheduler states, etc are added in the checkpoint too.

--- a/mlflow/recipes/utils/execution.py
+++ b/mlflow/recipes/utils/execution.py
@@ -358,8 +358,8 @@ def _run_make(
     Args:
         execution_directory_path: The absolute path of the execution directory on the local
             filesystem for the relevant recipe. The Makefile is created in this directory.
-        extra_env: Extra environment variables to be defined when running the Make child process.
         rule_name: The name of the Make rule to run.
+        extra_env: Extra environment variables to be defined when running the Make child process.
         recipe_steps: A list of step instances that is a subgraph containing the step specified
             by `rule_name`.
     """

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -189,9 +189,9 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         `request_message_class`.
 
         Args:
-            paths: The specified run-relative artifact paths within the MLflow Run.
-            run_id: The specified MLflow Run.
             request_message_class: Specifies the type of access credentials, read or write.
+            run_id: The specified MLflow Run.
+            paths: The specified run-relative artifact paths within the MLflow Run.
 
         Returns:
             A list of `ArtifactCredentialInfo` objects providing read access to the specified

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -195,11 +195,11 @@ def log_model(
             :py:func:`mlflow.pyfunc.load_model`.
         conda_env: {{ conda_env }}
         code_paths: {{ code_paths }}
+        signature: {{ signature }}
+        input_example: {{ input_example }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.
-        signature: {{ signature }}
-        input_example: {{ input_example }}
         await_registration_for: Number of seconds to wait for the model version to finish
             being created and is in ``READY`` status. By default, the function
             waits for five minutes. Specify 0 or None to skip waiting.
@@ -1100,12 +1100,12 @@ def autolog(
         checkpoint: Enable automatic model checkpointing.
         checkpoint_monitor: In automatic model checkpointing, the metric name to monitor if
             you set `model_checkpoint_save_best_only` to True.
-        checkpoint_save_best_only: If True, automatic model checkpointing only saves when
-            the model is considered the "best" model according to the quantity
-            monitored and previous checkpoint model is overwritten.
         checkpoint_mode: one of {"min", "max"}. In automatic model checkpointing,
             if save_best_only=True, the decision to overwrite the current save file is made based on
             either the maximization or the minimization of the monitored quantity.
+        checkpoint_save_best_only: If True, automatic model checkpointing only saves when
+            the model is considered the "best" model according to the quantity
+            monitored and previous checkpoint model is overwritten.
         checkpoint_save_weights_only: In automatic model checkpointing, if True, then
             only the model’s weights will be saved. Otherwise, the optimizer states,
             lr-scheduler states, etc are added in the checkpoint too.

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -131,6 +131,8 @@ def search_registered_models(
     """Search for registered models that satisfy the filter criteria.
 
     Args:
+        max_results: If passed, specifies the maximum number of models desired. If not
+            passed, all models will be returned.
         filter_string: Filter query string (e.g., "name = 'a_model_name' and tag.key = 'value1'"),
             defaults to searching for all registered models. The following identifiers, comparators,
             and logical operators are supported.
@@ -149,8 +151,6 @@ def search_registered_models(
             Logical operators
               - "AND": Combines two sub-queries and returns True if both of them are True.
 
-        max_results: If passed, specifies the maximum number of models desired. If not
-            passed, all models will be returned.
         order_by: List of column names with ASC|DESC annotation, to be used for ordering
             matching search results.
 
@@ -240,6 +240,8 @@ def search_model_versions(
         The model version search results may not have aliases populated for performance reasons.
 
     Args:
+        max_results: If passed, specifies the maximum number of models desired. If not
+            passed, all models will be returned.
         filter_string: Filter query string
             (e.g., ``"name = 'a_model_name' and tag.key = 'value1'"``),
             defaults to searching for all model versions. The following identifiers, comparators,
@@ -262,8 +264,6 @@ def search_model_versions(
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.
 
-        max_results: If passed, specifies the maximum number of models desired. If not
-            passed, all models will be returned.
         order_by: List of column names with ASC|DESC annotation, to be used for ordering
             matching search results.
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -795,10 +795,10 @@ class MlflowClient:
             name: The name of the span.
             request_id: The ID of the trace to attach the span to. This is synonym to
                 trace_id` in OpenTelemetry.
-            span_type: The type of the span. Can be either a string or a
-                :py:class:`SpanType <mlflow.entities.SpanType>` enum value.
             parent_id: The ID of the parent span. The parent span can be a span created by
                 both fluent APIs like `with mlflow.start_span()`, and imperative APIs like this.
+            span_type: The type of the span. Can be either a string or a
+                :py:class:`SpanType <mlflow.entities.SpanType>` enum value.
             inputs: Inputs to set on the span.
             attributes: A dictionary of attributes to set on the span.
             start_time_ns: The start time of the span in nano seconds since the UNIX epoch.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -842,11 +842,11 @@ def log_metric(
             All backend stores will support values up to length 5000, but some
             may support larger values.
         step: Metric step. Defaults to zero if unspecified.
-        timestamp: Time when this metric was calculated. Defaults to the current system time.
         synchronous: *Experimental* If True, blocks until the metric is logged
             successfully. If False, logs the metric asynchronously and
             returns a future representing the logging operation. If None, read from environment
             variable `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
+        timestamp: Time when this metric was calculated. Defaults to the current system time.
         run_id: If specified, log the metric to the specified run. If not specified, log the metric
             to the currently active run.
 

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -265,8 +265,8 @@ def dataframe_from_parsed_json(decoded_input, pandas_orient, schema=None):
 
     Args:
         decoded_input: Parsed json - either a list or a dictionary.
-        schema: MLflow schema used when parsing the data.
         pandas_orient: pandas data frame convention used to store the data.
+        schema: MLflow schema used when parsing the data.
 
     Returns:
         pandas.DataFrame.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13429?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13429/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13429
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #13355

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix docstring parameter order.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
