### PR TITLE
Use `ubuntu 24.04` for spark autologging 3.3.4

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -128,7 +128,7 @@ jobs:
   test1:
     needs: set-matrix
     if: ${{ needs.set-matrix.outputs.is_matrix1_empty == 'false' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -174,7 +174,7 @@ jobs:
   test2:
     needs: set-matrix
     if: ${{ needs.set-matrix.outputs.is_matrix2_empty == 'false' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -263,16 +263,10 @@ def get_matched_requirements(requirements, version=None):
 
 
 def get_java_version(java: Optional[Dict[str, str]], version: str) -> str:
-    default = "11"
-    if java is None:
-        return default
+    if java and (match := next(_find_matches(java, version), None)):
+        return match
 
-    for specifier, java_ver in java.items():
-        specifier_set = SpecifierSet(specifier.replace(DEV_VERSION, DEV_NUMERIC))
-        if specifier_set.contains(DEV_NUMERIC if version == DEV_VERSION else version):
-            return java_ver
-
-    return default
+    return "11"
 
 
 @functools.lru_cache(maxsize=128)

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -329,7 +329,7 @@ def get_python_version(python: Optional[Dict[str, str]], package: str, version: 
     return infer_python_version(package, version)
 
 
-def get_runs_on(runs_on: Optional[Dict[str, str]], package: str, version: str) -> str:
+def get_runs_on(runs_on: Optional[Dict[str, str]], version: str) -> str:
     if runs_on and (match := next(_find_matches(runs_on, version), None)):
         return match
 
@@ -572,7 +572,7 @@ def expand_config(config: Dict[str, Any], *, is_ref: bool = False) -> Set[Matrix
                 install = make_pip_install_command(requirements)
                 run = remove_comments(cfg.run)
                 python = get_python_version(cfg.python, package_info.pip_release, str(ver))
-                runs_on = get_runs_on(cfg.python, package_info.pip_release, DEV_VERSION)
+                runs_on = get_runs_on(cfg.runs_on, ver)
                 java = get_java_version(cfg.java, str(ver))
 
                 matrix.add(
@@ -602,7 +602,7 @@ def expand_config(config: Dict[str, Any], *, is_ref: bool = False) -> Set[Matrix
                 else:
                     install = install_dev
                 python = get_python_version(cfg.python, package_info.pip_release, DEV_VERSION)
-                runs_on = get_runs_on(cfg.python, package_info.pip_release, DEV_VERSION)
+                runs_on = get_runs_on(cfg.runs_on, DEV_VERSION)
                 java = get_java_version(cfg.java, DEV_VERSION)
 
                 run = remove_comments(cfg.run)

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -36,7 +36,7 @@ import sys
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, TypeVar
 
 import requests
 import yaml
@@ -49,6 +49,8 @@ VERSIONS_YAML_PATH = "mlflow/ml-package-versions.yml"
 DEV_VERSION = "dev"
 # Treat "dev" as "newer than any existing versions"
 DEV_NUMERIC = "9999.9999.9999"
+
+T = TypeVar("T")
 
 
 class Version(OriginalVersion):
@@ -76,6 +78,7 @@ class TestConfig(BaseModel, extra="forbid"):
     unsupported: Optional[List[Version]] = None
     requirements: Optional[Dict[str, List[str]]] = None
     python: Optional[Dict[str, str]] = None
+    runs_on: Optional[Dict[str, str]] = None
     java: Optional[Dict[str, str]] = None
     run: str
     allow_unreleased_max_version: Optional[bool] = None
@@ -125,6 +128,7 @@ class MatrixItem(BaseModel, extra="forbid"):
     java: str
     supported: bool
     free_disk_space: bool
+    runs_on: str
     pre_test: Optional[str] = None
 
     class Config:
@@ -302,14 +306,34 @@ def infer_python_version(package: str, version: str) -> str:
     return candidates[0]
 
 
+def _find_matches(spec: Dict[str, T], version: str) -> Iterator[T]:
+    """
+    Args:
+        spec: A dictionary with key as version specifier and value as the corresponding value.
+            For example, {"< 1.0.0": "numpy<2.0", ">= 1.0.0": "numpy>=2.0"}.
+        version: The version to match against the specifiers.
+
+    Returns:
+        An iterator of values that match the version.
+    """
+    for specifier, val in spec.items():
+        specifier_set = SpecifierSet(specifier.replace(DEV_VERSION, DEV_NUMERIC))
+        if specifier_set.contains(DEV_NUMERIC if version == DEV_VERSION else version):
+            yield val
+
+
 def get_python_version(python: Optional[Dict[str, str]], package: str, version: str) -> str:
-    if python:
-        for specifier, py_ver in python.items():
-            specifier_set = SpecifierSet(specifier.replace(DEV_VERSION, DEV_NUMERIC))
-            if specifier_set.contains(DEV_NUMERIC if version == DEV_VERSION else version):
-                return py_ver
+    if python and (match := next(_find_matches(python, version), None)):
+        return match
 
     return infer_python_version(package, version)
+
+
+def get_runs_on(runs_on: Optional[Dict[str, str]], package: str, version: str) -> str:
+    if runs_on and (match := next(_find_matches(runs_on, version), None)):
+        return match
+
+    return "ubuntu-latest"
 
 
 def remove_comments(s):
@@ -548,6 +572,7 @@ def expand_config(config: Dict[str, Any], *, is_ref: bool = False) -> Set[Matrix
                 install = make_pip_install_command(requirements)
                 run = remove_comments(cfg.run)
                 python = get_python_version(cfg.python, package_info.pip_release, str(ver))
+                runs_on = get_runs_on(cfg.python, package_info.pip_release, DEV_VERSION)
                 java = get_java_version(cfg.java, str(ver))
 
                 matrix.add(
@@ -564,6 +589,7 @@ def expand_config(config: Dict[str, Any], *, is_ref: bool = False) -> Set[Matrix
                         java=java,
                         supported=ver <= cfg.maximum,
                         free_disk_space=free_disk_space,
+                        runs_on=runs_on,
                         pre_test=cfg.pre_test,
                     )
                 )
@@ -576,6 +602,7 @@ def expand_config(config: Dict[str, Any], *, is_ref: bool = False) -> Set[Matrix
                 else:
                     install = install_dev
                 python = get_python_version(cfg.python, package_info.pip_release, DEV_VERSION)
+                runs_on = get_runs_on(cfg.python, package_info.pip_release, DEV_VERSION)
                 java = get_java_version(cfg.java, DEV_VERSION)
 
                 run = remove_comments(cfg.run)
@@ -594,6 +621,7 @@ def expand_config(config: Dict[str, Any], *, is_ref: bool = False) -> Set[Matrix
                         java=java,
                         supported=False,
                         free_disk_space=free_disk_space,
+                        runs_on=runs_on,
                         pre_test=cfg.pre_test,
                     )
                 )

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -351,6 +351,9 @@ spark:
       cd python/packaging/classic
       pip install '.[connect]'
       pyspark --version
+    runs_on:
+      # TODO: Remove this once ubuntu 24 is fully rolled out: https://github.com/actions/runner-images/issues/10636
+      "== 3.3.4": "ubuntu-24.04"
 
   models:
     minimum: "3.1.2"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -351,9 +351,6 @@ spark:
       cd python/packaging/classic
       pip install '.[connect]'
       pyspark --version
-    runs_on:
-      # TODO: Remove this once ubuntu 24 is fully rolled out: https://github.com/actions/runner-images/issues/10636
-      "== 3.3.4": "ubuntu-24.04"
 
   models:
     minimum: "3.1.2"
@@ -389,6 +386,9 @@ spark:
   autologging:
     minimum: "3.1.2"
     maximum: "3.5.3"
+    runs_on:
+      # TODO: Remove this once ubuntu 24 is fully rolled out: https://github.com/actions/runner-images/issues/10636
+      "== 3.3.4": "ubuntu-24.04"
     python:
       "== dev": "3.9"
     java:


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

For some reason, `spark / autologging / 3.3.4` only passes on Ubuntu 24.04 (#13489):

https://github.com/mlflow-automation/mlflow/actions/runs/11426688621/job/31793085823#step:12:412

```
Exception while attempting to initialize JVM-side state for Spark datasource autologging. Note that Spark datasource autologging only works with Spark 3.0 and above. Please create a new Spark session with required Spark version and ensure you have the mlflow-spark JAR attached to your Spark session as described in https://mlflow.org/docs/latest/tracking/autolog.html#spark Exception:
An error occurred while calling z:org.mlflow.spark.autologging.MlflowAutologEventPublisher.init.
: java.lang.RuntimeException: Unable to get active SparkSession. Please ensure you've started a SparkSession via SparkSession.builder.getOrCreate() before attempting to initialize Spark datasource autologging.
	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.$anonfun$spark$1(MlflowAutologEventPublisher.scala:42)
	at scala.Option.getOrElse(Option.scala:189)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.spark(MlflowAutologEventPublisher.scala:40)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.spark$(MlflowAutologEventPublisher.scala:39)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisher$.spark(MlflowAutologEventPublisher.scala:20)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.isInReplAwareContext(MlflowAutologEventPublisher.scala:52)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.getSparkDataSourceListener(MlflowAutologEventPublisher.scala:71)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.getSparkDataSourceListener$(MlflowAutologEventPublisher.scala:70)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisher$.getSparkDataSourceListener(MlflowAutologEventPublisher.scala:20)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.init(MlflowAutologEventPublisher.scala:82)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.init$(MlflowAutologEventPublisher.scala:80)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisher$.init(MlflowAutologEventPublisher.scala:20)
	at org.mlflow.spark.autologging.MlflowAutologEventPublisher.init(MlflowAutologEventPublisher.scala)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:282)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

I didn't investigate why `spark / autologging / 3.3.4` doesn't pass on the latest version of the ubuntu 22.04 image.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
