### PR TITLE
Fix code_path handling for LlamaIndex flavor

### DIFF
--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -120,7 +120,7 @@ def save_model(
     llama_index_model,
     path: str,
     engine_type: Optional[str] = None,
-    model_config: Optional[Dict[str, Any]] = None,
+    model_config: Optional[Union[str, Dict[str, Any]]] = None,
     code_paths=None,
     mlflow_model: Optional[Model] = None,
     signature: Optional[ModelSignature] = None,
@@ -383,6 +383,7 @@ def log_model(
             model.py:
 
             .. code-block:: python
+
                 import mlflow
                 from llama_index.vector_stores.qdrant import QdrantVectorStore
                 import qdrant_client
@@ -471,7 +472,7 @@ def _load_llama_model(path, flavor_conf):
         # file when it is saved. We should update the relative path in artifact directory.
         model_code_path = os.path.join(path, os.path.basename(model_code_path))
 
-        model_config = pyfunc_flavor_conf.get(MODEL_CONFIG, flavor_conf.get(MODEL_CONFIG, {}))
+        model_config = pyfunc_flavor_conf.get(MODEL_CONFIG) or flavor_conf.get(MODEL_CONFIG, {})
         if isinstance(model_config, str):
             config_path = os.path.join(path, os.path.basename(model_config))
             model_config = _validate_and_get_model_config_from_file(config_path)

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -10,7 +10,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.llama_index.pyfunc_wrapper import create_pyfunc_wrapper
 from mlflow.models import Model, ModelInputExample, ModelSignature
-from mlflow.models.model import MLMODEL_FILE_NAME, MODEL_CODE_PATH
+from mlflow.models.model import MLMODEL_FILE_NAME, MODEL_CODE_PATH, MODEL_CONFIG
 from mlflow.models.signature import _infer_signature_from_input_example
 from mlflow.models.utils import (
     _load_model_code_path,
@@ -40,6 +40,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _validate_and_copy_file_to_directory,
+    _validate_and_get_model_config_from_file,
     _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
@@ -159,10 +160,11 @@ def save_model(
             - ``"retriever"``: load the index as an instance of the LlamaIndex
               `Retriever <https://docs.llamaindex.ai/en/stable/module_guides/querying/retriever/>`_.
 
-        model_config: Keyword arguments to be passed to the LlamaIndex engine at instantiation.
-            Note that not all llama index objects have supported serialization; when an object is
-            not supported, an info log message will be emitted and the unsupported object will be
-            dropped.
+        model_config: The model configuration to apply when loading the model back with
+            ``mlflow.pyfunc.load_model()``. It will be applied in a different way depending on the
+            model type and saving method. See the docstring of :func:`log_model` for more details
+            and usage examples.
+
         code_paths: {{ code_paths }}
         mlflow_model: An MLflow model object that specifies the flavor that this model is being
             added to.
@@ -189,6 +191,9 @@ def save_model(
 
         path = os.path.abspath(path)
         _validate_and_prepare_target_save_path(path)
+
+        if isinstance(model_config, str):
+            model_config = _validate_and_get_model_config_from_file(model_config)
 
         model_code_path = None
         if isinstance(model_or_code_path, str):
@@ -342,10 +347,57 @@ def log_model(
             - ``"retriever"``: load the index as an instance of the LlamaIndex
               `Retriever <https://docs.llamaindex.ai/en/stable/module_guides/querying/retriever/>`_.
 
-        model_config: Keyword arguments to be passed to the LlamaIndex engine at instantiation.
-            Note that not all llama index objects have supported serialization; when an object is
-            not supported, an info log message will be emitted and the unsupported object will be
-            dropped.
+        model_config: The model configuration to apply when loading the model back with
+            ``mlflow.pyfunc.load_model()``. It will be applied in a different way depending on the
+            model type and saving method:
+
+            For in-memory Index objects saved directly, it will be passed as keyword arguments to
+            instantiate the LlamaIndex engine with the specified engine type at logging.
+
+            .. code-block:: python
+
+                with mlflow.start_run() as run:
+                    model_info = mlflow.llama_index.log_model(
+                        index,
+                        artifact_path="index",
+                        engine_type="chat",
+                        model_config={"top_k": 10},
+                    )
+
+                # When loading back, MLflow will call ``index.as_chat_engine(top_k=10)``
+                engine = mlflow.pyfunc.load_model(model_info.model_uri)
+
+            For other model types saved with the `Model-from-Code <https://www.mlflow.org/docs/latest/model/models-from-code.html>`
+            method, the config will be accessed via the :py:class`~mlflow.models.ModelConfig`
+            object within your model code.
+
+            .. code-block:: python
+
+                with mlflow.start_run() as run:
+                    model_info = mlflow.llama_index.log_model(
+                        "model.py",
+                        artifact_path="model",
+                        model_config={"qdrant_host": "localhost", "qdrant_port": 6333},
+                    )
+
+            model.py:
+
+            .. code-block:: python
+                import mlflow
+                from llama_index.vector_stores.qdrant import QdrantVectorStore
+                import qdrant_client
+
+
+                # The model configuration is accessible via the ModelConfig singleton
+                model_config = mlflow.models.ModelConfig()
+                qdrant_host = model_config.get("top_k", 5)
+                qdrant_port = model_config.get("qdrant_port", 6333)
+
+                client = qdrant_client.Client(host=qdrant_host, port=qdrant_port)
+                vectorstore = QdrantVectorStore(client)
+
+                # the rest of the model definition...
+
         code_paths: {{ code_paths }}
         registered_model_name: This argument may change or be removed in a
             future release without warning. If given, create a model
@@ -417,11 +469,14 @@ def _load_llama_model(path, flavor_conf):
     if model_code_path := pyfunc_flavor_conf.get(MODEL_CODE_PATH):
         # TODO: The code path saved in the MLModel file is the local absolute path to the code
         # file when it is saved. We should update the relative path in artifact directory.
-        model_code_path = os.path.join(
-            path,
-            os.path.basename(model_code_path),
-        )
-        return _load_model_code_path(model_code_path, flavor_conf)
+        model_code_path = os.path.join(path, os.path.basename(model_code_path))
+
+        model_config = pyfunc_flavor_conf.get(MODEL_CONFIG, flavor_conf.get(MODEL_CONFIG, {}))
+        if isinstance(model_config, str):
+            config_path = os.path.join(path, os.path.basename(model_config))
+            model_config = _validate_and_get_model_config_from_file(config_path)
+
+        return _load_model_code_path(model_code_path, model_config)
     else:
         # Use default vector store when loading from the serialized index
         index_path = os.path.join(path, _INDEX_PERSIST_FOLDER)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1786,8 +1786,8 @@ def _mock_dbutils(globals_dict):
 # This function addresses this by dynamically importing the `code path` module under a unique,
 # dynamically generated module name. This bypasses the caching mechanism, as each import is
 # considered a separate module by the Python interpreter.
-def _load_model_code_path(code_path: str, config: Optional[Union[str, Dict[str, Any]]]):
-    with _config_context(config):
+def _load_model_code_path(code_path: str, model_config: Optional[Union[str, Dict[str, Any]]]):
+    with _config_context(model_config):
         try:
             new_module_name = f"code_model_{uuid.uuid4().hex}"
             spec = importlib.util.spec_from_file_location(new_module_name, code_path)

--- a/tests/llama_index/sample_code/basic_chat_engine.py
+++ b/tests/llama_index/sample_code/basic_chat_engine.py
@@ -1,5 +1,5 @@
 """
-Sample code to define an chat engine and save it with model-from-code logging.
+Sample code to define a chat engine and save it with model-from-code logging.
 
 Ref: https://qdrant.tech/documentation/quickstart/
 """

--- a/tests/llama_index/sample_code/model_config.yaml
+++ b/tests/llama_index/sample_code/model_config.yaml
@@ -1,3 +1,3 @@
 llm:
-    model_name: "gpt-3.5-turbo"
-    temperature: 0.7
+  model_name: "gpt-3.5-turbo"
+  temperature: 0.7

--- a/tests/llama_index/sample_code/model_config.yaml
+++ b/tests/llama_index/sample_code/model_config.yaml
@@ -1,0 +1,3 @@
+llm:
+    model_name: "gpt-3.5-turbo"
+    temperature: 0.7

--- a/tests/llama_index/sample_code/model_config.yaml
+++ b/tests/llama_index/sample_code/model_config.yaml
@@ -1,3 +1,3 @@
 llm:
-  model_name: "gpt-3.5-turbo"
+  model_name: "gpt-4o-mini"
   temperature: 0.7

--- a/tests/llama_index/sample_code/query_engine_with_reranker.py
+++ b/tests/llama_index/sample_code/query_engine_with_reranker.py
@@ -1,5 +1,5 @@
 """
-Sample code to define an query engine with post processors and save it with model-from-code logging.
+Sample code to define a query engine with post processors and save it with model-from-code logging.
 
 Ref: https://qdrant.tech/documentation/quickstart/
 """

--- a/tests/llama_index/sample_code/with_model_config.py
+++ b/tests/llama_index/sample_code/with_model_config.py
@@ -1,0 +1,20 @@
+"""
+Sample code to define an chat engine and save it with model config (dictionary).
+"""
+
+from llama_index.core import Document, VectorStoreIndex
+from llama_index.core.chat_engine.types import ChatMode
+from llama_index.llms.openai import OpenAI
+
+import mlflow
+
+model_config = mlflow.models.ModelConfig()
+model_name = model_config.get("model_name")
+temperature = model_config.get("temperature")
+llm = OpenAI(model=model_name, temperature=temperature)
+
+index = VectorStoreIndex.from_documents(documents=[Document.example()])
+# Setting SIMPLE chat mode will create a SimpleChatEngine instance
+chat_engine = index.as_chat_engine(llm=llm, chat_mode=ChatMode.SIMPLE)
+
+mlflow.models.set_model(chat_engine)

--- a/tests/llama_index/sample_code/with_model_config.py
+++ b/tests/llama_index/sample_code/with_model_config.py
@@ -1,5 +1,5 @@
 """
-Sample code to define an chat engine and save it with model config (dictionary).
+Sample code to define a chat engine and save it with model config (dictionary).
 """
 
 from llama_index.core import Document, VectorStoreIndex

--- a/tests/llama_index/sample_code/with_model_config_yaml_file.py
+++ b/tests/llama_index/sample_code/with_model_config_yaml_file.py
@@ -1,5 +1,5 @@
 """
-Sample code to define an chat engine and save it with model config (YAML file).
+Sample code to define a chat engine and save it with model config (YAML file).
 """
 
 from llama_index.core import Document, VectorStoreIndex

--- a/tests/llama_index/sample_code/with_model_config_yaml_file.py
+++ b/tests/llama_index/sample_code/with_model_config_yaml_file.py
@@ -1,0 +1,21 @@
+"""
+Sample code to define an chat engine and save it with model config (YAML file).
+"""
+
+from llama_index.core import Document, VectorStoreIndex
+from llama_index.core.chat_engine.types import ChatMode
+from llama_index.llms.openai import OpenAI
+
+import mlflow
+
+model_config = mlflow.models.ModelConfig(development_config="model_config.yaml")
+llm_config = model_config.get("llm")
+model_name = llm_config.get("model_name")
+temperature = llm_config.get("temperature")
+llm = OpenAI(model=model_name, temperature=temperature)
+
+index = VectorStoreIndex.from_documents(documents=[Document.example()])
+# Setting SIMPLE chat mode will create a SimpleChatEngine instance
+chat_engine = index.as_chat_engine(llm=llm, chat_mode=ChatMode.SIMPLE)
+
+mlflow.models.set_model(chat_engine)

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -96,6 +96,23 @@ def test_llama_index_save_invalid_object_raise(single_index):
         )
 
 
+def test_llama_index_load_with_model_config(single_index):
+    from llama_index.core.response_synthesizers import Refine
+
+    with mlflow.start_run():
+        logged_model = mlflow.llama_index.log_model(
+            single_index,
+            "model",
+            engine_type="query",
+            model_config={"response_mode": "refine"},
+        )
+
+    loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
+    engine = loaded_model.get_raw_model()
+
+    assert isinstance(engine._response_synthesizer, Refine)
+
+
 @pytest.mark.parametrize(
     "engine_type",
     ["query", "retriever"],
@@ -462,6 +479,36 @@ def test_save_load_chat_engine_as_code():
     assert isinstance(pyfunc_loaded_model._model_impl, ChatEngineWrapper)
     assert isinstance(pyfunc_loaded_model.get_raw_model(), SimpleChatEngine)
     assert pyfunc_loaded_model.predict(_TEST_QUERY) != ""
+
+
+@pytest.mark.parametrize(
+    ("index_code_path", "model_config"),
+    [
+        (
+            "tests/llama_index/sample_code/with_model_config.py",
+            {
+                "model_name": "gpt-3.5-turbo",
+                "temperature": 0.7,
+            },
+        ),
+        (
+            "tests/llama_index/sample_code/with_model_config_yaml_file.py",
+            "tests/llama_index/sample_code/model_config.yaml",
+        ),
+    ],
+)
+def test_save_load_as_code_with_model_config(index_code_path, model_config):
+    with mlflow.start_run():
+        logged_model = mlflow.llama_index.log_model(
+            index_code_path,
+            "model",
+            model_config=model_config,
+        )
+
+    loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
+    engine = loaded_model.get_raw_model()
+    assert engine._llm.model == "gpt-3.5-turbo"
+    assert engine._llm.temperature == 0.7
 
 
 def test_save_engine_with_engine_type_issues_warning(model_path):

--- a/tests/llama_index/test_llama_index_model_export.py
+++ b/tests/llama_index/test_llama_index_model_export.py
@@ -487,7 +487,7 @@ def test_save_load_chat_engine_as_code():
         (
             "tests/llama_index/sample_code/with_model_config.py",
             {
-                "model_name": "gpt-3.5-turbo",
+                "model_name": "gpt-4o-mini",
                 "temperature": 0.7,
             },
         ),
@@ -507,7 +507,7 @@ def test_save_load_as_code_with_model_config(index_code_path, model_config):
 
     loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
     engine = loaded_model.get_raw_model()
-    assert engine._llm.model == "gpt-3.5-turbo"
+    assert engine._llm.model == "gpt-4o-mini"
     assert engine._llm.temperature == 0.7
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13486?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13486/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13486
```

</p>
</details>

### What changes are proposed in this pull request?

The LlamaIndex flavor does not set `model_config` when loading model logged with models-from-code. This PR updates the logic with the same manner as what LangChain flavor does.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix the issue in loading LlamaIndex model with `model_config`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
