### PR TITLE
Run cross version tests in Python 3.9 (except transformers)

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -293,6 +293,11 @@ def infer_python_version(package: str, version: str) -> str:
     Infer the minimum Python version required by the package.
     """
     candidates = ("3.9", "3.10")
+
+    # TODO: Figure out how to fix transformers tests for Python 3.9 and remove this.
+    if package == "transformers":
+        candidates = ("3.8", *candidates)
+
     if rp := _requires_python(package, version):
         spec = SpecifierSet(rp)
         return next(filter(spec.contains, candidates), candidates[0])

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -292,7 +292,7 @@ def infer_python_version(package: str, version: str) -> str:
     """
     Infer the minimum Python version required by the package.
     """
-    candidates = ("3.8", "3.9", "3.10")
+    candidates = ("3.9", "3.10")
     if rp := _requires_python(package, version):
         spec = SpecifierSet(rp)
         return next(filter(spec.contains, candidates), candidates[0])

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -332,7 +332,6 @@ statsmodels:
     python:
       "== dev": "3.9"
     requirements:
-      "== 0.0.0": ["numpy<2"]
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
       pytest tests/statsmodels/test_statsmodels_model_export.py
@@ -343,7 +342,6 @@ statsmodels:
     python:
       "== dev": "3.9"
     requirements:
-      "== 0.0.0": ["numpy<2"]
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
       pytest tests/statsmodels/test_statsmodels_autolog.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -150,7 +150,7 @@ xgboost:
     minimum: "1.4.2"
     maximum: "2.1.1"
     requirements:
-      ">= 0.0.0": ["scikit-learn"]
+      ">= 0.0.0": ["scikit-learn", "numpy<2.0"]
       "< 1.6": ["pandas<2"]
     python:
       "== dev": "3.10"
@@ -161,7 +161,7 @@ xgboost:
     minimum: "1.4.2"
     maximum: "2.1.1"
     requirements:
-      ">= 0.0.0": ["scikit-learn", "matplotlib"]
+      ">= 0.0.0": ["scikit-learn", "matplotlib", "numpy<2.0"]
       "< 1.6": ["pandas<2"]
     python:
       "== dev": "3.10"
@@ -180,7 +180,7 @@ lightgbm:
     minimum: "3.1.1"
     maximum: "4.5.0"
     requirements:
-      ">= 0.0.0": ["scikit-learn"]
+      ">= 0.0.0": ["scikit-learn", "numpy<2.0"]
     run: |
       pytest tests/lightgbm/test_lightgbm_model_export.py
 
@@ -188,7 +188,7 @@ lightgbm:
     minimum: "3.1.1"
     maximum: "4.5.0"
     requirements:
-      ">= 0.0.0": ["scikit-learn", "matplotlib"]
+      ">= 0.0.0": ["scikit-learn", "matplotlib", "numpy<2.0"]
     run: |
       pytest tests/lightgbm/test_lightgbm_autolog.py
 
@@ -204,7 +204,7 @@ catboost:
     minimum: "1.0.0"
     maximum: "1.2.7"
     requirements:
-      ">= 0.0.0": ["scikit-learn"]
+      ">= 0.0.0": ["scikit-learn", "numpy<2.0"]
       "< 1.1": ["pandas<2"]
     run: |
       pytest tests/catboost/test_catboost_model_export.py
@@ -311,6 +311,7 @@ spacy:
       ">= 0.0.0": ["scikit-learn", "click<8.1.0"]
       "<= 3.0.9": ["flask<2.1.0", "werkzeug<3"]
       ">= 3.0.9, < 3.4.0": ["typing_extensions<4.6.0", "sqlalchemy<2.0.25"]
+      "< 3.8": ["numpy<2.0"]
     run: |
       pytest tests/spacy/test_spacy_model_export.py
 
@@ -366,7 +367,7 @@ spark:
     # prior to their release on PyPI (e.g. Databricks)
     allow_unreleased_max_version: True
     requirements:
-      ">= 0.0.0": ["boto3", "scikit-learn", "pyarrow"]
+      ">= 0.0.0": ["boto3", "scikit-learn", "pyarrow", "numpy<2.0"]
       "< 3.4.0": ["pandas<2"]
       ">= 3.5.0": ["torch", "scikit-learn", "torcheval"]
       ">= 3.5.0, < dev": ["pyspark[connect]"]
@@ -400,7 +401,7 @@ spark:
     # prior to their release on PyPI (e.g. Databricks)
     allow_unreleased_max_version: True
     requirements:
-      ">= 0.0.0": ["scikit-learn"]
+      ">= 0.0.0": ["scikit-learn", "numpy<2.0"]
       "< 3.4.0": ["pandas<2"]
     run: |
       # Build Java package
@@ -518,7 +519,7 @@ shap:
   package_info:
     pip_release: "shap"
   models:
-    minimum: "0.41.0"
+    minimum: "0.42.1"
     maximum: "0.46.0"
     requirements:
       "< 0.46.0": ["numpy<1.24.0"]
@@ -574,6 +575,7 @@ transformers:
           "protobuf<=3.20.3", # fix error `Couldn't build proto file into descriptor pool: duplicate file name sentencepiece_model.proto`
           "typing_extensions>=4.6.0", # fix error for SqlAlchemy == 2.0.25 cannot import name 'TypeAliasType' from 'typing_extensions'
           "accelerate<1",
+          "tf-keras",
         ]
       # tensorflow 2.13.0 made all Keras private functions inaccessible. transformers versions
       # prior to 4.30.0 are incompatible with this breaking change in Keras.
@@ -618,6 +620,7 @@ transformers:
           "setfit",
           "optuna",
           "accelerate<1",
+          "tf-keras",
         ]
       # sentence-transformers >= 2.4.0 relies on `transformers.utils.import_utils.is_nltk_available`
       # to check nltk availability. This function is only available in transformers>=4.34.0.

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -332,7 +332,7 @@ statsmodels:
     python:
       "== dev": "3.9"
     requirements:
-      "0.0.0": ["numpy<2"]
+      "== 0.0.0": ["numpy<2"]
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
       pytest tests/statsmodels/test_statsmodels_model_export.py
@@ -343,7 +343,7 @@ statsmodels:
     python:
       "== dev": "3.9"
     requirements:
-      "0.0.0": ["numpy<2"]
+      "== 0.0.0": ["numpy<2"]
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
       pytest tests/statsmodels/test_statsmodels_autolog.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -44,6 +44,7 @@ pytorch:
     requirements:
       ">= 0.0.0": ["torchvision", "scikit-learn"]
       ">= 1.8": ["transformers"]
+      "< 2.3": ["numpy<2"]
     python:
       ">= 2.5.0": "3.9"
     run: |
@@ -156,7 +157,7 @@ xgboost:
     maximum: "2.1.1"
     requirements:
       ">= 0.0.0": ["scikit-learn"]
-      "< 1.6": ["pandas<2"]
+      "< 1.6": ["pandas<2", "numpy<2"]
     python:
       "== dev": "3.10"
     run: |
@@ -167,7 +168,7 @@ xgboost:
     maximum: "2.1.1"
     requirements:
       ">= 0.0.0": ["scikit-learn", "matplotlib"]
-      "< 1.6": ["pandas<2"]
+      "< 1.6": ["pandas<2", "numpy<2"]
     python:
       "== dev": "3.10"
     run: |
@@ -186,6 +187,7 @@ lightgbm:
     maximum: "4.5.0"
     requirements:
       ">= 0.0.0": ["scikit-learn"]
+      "== 4.0.*": ["numpy<2"]
     run: |
       pytest tests/lightgbm/test_lightgbm_model_export.py
 
@@ -194,6 +196,7 @@ lightgbm:
     maximum: "4.5.0"
     requirements:
       ">= 0.0.0": ["scikit-learn", "matplotlib"]
+      "== 4.0.*": ["numpy<2"]
     run: |
       pytest tests/lightgbm/test_lightgbm_autolog.py
 
@@ -211,6 +214,7 @@ catboost:
     requirements:
       ">= 0.0.0": ["scikit-learn"]
       "< 1.1": ["pandas<2"]
+      "< 1.2": ["numpy<2"]
     run: |
       pytest tests/catboost/test_catboost_model_export.py
 
@@ -333,6 +337,7 @@ statsmodels:
       "== dev": "3.9"
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
+      "== 0.13.*": ["numpy<2"]
     run: |
       pytest tests/statsmodels/test_statsmodels_model_export.py
 
@@ -343,6 +348,7 @@ statsmodels:
       "== dev": "3.9"
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
+      "== 0.13.*": ["numpy<2"]
     run: |
       pytest tests/statsmodels/test_statsmodels_autolog.py
 
@@ -583,7 +589,6 @@ transformers:
           "protobuf<=3.20.3", # fix error `Couldn't build proto file into descriptor pool: duplicate file name sentencepiece_model.proto`
           "typing_extensions>=4.6.0", # fix error for SqlAlchemy == 2.0.25 cannot import name 'TypeAliasType' from 'typing_extensions'
           "accelerate<1",
-          "tf-keras",
         ]
       # tensorflow 2.13.0 made all Keras private functions inaccessible. transformers versions
       # prior to 4.30.0 are incompatible with this breaking change in Keras.
@@ -628,7 +633,6 @@ transformers:
           "setfit",
           "optuna",
           "accelerate<1",
-          "tf-keras",
         ]
       # sentence-transformers >= 2.4.0 relies on `transformers.utils.import_utils.is_nltk_available`
       # to check nltk availability. This function is only available in transformers>=4.34.0.

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -136,7 +136,6 @@ tensorflow:
     python:
       "== dev": "3.9"
     requirements:
-      ">= 0.0.0": ["numpy<2"]
       "== dev": ["scikit-learn"]
       "< 2.12.0": ["numpy<2"]
       # TensorFlow 2.12.1 and 2.13.1 requires typing_extensions < 4.6.0, which is

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -8,6 +8,7 @@ sklearn:
     minimum: "0.24.1"
     maximum: "1.5.2"
     requirements:
+      "< 1.3.0": ["numpy<2"]
       "< 1.0": ["scipy==1.7.3"]
     python:
       "== dev": "3.9"
@@ -21,6 +22,7 @@ sklearn:
       "== dev": "3.9"
     requirements:
       ">= 0.0.0": ["matplotlib"]
+      "< 1.3.0": ["numpy<2"]
       "< 1.0": ["scipy==1.7.3"]
     run: |
       pytest tests/sklearn/test_sklearn_autolog.py
@@ -114,6 +116,7 @@ tensorflow:
     requirements:
       # Requirements to run tests for keras
       ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1"]
+      "< 2.12.0": ["numpy<2"]
       # TensorFlow 2.12.1 and 2.13.1 requires typing_extensions < 4.6.0, which is
       # incompatible with SQLAlchemy 2.0.25 with error
       # `cannot import name 'TypeAliasType' from 'typing_extensions'`
@@ -132,7 +135,9 @@ tensorflow:
     python:
       "== dev": "3.9"
     requirements:
+      ">= 0.0.0": ["numpy<2"]
       "== dev": ["scikit-learn"]
+      "< 2.12.0": ["numpy<2"]
       # TensorFlow 2.12.1 and 2.13.1 requires typing_extensions < 4.6.0, which is
       # incompatible with SQLAlchemy 2.0.25 with error
       # `cannot import name 'TypeAliasType' from 'typing_extensions'`
@@ -150,7 +155,7 @@ xgboost:
     minimum: "1.4.2"
     maximum: "2.1.1"
     requirements:
-      ">= 0.0.0": ["scikit-learn", "numpy<2.0"]
+      ">= 0.0.0": ["scikit-learn"]
       "< 1.6": ["pandas<2"]
     python:
       "== dev": "3.10"
@@ -161,7 +166,7 @@ xgboost:
     minimum: "1.4.2"
     maximum: "2.1.1"
     requirements:
-      ">= 0.0.0": ["scikit-learn", "matplotlib", "numpy<2.0"]
+      ">= 0.0.0": ["scikit-learn", "matplotlib"]
       "< 1.6": ["pandas<2"]
     python:
       "== dev": "3.10"
@@ -180,7 +185,7 @@ lightgbm:
     minimum: "3.1.1"
     maximum: "4.5.0"
     requirements:
-      ">= 0.0.0": ["scikit-learn", "numpy<2.0"]
+      ">= 0.0.0": ["scikit-learn"]
     run: |
       pytest tests/lightgbm/test_lightgbm_model_export.py
 
@@ -188,7 +193,7 @@ lightgbm:
     minimum: "3.1.1"
     maximum: "4.5.0"
     requirements:
-      ">= 0.0.0": ["scikit-learn", "matplotlib", "numpy<2.0"]
+      ">= 0.0.0": ["scikit-learn", "matplotlib"]
     run: |
       pytest tests/lightgbm/test_lightgbm_autolog.py
 
@@ -204,7 +209,7 @@ catboost:
     minimum: "1.0.0"
     maximum: "1.2.7"
     requirements:
-      ">= 0.0.0": ["scikit-learn", "numpy<2.0"]
+      ">= 0.0.0": ["scikit-learn"]
       "< 1.1": ["pandas<2"]
     run: |
       pytest tests/catboost/test_catboost_model_export.py
@@ -311,7 +316,7 @@ spacy:
       ">= 0.0.0": ["scikit-learn", "click<8.1.0"]
       "<= 3.0.9": ["flask<2.1.0", "werkzeug<3"]
       ">= 3.0.9, < 3.4.0": ["typing_extensions<4.6.0", "sqlalchemy<2.0.25"]
-      "< 3.8": ["numpy<2.0"]
+      "< 3.8": ["numpy<2"]
     run: |
       pytest tests/spacy/test_spacy_model_export.py
 
@@ -327,6 +332,7 @@ statsmodels:
     python:
       "== dev": "3.9"
     requirements:
+      "0.0.0": ["numpy<2"]
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
       pytest tests/statsmodels/test_statsmodels_model_export.py
@@ -337,6 +343,7 @@ statsmodels:
     python:
       "== dev": "3.9"
     requirements:
+      "0.0.0": ["numpy<2"]
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
       pytest tests/statsmodels/test_statsmodels_autolog.py
@@ -367,7 +374,7 @@ spark:
     # prior to their release on PyPI (e.g. Databricks)
     allow_unreleased_max_version: True
     requirements:
-      ">= 0.0.0": ["boto3", "scikit-learn", "pyarrow", "numpy<2.0"]
+      ">= 0.0.0": ["boto3", "scikit-learn", "pyarrow", "numpy<2"]
       "< 3.4.0": ["pandas<2"]
       ">= 3.5.0": ["torch", "scikit-learn", "torcheval"]
       ">= 3.5.0, < dev": ["pyspark[connect]"]
@@ -401,7 +408,7 @@ spark:
     # prior to their release on PyPI (e.g. Databricks)
     allow_unreleased_max_version: True
     requirements:
-      ">= 0.0.0": ["scikit-learn", "numpy<2.0"]
+      ">= 0.0.0": ["scikit-learn", "numpy<2"]
       "< 3.4.0": ["pandas<2"]
     run: |
       # Build Java package
@@ -481,7 +488,7 @@ pmdarima:
     requirements:
       "< 1.9": ["scikit-learn<1.3"]
       # Avoid holidays 0.25 due to https://github.com/dr-prodigy/python-holidays/issues/1200
-      ">= 0.0.0": ["prophet", "holidays!=0.25"]
+      ">= 0.0.0": ["prophet", "holidays!=0.25", "numpy<2"]
     run: |
       pytest tests/pmdarima/test_pmdarima_model_export.py
 
@@ -497,7 +504,7 @@ diviner:
     requirements:
       # https://github.com/alan-turing-institute/sktime/issues/2898
       # Avoid holidays 0.25 due to https://github.com/dr-prodigy/python-holidays/issues/1200
-      ">= 0.0": ["cmdstanpy!=1.0.2", "holidays!=0.25"]
+      ">= 0.0": ["cmdstanpy!=1.0.2", "holidays!=0.25", "numpy<2"]
       "<= 0.1.0": ["pmdarima<2.0.0"]
       # Diviner <= 0.1.1 isn't compatible with pandas>=2
       "<= 0.1.1": ["pandas<2"]
@@ -533,12 +540,15 @@ paddle:
     minimum: "2.4.1"
     maximum: "2.6.2"
     requirements:
+      "< 2.6.0": ["numpy<2"]
       "< 2.5.0": ["google-cloud-storage==2.14.0"]
     run: |
       pytest tests/paddle/test_paddle_model_export.py
   autologging:
     minimum: "2.4.1"
     maximum: "2.6.2"
+    requirements:
+      "< 2.6.0": ["numpy<2"]
     run: |
       pytest tests/paddle/test_paddle_autolog.py
 
@@ -902,5 +912,6 @@ promptflow:
       # Requirements to run sparkudf predict test
       ">= 0.0.0": ["pyspark", "jinja2"]
       ">= 1.11.0": ["openai>=1"]
+      "< 1.18": ["numpy<2"]
     run: |
       pytest tests/promptflow/test_promptflow_model_export.py

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -220,7 +220,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "shap"
         },
         "models": {
-            "minimum": "0.41.0",
+            "minimum": "0.42.1",
             "maximum": "0.46.0"
         }
     },

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -60,8 +60,12 @@ def spark_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     additional_pip_deps = ["/opt/mlflow", "pyspark", "pytest"]
     if Version(pyspark.__version__) <= Version("3.3.2"):
-        # Versions of PySpark <= 3.3.2 are incompatible with pandas >= 2
-        additional_pip_deps.append("pandas<2")
+        additional_pip_deps.append(
+            # Versions of PySpark <= 3.3.2 are incompatible with pandas >= 2
+            "pandas<2",
+            # pandas<2.0 is incompatible with numpy>=2.0
+            "numpy<2.0",
+        )
     _mlflow_conda_env(conda_env, additional_pip_deps=additional_pip_deps)
     return conda_env
 

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -60,11 +60,13 @@ def spark_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     additional_pip_deps = ["/opt/mlflow", "pyspark", "pytest"]
     if Version(pyspark.__version__) <= Version("3.3.2"):
-        additional_pip_deps.append(
-            # Versions of PySpark <= 3.3.2 are incompatible with pandas >= 2
-            "pandas<2",
-            # pandas<2.0 is incompatible with numpy>=2.0
-            "numpy<2.0",
+        additional_pip_deps.extend(
+            [
+                # Versions of PySpark <= 3.3.2 are incompatible with pandas >= 2
+                "pandas<2",
+                # pandas<2.0 is incompatible with numpy>=2.0
+                "numpy<2.0",
+            ]
         )
     _mlflow_conda_env(conda_env, additional_pip_deps=additional_pip_deps)
     return conda_env


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13507?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13507/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13507
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Python 3.8 EOL-ed recently. Lots of ML/DL/LLM packages has already dropped its support. MLflow also should. This PR is a stepping stone to bump the minimum supported version of MLflow. Makes two changes.

1. Run cross versions tests on Python 3.9.
2. 1 unleashes numpy 2.0 and breaks many tests. To prevent that, add `numpy<2` (if required).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
