### PR TITLE
Remove unused requirements in `ml-package-versions.yml`

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -497,7 +497,7 @@ def validate_requirements(
             continue
 
         # Does this version specifier (e.g. '< 1.0.0') match at least one version?
-        #　If not, raise an error.
+        # If not, raise an error.
         spec_set = SpecifierSet(specifier)
         if not any(map(spec_set.contains, versions)):
             raise ValueError(

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -501,7 +501,7 @@ def validate_requirements(
         if not any(map(spec_set.contains, versions)):
             raise ValueError(
                 f"Found unused requirements {specifier!r} for {name} / {category}. "
-                "Please remove it."
+                "Please remove it or adjust the version specifier."
             )
 
 

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -497,6 +497,7 @@ def validate_requirements(
             continue
 
         # Does this version specifier (e.g. '< 1.0.0') match at least one version?
+        #　If not, raise an error.
         spec_set = SpecifierSet(specifier)
         if not any(map(spec_set.contains, versions)):
             raise ValueError(
@@ -532,7 +533,7 @@ def expand_config(config: Dict[str, Any], *, is_ref: bool = False) -> Set[Matrix
             if cfg.minimum not in versions:
                 versions.append(cfg.minimum)
 
-            if cfg.requirements and not is_ref:
+            if not is_ref and cfg.requirements:
                 validate_requirements(cfg.requirements, name, category, package_info, versions)
 
             for ver in versions:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -501,11 +501,12 @@ def validate_requirements(
                 break
         else:
             raise ValueError(
-                f"Requirements {specifier!r} for {name} / {category} is unused. Please remove it."
+                f"Found unused requirements {specifier!r} for {name} / {category}. "
+                "Please remove it."
             )
 
 
-def expand_config(config: Dict[str, Any], *, is_ref: bool = False):
+def expand_config(config: Dict[str, Any], *, is_ref: bool = False) -> Set[MatrixItem]:
     matrix = set()
     for name, flavor_config in config.items():
         flavor = get_flavor(name)

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -488,18 +488,17 @@ def validate_requirements(
             minimum: "1.3.0"
             maximum: "1.5.0"
             requirements:
-                "< 1.0.0": ["numpy<2.0"]    # Unused -> this will raise an error
+                "< 1.0.0": ["numpy<2.0"]    # Unused
                 ">= 1.5.0": ["numpy>=2.0"]  # Used
     ```
     """
     for specifier in requirements:
-        for v in versions:
-            if "dev" in specifier and package_info.install_dev:
-                break
+        if "dev" in specifier and package_info.install_dev:
+            continue
 
-            if SpecifierSet(specifier).contains(v):
-                break
-        else:
+        # Does this version specifier (e.g. '< 1.0.0') match at least one version?
+        spec_set = SpecifierSet(specifier)
+        if not any(map(spec_set.contains, versions)):
             raise ValueError(
                 f"Found unused requirements {specifier!r} for {name} / {category}. "
                 "Please remove it."

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -476,6 +476,23 @@ def validate_requirements(
     package_info: PackageInfo,
     versions: List[Version],
 ) -> None:
+    """
+    Validate that the requirements specified in the config don't contain unused items.
+
+    Example:
+
+    ```
+    sklearn:
+        package_info:
+            pip_release: "scikit-learn"
+        autologging:
+            minimum: "1.3.0"
+            maximum: "1.5.0"
+            requirements:
+                "< 1.0.0": ["numpy<2.0"]    # Unused -> this will raise an error
+                ">= 1.5.0": ["numpy>=2.0"]  # Used
+    ```
+    """
     for specifier in requirements:
         for v in versions:
             if "dev" in specifier and package_info.install_dev:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -470,13 +470,13 @@ def _get_test_files_from_pytest_command(cmd, test_dir):
 
 
 def validate_requirements(
-    cfg: TestConfig,
+    requirements: Dict[str, List[str]],
     name: str,
     category: str,
     package_info: PackageInfo,
     versions: List[Version],
 ) -> None:
-    for specifier, packages in cfg.requirements.items():
+    for specifier in requirements:
         for v in versions:
             if "dev" in specifier and package_info.install_dev:
                 break
@@ -485,8 +485,7 @@ def validate_requirements(
                 break
         else:
             raise ValueError(
-                f"Requirements specifier {specifier!r} for {name} / {category} is "
-                "unused. Please remove it."
+                f"Requirements {specifier!r} for {name} / {category} is unused. Please remove it."
             )
 
 
@@ -518,7 +517,7 @@ def expand_config(config: Dict[str, Any], *, is_ref: bool = False):
                 versions.append(cfg.minimum)
 
             if cfg.requirements and not is_ref:
-                validate_requirements(cfg, name, category, package_info, versions)
+                validate_requirements(cfg.requirements, name, category, package_info, versions)
 
             for ver in versions:
                 requirements = [f"{package_info.pip_release}=={ver}"]

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -478,8 +478,7 @@ def validate_requirements(
 ) -> None:
     """
     Validate that the requirements specified in the config don't contain unused items.
-
-    Example:
+    Here's an example of invalid requirements:
 
     ```
     sklearn:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -489,7 +489,7 @@ def validate_requirements(
             maximum: "1.5.0"
             requirements:
                 "< 1.0.0": ["numpy<2.0"]    # Unused
-                ">= 1.5.0": ["numpy>=2.0"]  # Used
+                ">= 1.4.0": ["numpy>=2.0"]  # Used
     ```
     """
     for specifier in requirements:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -42,7 +42,6 @@ pytorch:
     requirements:
       ">= 0.0.0": ["torchvision", "scikit-learn"]
       ">= 1.8": ["transformers"]
-      "< 1.8": ["transformers<4.32.0"]
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 
@@ -66,16 +65,6 @@ pytorch-lightning:
     maximum: "2.4.0"
     requirements:
       ">= 0.0.0": ["scikit-learn", "torchvision", "protobuf<4.0.0", "tensorboard", "greenlet<3"]
-      # torchmetrics==0.8.0 released a breaking change for versions 1.3 and 1.4 where
-      # torchmetrics dependency was defined as non-upper-bounded in its requirements.
-      # see: https://github.com/PyTorchLightning/metrics/commit/c537c9b3e8e801772a7e5670ff273321ed26e77b
-      # for the removed function that causes pytorch-lightning imports to fail with torchmetrics==0.8.0
-      ">= 1.3.0, < 1.5.0": ["torchmetrics<0.8.0"]
-      # torchmetrics==1.0.0 released a breaking change in version 1.0.0 that is incompatible with
-      # the usage of a private utility within torchmetrics for pytorch-lightning~=1.7 that was
-      # modified in pytorch-lightning>=1.8.
-      # The problematic commit: https://github.com/Lightning-AI/torchmetrics/commit/3527e17516902eb5265cd2a4f76ad6b0f9f77692
-      "< 1.8.0": ["torchmetrics<1.0.0"]
     run: |
       pytest tests/pytorch/test_pytorch_autolog.py
 
@@ -260,9 +249,7 @@ fastai:
       #  To migrate fastai tests to python 3.9, we need to address error
       #  when installing old version scipy: "No module named 'distutils.msvccompiler'"
       #  similar issue link: https://github.com/numpy/numpy/issues/27405
-      "> 0.0.0": ["spacy<3.8.2"]
-      "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
-      ">= 2.8.0": ["torch", "torchvision"]
+      "> 0.0.0": ["spacy<3.8.2", "torch<1.13.0", "torchvision<0.14.0"]
     run: |
       pytest tests/fastai/test_fastai_model_export.py
 
@@ -270,9 +257,7 @@ fastai:
     minimum: "2.4.1"
     maximum: "2.7.17"
     requirements:
-      "> 0.0.0": ["spacy<3.8.2"]
-      "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
-      ">= 2.8.0": ["torch", "torchvision"]
+      "> 0.0.0": ["spacy<3.8.2", "torch<1.13.0", "torchvision<0.14.0"]
     run: |
       pytest tests/fastai/test_fastai_autolog.py
 
@@ -303,7 +288,6 @@ onnx:
     maximum: "1.17.0"
     requirements:
       ">= 0.0.0": ["onnxruntime", "torch", "scikit-learn", "protobuf<4.0.0"]
-      "< 1.11.0": ["numpy<1.24.0"]
     run: |
       pytest tests/onnx/test_onnx_model_export.py
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13430?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13430/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13430
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`ml-package-versions.yml` contains several unused requirements. This PR removes them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
