### PR TITLE
Remove warnings during Settings serialization

### DIFF
--- a/docs/source/llms/llama-index/index.rst
+++ b/docs/source/llms/llama-index/index.rst
@@ -107,7 +107,7 @@ query and returns a response based on the index. The ``ChatEngine`` is designed 
 
 The ``Settings`` object is a global service context that bundles commonly used resources throughout the
 LlamaIndex application. It includes settings such as the LLM model, embedding model, callbacks, and more. When logging a LlamaIndex index/engine/workflow, MLflow tracks 
-the state of the ``Settings`` object so that you can easily reproduce the same result when loading the model back for inference.
+the state of the ``Settings`` object so that you can easily reproduce the same result when loading the model back for inference (note that some objects like API keys, non-serializable objects, etc., are not tracked).
 
 
 Usage

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -139,6 +139,15 @@ def save_model(
         Please refer to the `Models From Code Guide <https://www.mlflow.org/docs/latest/model/models-from-code.html>`_
         for more information.
 
+    .. note::
+
+        When logging a model, MLflow will automatically saves the state of the ``Settings``
+        object so that you can use the same settings at inference time. However, please
+        note that some information in the ``Settings`` object will not be saved, including:
+
+            - API keys for avoiding key leakage.
+            - Function objects which are not serializable.
+
     Args:
         llama_index_model: A LlamaIndex object to be saved. Supported model types are:
 
@@ -325,6 +334,15 @@ def log_model(
         Saving a non-index object is only supported in the 'Model-from-Code' saving mode.
         Please refer to the `Models From Code Guide <https://www.mlflow.org/docs/latest/model/models-from-code.html>`_
         for more information.
+
+    .. note::
+
+        When logging a model, MLflow will automatically saves the state of the ``Settings``
+        object so that you can use the same settings at inference time. However, please
+        note that some information in the ``Settings`` object will not be saved, including:
+
+            - API keys for avoiding key leakage.
+            - Function objects which are not serializable.
 
     Args:
         llama_index_model: A LlamaIndex object to be saved. Supported model types are:

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -141,7 +141,7 @@ def save_model(
 
     .. note::
 
-        When logging a model, MLflow will automatically saves the state of the ``Settings``
+        When logging a model, MLflow will automatically save the state of the ``Settings``
         object so that you can use the same settings at inference time. However, please
         note that some information in the ``Settings`` object will not be saved, including:
 
@@ -337,7 +337,7 @@ def log_model(
 
     .. note::
 
-        When logging a model, MLflow will automatically saves the state of the ``Settings``
+        When logging a model, MLflow will automatically save the state of the ``Settings``
         object so that you can use the same settings at inference time. However, please
         note that some information in the ``Settings`` object will not be saved, including:
 

--- a/mlflow/llama_index/serialize_objects.py
+++ b/mlflow/llama_index/serialize_objects.py
@@ -43,11 +43,6 @@ def object_to_dict(o: object):
             field_val = getattr(o, k, None)
             if field_val != v.default and callable(field_val):
                 callable_fields.add(k)
-        if callable_fields:
-            _logger.warning(
-                f"Object {o} contains callable fields that are not serializable: {callable_fields},"
-                f" removing these fields and saving the object."
-            )
         # exclude default values from serialization to avoid
         # unnecessary clutter in the serialized object
         o_state_as_dict = o.to_dict(exclude=callable_fields)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13503?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13503/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13503
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.llama_index.log_model()` generates a wall of warning texts.

![Screenshot 2024-10-20 at 23 25 49](https://github.com/user-attachments/assets/130458b8-9f9b-4b5b-8742-cd584ac36ee3)

We should remove "xxx are not serializable" warning because
1. The non-serializable objects often come from very low-level LlamaIndex object that users don't touch at all. (e.g. [id_func](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/node_parser/interface.py#L63) in the example).
2. The warning is not actionable. There is nothing users can do to prevent this behavior.
3. The warning was introduced when we fixed [x-version test issue](https://github.com/mlflow/mlflow/pull/13029) and not from an actual demand from users.
4. It exposes API key.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
