### PR TITLE
Fix default evaluator resolution for list case

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -775,7 +775,18 @@ def _start_run_or_reuse_active_run():
         yield active_run.info.run_id
 
 
-def _resolve_default_evaluator(model_type, evaluator_config):
+# NB: We often pass around evaluator name, config, and its instance together. Ideally, the
+# evaluator class should have name and config as class attributes, however, it was not
+# designed that way. Adding them while keeping backward compatibility is not trivial.
+# So, we use a dataclass to bundle them together.
+@dataclass
+class EvaluatorBundle:
+    name: str
+    evaluator: ModelEvaluator
+    config: Dict[str, Any]
+
+
+def _resolve_default_evaluator(model_type, default_config) -> List[EvaluatorBundle]:
     """
     Determine which built-in evaluators should be used for the given model type by default.
 
@@ -786,34 +797,27 @@ def _resolve_default_evaluator(model_type, evaluator_config):
 
     Args:
         model_type: A string describing the model type (e.g., "regressor", "classifier", …).
-        evaluator_config: A dictionary of additional configurations for the evaluator.
+        default_config: A dictionary of configurations for the "default" evaluator. If any
+            non-default built-in evaluator is applicable, this config will be applied to them.
     """
     from mlflow.models.evaluation.evaluator_registry import _model_evaluation_registry
 
     builtin_evaluators = []
-    for name, evaluator in _model_evaluation_registry._registry.items():
+    for name in _model_evaluation_registry._registry:
+        evaluator = _model_evaluation_registry.get_evaluator(name)
         if (
             name != "default"
             and _model_evaluation_registry.is_builtin(name)
-            and evaluator.can_evaluate(
-                model_type=model_type, evaluator_config=evaluator_config or {}
-            )
+            and evaluator.can_evaluate(model_type=model_type, evaluator_config=default_config)
         ):
-            builtin_evaluators.append(name)
+            builtin_evaluators.append(EvaluatorBundle(name, evaluator, default_config))
 
     # We should use DefaultEvaluator only if there is no other built-in evaluator applicable.
-    return builtin_evaluators or ["default"]
+    if not builtin_evaluators:
+        default_evaluator = _model_evaluation_registry.get_evaluator("default")
+        builtin_evaluators = [EvaluatorBundle("default", default_evaluator, default_config)]
 
-
-# NB: We often pass around evaluator name, config, and its instance together. Ideally, the
-# evaluator class should have name and config as class attributes, however, it was not
-# designed that way. Adding them while keeping backward compatibility is not trivial.
-# So, we use a dataclass to bundle them together.
-@dataclass
-class EvaluatorBundle:
-    name: str
-    evaluator: ModelEvaluator
-    config: Dict[str, Any]
+    return builtin_evaluators
 
 
 def resolve_evaluators_and_configs(
@@ -893,18 +897,13 @@ def resolve_evaluators_and_configs(
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
+        evaluator_config = evaluator_config or {}
         if evaluators == "default":
             # Previously we only had a single "default" evaluator used for all models.
             # We need to map "default" to the new dedicated builtin evaluators.
-            builtin_evaluators = _resolve_default_evaluator(model_type, evaluator_config)
-            return [
-                EvaluatorBundle(name, rg.get_evaluator(name), evaluator_config or {})
-                for name in builtin_evaluators
-            ]
+            return _resolve_default_evaluator(model_type, evaluator_config)
         elif rg.is_registered(evaluators):
-            return [
-                EvaluatorBundle(evaluators, rg.get_evaluator(evaluators), evaluator_config or {})
-            ]
+            return [EvaluatorBundle(evaluators, rg.get_evaluator(evaluators), evaluator_config)]
         else:
             return []
 
@@ -919,12 +918,18 @@ def resolve_evaluators_and_configs(
                 error_code=INVALID_PARAMETER_VALUE,
             )
         evaluator_config = evaluator_config or {}
-        return [
-            EvaluatorBundle(name, rg.get_evaluator(name), evaluator_config.get(name, {}))
-            for name in evaluators
-            if rg.is_registered(name)
-        ]
 
+        # Previously we only had a single "default" evaluator used for all models.
+        # We need to map "default" to the new dedicated builtin evaluators.
+        resolved = []
+        for name in evaluators:
+            config = evaluator_config.get(name, {})
+            if name == "default":
+                builtin_evaluators = _resolve_default_evaluator(model_type, config)
+                resolved.extend(builtin_evaluators)
+            else:
+                resolved.append(EvaluatorBundle(name, rg.get_evaluator(name), config))
+        return resolved
     else:
         raise MlflowException(
             message="Invalid `evaluators` and `evaluator_config` arguments. "

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1368,9 +1368,19 @@ def test_resolve_evaluators_and_configs():
             model_type="classifier",
         ),
         expected=[
-            ("default", DefaultEvaluator, {"a": 5}),
+            ("classifier", ClassifierEvaluator, {"a": 5}),
+            ("shap", ShapEvaluator, {"a": 5}),
             ("dummy_evaluator", DummyEvaluator, {"a": 3}),
         ],
+    )
+
+    assert_equal(
+        actual=resolve_evaluators_and_configs(
+            evaluators=["regressor"],
+            evaluator_config={"regressor": {"a": 5}},
+            model_type="regressor",
+        ),
+        expected=[("regressor", RegressorEvaluator, {"a": 5})],
     )
 
     with pytest.raises(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13450?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13450/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13450
```

</p>
</details>

### What changes are proposed in this pull request?

The refactoring PR https://github.com/mlflow/mlflow/pull/13360 broke one of the example test: https://github.com/mlflow-automation/mlflow/actions/runs/11366512290/job/31617054045

The root cause is an edge case in resolving default evaluator. In the refactoring, we split the `DefaultEvaluator` into multiple built-in evaluators like `ClassifierEvaluator`, `RegressorEvaluator`. To keep backward compatibility, when users specify `"default"` for evaluators, we translate it to proper built-in evaluator according to the model type. For example, if users specify `evaluators="default", model_type="classifier"`, we use `ClassifierEvaluator`.

In the refactoring PR, this default resolution was implemented for the case where `evaluators` argument is a single string i.e. `"default"`. However, users can also pass a list of evaluator names like `["default", ...]`, and current implementation does not handle it. As a result, the proper built-in evaluator was not used and caused test failure.

This PR fixes it by adding the default resolution logic to list of strings.

Note: The default resolution logic is complex and not very maintainable. However, this is temporary solution because we will soon introduce another change for the role of `evaluators` parameter. After that change, we no longer need to maintain the backward compatibility (and the evaluator config handling logic will also be simplified a lot).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
