### PR TITLE
Refactor CompareRunView into functional component (new)

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -1,13 +1,6 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
-import React, { Component } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
-import { injectIntl, FormattedMessage, type IntlShape } from 'react-intl';
+import { injectIntl, FormattedMessage, IntlShape } from 'react-intl';
 import { Spacer, Switch, Tabs, LegacyTooltip } from '@databricks/design-system';
 
 import { getExperiment, getParams, getRunInfo, getRunTags } from '../reducers/Reducers';
@@ -44,85 +37,173 @@ type CompareRunViewProps = {
   intl: IntlShape;
 };
 
-type CompareRunViewState = any;
-export class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState> {
-  compareRunViewRef: any;
-  runDetailsTableRef: any;
+const CompareRunView: React.FC<CompareRunViewProps> = ({
+  experiments,
+  experimentIds,
+  comparedExperimentIds,
+  hasComparedExperimentsBefore,
+  runInfos,
+  runUuids,
+  metricLists,
+  paramLists,
+  tagLists,
+  runNames,
+  runDisplayNames,
+  intl,
+}) => {
+  const [tableWidth, setTableWidth] = useState<number | null>(null);
+  const [onlyShowParamDiff, setOnlyShowParamDiff] = useState(false);
+  const [onlyShowTagDiff, setOnlyShowTagDiff] = useState(false);
+  const [onlyShowMetricDiff, setOnlyShowMetricDiff] = useState(false);
 
-  constructor(props: CompareRunViewProps) {
-    super(props);
-    this.state = {
-      tableWidth: null,
-      onlyShowParamDiff: false,
-      onlyShowTagDiff: false,
-      onlyShowMetricDiff: false,
-    };
-    this.onResizeHandler = this.onResizeHandler.bind(this);
-    this.onCompareRunTableScrollHandler = this.onCompareRunTableScrollHandler.bind(this);
+  const runDetailsTableRef = useRef<HTMLDivElement>(null);
+  const compareRunViewRef = useRef<HTMLDivElement>(null);
 
-    this.runDetailsTableRef = React.createRef();
-    this.compareRunViewRef = React.createRef();
-  }
+  const paramsLabel = intl.formatMessage({
+    defaultMessage: 'Parameters',
+    description: 'Row group title for parameters of runs on the experiment compare runs page',
+  });
 
-  onResizeHandler(e: any) {
-    const table = this.runDetailsTableRef.current;
-    if (table !== null) {
-      const containerWidth = table.clientWidth;
-      this.setState({ tableWidth: containerWidth });
-    }
-  }
+  const metricsLabel = intl.formatMessage({
+    defaultMessage: 'Metrics',
+    description: 'Row group title for metrics of runs on the experiment compare runs page',
+  });
 
-  onCompareRunTableScrollHandler(e: any) {
-    const blocks = this.compareRunViewRef.current.querySelectorAll('.compare-run-table');
-    blocks.forEach((_: any, index: any) => {
-      const block = blocks[index];
-      if (block !== e.target) {
-        block.scrollLeft = e.target.scrollLeft;
-      }
-    });
-  }
+  const artifactsLabel = intl.formatMessage({
+    defaultMessage: 'Artifacts',
+    description: 'Row group title for artifacts of runs on the experiment compare runs page',
+  });
 
-  componentDidMount() {
-    const pageTitle = this.props.intl.formatMessage(
+  const tagsLabel = intl.formatMessage({
+    defaultMessage: 'Tags',
+    description: 'Row group title for tags of runs on the experiment compare runs page',
+  });
+
+  const diffOnlyLabel = intl.formatMessage({
+    defaultMessage: 'Show diff only',
+    description:
+      'Label next to the switch that controls displaying only differing values in comparison tables on the compare runs page',
+  });
+
+  useEffect(() => {
+    const pageTitle = intl.formatMessage(
       {
         description: 'Page title for the compare runs page',
         defaultMessage: 'Comparing {runs} MLflow Runs',
       },
       {
-        runs: this.props.runInfos.length,
+        runs: runInfos.length,
       },
     );
     Utils.updatePageTitle(pageTitle);
 
-    window.addEventListener('resize', this.onResizeHandler, true);
-    window.dispatchEvent(new Event('resize'));
-  }
+    const handleResize = () => {
+      const table = runDetailsTableRef.current;
+      if (table !== null) {
+        setTableWidth(table.clientWidth);
+      }
+    };
 
-  componentWillUnmount() {
-    // Avoid registering `onResizeHandler` every time this component mounts
-    window.removeEventListener('resize', this.onResizeHandler, true);
-  }
+    window.addEventListener('resize', handleResize, true);
+    handleResize();
 
-  getTableColumnWidth() {
+    return () => {
+      window.removeEventListener('resize', handleResize, true);
+    };
+  }, [runInfos.length, intl]);
+
+  const onCompareRunTableScrollHandler = (e: React.UIEvent) => {
+    const blocks = compareRunViewRef.current?.querySelectorAll('.compare-run-table') || [];
+    blocks.forEach((block, index) => {
+      if (block !== e.target) {
+        block.scrollLeft = (e.target as HTMLDivElement).scrollLeft;
+      }
+    });
+  };
+
+  const genWidthStyle = (width: any) => {
+    return {
+      width: `${width}px`,
+      minWidth: `${width}px`,
+      maxWidth: `${width}px`,
+    };
+  };
+
+  const getTableColumnWidth = () => {
     const minColWidth = 200;
     let colWidth = minColWidth;
 
-    // @ts-expect-error TS(4111): Property 'tableWidth' comes from an index signatur... Remove this comment to see the full error message
-    if (this.state.tableWidth !== null) {
-      // @ts-expect-error TS(4111): Property 'tableWidth' comes from an index signatur... Remove this comment to see the full error message
-      colWidth = Math.round(this.state.tableWidth / (this.props.runInfos.length + 1));
+    if (tableWidth !== null) {
+      colWidth = Math.round(tableWidth / (runInfos.length + 1));
       if (colWidth < minColWidth) {
         colWidth = minColWidth;
       }
     }
     return colWidth;
-  }
+  };
 
-  renderExperimentNameRowItems() {
-    const { experiments } = this.props;
-    const experimentNameMap = Utils.getExperimentNameMap(Utils.sortExperimentsById(experiments));
-    return this.props.runInfos.map(({ experimentId, runUuid }) => {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+  const getExperimentPageLink = (experimentId: any, experimentName: any) => {
+    return <Link to={Routes.getExperimentPageRoute(experimentId)}>{experimentName}</Link>;
+  };
+
+  const getCompareExperimentsPageLinkText = (numExperiments: any) => {
+    return (
+      <FormattedMessage
+        defaultMessage="Displaying Runs from {numExperiments} Experiments"
+        // eslint-disable-next-line max-len
+        description="Breadcrumb nav item to link to compare-experiments page on compare runs page"
+        values={{ numExperiments }}
+      />
+    );
+  };
+
+  const getCompareExperimentsPageLink = (experimentIds: any) => {
+    return (
+      <Link to={Routes.getCompareExperimentsPageRoute(experimentIds)}>
+        {getCompareExperimentsPageLinkText(experimentIds.length)}
+      </Link>
+    );
+  };
+
+  const getExperimentLink = () => {
+    if (hasComparedExperimentsBefore) {
+      return getCompareExperimentsPageLink(comparedExperimentIds);
+    }
+
+    if (hasMultipleExperiments) {
+      return getCompareExperimentsPageLink(experimentIds);
+    }
+
+    return getExperimentPageLink(experimentIds[0], experiments[0].name);
+  };
+
+  const getTitle = () => {
+    return hasMultipleExperiments ? (
+      <FormattedMessage
+        defaultMessage="Comparing {numRuns} Runs from {numExperiments} Experiments"
+        // eslint-disable-next-line max-len
+        description="Breadcrumb title for compare runs page with multiple experiments"
+        values={{
+          numRuns: runInfos.length,
+          numExperiments: experimentIds.length,
+        }}
+      />
+    ) : (
+      <FormattedMessage
+        defaultMessage="Comparing {numRuns} Runs from 1 Experiment"
+        description="Breadcrumb title for compare runs page with single experiment"
+        values={{
+          numRuns: runInfos.length,
+        }}
+      />
+    );
+  };
+
+  const renderExperimentNameRowItems = () => {
+    const experimentNameMap: Record<string, { name: string; basename: string }> = Utils.getExperimentNameMap(
+      Utils.sortExperimentsById(experiments),
+    );
+    return runInfos.map(({ experimentId, runUuid }) => {
       const { name, basename } = experimentNameMap[experimentId];
       return (
         <td className="meta-info" key={runUuid}>
@@ -132,546 +213,52 @@ export class CompareRunView extends Component<CompareRunViewProps, CompareRunVie
         </td>
       );
     });
-  }
+  };
 
-  hasMultipleExperiments() {
-    return this.props.experimentIds.length > 1;
-  }
+  const hasMultipleExperiments = experimentIds.length > 1;
 
-  shouldShowExperimentNameRow() {
-    return this.props.hasComparedExperimentsBefore || this.hasMultipleExperiments();
-  }
+  const shouldShowExperimentNameRow = () => hasComparedExperimentsBefore || hasMultipleExperiments;
 
-  getExperimentPageLink(experimentId: any, experimentName: any) {
-    return <Link to={Routes.getExperimentPageRoute(experimentId)}>{experimentName}</Link>;
-  }
-
-  getCompareExperimentsPageLinkText(numExperiments: any) {
-    return (
-      <FormattedMessage
-        defaultMessage="Displaying Runs from {numExperiments} Experiments"
-        // eslint-disable-next-line max-len
-        description="Breadcrumb nav item to link to compare-experiments page on compare runs page"
-        values={{ numExperiments }}
-      />
-    );
-  }
-
-  getCompareExperimentsPageLink(experimentIds: any) {
-    return (
-      <Link to={Routes.getCompareExperimentsPageRoute(experimentIds)}>
-        {this.getCompareExperimentsPageLinkText(experimentIds.length)}
-      </Link>
-    );
-  }
-
-  getExperimentLink() {
-    const { comparedExperimentIds, hasComparedExperimentsBefore, experimentIds, experiments } = this.props;
-
-    if (hasComparedExperimentsBefore) {
-      return this.getCompareExperimentsPageLink(comparedExperimentIds);
-    }
-
-    if (this.hasMultipleExperiments()) {
-      return this.getCompareExperimentsPageLink(experimentIds);
-    }
-
-    return this.getExperimentPageLink(experimentIds[0], experiments[0].name);
-  }
-
-  getTitle() {
-    return this.hasMultipleExperiments() ? (
-      <FormattedMessage
-        defaultMessage="Comparing {numRuns} Runs from {numExperiments} Experiments"
-        // eslint-disable-next-line max-len
-        description="Breadcrumb title for compare runs page with multiple experiments"
-        values={{
-          numRuns: this.props.runInfos.length,
-          numExperiments: this.props.experimentIds.length,
-        }}
-      />
-    ) : (
-      <FormattedMessage
-        defaultMessage="Comparing {numRuns} Runs from 1 Experiment"
-        description="Breadcrumb title for compare runs page with single experiment"
-        values={{
-          numRuns: this.props.runInfos.length,
-        }}
-      />
-    );
-  }
-
-  renderParamTable(colWidth: any) {
-    const dataRows = this.renderDataRows(
-      this.props.paramLists,
-      colWidth,
-      // @ts-expect-error TS(4111): Property 'onlyShowParamDiff' comes from an index s... Remove this comment to see the full error message
-      this.state.onlyShowParamDiff,
-      true,
-      (key: any, data: any) => key,
-      (value) => {
-        try {
-          const jsonValue = parsePythonDictString(value);
-
-          // Pretty print if parsed value is an object or array
-          if (typeof jsonValue === 'object' && jsonValue !== null) {
-            return this.renderPrettyJson(jsonValue);
-          } else {
-            return value;
-          }
-        } catch (e) {
-          return value;
-        }
-      },
-    );
-    if (dataRows.length === 0) {
-      return (
-        <h2>
-          <FormattedMessage
-            defaultMessage="No parameters to display."
-            description="Text shown when there are no parameters to display"
-          />
-        </h2>
-      );
-    }
-    return (
-      <table
-        className="table compare-table compare-run-table"
-        css={{ maxHeight: '500px' }}
-        onScroll={this.onCompareRunTableScrollHandler}
-      >
-        <tbody>{dataRows}</tbody>
-      </table>
-    );
-  }
-
-  renderPrettyJson(jsonValue: any) {
-    return <pre>{JSON.stringify(jsonValue, null, 2)}</pre>;
-  }
-
-  renderMetricTable(colWidth: any, experimentIds: any) {
-    const dataRows = this.renderDataRows(
-      this.props.metricLists,
-      colWidth,
-      // @ts-expect-error TS(4111): Property 'onlyShowMetricDiff' comes from an index ... Remove this comment to see the full error message
-      this.state.onlyShowMetricDiff,
-      false,
-      (key, data) => {
-        return (
-          <Link
-            to={Routes.getMetricPageRoute(
-              this.props.runInfos.map((info) => info.runUuid).filter((uuid, idx) => data[idx] !== undefined),
-              key,
-              experimentIds,
-            )}
-            title="Plot chart"
-          >
-            {key}
-            <i className="fas fa-chart-line" css={{ paddingLeft: '6px' }} />
-          </Link>
-        );
-      },
-      Utils.formatMetric,
-    );
-    if (dataRows.length === 0) {
-      return (
-        <h2>
-          <FormattedMessage
-            defaultMessage="No metrics to display."
-            description="Text shown when there are no metrics to display"
-          />
-        </h2>
-      );
-    }
-    return (
-      <table
-        className="table compare-table compare-run-table"
-        css={{ maxHeight: '300px' }}
-        onScroll={this.onCompareRunTableScrollHandler}
-      >
-        <tbody>{dataRows}</tbody>
-      </table>
-    );
-  }
-
-  renderArtifactTable(colWidth: any) {
-    return <CompareRunArtifactView runUuids={this.props.runUuids} runInfos={this.props.runInfos} colWidth={colWidth} />;
-  }
-
-  renderTagTable(colWidth: any) {
-    const dataRows = this.renderDataRows(
-      this.props.tagLists,
-      colWidth,
-      // @ts-expect-error TS(4111): Property 'onlyShowTagDiff' comes from an index sig... Remove this comment to see the full error message
-      this.state.onlyShowTagDiff,
-      true,
-    );
-    if (dataRows.length === 0) {
-      return (
-        <h2>
-          <FormattedMessage
-            defaultMessage="No tags to display."
-            description="Text shown when there are no tags to display"
-          />
-        </h2>
-      );
-    }
-    return (
-      <table
-        className="table compare-table compare-run-table"
-        css={{ maxHeight: '500px' }}
-        onScroll={this.onCompareRunTableScrollHandler}
-      >
-        <tbody>{dataRows}</tbody>
-      </table>
-    );
-  }
-
-  renderTimeRows(colWidthStyle: any) {
-    const unknown = (
-      <FormattedMessage
-        defaultMessage="(unknown)"
-        description="Filler text when run's time information is unavailable"
-      />
-    );
-    const getTimeAttributes = (runInfo: RunInfoEntity) => {
-      const startTime = runInfo.startTime;
-      const endTime = runInfo.endTime;
-      return {
-        runUuid: runInfo.runUuid,
-        startTime: startTime ? Utils.formatTimestamp(startTime) : unknown,
-        endTime: endTime ? Utils.formatTimestamp(endTime) : unknown,
-        duration: startTime && endTime ? Utils.getDuration(startTime, endTime) : unknown,
-      };
-    };
-    const timeAttributes = this.props.runInfos.map(getTimeAttributes);
-    const rows = [
-      {
-        key: 'startTime',
-        title: (
-          <FormattedMessage
-            defaultMessage="Start Time:"
-            description="Row title for the start time of runs on the experiment compare runs page"
-          />
-        ),
-        data: timeAttributes.map(({ runUuid, startTime }) => [runUuid, startTime]),
-      },
-      {
-        key: 'endTime',
-        title: (
-          <FormattedMessage
-            defaultMessage="End Time:"
-            description="Row title for the end time of runs on the experiment compare runs page"
-          />
-        ),
-        data: timeAttributes.map(({ runUuid, endTime }) => [runUuid, endTime]),
-      },
-      {
-        key: 'duration',
-        title: (
-          <FormattedMessage
-            defaultMessage="Duration:"
-            description="Row title for the duration of runs on the experiment compare runs page"
-          />
-        ),
-        data: timeAttributes.map(({ runUuid, duration }) => [runUuid, duration]),
-      },
-    ];
-    return rows.map(({ key, title, data }) => (
-      <tr key={key}>
-        <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
-          {title}
-        </th>
-        {data.map(([runUuid, value]) => (
-          <td className="data-value" key={runUuid} css={colWidthStyle}>
-            <LegacyTooltip
-              title={value}
-              // @ts-expect-error TS(2322): Type '{ children: any; title: any; color: string; ... Remove this comment to see the full error message
-              color="gray"
-              placement="topLeft"
-              overlayStyle={{ maxWidth: '400px' }}
-              // mouseEnterDelay prop is not available in DuBois design system (yet)
-              dangerouslySetAntdProps={{ mouseEnterDelay: 1 }}
-            >
-              {value}
-            </LegacyTooltip>
-          </td>
-        ))}
-      </tr>
-    ));
-  }
-
-  render() {
-    const { experimentIds } = this.props;
-    const { runInfos, runNames, paramLists, metricLists, runUuids } = this.props;
-
-    const colWidth = this.getTableColumnWidth();
-    const colWidthStyle = this.genWidthStyle(colWidth);
-
-    const title = this.getTitle();
-    /* eslint-disable-next-line prefer-const */
-    let breadcrumbs = [this.getExperimentLink()];
-
-    const paramsLabel = this.props.intl.formatMessage({
-      defaultMessage: 'Parameters',
-      description: 'Row group title for parameters of runs on the experiment compare runs page',
-    });
-
-    const metricsLabel = this.props.intl.formatMessage({
-      defaultMessage: 'Metrics',
-      description: 'Row group title for metrics of runs on the experiment compare runs page',
-    });
-
-    const artifactsLabel = this.props.intl.formatMessage({
-      defaultMessage: 'Artifacts',
-      description: 'Row group title for artifacts of runs on the experiment compare runs page',
-    });
-
-    const tagsLabel = this.props.intl.formatMessage({
-      defaultMessage: 'Tags',
-      description: 'Row group title for tags of runs on the experiment compare runs page',
-    });
-    const diffOnlyLabel = this.props.intl.formatMessage({
-      defaultMessage: 'Show diff only',
-      description:
-        // eslint-disable-next-line max-len
-        'Label next to the switch that controls displaying only differing values in comparision tables on the compare runs page',
-    });
-
-    const displayChartSection = !shouldDisableLegacyRunCompareCharts();
-
-    return (
-      <div className="CompareRunView" ref={this.compareRunViewRef}>
-        <PageHeader title={title} breadcrumbs={breadcrumbs} />
-        {displayChartSection && (
-          <CollapsibleSection
-            title={this.props.intl.formatMessage({
-              defaultMessage: 'Visualizations',
-              description: 'Tabs title for plots on the compare runs page',
-            })}
-          >
-            <Tabs>
-              <TabPane
-                tab={
-                  <FormattedMessage
-                    defaultMessage="Parallel Coordinates Plot"
-                    // eslint-disable-next-line max-len
-                    description="Tab pane title for parallel coordinate plots on the compare runs page"
-                  />
-                }
-                key="parallel-coordinates-plot"
-              >
-                <ParallelCoordinatesPlotPanel runUuids={this.props.runUuids} />
-              </TabPane>
-              <TabPane
-                tab={
-                  <FormattedMessage
-                    defaultMessage="Scatter Plot"
-                    description="Tab pane title for scatterplots on the compare runs page"
-                  />
-                }
-                key="scatter-plot"
-              >
-                <CompareRunScatter runUuids={this.props.runUuids} runDisplayNames={this.props.runDisplayNames} />
-              </TabPane>
-              <TabPane
-                tab={
-                  <FormattedMessage
-                    defaultMessage="Box Plot"
-                    description="Tab pane title for box plot on the compare runs page"
-                  />
-                }
-                key="box-plot"
-              >
-                <CompareRunBox
-                  runUuids={runUuids}
-                  runInfos={runInfos}
-                  paramLists={paramLists}
-                  metricLists={metricLists}
-                />
-              </TabPane>
-              <TabPane
-                tab={
-                  <FormattedMessage
-                    defaultMessage="Contour Plot"
-                    description="Tab pane title for contour plots on the compare runs page"
-                  />
-                }
-                key="contour-plot"
-              >
-                <CompareRunContour runUuids={this.props.runUuids} runDisplayNames={this.props.runDisplayNames} />
-              </TabPane>
-            </Tabs>
-          </CollapsibleSection>
-        )}
-        <CollapsibleSection
-          title={this.props.intl.formatMessage({
-            defaultMessage: 'Run details',
-            description: 'Compare table title on the compare runs page',
-          })}
-        >
-          <table
-            className="table compare-table compare-run-table"
-            ref={this.runDetailsTableRef}
-            onScroll={this.onCompareRunTableScrollHandler}
-          >
-            <thead>
-              <tr>
-                <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
-                  <FormattedMessage
-                    defaultMessage="Run ID:"
-                    description="Row title for the run id on the experiment compare runs page"
-                  />
-                </th>
-                {this.props.runInfos.map((r) => (
-                  <th scope="row" className="data-value" key={r.runUuid} css={colWidthStyle}>
-                    <LegacyTooltip
-                      title={r.runUuid}
-                      // @ts-expect-error TS(2322): Type '{ children: Element; title: any; color: stri... Remove this comment to see the full error message
-                      color="gray"
-                      placement="topLeft"
-                      overlayStyle={{ maxWidth: '400px' }}
-                      mouseEnterDelay={1.0}
-                    >
-                      <Link to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
-                    </LegacyTooltip>
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
-                  <FormattedMessage
-                    defaultMessage="Run Name:"
-                    description="Row title for the run name on the experiment compare runs page"
-                  />
-                </th>
-                {runNames.map((runName, i) => {
-                  return (
-                    <td className="data-value" key={runInfos[i].runUuid} css={colWidthStyle}>
-                      <div className="truncate-text single-line">
-                        <LegacyTooltip
-                          title={runName}
-                          // @ts-expect-error TS(2322): Type '{ children: string; title: string; color: st... Remove this comment to see the full error message
-                          color="gray"
-                          placement="topLeft"
-                          overlayStyle={{ maxWidth: '400px' }}
-                          mouseEnterDelay={1.0}
-                        >
-                          {runName}
-                        </LegacyTooltip>
-                      </div>
-                    </td>
-                  );
-                })}
-              </tr>
-              {this.renderTimeRows(colWidthStyle)}
-              {this.shouldShowExperimentNameRow() && (
-                <tr>
-                  <th scope="row" className="data-value">
-                    <FormattedMessage
-                      defaultMessage="Experiment Name:"
-                      // eslint-disable-next-line max-len
-                      description="Row title for the experiment IDs of runs on the experiment compare runs page"
-                    />
-                  </th>
-                  {this.renderExperimentNameRowItems()}
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </CollapsibleSection>
-        <CollapsibleSection title={paramsLabel}>
-          <Switch
-            componentId="codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_570"
-            label={diffOnlyLabel}
-            aria-label={[paramsLabel, diffOnlyLabel].join(' - ')}
-            // @ts-expect-error TS(4111): Property 'onlyShowParamDiff' comes from an index s... Remove this comment to see the full error message
-            checked={this.state.onlyShowParamDiff}
-            onChange={(checked, e) => this.setState({ onlyShowParamDiff: checked })}
-          />
-          <Spacer size="lg" />
-          {this.renderParamTable(colWidth)}
-        </CollapsibleSection>
-        <CollapsibleSection title={metricsLabel}>
-          <Switch
-            componentId="codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_581"
-            label={diffOnlyLabel}
-            aria-label={[metricsLabel, diffOnlyLabel].join(' - ')}
-            // @ts-expect-error TS(4111): Property 'onlyShowMetricDiff' comes from an index ... Remove this comment to see the full error message
-            checked={this.state.onlyShowMetricDiff}
-            onChange={(checked, e) => this.setState({ onlyShowMetricDiff: checked })}
-          />
-          <Spacer size="lg" />
-          {this.renderMetricTable(colWidth, experimentIds)}
-        </CollapsibleSection>
-        <CollapsibleSection title={artifactsLabel}>{this.renderArtifactTable(colWidth)}</CollapsibleSection>
-        <CollapsibleSection title={tagsLabel}>
-          <Switch
-            componentId="codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_592"
-            label={diffOnlyLabel}
-            aria-label={[tagsLabel, diffOnlyLabel].join(' - ')}
-            // @ts-expect-error TS(4111): Property 'onlyShowTagDiff' comes from an index sig... Remove this comment to see the full error message
-            checked={this.state.onlyShowTagDiff}
-            onChange={(checked, e) => this.setState({ onlyShowTagDiff: checked })}
-          />
-          <Spacer size="lg" />
-          {this.renderTagTable(colWidth)}
-        </CollapsibleSection>
-      </div>
-    );
-  }
-
-  genWidthStyle(width: any) {
-    return {
-      width: `${width}px`,
-      minWidth: `${width}px`,
-      maxWidth: `${width}px`,
-    };
-  }
-
-  // eslint-disable-next-line no-unused-vars
-  renderDataRows(
-    list: any,
-    colWidth: any,
-    onlyShowDiff: any,
+  const renderDataRows = (
+    dataList: any[],
+    colWidth: number,
+    diffOnly: boolean,
     highlightDiff = false,
     headerMap = (key: any, data: any) => key,
-    formatter = (value: any) => value,
-  ) {
+    formatter = (x: any) => x,
+  ) => {
     // @ts-expect-error TS(2554): Expected 2 arguments, but got 1.
-    const keys = CompareRunUtil.getKeys(list);
+    const keys = CompareRunUtil.getKeys(dataList);
     const data = {};
     const checkHasDiff = (values: any) => values.some((x: any) => x !== values[0]);
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    keys.forEach((k) => (data[k] = { values: Array(list.length).fill(undefined) }));
-    list.forEach((records: any, i: any) => {
+    keys.forEach((k) => (data[k] = { values: Array(dataList.length).fill(undefined) }));
+    dataList.forEach((records: any, i: any) => {
       // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       records.forEach((r: any) => (data[r.key].values[i] = r.value));
     });
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     keys.forEach((k) => (data[k].hasDiff = checkHasDiff(data[k].values)));
 
-    const colWidthStyle = this.genWidthStyle(colWidth);
+    const colWidthStyle = genWidthStyle(colWidth);
 
     return (
       keys
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        .filter((k) => !onlyShowDiff || data[k].hasDiff)
+        .filter((k) => !diffOnly || data[k].hasDiff)
         .map((k) => {
           // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           const { values, hasDiff } = data[k];
           const rowClass = highlightDiff && hasDiff ? 'diff-row' : undefined;
           return (
             <tr key={k} className={rowClass}>
-              <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
+              <th scope="row" className="head-value sticky-header" style={colWidthStyle}>
                 {headerMap(k, values)}
               </th>
               {values.map((value: any, i: any) => {
                 const cellText = value === undefined ? '' : formatter(value);
                 return (
-                  <td className="data-value" key={this.props.runInfos[i].runUuid} css={colWidthStyle}>
+                  <td className="data-value" key={runInfos[i].runUuid} style={colWidthStyle}>
                     <LegacyTooltip
                       title={cellText}
                       // @ts-expect-error TS(2322): Type '{ children: Element; title: any; color: stri... Remove this comment to see the full error message
@@ -689,8 +276,329 @@ export class CompareRunView extends Component<CompareRunViewProps, CompareRunVie
           );
         })
     );
-  }
-}
+  };
+
+  const renderParamTable = (colWidth: number) => {
+    const dataRows = renderDataRows(
+      paramLists,
+      colWidth,
+      onlyShowParamDiff,
+      true,
+      (key: any, data: any) => key,
+      (value: any) => {
+        try {
+          const jsonValue = parsePythonDictString(value);
+
+          // Pretty print if parsed value is an object or array
+          if (typeof jsonValue === 'object' && jsonValue !== null) {
+            return renderPrettyJson(jsonValue);
+          } else {
+            return value;
+          }
+        } catch (e) {
+          return value; // Fallback if JSON parsing fails
+        }
+      },
+    );
+
+    return dataRows.length === 0 ? (
+      <h2>
+        <FormattedMessage defaultMessage="No parameters to display." description="No parameters to display" />
+      </h2>
+    ) : (
+      <table
+        className="table compare-table compare-run-table"
+        style={{ maxHeight: '500px' }}
+        onScroll={onCompareRunTableScrollHandler}
+      >
+        <tbody>{dataRows}</tbody>
+      </table>
+    );
+  };
+
+  const renderPrettyJson = (jsonValue: any) => {
+    return <pre>{JSON.stringify(jsonValue, null, 2)}</pre>;
+  };
+
+  const renderMetricTable = (colWidth: number, experimentIds: string[]) => {
+    const dataRows = renderDataRows(
+      metricLists,
+      colWidth,
+      onlyShowMetricDiff,
+      false,
+      (key, data) => (
+        <Link
+          to={Routes.getMetricPageRoute(
+            runInfos.map((info) => info.runUuid).filter((uuid, idx) => data[idx] !== undefined),
+            key,
+            experimentIds,
+          )}
+          title="Plot chart"
+        >
+          {key}
+          <i className="fas fa-chart-line" style={{ paddingLeft: '6px' }} />
+        </Link>
+      ),
+      Utils.formatMetric,
+    );
+
+    return dataRows.length === 0 ? (
+      <h2>
+        <FormattedMessage defaultMessage="No metrics to display." description="No metrics to display" />
+      </h2>
+    ) : (
+      <table
+        className="table compare-table compare-run-table"
+        style={{ maxHeight: '300px' }}
+        onScroll={onCompareRunTableScrollHandler}
+      >
+        <tbody>{dataRows}</tbody>
+      </table>
+    );
+  };
+
+  const renderArtifactTable = (colWidth: any) => {
+    return <CompareRunArtifactView runUuids={runUuids} runInfos={runInfos} colWidth={colWidth} />;
+  };
+
+  const renderTagTable = (colWidth: number) => {
+    const dataRows = renderDataRows(tagLists, colWidth, onlyShowTagDiff, true);
+    return dataRows.length === 0 ? (
+      <h2>
+        <FormattedMessage defaultMessage="No tags to display." description="No tags to display" />
+      </h2>
+    ) : (
+      <table
+        className="table compare-table compare-run-table"
+        style={{ maxHeight: '500px' }}
+        onScroll={onCompareRunTableScrollHandler}
+      >
+        <tbody>{dataRows}</tbody>
+      </table>
+    );
+  };
+
+  const renderTimeRows = (colWidthStyle: any) => {
+    const unknown = <FormattedMessage defaultMessage="(unknown)" description="Unknown time" />;
+    const timeAttributes = runInfos.map(({ runUuid, startTime, endTime }) => ({
+      runUuid,
+      startTime: startTime ? Utils.formatTimestamp(startTime) : unknown,
+      endTime: endTime ? Utils.formatTimestamp(endTime) : unknown,
+      duration: startTime && endTime ? Utils.getDuration(startTime, endTime) : unknown,
+    }));
+
+    const rows = [
+      {
+        key: 'startTime',
+        title: <FormattedMessage defaultMessage="Start Time:" />,
+        data: timeAttributes.map(({ runUuid, startTime }) => [runUuid, startTime]),
+      },
+      {
+        key: 'endTime',
+        title: <FormattedMessage defaultMessage="End Time:" />,
+        data: timeAttributes.map(({ runUuid, endTime }) => [runUuid, endTime]),
+      },
+      {
+        key: 'duration',
+        title: <FormattedMessage defaultMessage="Duration:" />,
+        data: timeAttributes.map(({ runUuid, duration }) => [runUuid, duration]),
+      },
+    ];
+
+    return rows.map(({ key, title, data }) => (
+      <tr key={key}>
+        <th scope="row" className="head-value sticky-header" style={colWidthStyle}>
+          {title}
+        </th>
+        {data.map(([runUuid, value]) => (
+          <td className="data-value" key={runUuid} style={colWidthStyle}>
+            <LegacyTooltip title={value} color="gray" placement="topLeft" overlayStyle={{ maxWidth: '400px' }}>
+              {value}
+            </LegacyTooltip>
+          </td>
+        ))}
+      </tr>
+    ));
+  };
+
+  const displayChartSection = !shouldDisableLegacyRunCompareCharts();
+
+  const colWidth = getTableColumnWidth();
+  const colWidthStyle = genWidthStyle(colWidth);
+
+  const title = getTitle();
+  const breadcrumbs = [getExperimentLink()];
+
+  return (
+    <div className="CompareRunView" ref={compareRunViewRef}>
+      <PageHeader title={title} breadcrumbs={breadcrumbs} />
+      {displayChartSection && (
+        <CollapsibleSection
+          title={intl.formatMessage({
+            defaultMessage: 'Visualizations',
+            description: 'Tabs title for plots on the compare runs page',
+          })}
+        >
+          <Tabs>
+            <TabPane
+              tab={
+                <FormattedMessage
+                  defaultMessage="Parallel Coordinates Plot"
+                  description="Tab pane title for parallel coordinate plots on the compare runs page"
+                />
+              }
+              key="parallel-coordinates-plot"
+            >
+              <ParallelCoordinatesPlotPanel runUuids={runUuids} />
+            </TabPane>
+            <TabPane
+              tab={
+                <FormattedMessage
+                  defaultMessage="Scatter Plot"
+                  description="Tab pane title for scatterplots on the compare runs page"
+                />
+              }
+              key="scatter-plot"
+            >
+              <CompareRunScatter runUuids={runUuids} runDisplayNames={runDisplayNames} />
+            </TabPane>
+            <TabPane
+              tab={
+                <FormattedMessage
+                  defaultMessage="Box Plot"
+                  description="Tab pane title for box plot on the compare runs page"
+                />
+              }
+              key="box-plot"
+            >
+              <CompareRunBox
+                runUuids={runUuids}
+                runInfos={runInfos}
+                paramLists={paramLists}
+                metricLists={metricLists}
+              />
+            </TabPane>
+            <TabPane
+              tab={
+                <FormattedMessage
+                  defaultMessage="Contour Plot"
+                  description="Tab pane title for contour plots on the compare runs page"
+                />
+              }
+              key="contour-plot"
+            >
+              <CompareRunContour runUuids={runUuids} runDisplayNames={runDisplayNames} />
+            </TabPane>
+          </Tabs>
+        </CollapsibleSection>
+      )}
+      <CollapsibleSection
+        title={intl.formatMessage({
+          defaultMessage: 'Run details',
+          description: 'Compare table title on the compare runs page',
+        })}
+      >
+        <table
+          className="table compare-table compare-run-table"
+          ref={runDetailsTableRef}
+          onScroll={onCompareRunTableScrollHandler}
+        >
+          <thead>
+            <tr>
+              <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
+                <FormattedMessage
+                  defaultMessage="Run ID:"
+                  description="Row title for the run id on the experiment compare runs page"
+                />
+              </th>
+              {runInfos.map((r) => (
+                <th scope="row" className="data-value" key={r.runUuid} css={colWidthStyle}>
+                  <LegacyTooltip
+                    title={r.runUuid}
+                    color="gray"
+                    placement="topLeft"
+                    overlayStyle={{ maxWidth: '400px' }}
+                    mouseEnterDelay={1.0}
+                  >
+                    <Link to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
+                  </LegacyTooltip>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
+                <FormattedMessage
+                  defaultMessage="Run Name:"
+                  description="Row title for the run name on the experiment compare runs page"
+                />
+              </th>
+              {runNames.map((runName, i) => (
+                <td className="data-value" key={runInfos[i].runUuid} css={colWidthStyle}>
+                  <div className="truncate-text single-line">
+                    <LegacyTooltip
+                      title={runName}
+                      color="gray"
+                      placement="topLeft"
+                      overlayStyle={{ maxWidth: '400px' }}
+                      mouseEnterDelay={1.0}
+                    >
+                      {runName}
+                    </LegacyTooltip>
+                  </div>
+                </td>
+              ))}
+            </tr>
+            {renderTimeRows(colWidthStyle)}
+            {shouldShowExperimentNameRow() && (
+              <tr>
+                <th scope="row" className="data-value">
+                  <FormattedMessage
+                    defaultMessage="Experiment Name:"
+                    description="Row title for the experiment IDs of runs on the experiment compare runs page"
+                  />
+                </th>
+                {renderExperimentNameRowItems()}
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </CollapsibleSection>
+      <CollapsibleSection title={paramsLabel}>
+        <Switch
+          label={diffOnlyLabel}
+          aria-label={[paramsLabel, diffOnlyLabel].join(' - ')}
+          checked={onlyShowParamDiff}
+          onChange={(checked) => setOnlyShowParamDiff(checked)}
+        />
+        <Spacer size="lg" />
+        {renderParamTable(colWidth)}
+      </CollapsibleSection>
+      <CollapsibleSection title={metricsLabel}>
+        <Switch
+          label={diffOnlyLabel}
+          aria-label={[metricsLabel, diffOnlyLabel].join(' - ')}
+          checked={onlyShowMetricDiff}
+          onChange={(checked) => setOnlyShowMetricDiff(checked)}
+        />
+        <Spacer size="lg" />
+        {renderMetricTable(colWidth, experimentIds)}
+      </CollapsibleSection>
+      <CollapsibleSection title={artifactsLabel}>{renderArtifactTable(colWidth)}</CollapsibleSection>
+      <CollapsibleSection title={tagsLabel}>
+        <Switch
+          label={diffOnlyLabel}
+          aria-label={[tagsLabel, diffOnlyLabel].join(' - ')}
+          checked={onlyShowTagDiff}
+          onChange={(checked) => setOnlyShowTagDiff(checked)}
+        />
+        <Spacer size="lg" />
+        {renderTagTable(colWidth)}
+      </CollapsibleSection>
+    </div>
+  );
+};
 
 const mapStateToProps = (state: any, ownProps: any) => {
   const { comparedExperimentIds, hasComparedExperimentsBefore } = state.compareExperiments;

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -231,6 +231,10 @@
     "defaultMessage": "Evaluation not available when grouping is enabled",
     "description": "Experiment page > artifact compare view > disabled due to run grouping > title"
   },
+  "2jm4sV": {
+    "defaultMessage": "No tags to display.",
+    "description": "No tags to display"
+  },
   "2oFAO4": {
     "defaultMessage": "Share",
     "description": "Text for share button on experiment view page header"
@@ -479,10 +483,6 @@
     "defaultMessage": "{timeSince, plural, =1 {1 minute} other {# minutes}} ago",
     "description": "Text for time in minutes since given date for MLflow views"
   },
-  "7kUi8J": {
-    "defaultMessage": "Duration:",
-    "description": "Row title for the duration of runs on the experiment compare runs page"
-  },
   "7m2B5x": {
     "defaultMessage": "There are no evaluable rows within this column",
     "description": "Experiment page > artifact compare view > run column header > Disabled \"Evaluate all\" button tooltip when no rows are evaluable"
@@ -678,6 +678,9 @@
   "AyceYA": {
     "defaultMessage": "Served LLM model",
     "description": "Experiment page > new run modal > served LLM model endpoint label"
+  },
+  "B2NIb5": {
+    "defaultMessage": "Start Time:"
   },
   "B80MC6": {
     "defaultMessage": "Contour Plot",
@@ -883,10 +886,6 @@
     "defaultMessage": "Compare",
     "description": "Text for compare button to compare versions under details tab\n                       on the model view page"
   },
-  "G0gYkS": {
-    "defaultMessage": "End Time:",
-    "description": "Row title for the end time of runs on the experiment compare runs page"
-  },
   "G5mMJI": {
     "defaultMessage": "Difference view",
     "description": "Experiment tracking > runs charts > add chart menu > difference view"
@@ -926,6 +925,9 @@
   "Gs+blV": {
     "defaultMessage": "Last modified",
     "description": "Column title for last modified timestamp for a model in the registered model page"
+  },
+  "GyHhEq": {
+    "defaultMessage": "End Time:"
   },
   "H+4gFh": {
     "defaultMessage": "Show diff only",
@@ -1239,10 +1241,6 @@
     "defaultMessage": "Tokens",
     "description": "Experiment page > traces table > tokens column header"
   },
-  "O9r1RR": {
-    "defaultMessage": "Start Time:",
-    "description": "Row title for the start time of runs on the experiment compare runs page"
-  },
   "OEGyWZ": {
     "defaultMessage": "Predict on a Spark DataFrame.",
     "description": "Code comment which states on how we can predict using spark DataFrame"
@@ -1547,10 +1545,6 @@
     "defaultMessage": "Add New Tag",
     "description": "Add new key-value tag modal > Modal title"
   },
-  "VP+qFF": {
-    "defaultMessage": "Show diff only",
-    "description": "Label next to the switch that controls displaying only differing values in comparision tables on the compare runs page"
-  },
   "VPU43C": {
     "defaultMessage": "Compare parameter importance",
     "description": "Experiment page > compare runs > parallel coordinates chart > chart not configured warning > title"
@@ -1602,6 +1596,9 @@
   "WQwCH6": {
     "defaultMessage": "Aliased versions",
     "description": "Column title for aliased versions in the registered model page"
+  },
+  "WRf1yI": {
+    "defaultMessage": "Duration:"
   },
   "Wd8Tga": {
     "defaultMessage": "No schema. See <link>MLflow docs</link> for how to include input and output schema with your model.",
@@ -1727,13 +1724,13 @@
     "defaultMessage": "Relative Time",
     "description": "Label for the relative axis on the runs compare chart"
   },
-  "Zc48NC": {
-    "defaultMessage": "(unknown)",
-    "description": "Filler text when run's time information is unavailable"
-  },
   "ZgAOhX": {
     "defaultMessage": "Chart name",
     "description": "Runs charts > components > config > RunsChartsConfigureDifferenceChart > Chart name config section"
+  },
+  "ZhjWaP": {
+    "defaultMessage": "(unknown)",
+    "description": "Unknown time"
   },
   "ZoIjun": {
     "defaultMessage": "Duration",
@@ -1943,6 +1940,10 @@
     "defaultMessage": "No system metrics recorded",
     "description": "Run page > Charts tab > System charts section > empty label"
   },
+  "dQghMA": {
+    "defaultMessage": "No parameters to display.",
+    "description": "No parameters to display"
+  },
   "dTLq6E": {
     "defaultMessage": "expand {title}",
     "description": "Common component > collapsible section > alternative label when collapsed"
@@ -1982,10 +1983,6 @@
   "e7K2T3": {
     "defaultMessage": "Show all runs",
     "description": "Experiment page > compare runs tab > chart header > move down option"
-  },
-  "eBGO2d": {
-    "defaultMessage": "No metrics to display.",
-    "description": "Text shown when there are no metrics to display"
   },
   "eE5VIF": {
     "defaultMessage": "Click to hide the run",
@@ -2054,6 +2051,10 @@
   "fMf88R": {
     "defaultMessage": "Columns",
     "description": "Run page > artifact view > logged table view > columns selector label"
+  },
+  "fU1PZR": {
+    "defaultMessage": "Show diff only",
+    "description": "Label next to the switch that controls displaying only differing values in comparison tables on the compare runs page"
   },
   "fWEvZL": {
     "defaultMessage": ", . : / - = and blank spaces are not allowed",
@@ -2355,10 +2356,6 @@
     "defaultMessage": "The following variable names contain spaces which is disallowed: {invalidNames}",
     "description": "Experiment page > new run modal > variable name validation > including spaces error"
   },
-  "lNO3kK": {
-    "defaultMessage": "No parameters to display.",
-    "description": "Text shown when there are no parameters to display"
-  },
   "lTngfr": {
     "defaultMessage": "Select a cell to display preview",
     "description": "Experiment page > artifact compare view > preview sidebar > nothing selected"
@@ -2382,10 +2379,6 @@
   "m4159e": {
     "defaultMessage": "Metrics ({length})",
     "description": "Run page > Overview > Metrics table > Section title"
-  },
-  "m9e01X": {
-    "defaultMessage": "No tags to display.",
-    "description": "Text shown when there are no tags to display"
   },
   "mIk1MU": {
     "defaultMessage": "Create Model",
@@ -2778,6 +2771,10 @@
   "tx3aAM": {
     "defaultMessage": "Add tag",
     "description": "Key-value tag editor modal > Add tag button"
+  },
+  "u/M6ta": {
+    "defaultMessage": "No metrics to display.",
+    "description": "No metrics to display"
   },
   "uBTAtY": {
     "defaultMessage": "Prompt Template",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jescalada/mlflow/pull/13431?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13431/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13431
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #13264 

### What changes are proposed in this pull request?

In this PR, I refactored the `CompareRunView` component from a class component to a functional component. It is a bit shorter now, however we could improve this further by separating the sections into individual components perhaps?

I remade #13288 which got too messy.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
**TODO:** Attach manual testing video

#### Before refactoring:
https://github.com/user-attachments/assets/0b9651fc-9bec-4856-ae11-6d3dcd44f750

#### After refactoring:
https://github.com/user-attachments/assets/bf4bbf05-38c4-4ede-9d23-e379a43031f5

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes
Refactored `CompareRunView` into functional component.

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
