### PR TITLE
Make `set_logged_model_tags` return `None`

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -768,7 +768,7 @@ class AbstractStore:
         """
         raise NotImplementedError
 
-    def set_logged_model_tags(self, model_id: str, tags: List[LoggedModelTag]) -> LoggedModel:
+    def set_logged_model_tags(self, model_id: str, tags: List[LoggedModelTag]) -> None:
         """
         Set tags on the specified logged model.
 

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -777,7 +777,7 @@ class AbstractStore:
             tags: Tags to set on the model.
 
         Returns:
-            The model with the updated tags.
+            None
         """
         raise NotImplementedError
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -2023,7 +2023,7 @@ class FileStore(AbstractStore):
         write_yaml(model_dir, FileStore.META_DATA_FILE_NAME, model_info_dict, overwrite=True)
         return self.get_logged_model(model_id)
 
-    def set_logged_model_tags(self, model_id: str, tags: List[LoggedModelTag]) -> LoggedModel:
+    def set_logged_model_tags(self, model_id: str, tags: List[LoggedModelTag]) -> None:
         """
         Set tags on the specified logged model.
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -2032,7 +2032,7 @@ class FileStore(AbstractStore):
             tags: Tags to set on the model.
 
         Returns:
-            The model with the updated tags
+            None
         """
         model = self.get_logged_model(model_id)
         for tag in tags:

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -706,10 +706,7 @@ class RestStore(AbstractStore):
         json_body = message_to_json(
             SetLoggedModelTags(model_id=model_id, tags=[tag.to_proto() for tag in tags])
         )
-        response_proto = self._call_endpoint(
-            SetLoggedModelTags, json_body=json_body, endpoint=f"{endpoint}/tags"
-        )
-        LoggedModel.from_proto(response_proto.model)
+        self._call_endpoint(SetLoggedModelTags, json_body=json_body, endpoint=f"{endpoint}/tags")
 
     def delete_logged_model_tag(self, model_id: str, key: str) -> None:
         """

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -691,7 +691,7 @@ class RestStore(AbstractStore):
         )
         return self._call_endpoint(FinalizeLoggedModel, json_body=json_body, endpoint=endpoint)
 
-    def set_logged_model_tags(self, model_id: str, tags: List[LoggedModelTag]) -> LoggedModel:
+    def set_logged_model_tags(self, model_id: str, tags: List[LoggedModelTag]) -> None:
         """
         Set tags on the specified logged model.
 
@@ -700,7 +700,7 @@ class RestStore(AbstractStore):
             tags: Tags to set on the model.
 
         Returns:
-            The model with the updated tags.
+            None
         """
         endpoint = get_logged_model_endpoint(model_id)
         json_body = message_to_json(
@@ -709,7 +709,7 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(
             SetLoggedModelTags, json_body=json_body, endpoint=f"{endpoint}/tags"
         )
-        return LoggedModel.from_proto(response_proto.model)
+        LoggedModel.from_proto(response_proto.model)
 
     def delete_logged_model_tag(self, model_id: str, key: str) -> None:
         """

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -1107,8 +1107,8 @@ class TrackingServiceClient:
     def get_logged_model(self, model_id: str) -> LoggedModel:
         return self.store.get_logged_model(model_id)
 
-    def set_logged_model_tags(self, model_id: str, tags: Dict[str, Any]) -> LoggedModel:
-        return self.store.set_logged_model_tags(
+    def set_logged_model_tags(self, model_id: str, tags: Dict[str, Any]) -> None:
+        self.store.set_logged_model_tags(
             model_id, [LoggedModelTag(str(key), str(value)) for key, value in tags.items()]
         )
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -4834,7 +4834,7 @@ class MlflowClient:
         """
         return self._tracking_client.get_logged_model(model_id)
 
-    def set_logged_model_tags(self, model_id: str, tags: Dict[str, Any]) -> LoggedModel:
+    def set_logged_model_tags(self, model_id: str, tags: Dict[str, Any]) -> None:
         """
         Set tags on the specified logged model.
 
@@ -4845,7 +4845,7 @@ class MlflowClient:
         Returns:
             The model with the updated tags.
         """
-        return self._tracking_client.set_logged_model_tags(model_id, tags)
+        self._tracking_client.set_logged_model_tags(model_id, tags)
 
     def delete_logged_model_tag(self, model_id: str, key: str) -> None:
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -4843,7 +4843,7 @@ class MlflowClient:
             tags: Tags to set on the model.
 
         Returns:
-            The model with the updated tags.
+            None
         """
         self._tracking_client.set_logged_model_tags(model_id, tags)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13467?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13467/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13467
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`set_logged_model_tags` currently returns a `LoggedModel` instance. To align with the backend which returns nothing, `set_logged_model_tags` should return `None`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
