### PR TITLE
Fix nightly eval instrumentation test

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -964,24 +964,29 @@ def _get_last_failed_evaluator():
     return _last_failed_evaluator
 
 
+# BE CAREFUL WHEN EDITING SIGNATURE OF THIS FUNCTION.
+# This function is monkeypatched in Databricks codebase, and the order of arguments
+# must be kept the same, even if some of them are unused by MLflow.
 def _evaluate(
     *,
     model,
     model_type,
     dataset,
     run_id,
-    evaluators,
+    # The `evaluator_name_list` and `evaluator_name_to_conf_map` are not used by MLflow at all,
+    # but we need to keep this for compatibility with Databricks codebase.
+    evaluator_name_list,
+    evaluator_name_to_conf_map,
     custom_metrics,
     extra_metrics,
     custom_artifacts,
     predictions,
+    evaluators,
 ):
     """
     The public API "evaluate" will verify argument first, and then pass normalized arguments
     to the _evaluate method.
     """
-    # import _model_evaluation_registry and PyFuncModel inside function to avoid circuit importing
-
     global _last_failed_evaluator
     _last_failed_evaluator = None
 
@@ -1688,6 +1693,13 @@ def evaluate(  # noqa: D417
         evaluators, evaluator_config, model_type
     )
 
+    # NB: MLflow do not use either of these two variables. However, we need to pass these to
+    # _evaluate() function because Databricks codebase monkeypatch the function with hard-coding
+    # argument names. Once we fixes the hard-coding issue in Databricks side, we can safely
+    # remove these two variables.
+    evaluator_name_list = [evaluator.name for evaluator in evaluators]
+    evaluator_name_to_conf_map = {evaluator.name: evaluator.config for evaluator in evaluators}
+
     with _start_run_or_reuse_active_run() as run_id:
         if not isinstance(data, Dataset):
             # Convert data to `mlflow.data.dataset.Dataset`.
@@ -1730,11 +1742,13 @@ def evaluate(  # noqa: D417
                 model_type=model_type,
                 dataset=dataset,
                 run_id=run_id,
-                evaluators=evaluators,
+                evaluator_name_list=evaluator_name_list,
+                evaluator_name_to_conf_map=evaluator_name_to_conf_map,
                 custom_metrics=custom_metrics,
                 extra_metrics=extra_metrics,
                 custom_artifacts=custom_artifacts,
                 predictions=predictions_expected_in_model_output,
+                evaluators=evaluators,
             )
         finally:
             if isinstance(model, _ServedPyFuncModel):
@@ -1763,11 +1777,13 @@ def evaluate(  # noqa: D417
             model_type=model_type,
             dataset=dataset,
             run_id=run_id,
-            evaluators=evaluators,
+            evaluator_name_list=evaluator_name_list,
+            evaluator_name_to_conf_map=evaluator_name_to_conf_map,
             custom_metrics=custom_metrics,
             extra_metrics=extra_metrics,
             custom_artifacts=custom_artifacts,
             predictions=predictions_expected_in_model_output,
+            evaluators=evaluators,
         )
         return validate_evaluation_results(
             validation_thresholds=validation_thresholds,

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -964,9 +964,9 @@ def _get_last_failed_evaluator():
     return _last_failed_evaluator
 
 
-# BE CAREFUL WHEN EDITING SIGNATURE OF THIS FUNCTION.
-# This function is monkeypatched in Databricks codebase, and the order of arguments
-# must be kept the same, even if some of them are unused by MLflow.
+# DO NOT CHANGE THE ORDER OF THE ARGUMENTS
+# The order of the arguments need to be preserved. You can add new arguments at the end
+# of the argument list, but do not change the order of the existing arguments.
 def _evaluate(
     *,
     model,
@@ -974,7 +974,7 @@ def _evaluate(
     dataset,
     run_id,
     # The `evaluator_name_list` and `evaluator_name_to_conf_map` are not used by MLflow at all,
-    # but we need to keep this for compatibility with Databricks codebase.
+    # but we need to keep these for backward compatibility.
     evaluator_name_list,
     evaluator_name_to_conf_map,
     custom_metrics,
@@ -1694,9 +1694,7 @@ def evaluate(  # noqa: D417
     )
 
     # NB: MLflow do not use either of these two variables. However, we need to pass these to
-    # _evaluate() function because Databricks codebase monkeypatch the function with hard-coding
-    # argument names. Once we fixes the hard-coding issue in Databricks side, we can safely
-    # remove these two variables.
+    # _evaluate() function for backward compatibility.
     evaluator_name_list = [evaluator.name for evaluator in evaluators]
     evaluator_name_to_conf_map = {evaluator.name: evaluator.config for evaluator in evaluators}
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13444?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13444/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13444
```

</p>
</details>

### What changes are proposed in this pull request?

In https://github.com/mlflow/mlflow/actions/runs/11260078777/job/31310498869?pr=13360, we refactored evaluation logic which changed the signature of `_evaluate()`. This breaks nightly integration test with Databricks, because the eval instrumentation code in Databricks monkeypatch `_evaluate` with hard-coding the arguments.

This PR is a band-aid fix that reverts the signature change. However, we will highly likely edit this function again in the planned simplification, so I will also update the Databricks logic not to rely on hard-code the arguments.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

(The refactoring PR is not marked as patch as well)