### PR TITLE
Make MLflow run thread-safe

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import mlflow
@@ -16,3 +18,11 @@ def tracking_uri_mock(tmp_path, monkeypatch):
 def reset_active_experiment_id():
     yield
     mlflow.tracking.fluent._active_experiment_id = None
+    os.environ.pop("MLFLOW_EXPERIMENT_ID", None)
+
+
+@pytest.fixture(autouse=True)
+def reset_mlflow_uri():
+    yield
+    os.environ.pop("MLFLOW_TRACKING_URI", None)
+    os.environ.pop("MLFLOW_REGISTRY_URI", None)

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -222,6 +222,7 @@ def process_api_requests(
     """
     Processes API requests in parallel.
     """
+    from mlflow.tracking.fluent import _get_active_run_stack, _set_active_run_stack
 
     # initialize trackers
     retry_queue = queue.Queue()
@@ -266,11 +267,24 @@ def process_api_requests(
             else:
                 next_request = None
 
+            active_run_stack = _get_active_run_stack()
+
+            def call_api(requester, status_tracker, callback_handlers):
+                # langchain inference tracing will read current active run,
+                # but active run stack is thread local, to make it work,
+                # copy current thread active run stack to inference worker thread.
+                _set_active_run_stack(active_run_stack)
+                return requester.call_api(
+                    status_tracker=status_tracker,
+                    callback_handlers=callback_handlers
+                )
+
             # if enough capacity available, call API
             if next_request:
                 # call API
                 executor.submit(
-                    next_request.call_api,
+                    call_api,
+                    requester=next_request,
                     status_tracker=status_tracker,
                     callback_handlers=callback_handlers,
                 )

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -273,7 +273,7 @@ def process_api_requests(
                 # langchain inference tracing will read current active run,
                 # but active run stack is thread local, to make it work,
                 # copy current thread active run stack to inference worker thread.
-                _set_active_run_stack(active_run_stack)
+                _set_active_run_stack(active_run_stack.copy())
                 return requester.call_api(
                     status_tracker=status_tracker,
                     callback_handlers=callback_handlers

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -275,8 +275,7 @@ def process_api_requests(
                 # copy current thread active run stack to inference worker thread.
                 _set_active_run_stack(active_run_stack.copy())
                 return requester.call_api(
-                    status_tracker=status_tracker,
-                    callback_handlers=callback_handlers
+                    status_tracker=status_tracker, callback_handlers=callback_handlers
                 )
 
             # if enough capacity available, call API

--- a/mlflow/tracking/_model_registry/registry.py
+++ b/mlflow/tracking/_model_registry/registry.py
@@ -4,7 +4,6 @@ from functools import lru_cache
 
 from mlflow.tracking.registry import StoreRegistry
 
-
 _building_store_lock = threading.Lock()
 
 

--- a/mlflow/tracking/_model_registry/registry.py
+++ b/mlflow/tracking/_model_registry/registry.py
@@ -1,7 +1,11 @@
 import inspect
+import threading
 from functools import lru_cache
 
 from mlflow.tracking.registry import StoreRegistry
+
+
+_building_store_lock = threading.Lock()
 
 
 class ModelRegistryStoreRegistry(StoreRegistry):
@@ -52,12 +56,13 @@ class ModelRegistryStoreRegistry(StoreRegistry):
         Caching is done on resolved URIs because the meaning of an unresolved (None) URI may change
         depending on external configuration, such as environment variables
         """
-        builder = self.get_store_builder(resolved_store_uri)
-        builder_param_names = set(inspect.signature(builder).parameters.keys())
-        if "store_uri" in builder_param_names and "tracking_uri" in builder_param_names:
-            return builder(store_uri=resolved_store_uri, tracking_uri=resolved_tracking_uri)
-        else:
-            # Not all model registry stores accept a tracking_uri parameter
-            # (e.g. old plugins may not recognize it), so we fall back to
-            # passing just the registry URI
-            return builder(store_uri=resolved_store_uri)
+        with _building_store_lock:
+            builder = self.get_store_builder(resolved_store_uri)
+            builder_param_names = set(inspect.signature(builder).parameters.keys())
+            if "store_uri" in builder_param_names and "tracking_uri" in builder_param_names:
+                return builder(store_uri=resolved_store_uri, tracking_uri=resolved_tracking_uri)
+            else:
+                # Not all model registry stores accept a tracking_uri parameter
+                # (e.g. old plugins may not recognize it), so we fall back to
+                # passing just the registry URI
+                return builder(store_uri=resolved_store_uri)

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -76,7 +76,8 @@ def set_registry_uri(uri: str) -> None:
     """
     global _registry_uri
     _registry_uri = uri
-    MLFLOW_REGISTRY_URI.set(_registry_uri)
+    if uri:
+        MLFLOW_REGISTRY_URI.set(_registry_uri)
 
 
 def _get_registry_uri_from_spark_session():

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -76,6 +76,7 @@ def set_registry_uri(uri: str) -> None:
     """
     global _registry_uri
     _registry_uri = uri
+    MLFLOW_REGISTRY_URI.set(_registry_uri)
 
 
 def _get_registry_uri_from_spark_session():

--- a/mlflow/tracking/_tracking_service/registry.py
+++ b/mlflow/tracking/_tracking_service/registry.py
@@ -3,7 +3,6 @@ from functools import lru_cache
 
 from mlflow.tracking.registry import StoreRegistry
 
-
 _building_store_lock = threading.Lock()
 
 

--- a/mlflow/tracking/_tracking_service/registry.py
+++ b/mlflow/tracking/_tracking_service/registry.py
@@ -1,6 +1,10 @@
+import threading
 from functools import lru_cache
 
 from mlflow.tracking.registry import StoreRegistry
+
+
+_building_store_lock = threading.Lock()
 
 
 class TrackingStoreRegistry(StoreRegistry):
@@ -48,5 +52,6 @@ class TrackingStoreRegistry(StoreRegistry):
         Caching is done on resolved URIs because the meaning of an unresolved (None) URI may change
         depending on external configuration, such as environment variables
         """
-        builder = self.get_store_builder(resolved_store_uri)
-        return builder(store_uri=resolved_store_uri, artifact_uri=artifact_uri)
+        with _building_store_lock:
+            builder = self.get_store_builder(resolved_store_uri)
+            return builder(store_uri=resolved_store_uri, artifact_uri=artifact_uri)

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -70,7 +70,8 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
 
     if _tracking_uri != uri:
         _tracking_uri = uri
-        MLFLOW_TRACKING_URI.set(_tracking_uri)
+        if _tracking_uri:
+            MLFLOW_TRACKING_URI.set(_tracking_uri)
 
         # Tracer provider uses tracking URI to determine where to export traces.
         # Tracer provider stores the URI as its state so we need to reset

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -70,6 +70,7 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
 
     if _tracking_uri != uri:
         _tracking_uri = uri
+        MLFLOW_TRACKING_URI.set(_tracking_uri)
 
         # Tracer provider uses tracking URI to determine where to export traces.
         # Tracer provider stores the URI as its state so we need to reset

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -163,12 +163,12 @@ def set_experiment(
         if experiment_id is None:
             experiment = client.get_experiment_by_name(experiment_name)
             if not experiment:
-                _logger.info(
-                    "Experiment with name '%s' does not exist. Creating a new experiment.",
-                    experiment_name,
-                )
                 try:
                     experiment_id = client.create_experiment(experiment_name)
+                    _logger.info(
+                        "Experiment with name '%s' does not exist. Created a new experiment.",
+                        experiment_name,
+                    )
                 except MlflowException as e:
                     if e.error_code == "RESOURCE_ALREADY_EXISTS":
                         # NB: If two simultaneous processes attempt to set the same experiment

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -170,7 +170,7 @@ def set_experiment(
                 try:
                     experiment_id = client.create_experiment(experiment_name)
                     _logger.info(
-                        "Experiment with name '%s' does not exist. Created a new experiment.",
+                        "Experiment with name '%s' does not exist. Creating a new experiment.",
                         experiment_name,
                     )
                 except MlflowException as e:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -65,9 +65,9 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_RUN_NAME,
     MLFLOW_RUN_NOTE,
 )
+from mlflow.utils.thread_utils import get_thread_local_var, set_thread_local_var
 from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.validation import _validate_experiment_id_type, _validate_run_id
-from mlflow.utils.thread_utils import get_thread_local_var, set_thread_local_var
 
 if TYPE_CHECKING:
     import matplotlib
@@ -176,8 +176,8 @@ def set_experiment(
                 except MlflowException as e:
                     if e.error_code == "RESOURCE_ALREADY_EXISTS":
                         # NB: If two simultaneous processes attempt to set the same experiment
-                        # simultaneously, a race condition may be encountered here wherein experiment
-                        # creation fails
+                        # simultaneously, a race condition may be encountered here wherein
+                        # experiment creation fails
                         return client.get_experiment_by_name(experiment_name)
 
                 experiment = client.get_experiment(experiment_id)
@@ -426,9 +426,7 @@ def start_run(
                     f"because it is in the deleted state."
                 )
         else:
-            parent_run_id = (
-                active_run_stack[-1].info.run_id if len(active_run_stack) > 0 else None
-            )
+            parent_run_id = active_run_stack[-1].info.run_id if len(active_run_stack) > 0 else None
 
         exp_id_for_run = experiment_id if experiment_id is not None else _get_experiment_id()
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -86,12 +86,11 @@ NUM_RUNS_PER_PAGE_PANDAS = 10000
 _logger = logging.getLogger(__name__)
 
 
+run_id_to_system_metrics_monitor = {}
+
+
 def _get_active_run_stack():
     return get_thread_local_var("active_run_stack", init_value=[])
-
-
-def _get_run_id_to_system_metrics_monitor():
-    return get_thread_local_var("run_id_to_system_metrics_monitor", init_value={})
 
 
 def _get_last_active_run_id():
@@ -470,8 +469,6 @@ def start_run(
                 active_run_obj.info.run_id,
                 resume_logging=existing_run_id is not None,
             )
-            run_id_to_system_metrics_monitor = _get_run_id_to_system_metrics_monitor()
-
             run_id_to_system_metrics_monitor[active_run_obj.info.run_id] = system_monitor
             system_monitor.start()
         except Exception as e:
@@ -514,7 +511,6 @@ def end_run(status: str = RunStatus.to_string(RunStatus.FINISHED)) -> None:
         Active run: None
     """
     active_run_stack = _get_active_run_stack()
-    run_id_to_system_metrics_monitor = _get_run_id_to_system_metrics_monitor()
     if len(active_run_stack) > 0:
         # Clear out the global existing run environment variable as well.
         MLFLOW_RUN_ID.unset()

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -93,6 +93,10 @@ def _get_active_run_stack():
     return get_thread_local_var("active_run_stack", init_value=[])
 
 
+def _set_active_run_stack(run_stack):
+    set_thread_local_var("active_run_stack", run_stack)
+
+
 def _get_last_active_run_id():
     return get_thread_local_var("last_active_run_id", init_value=None)
 

--- a/mlflow/utils/thread_utils.py
+++ b/mlflow/utils/thread_utils.py
@@ -1,0 +1,36 @@
+import threading
+import os
+
+_thread_locals = threading.local()
+_globals = {}
+_globals_lock = threading.Lock()
+
+
+def set_thread_local_var(key, value):
+    """
+    Set a thread-local variable.
+    """
+    global _thread_locals
+    setattr(_thread_locals, key, (value, os.getpid()))
+
+
+def get_thread_local_var(key, init_value, reset_in_subprocess=True):
+    """
+    Get a thread-local variable.
+    If the thread-local variable is not set, return the provided `init_value` value.
+    If `get_thread_local_var` is called in a forked subprocess and `reset_in_subprocess` is True,
+    return the provided `init_value` value
+    """
+    global _thread_locals
+
+    if hasattr(_thread_locals, key):
+        value, pid = getattr(_thread_locals, key)
+        if reset_in_subprocess and pid != os.getpid():
+            # `get_thread_local_var` is called in a forked subprocess, reset it.
+            set_thread_local_var(key, init_value)
+            return init_value
+        else:
+            return value
+    else:
+        set_thread_local_var(key, init_value)
+        return init_value

--- a/mlflow/utils/thread_utils.py
+++ b/mlflow/utils/thread_utils.py
@@ -1,5 +1,5 @@
-import threading
 import os
+import threading
 
 _thread_locals = threading.local()
 _globals = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,14 @@ def tracking_uri_mock(tmp_path, request):
 def reset_active_experiment_id():
     yield
     mlflow.tracking.fluent._active_experiment_id = None
+    os.environ.pop("MLFLOW_EXPERIMENT_ID", None)
+
+
+@pytest.fixture(autouse=True)
+def reset_mlflow_uri():
+    yield
+    os.environ.pop("MLFLOW_TRACKING_URI", None)
+    os.environ.pop("MLFLOW_REGISTRY_URI", None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -514,7 +514,7 @@ def test_search_model_versions(tmp_path):
 
 @pytest.fixture
 def empty_active_run_stack():
-    with mock.patch("mlflow.tracking.fluent._active_run_stack", []):
+    with mock.patch("mlflow.tracking.fluent._get_active_run_stack", return_value=[]):
         yield
 
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1,9 +1,12 @@
 import json
 import os
 import random
+import subprocess
+import sys
 import threading
 import time
 import uuid
+import multiprocessing
 from collections import defaultdict
 from importlib import reload
 from itertools import zip_longest
@@ -1484,3 +1487,134 @@ def test_registry_uri_from_spark_conf(spark_session_with_registry_uri):
     # spark conf if present
     with mock.patch.dict(os.environ, {MLFLOW_REGISTRY_URI.name: "something-else"}):
         assert mlflow.get_registry_uri() == "something-else"
+
+
+def test_set_experiment_thread_safety(tmp_path):
+    sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
+    mlflow.set_tracking_uri(sqlite_uri)
+
+    origin_create_experiment = MlflowClient.create_experiment
+
+    def patched_create_experiment(self, *args, **kwargs):
+        time.sleep(2)
+        return origin_create_experiment(self, *args, **kwargs)
+
+    with mock.patch(
+        "mlflow.tracking.client.MlflowClient.create_experiment",
+        patched_create_experiment
+    ):
+        created_exp_ids = []
+
+        def thread_target():
+            exp_id = mlflow.set_experiment("test_experiment")
+            created_exp_ids.append(exp_id)
+
+        t1 = threading.Thread(target=thread_target)
+        t1.start()
+        t2 = threading.Thread(target=thread_target)
+        t2.start()
+
+        t1.join()
+        t2.join()
+
+        # assert the `set_experiment` invocations in the 2 threads both succeed.
+        assert len(created_exp_ids) == 2
+        # assert the `set_experiment` invocations in the 2 threads use the same experiment ID.
+        assert created_exp_ids[0] == created_exp_ids[1]
+
+        mp_ctx = multiprocessing.get_context("fork")
+        queue = mp_ctx.Queue()
+
+        def subprocess_target(que):
+            exp_id = mlflow.set_experiment("test_experiment2")
+            que.put(exp_id)
+
+        subproc1 = mp_ctx.Process(target=subprocess_target, args=(queue,))
+        subproc1.start()
+        subproc2 = mp_ctx.Process(target=subprocess_target, args=(queue,))
+        subproc2.start()
+
+        subproc1.join()
+        subproc2.join()
+
+        assert subproc1.exitcode == 0
+        assert subproc2.exitcode == 0
+
+        exp_id1 = queue.get(block=False)
+        exp_id2 = queue.get(block=False)
+        assert exp_id1 == exp_id2
+
+
+def test_subprocess_inherit_active_experiment(tmp_path):
+    sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
+    mlflow.set_tracking_uri(sqlite_uri)
+
+    exp = mlflow.set_experiment("test_experiment")
+    exp_id = exp.experiment_id
+
+    subprocess.check_call([
+        sys.executable, "-c",
+        f"import mlflow; assert mlflow.tracking.fluent._get_experiment_id() == {exp_id}"]
+    )
+
+
+def test_mlflow_active_run_thread_local(tmp_path):
+    sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
+    mlflow.set_tracking_uri(sqlite_uri)
+
+    with mlflow.start_run():
+        thread_active_run = None
+
+        def thread_target():
+            nonlocal thread_active_run
+            thread_active_run = mlflow.active_run()
+
+        thread1 = threading.Thread(target=thread_target())
+        thread1.start()
+        thread1.join()
+        # assert in another thread, active run is None.
+        assert thread_active_run is None
+
+        mp_ctx = multiprocessing.get_context("fork")
+
+        def subprocess_target():
+            # assert in subprocess, active run is None.
+            assert mlflow.active_run() is None
+
+        subproc = mp_ctx.Process(target=subprocess_target)
+        subproc.start()
+        subproc.join()
+        assert subproc.exitcode == 0
+
+
+def test_mlflow_last_active_run_thread_local(tmp_path):
+    sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
+    mlflow.set_tracking_uri(sqlite_uri)
+
+    with mlflow.start_run() as run:
+        pass
+
+    assert mlflow.last_active_run().info.run_id == run.info.run_id
+
+    thread_last_active_run = None
+
+    def thread_target():
+        nonlocal thread_last_active_run
+        thread_last_active_run = mlflow.last_active_run()
+
+    thread1 = threading.Thread(target=thread_target())
+    thread1.start()
+    thread1.join()
+    # assert in another thread, active run is None.
+    assert thread_last_active_run is None
+
+    mp_ctx = multiprocessing.get_context("fork")
+
+    def subprocess_target():
+        # assert in subprocess, active run is None.
+        assert mlflow.last_active_run() is None
+
+    subproc = mp_ctx.Process(target=subprocess_target)
+    subproc.start()
+    subproc.join()
+    assert subproc.exitcode == 0

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -720,7 +720,9 @@ def test_start_run_with_parent():
     mock_experiment_id = "123456"
     mock_source_name = mock.Mock()
 
-    active_run_stack_patch = mock.patch("mlflow.tracking.fluent._active_run_stack", [parent_run])
+    active_run_stack_patch = mock.patch(
+        "mlflow.tracking.fluent._get_active_run_stack", lambda: [parent_run]
+    )
 
     mock_user = mock.Mock()
     user_patch = mock.patch(

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1506,8 +1506,8 @@ def test_set_experiment_thread_safety(tmp_path):
         created_exp_ids = []
 
         def thread_target():
-            exp_id = mlflow.set_experiment("test_experiment")
-            created_exp_ids.append(exp_id)
+            exp = mlflow.set_experiment("test_experiment")
+            created_exp_ids.append(exp.experiment_id)
 
         t1 = threading.Thread(target=thread_target)
         t1.start()
@@ -1526,8 +1526,8 @@ def test_set_experiment_thread_safety(tmp_path):
         queue = mp_ctx.Queue()
 
         def subprocess_target(que):
-            exp_id = mlflow.set_experiment("test_experiment2")
-            que.put(exp_id)
+            exp = mlflow.set_experiment("test_experiment2")
+            que.put(exp.experiment_id)
 
         subproc1 = mp_ctx.Process(target=subprocess_target, args=(queue,))
         subproc1.start()
@@ -1554,8 +1554,8 @@ def test_subprocess_inherit_active_experiment(tmp_path):
 
     subprocess.check_call([
         sys.executable, "-c",
-        f"import mlflow; assert mlflow.tracking.fluent._get_experiment_id() == {exp_id}"]
-    )
+        f"import mlflow; assert mlflow.tracking.fluent._get_experiment_id() == '{exp_id}'"
+    ])
 
 
 def test_mlflow_active_run_thread_local(tmp_path):
@@ -1569,7 +1569,7 @@ def test_mlflow_active_run_thread_local(tmp_path):
             nonlocal thread_active_run
             thread_active_run = mlflow.active_run()
 
-        thread1 = threading.Thread(target=thread_target())
+        thread1 = threading.Thread(target=thread_target)
         thread1.start()
         thread1.join()
         # assert in another thread, active run is None.
@@ -1602,7 +1602,7 @@ def test_mlflow_last_active_run_thread_local(tmp_path):
         nonlocal thread_last_active_run
         thread_last_active_run = mlflow.last_active_run()
 
-    thread1 = threading.Thread(target=thread_target())
+    thread1 = threading.Thread(target=thread_target)
     thread1.start()
     thread1.join()
     # assert in another thread, active run is None.

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1554,13 +1554,15 @@ def test_subprocess_inherit_active_experiment(tmp_path):
     exp = mlflow.set_experiment("test_experiment")
     exp_id = exp.experiment_id
 
-    subprocess.check_call(
+    stdout = subprocess.check_output(
         [
             sys.executable,
             "-c",
-            f"import mlflow; assert mlflow.tracking.fluent._get_experiment_id() == '{exp_id}'",
-        ]
+            "import mlflow; print(mlflow.tracking.fluent._get_experiment_id())",
+        ],
+        text=True,
     )
+    assert exp_id in stdout
 
 
 def test_mlflow_active_run_thread_local(tmp_path):
@@ -1631,25 +1633,27 @@ def test_subprocess_inherit_tracking_uri(tmp_path):
     sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
     mlflow.set_tracking_uri(sqlite_uri)
 
-    subprocess.check_call(
+    stdout = subprocess.check_output(
         [
             sys.executable,
             "-c",
-            f"import mlflow; assert mlflow.get_tracking_uri() == '{sqlite_uri}'",
+            "import mlflow; print(mlflow.get_tracking_uri())",
         ],
-        env=os.environ,
+        text=True,
     )
+    assert sqlite_uri in stdout
 
 
 def test_subprocess_inherit_registry_uri(tmp_path):
     sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
     mlflow.set_registry_uri(sqlite_uri)
 
-    subprocess.check_call(
+    stdout = subprocess.check_output(
         [
             sys.executable,
             "-c",
-            f"import mlflow; assert mlflow.get_registry_uri() == '{sqlite_uri}'",
+            "import mlflow; print(mlflow.get_registry_uri())",
         ],
-        env=os.environ,
+        text=True,
     )
+    assert sqlite_uri in stdout

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1618,3 +1618,23 @@ def test_mlflow_last_active_run_thread_local(tmp_path):
     subproc.start()
     subproc.join()
     assert subproc.exitcode == 0
+
+
+def test_subprocess_inherit_tracking_uri(tmp_path):
+    sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
+    mlflow.set_tracking_uri(sqlite_uri)
+
+    subprocess.check_call([
+        sys.executable, "-c",
+        f"import mlflow; assert mlflow.get_tracking_uri() == '{sqlite_uri}'"
+    ])
+
+
+def test_subprocess_inherit_registry_uri(tmp_path):
+    sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
+    mlflow.set_registry_uri(sqlite_uri)
+
+    subprocess.check_call([
+        sys.executable, "-c",
+        f"import mlflow; assert mlflow.get_registry_uri() == '{sqlite_uri}'"
+    ])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/13456?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13456/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13456
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Make MLflow run thread-safe

Design: https://docs.google.com/document/d/1UrIj_nTyZlqQRj3_q-NYLwMeCdHnZGR-AIi-eii0oRo/edit?tab=t.0

Changes in this PR:

* Make `set_experiment` thread safe and cross processes safe and fix race conditions.
* Make MLflow active run thread local, and prevent forked subprocess inheriting active run in parent process.
* Make subprocess inherits active experiment / tracking URI / registry URI from parent process.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

I built a package for easier testing:

https://ml-team-public-read.s3.us-west-2.amazonaws.com/weichen-temp/mlflow-2.17.2.dev0-py3-none-any.whl


#### Manual test 1: Optuna mutiple-thread mode

```
import optuna
import mlflow

mlflow.set_tracking_uri("sqlite:////tmp/tune.db")
mlflow.set_experiment("tune1")


with mlflow.start_run() as parent_run:
    def objective(trial):
        with mlflow.start_run(parent_run_id=parent_run.info.run_id):
            x = trial.suggest_float('x', -10, 10)
            mlflow.log_param("x", x)
            loss = (x - 2) ** 2
            mlflow.log_metric("loss", loss)
            return loss

    study = optuna.create_study()
    # NOTE: we need to specify `n_jobs` argument otherwise
    #  no new threads are created and tuning tasks are executed
    #  within the same main thread.
    study.optimize(objective, n_trials=8, n_jobs=4)

    print("best param:", study.best_params)
```

#### Manual test 2: Optuna mutiple-process mode
Ref doc: https://optuna.readthedocs.io/en/v2.0.0/tutorial/distributed.html

```
import subprocess

import optuna
import mlflow
import multiprocessing
import uuid

mlflow.set_tracking_uri("sqlite:////tmp/tune.db")
mlflow.set_experiment("tune2")


# optuna trial storage db path
trial_db = "sqlite:////tmp/tune1.db"
study_name = f"distributed-{uuid.uuid4().hex}"

subprocess.check_call(
    f"optuna create-study --study-name {study_name} --storage {trial_db}",
    shell=True
)

with mlflow.start_run() as parent_run:
    def objective(trial):
        with mlflow.start_run(parent_run_id=parent_run.info.run_id):
            x = trial.suggest_float('x', -10, 10)
            mlflow.log_param("x", x)
            loss = (x - 2) ** 2
            mlflow.log_metric("loss", loss)
            return loss

    def subproc_fn():
        study = optuna.load_study(
            study_name=study_name, storage=trial_db
        )
        study.optimize(objective, n_trials=8)

    mp_ctx = multiprocessing.get_context('fork')

    subprocs = [
        mp_ctx.Process(target=subproc_fn)
        for _ in range(4)
    ]

    for subproc in subprocs:
        subproc.start()

    for subproc in subprocs:
        subproc.join()

    for subproc in subprocs:
        assert subproc.exitcode == 0
```

Above examples works well and logged runs are organised as nested runs, we can view them from UI like:
<img width="948" alt="image" src="https://github.com/user-attachments/assets/0d6b17d2-78f1-45b9-af0c-00e18a6cbfec">




<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Make MLflow run thread-safe

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
