### PR TITLE
Update databricks deployments to support AI gateway & additional update endpoints

### DIFF
--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -336,12 +336,17 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         Args:
             name: The name of the serving endpoint to create.
-                .. Warning:: Deprecated. Include `name` in `config` instead.
+
+                .. warning::
+                    Deprecated. Include `name` in `config` instead.
+
             config: A dictionary containing either the full API request payload
-                    or the configuration of the serving endpoint to create (deprecated).
+                or the configuration of the serving endpoint to create.
             route_optimized: A boolean which defines whether databricks serving endpoint
                 is optimized for routing traffic. Only used in the deprecated approach.
-                .. Warning:: Deprecated. Include `route_optimized` in `config` instead.
+
+                .. warning::
+                    Deprecated. Include `route_optimized` in `config` instead.
 
         Returns:
             A :py:class:`DatabricksEndpoint` object containing the request response.
@@ -462,9 +467,12 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         return self._call_endpoint(method="POST", json_body=payload)
 
-    @deprecated("The `update_endpoint` method is deprecated. Use the specific update methods—"
-                "`update_endpoint_config`, `update_endpoint_tags`, `update_endpoint_rate_limits`, "
-                "`update_endpoint_ai_gateway`—instead.")
+    @deprecated(
+        alternative=(
+            "update_endpoint_config, update_endpoint_tags, update_endpoint_rate_limits, "
+            "or update_endpoint_ai_gateway"
+        )
+    )
     def update_endpoint(self, endpoint, config=None):
         """
         Update a specified serving endpoint with the provided configuration.

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -385,16 +385,18 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                 "task": "llm/v1/chat",
                 "endpoint_type": "EXTERNAL_MODEL",
                 "creator_display_name": "Alice",
-                "creator_kind": "User"
+                "creator_kind": "User",
             }
 
         """
         if config and "config" in config:
             # config contains the full API request payload
             if route_optimized or name:
-                raise ValueError("'route_optimized' and 'name' parameters cannot be used when "
-                                 "'config' contains the full API request payload. Include "
-                                 "'route_optimized' and/or 'name' in the payload instead.")
+                raise ValueError(
+                    "'route_optimized' and 'name' parameters cannot be used when "
+                    "'config' contains the full API request payload. Include "
+                    "'route_optimized' and/or 'name' in the payload instead."
+                )
             payload = config
         else:
             # for backwards compatibility
@@ -575,18 +577,9 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
             client = get_deploy_client("databricks")
             updated_tags = client.update_endpoint_tags(
-                endpoint="test",
-                config={
-                    "add_tags": [
-                        {"key": "project", "value": "test"}
-                    ]
-                }
+                endpoint="test", config={"add_tags": [{"key": "project", "value": "test"}]}
             )
-            assert updated_tags == {
-                "tags": [
-                    {"key": "project", "value": "test"}
-                ]
-            }
+            assert updated_tags == {"tags": [{"key": "project", "value": "test"}]}
         """
         return self._call_endpoint(
             method="PATCH", route=posixpath.join(endpoint, "tags"), json_body=config
@@ -615,24 +608,13 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             client = get_deploy_client("databricks")
             name = "databricks-dbrx-instruct"
             rate_limits = {
-                "rate_limits": [
-                    {
-                        "calls": 10,
-                        "key": "endpoint",
-                        "renewal_period": "minute"
-                    }
-                ]
+                "rate_limits": [{"calls": 10, "key": "endpoint", "renewal_period": "minute"}]
             }
-            updated_rate_limits = client.update_endpoint_rate_limits(endpoint=name,
-                                                                    config=rate_limits)
+            updated_rate_limits = client.update_endpoint_rate_limits(
+                endpoint=name, config=rate_limits
+            )
             assert updated_rate_limits == {
-                "rate_limits": [
-                    {
-                        "calls": 10,
-                        "key": "endpoint",
-                        "renewal_period": "minute"
-                    }
-                ]
+                "rate_limits": [{"calls": 10, "key": "endpoint", "renewal_period": "minute"}]
             }
         """
         return self._call_endpoint(
@@ -669,22 +651,22 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                 },
             }
 
-            updated_gateway = client.update_endpoint_ai_gateway(endpoint=name,
-                                                                config=gateway_config)
+            updated_gateway = client.update_endpoint_ai_gateway(
+                endpoint=name, config=gateway_config
+            )
             assert updated_gateway == {
-                'usage_tracking_config': {'enabled': True},
-                'inference_table_config': {
-                    'catalog_name': 'my_catalog',
-                    'schema_name': 'my_schema',
-                    'table_name_prefix': 'test',
-                    'enabled': True
-                }
+                "usage_tracking_config": {"enabled": True},
+                "inference_table_config": {
+                    "catalog_name": "my_catalog",
+                    "schema_name": "my_schema",
+                    "table_name_prefix": "test",
+                    "enabled": True,
+                },
             }
         """
         return self._call_endpoint(
             method="PUT", route=posixpath.join(endpoint, "ai-gateway"), json_body=config
         )
-
 
     @experimental
     def delete_endpoint(self, endpoint):
@@ -786,4 +768,3 @@ def run_local(name, model_uri, flavor=None, config=None):
 
 def target_help():
     pass
-

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -536,6 +536,13 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                 ],
             }
         """
+        warnings.warn(
+            "The `update_endpoint` method is deprecated. Use the specific update methods—"
+            "`update_endpoint_config`, `update_endpoint_tags`, `update_endpoint_rate_limits`, "
+            "`update_endpoint_ai_gateway`—instead.",
+            UserWarning,
+        )
+
         if list(config) == ["rate_limits"]:
             return self._call_endpoint(
                 method="PUT", route=posixpath.join(endpoint, "rate-limits"), json_body=config

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -401,8 +401,9 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         else:
             # for backwards compatibility
             warnings.warn(
-                "The current usage of create_endpoint is deprecated. "
-                "Please pass the full API request payload in the 'config' parameter.",
+                "Passing 'name', 'config', and 'route_optimized' as separate parameters to "
+                "create_endpoint() is deprecated. Please pass the full API request payload "
+                "as a single dictionary in the 'config' parameter instead.",
                 UserWarning,
             )
             config = config.copy() if config else {}  # avoid mutating config

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -327,7 +327,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             yield json.loads(value)
 
     @experimental
-    def create_endpoint(self, name, config=None, route_optimized=False):
+    def create_endpoint(self, name=None, config=None, route_optimized=False):
         """
         Create a new serving endpoint with the provided name and configuration.
 
@@ -352,26 +352,27 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
             client = get_deploy_client("databricks")
             endpoint = client.create_endpoint(
-                name="chat",
                 config={
-                    "served_entities": [
-                        {
-                            "name": "test",
-                            "external_model": {
-                                "name": "gpt-4",
-                                "provider": "openai",
-                                "task": "llm/v1/chat",
-                                "openai_config": {
-                                    "openai_api_key": "{{secrets/scope/key}}",
+                    "name": "test",
+                    "config": {
+                        "served_entities": [
+                            {
+                                "external_model": {
+                                    "name": "gpt-4",
+                                    "provider": "openai",
+                                    "task": "llm/v1/chat",
+                                    "openai_config": {
+                                        "openai_api_key": "{{secrets/scope/key}}",
+                                    },
                                 },
-                            },
-                        }
-                    ],
+                            }
+                        ],
+                        "route_optimized": True,
+                    },
                 },
-                route_optimized=True,
             )
             assert endpoint == {
-                "name": "chat",
+                "name": "test",
                 "creator": "alice@company.com",
                 "creation_timestamp": 0,
                 "last_updated_timestamp": 0,
@@ -379,6 +380,12 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                 "config": {...},
                 "tags": [...],
                 "id": "88fd3f75a0d24b0380ddc40484d7a31b",
+                "permission_level": "CAN_MANAGE",
+                "route_optimized": False,
+                "task": "llm/v1/chat",
+                "endpoint_type": "EXTERNAL_MODEL",
+                "creator_display_name": "Alice",
+                "creator_kind": "User"
             }
 
         """

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -392,8 +392,8 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         if config and "config" in config:
             # config contains the full API request payload
             if route_optimized or name:
-                raise ValueError("'route_optimized' and 'name' parameters cannot be used when 'config' "
-                                 "contains the full API request payload. Include "
+                raise ValueError("'route_optimized' and 'name' parameters cannot be used when "
+                                 "'config' contains the full API request payload. Include "
                                  "'route_optimized' and/or 'name' in the payload instead.")
             payload = config
         else:
@@ -492,6 +492,199 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             return self._call_endpoint(
                 method="PUT", route=posixpath.join(endpoint, "config"), json_body=config
             )
+
+    @experimental
+    def update_endpoint_config(self, endpoint, config):
+        """
+        Update the configuration of a specified serving endpoint. See
+        https://docs.databricks.com/api/workspace/servingendpoints/updateconfig for request/response
+        request/response schema.
+
+        Args:
+            endpoint: The name of the serving endpoint to update.
+            config: A dictionary containing the configuration of the serving endpoint to update.
+
+        Returns:
+            A :py:class:`DatabricksEndpoint` object containing the request response.
+
+        Example:
+
+        .. code-block:: python
+
+            from mlflow.deployments import get_deploy_client
+
+            client = get_deploy_client("databricks")
+            updated_endpoint = client.update_endpoint_config(
+                endpoint="test",
+                config={
+                    "served_entities": [
+                        {
+                            "name": "gpt-4o-mini",
+                            "external_model": {
+                                "name": "gpt-4o-mini",
+                                "provider": "openai",
+                                "task": "llm/v1/chat",
+                                "openai_config": {
+                                    "openai_api_key": "{{secrets/scope/key}}",
+                                },
+                            },
+                        }
+                    ]
+                },
+            )
+            assert updated_endpoint == {
+                "name": "test",
+                "creator": "alice@company.com",
+                "creation_timestamp": 1729527763000,
+                "last_updated_timestamp": 1729530896000,
+                "state": {"ready": "READY", "config_update": "NOT_UPDATING"},
+                "config": {...},
+                "id": "44b258fb39804564b37603d8d14b853e",
+                "permission_level": "CAN_MANAGE",
+                "route_optimized": False,
+                "task": "llm/v1/chat",
+                "endpoint_type": "EXTERNAL_MODEL",
+                "creator_display_name": "Alice",
+                "creator_kind": "User",
+            }
+        """
+
+        return self._call_endpoint(
+            method="PUT", route=posixpath.join(endpoint, "config"), json_body=config
+        )
+
+    @experimental
+    def update_endpoint_tags(self, endpoint, config):
+        """
+        Update the tags of a specified serving endpoint. See
+        https://docs.databricks.com/api/workspace/servingendpoints/patch for request/response
+        schema.
+
+        Args:
+            endpoint: The name of the serving endpoint to update.
+            config: A dictionary containing tags to add and/or remove.
+
+        Returns:
+            A :py:class:`DatabricksEndpoint` object containing the request response.
+
+        Example:
+
+        .. code-block:: python
+
+            from mlflow.deployments import get_deploy_client
+
+            client = get_deploy_client("databricks")
+            updated_tags = client.update_endpoint_tags(
+                endpoint="test",
+                config={
+                    "add_tags": [
+                        {"key": "project", "value": "test"}
+                    ]
+                }
+            )
+            assert updated_tags == {
+                "tags": [
+                    {"key": "project", "value": "test"}
+                ]
+            }
+        """
+        return self._call_endpoint(
+            method="PATCH", route=posixpath.join(endpoint, "tags"), json_body=config
+        )
+
+    @experimental
+    def update_endpoint_rate_limits(self, endpoint, config):
+        """
+        Update the rate limits of a specified serving endpoint.
+        See https://docs.databricks.com/api/workspace/servingendpoints/put for request/response
+        schema.
+
+        Args:
+            endpoint: The name of the serving endpoint to update.
+            config: A dictionary containing the updated rate limit configuration.
+
+        Returns:
+            A :py:class:`DatabricksEndpoint` object containing the updated rate limits.
+
+        Example:
+
+        .. code-block:: python
+
+            from mlflow.deployments import get_deploy_client
+
+            client = get_deploy_client("databricks")
+            name = "databricks-dbrx-instruct"
+            rate_limits = {
+                "rate_limits": [
+                    {
+                        "calls": 10,
+                        "key": "endpoint",
+                        "renewal_period": "minute"
+                    }
+                ]
+            }
+            updated_rate_limits = client.update_endpoint_rate_limits(endpoint=name,
+                                                                    config=rate_limits)
+            assert updated_rate_limits == {
+                "rate_limits": [
+                    {
+                        "calls": 10,
+                        "key": "endpoint",
+                        "renewal_period": "minute"
+                    }
+                ]
+            }
+        """
+        return self._call_endpoint(
+            method="PUT", route=posixpath.join(endpoint, "rate-limits"), json_body=config
+        )
+
+    @experimental
+    def update_endpoint_ai_gateway(self, endpoint, config):
+        """
+        Update the AI Gateway configuration of a specified serving endpoint.
+
+        Args:
+            endpoint (str): The name of the serving endpoint to update.
+            config (dict): A dictionary containing the AI Gateway configuration to update.
+
+        Returns:
+            dict: A dictionary containing the updated AI Gateway configuration.
+
+        Example:
+
+        .. code-block:: python
+
+            from mlflow.deployments import get_deploy_client
+
+            client = get_deploy_client("databricks")
+            name = "test"
+
+            gateway_config = {
+                "usage_tracking_config": {"enabled": True},
+                "inference_table_config": {
+                    "enabled": True,
+                    "catalog_name": "my_catalog",
+                    "schema_name": "my_schema",
+                },
+            }
+
+            updated_gateway = client.update_endpoint_ai_gateway(endpoint=name,
+                                                                config=gateway_config)
+            assert updated_gateway == {
+                'usage_tracking_config': {'enabled': True},
+                'inference_table_config': {
+                    'catalog_name': 'my_catalog',
+                    'schema_name': 'my_schema',
+                    'table_name_prefix': 'test',
+                    'enabled': True
+                }
+            }
+        """
+        return self._call_endpoint(
+            method="PUT", route=posixpath.join(endpoint, "ai-gateway"), json_body=config
+        )
+
 
     @experimental
     def delete_endpoint(self, endpoint):

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -391,10 +391,10 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         """
         if config and "config" in config:
             # config contains the full API request payload
-            if route_optimized:
-                raise ValueError("'route_optimized' parameter cannot be used when 'config' "
+            if route_optimized or name:
+                raise ValueError("'route_optimized' and 'name' parameters cannot be used when 'config' "
                                  "contains the full API request payload. Include "
-                                 "'route_optimized' in the payload instead.")
+                                 "'route_optimized' and/or 'name' in the payload instead.")
             payload = config
         else:
             # for backwards compatibility
@@ -593,3 +593,4 @@ def run_local(name, model_uri, flavor=None, config=None):
 
 def target_help():
     pass
+

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -13,7 +13,7 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import MlflowException
 from mlflow.utils import AttrDict
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import experimental, deprecated
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
 
@@ -336,10 +336,12 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         Args:
             name: The name of the serving endpoint to create.
+                .. Warning:: Deprecated. Include `name` in `config` instead.
             config: A dictionary containing either the full API request payload
                     or the configuration of the serving endpoint to create (deprecated).
             route_optimized: A boolean which defines whether databricks serving endpoint
                 is optimized for routing traffic. Only used in the deprecated approach.
+                .. Warning:: Deprecated. Include `route_optimized` in `config` instead.
 
         Returns:
             A :py:class:`DatabricksEndpoint` object containing the request response.
@@ -415,7 +417,9 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         return self._call_endpoint(method="POST", json_body=payload)
 
-    @experimental
+    @deprecated("The `update_endpoint` method is deprecated. Use the specific update methods—"
+                "`update_endpoint_config`, `update_endpoint_tags`, `update_endpoint_rate_limits`, "
+                "`update_endpoint_ai_gateway`—instead.")
     def update_endpoint(self, endpoint, config=None):
         """
         Update a specified serving endpoint with the provided configuration.

--- a/tests/deployments/databricks/test_databricks.py
+++ b/tests/deployments/databricks/test_databricks.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from mlflow.deployments import get_deploy_client
+from mlflow.exceptions import MlflowException
 
 
 @pytest.fixture(autouse=True)
@@ -77,6 +78,233 @@ def test_create_endpoint_config_only():
         mock_request.assert_called_once()
         assert resp == {"name": "test"}
 
+def test_create_endpoint_name_match():
+    """Test when name is provided both in config and as named arg with matching values.
+    Should emit a deprecation warning about using name parameter.
+    """
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {"name": "test"}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        with pytest.warns(UserWarning, match="Passing 'name' as a parameter is deprecated. "
+                                        "Please specify 'name' only within the config dictionary."):
+            resp = client.create_endpoint(
+                name="test",
+                config={
+                    "name": "test",
+                    "config": {
+                        "served_entities": [
+                            {
+                                "name": "test",
+                                "external_model": {
+                                    "name": "gpt-4",
+                                    "provider": "openai",
+                                    "openai_config": {
+                                        "openai_api_key": "secret",
+                                    },
+                                },
+                            }
+                        ],
+                        "task": "llm/v1/chat",
+                    },
+                },
+            )
+        mock_request.assert_called_once()
+        assert resp == {"name": "test"}
+
+def test_create_endpoint_name_mismatch():
+    """Test when name is provided both in config and as named arg with different values.
+    Should raise an MlflowException.
+    """
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {"name": "test"}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        with pytest.raises(MlflowException,
+                           match="Name mismatch. Found 'test1' as parameter and 'test2' "
+                                 "in config. Please specify 'name' only within the config "
+                                 "dictionary as this parameter is deprecated."):
+            client.create_endpoint(
+                name="test1",
+                config={
+                    "name": "test2",
+                    "config": {
+                        "served_entities": [
+                            {
+                                "name": "test",
+                                "external_model": {
+                                    "name": "gpt-4",
+                                    "provider": "openai",
+                                    "openai_config": {
+                                        "openai_api_key": "secret",
+                                    },
+                                },
+                            }
+                        ],
+                        "task": "llm/v1/chat",
+                    },
+                },
+            )
+        mock_request.assert_not_called()
+
+def test_create_endpoint_route_optimized_match():
+    """Test when route_optimized is provided both in config and as named arg with matching values.
+    Should emit a deprecation warning.
+    """
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {"name": "test"}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        with pytest.warns(UserWarning,
+                          match="Passing 'route_optimized' as a parameter is deprecated. "
+                            "Please specify 'route_optimized' only within the config dictionary."):
+            resp = client.create_endpoint(
+                name="test",
+                route_optimized=True,
+                config={
+                    "name": "test",
+                    "route_optimized": True,
+                    "config": {
+                        "served_entities": [
+                            {
+                                "name": "test",
+                                "external_model": {
+                                    "name": "gpt-4",
+                                    "provider": "openai",
+                                    "openai_config": {
+                                        "openai_api_key": "secret",
+                                    },
+                                },
+                            }
+                        ],
+                        "task": "llm/v1/chat",
+                    },
+                },
+            )
+        mock_request.assert_called_once()
+        assert resp == {"name": "test"}
+
+def test_create_endpoint_route_optimized_mismatch():
+    """Test when route_optimized is provided both in config and as named arg with different values.
+    Should raise an MlflowException.
+    """
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {"name": "test"}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        with pytest.raises(MlflowException,
+                         match="Conflicting 'route_optimized' values found. "
+                               "Please specify 'route_optimized' only within the config dictionary "
+                               "as this parameter is deprecated."):
+            client.create_endpoint(
+                name="test",
+                route_optimized=True,
+                config={
+                    "name": "test",
+                    "route_optimized": False,
+                    "config": {
+                        "served_entities": [
+                            {
+                                "name": "test",
+                                "external_model": {
+                                    "name": "gpt-4",
+                                    "provider": "openai",
+                                    "openai_config": {
+                                        "openai_api_key": "secret",
+                                    },
+                                },
+                            }
+                        ],
+                        "task": "llm/v1/chat",
+                    },
+                },
+            )
+        mock_request.assert_not_called()
+
+def test_create_endpoint_named_name():
+    """Test using the legacy format with separate parameters instead of full API payload.
+    Should emit a deprecation warning about the old format.
+    """
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {"name": "test"}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        with pytest.warns(UserWarning,
+                match="Passing 'name', 'config', and 'route_optimized' as separate parameters is "
+                    "deprecated. Please pass the full API request payload as a single dictionary "
+                    "in the 'config' parameter."):
+            resp = client.create_endpoint(
+                name="test",
+                config={
+                    "served_entities": [
+                        {
+                            "name": "test",
+                            "external_model": {
+                                "name": "gpt-4",
+                                "provider": "openai",
+                                "openai_config": {
+                                    "openai_api_key": "secret",
+                                },
+                            },
+                        }
+                    ],
+                    "task": "llm/v1/chat",
+                }
+            )
+        mock_request.assert_called_once()
+        assert resp == {"name": "test"}
+
+def test_create_endpoint_named_route_optimized():
+    """Test using the legacy format with route_optimized parameter.
+    Should emit a deprecation warning about the old format.
+    """
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {"name": "test"}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        with pytest.warns(UserWarning,
+                match="Passing 'name', 'config', and 'route_optimized' as separate parameters is "
+                "deprecated. Please pass the full API request payload as a single dictionary "
+                "in the 'config' parameter."):
+            resp = client.create_endpoint(
+                name="test",
+                route_optimized=True,
+                config={
+                    "served_entities": [
+                        {
+                            "name": "test",
+                            "external_model": {
+                                "name": "gpt-4",
+                                "provider": "openai",
+                                "openai_config": {
+                                    "openai_api_key": "secret",
+                                },
+                            },
+                        }
+                    ],
+                    "task": "llm/v1/chat",
+                }
+            )
+        mock_request.assert_called_once()
+        assert resp == {"name": "test"}
+
 
 def test_get_endpoint():
     client = get_deploy_client("databricks")
@@ -109,24 +337,28 @@ def test_update_endpoint():
     mock_resp.url = os.environ["DATABRICKS_HOST"]
     mock_resp.status_code = 200
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
-        resp = client.update_endpoint(
-            endpoint="test",
-            config={
-                "served_entities": [
-                    {
-                        "name": "test",
-                        "external_model": {
-                            "name": "gpt-4",
-                            "provider": "openai",
-                            "openai_config": {
-                                "openai_api_key": "secret",
+        with pytest.warns(UserWarning,
+            match="The `update_endpoint` method is deprecated. Use the specific update methods—"
+                "`update_endpoint_config`, `update_endpoint_tags`, `update_endpoint_rate_limits`, "
+                "`update_endpoint_ai_gateway`—instead."):
+            resp = client.update_endpoint(
+                endpoint="test",
+                config={
+                    "served_entities": [
+                        {
+                            "name": "test",
+                            "external_model": {
+                                "name": "gpt-4",
+                                "provider": "openai",
+                                "openai_config": {
+                                    "openai_api_key": "secret",
+                                },
                             },
-                        },
-                    }
-                ],
-                "task": "llm/v1/chat",
-            },
-        )
+                        }
+                    ],
+                    "task": "llm/v1/chat",
+                },
+            )
         mock_request.assert_called_once()
         assert resp == {}
 

--- a/tests/deployments/databricks/test_databricks.py
+++ b/tests/deployments/databricks/test_databricks.py
@@ -78,6 +78,7 @@ def test_create_endpoint_config_only():
         mock_request.assert_called_once()
         assert resp == {"name": "test"}
 
+
 def test_create_endpoint_name_match():
     """Test when name is provided both in config and as named arg with matching values.
     Should emit a deprecation warning about using name parameter.
@@ -88,8 +89,11 @@ def test_create_endpoint_name_match():
     mock_resp.url = os.environ["DATABRICKS_HOST"]
     mock_resp.status_code = 200
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
-        with pytest.warns(UserWarning, match="Passing 'name' as a parameter is deprecated. "
-                                        "Please specify 'name' only within the config dictionary."):
+        with pytest.warns(
+            UserWarning,
+            match="Passing 'name' as a parameter is deprecated. "
+            "Please specify 'name' only within the config dictionary.",
+        ):
             resp = client.create_endpoint(
                 name="test",
                 config={
@@ -114,6 +118,7 @@ def test_create_endpoint_name_match():
         mock_request.assert_called_once()
         assert resp == {"name": "test"}
 
+
 def test_create_endpoint_name_mismatch():
     """Test when name is provided both in config and as named arg with different values.
     Should raise an MlflowException.
@@ -125,10 +130,12 @@ def test_create_endpoint_name_mismatch():
     mock_resp.status_code = 200
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
-        with pytest.raises(MlflowException,
-                           match="Name mismatch. Found 'test1' as parameter and 'test2' "
-                                 "in config. Please specify 'name' only within the config "
-                                 "dictionary as this parameter is deprecated."):
+        with pytest.raises(
+            MlflowException,
+            match="Name mismatch. Found 'test1' as parameter and 'test2' "
+            "in config. Please specify 'name' only within the config "
+            "dictionary as this parameter is deprecated.",
+        ):
             client.create_endpoint(
                 name="test1",
                 config={
@@ -152,6 +159,7 @@ def test_create_endpoint_name_mismatch():
             )
         mock_request.assert_not_called()
 
+
 def test_create_endpoint_route_optimized_match():
     """Test when route_optimized is provided both in config and as named arg with matching values.
     Should emit a deprecation warning.
@@ -163,9 +171,11 @@ def test_create_endpoint_route_optimized_match():
     mock_resp.status_code = 200
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
-        with pytest.warns(UserWarning,
-                          match="Passing 'route_optimized' as a parameter is deprecated. "
-                            "Please specify 'route_optimized' only within the config dictionary."):
+        with pytest.warns(
+            UserWarning,
+            match="Passing 'route_optimized' as a parameter is deprecated. "
+            "Please specify 'route_optimized' only within the config dictionary.",
+        ):
             resp = client.create_endpoint(
                 name="test",
                 route_optimized=True,
@@ -192,6 +202,7 @@ def test_create_endpoint_route_optimized_match():
         mock_request.assert_called_once()
         assert resp == {"name": "test"}
 
+
 def test_create_endpoint_route_optimized_mismatch():
     """Test when route_optimized is provided both in config and as named arg with different values.
     Should raise an MlflowException.
@@ -203,10 +214,12 @@ def test_create_endpoint_route_optimized_mismatch():
     mock_resp.status_code = 200
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
-        with pytest.raises(MlflowException,
-                         match="Conflicting 'route_optimized' values found. "
-                               "Please specify 'route_optimized' only within the config dictionary "
-                               "as this parameter is deprecated."):
+        with pytest.raises(
+            MlflowException,
+            match="Conflicting 'route_optimized' values found. "
+            "Please specify 'route_optimized' only within the config dictionary "
+            "as this parameter is deprecated.",
+        ):
             client.create_endpoint(
                 name="test",
                 route_optimized=True,
@@ -232,6 +245,7 @@ def test_create_endpoint_route_optimized_mismatch():
             )
         mock_request.assert_not_called()
 
+
 def test_create_endpoint_named_name():
     """Test using the legacy format with separate parameters instead of full API payload.
     Should emit a deprecation warning about the old format.
@@ -243,10 +257,12 @@ def test_create_endpoint_named_name():
     mock_resp.status_code = 200
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
-        with pytest.warns(UserWarning,
-                match="Passing 'name', 'config', and 'route_optimized' as separate parameters is "
-                    "deprecated. Please pass the full API request payload as a single dictionary "
-                    "in the 'config' parameter."):
+        with pytest.warns(
+            UserWarning,
+            match="Passing 'name', 'config', and 'route_optimized' as separate parameters is "
+            "deprecated. Please pass the full API request payload as a single dictionary "
+            "in the 'config' parameter.",
+        ):
             resp = client.create_endpoint(
                 name="test",
                 config={
@@ -263,10 +279,11 @@ def test_create_endpoint_named_name():
                         }
                     ],
                     "task": "llm/v1/chat",
-                }
+                },
             )
         mock_request.assert_called_once()
         assert resp == {"name": "test"}
+
 
 def test_create_endpoint_named_route_optimized():
     """Test using the legacy format with route_optimized parameter.
@@ -279,10 +296,12 @@ def test_create_endpoint_named_route_optimized():
     mock_resp.status_code = 200
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
-        with pytest.warns(UserWarning,
-                match="Passing 'name', 'config', and 'route_optimized' as separate parameters is "
-                "deprecated. Please pass the full API request payload as a single dictionary "
-                "in the 'config' parameter."):
+        with pytest.warns(
+            UserWarning,
+            match="Passing 'name', 'config', and 'route_optimized' as separate parameters is "
+            "deprecated. Please pass the full API request payload as a single dictionary "
+            "in the 'config' parameter.",
+        ):
             resp = client.create_endpoint(
                 name="test",
                 route_optimized=True,
@@ -300,7 +319,7 @@ def test_create_endpoint_named_route_optimized():
                         }
                     ],
                     "task": "llm/v1/chat",
-                }
+                },
             )
         mock_request.assert_called_once()
         assert resp == {"name": "test"}
@@ -337,10 +356,12 @@ def test_update_endpoint():
     mock_resp.url = os.environ["DATABRICKS_HOST"]
     mock_resp.status_code = 200
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
-        with pytest.warns(UserWarning,
+        with pytest.warns(
+            UserWarning,
             match="The `update_endpoint` method is deprecated. Use the specific update methods—"
-                "`update_endpoint_config`, `update_endpoint_tags`, `update_endpoint_rate_limits`, "
-                "`update_endpoint_ai_gateway`—instead."):
+            "`update_endpoint_config`, `update_endpoint_tags`, `update_endpoint_rate_limits`, "
+            "`update_endpoint_ai_gateway`—instead.",
+        ):
             resp = client.update_endpoint(
                 endpoint="test",
                 config={

--- a/tests/deployments/databricks/test_databricks.py
+++ b/tests/deployments/databricks/test_databricks.py
@@ -45,6 +45,7 @@ def test_create_endpoint():
         mock_request.assert_called_once()
         assert resp == {"name": "test"}
 
+
 def test_create_endpoint_config_only():
     client = get_deploy_client("databricks")
     mock_resp = mock.Mock()
@@ -75,6 +76,7 @@ def test_create_endpoint_config_only():
         )
         mock_request.assert_called_once()
         assert resp == {"name": "test"}
+
 
 def test_get_endpoint():
     client = get_deploy_client("databricks")
@@ -128,6 +130,7 @@ def test_update_endpoint():
         mock_request.assert_called_once()
         assert resp == {}
 
+
 def test_update_endpoint_config():
     client = get_deploy_client("databricks")
     mock_resp = mock.Mock()
@@ -156,6 +159,7 @@ def test_update_endpoint_config():
         mock_request.assert_called_once()
         assert resp == {}
 
+
 def test_update_endpoint_tags():
     client = get_deploy_client("databricks")
     mock_resp = mock.Mock()
@@ -165,14 +169,11 @@ def test_update_endpoint_tags():
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.update_endpoint_tags(
             endpoint="test",
-            config={
-                "add_tags": [
-                    {"key": "project", "value": "test"}
-                ]
-            },
+            config={"add_tags": [{"key": "project", "value": "test"}]},
         )
         mock_request.assert_called_once()
         assert resp == {}
+
 
 def test_update_endpoint_rate_limits():
     client = get_deploy_client("databricks")
@@ -183,18 +184,11 @@ def test_update_endpoint_rate_limits():
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.update_endpoint_rate_limits(
             endpoint="test",
-            config={
-                "rate_limits": [
-                    {
-                        "calls": 10,
-                        "key": "endpoint",
-                        "renewal_period": "minute"
-                    }
-                ]
-            },
+            config={"rate_limits": [{"calls": 10, "key": "endpoint", "renewal_period": "minute"}]},
         )
         mock_request.assert_called_once()
         assert resp == {}
+
 
 def test_update_endpoint_ai_gateway():
     client = get_deploy_client("databricks")
@@ -216,6 +210,7 @@ def test_update_endpoint_ai_gateway():
         )
         mock_request.assert_called_once()
         assert resp == {}
+
 
 def test_delete_endpoint():
     client = get_deploy_client("databricks")

--- a/tests/deployments/databricks/test_databricks.py
+++ b/tests/deployments/databricks/test_databricks.py
@@ -45,6 +45,36 @@ def test_create_endpoint():
         mock_request.assert_called_once()
         assert resp == {"name": "test"}
 
+def test_create_endpoint_config_only():
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {"name": "test"}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        resp = client.create_endpoint(
+            config={
+                "name": "test_new",
+                "config": {
+                    "served_entities": [
+                        {
+                            "name": "test_entity",
+                            "external_model": {
+                                "name": "gpt-4",
+                                "provider": "openai",
+                                "task": "llm/v1/chat",
+                                "openai_config": {
+                                    "openai_api_key": "secret",
+                                },
+                            },
+                        }
+                    ],
+                    "route_optimized": True,
+                },
+            },
+        )
+        mock_request.assert_called_once()
+        assert resp == {"name": "test"}
 
 def test_get_endpoint():
     client = get_deploy_client("databricks")
@@ -98,6 +128,94 @@ def test_update_endpoint():
         mock_request.assert_called_once()
         assert resp == {}
 
+def test_update_endpoint_config():
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        resp = client.update_endpoint_config(
+            endpoint="test",
+            config={
+                "served_entities": [
+                    {
+                        "name": "gpt-4-mini",
+                        "external_model": {
+                            "name": "gpt-4-mini",
+                            "provider": "openai",
+                            "task": "llm/v1/chat",
+                            "openai_config": {
+                                "openai_api_key": "{{secrets/scope/key}}",
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+        mock_request.assert_called_once()
+        assert resp == {}
+
+def test_update_endpoint_tags():
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        resp = client.update_endpoint_tags(
+            endpoint="test",
+            config={
+                "add_tags": [
+                    {"key": "project", "value": "test"}
+                ]
+            },
+        )
+        mock_request.assert_called_once()
+        assert resp == {}
+
+def test_update_endpoint_rate_limits():
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        resp = client.update_endpoint_rate_limits(
+            endpoint="test",
+            config={
+                "rate_limits": [
+                    {
+                        "calls": 10,
+                        "key": "endpoint",
+                        "renewal_period": "minute"
+                    }
+                ]
+            },
+        )
+        mock_request.assert_called_once()
+        assert resp == {}
+
+def test_update_endpoint_ai_gateway():
+    client = get_deploy_client("databricks")
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = {}
+    mock_resp.url = os.environ["DATABRICKS_HOST"]
+    mock_resp.status_code = 200
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        resp = client.update_endpoint_ai_gateway(
+            endpoint="test",
+            config={
+                "usage_tracking_config": {"enabled": True},
+                "inference_table_config": {
+                    "enabled": True,
+                    "catalog_name": "my_catalog",
+                    "schema_name": "my_schema",
+                },
+            },
+        )
+        mock_request.assert_called_once()
+        assert resp == {}
 
 def test_delete_endpoint():
     client = get_deploy_client("databricks")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/djliden/mlflow/pull/13513?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13513/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13513
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->

#13344 

### What changes are proposed in this pull request?

1. Updates the `create_endpoint` method to accept the whole API request in the config argument, rather than just the `config` component of the payload, so now users can include e.g. the AI gateway configuration, tags, etc.
2. Adds update methods corresponding to the api endpoints for updating config, tags, gateway, rate limits
3. Adds new tests for the new & updated methods

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

```python
# Create
from mlflow.deployments import get_deploy_client

client = get_deploy_client("databricks")
endpoint = client.create_endpoint(
    config={
        "name": "test",
        "config": {
            "served_entities": [
                {
                    "external_model": {
                        "name": "gpt-4",
                        "provider": "openai",
                        "task": "llm/v1/chat",
                        "openai_config": {
                            "openai_api_key": "{{secrets/scope/key}}",
                        },
                    },
                }
            ],
            "route_optimized": True,
        },
    },
)

# update config

name = "test"
config = {
    "served_entities": [
        {
            "name": "gpt-4o-mini",
            "external_model": {
                "name": "gpt-4o-mini",
                "provider": "openai",
                "task": "llm/v1/chat",
                "openai_config": {"openai_api_key_plaintext": os.getenv("OPENAI_API_KEY")},
            },
        }
    ]
}

updated_endpoint = client.update_endpoint_config(endpoint=name, config=config)

updated_endpoint
# {'name': 'test',
#  'creator': 'daniel.liden@databricks.com',
#  'creation_timestamp': 1729527763000,
#  'last_updated_timestamp': 1729531568000,
#  'state': {'ready': 'READY', 'config_update': 'NOT_UPDATING'},
#  'config': {'served_entities': [{'name': 'gpt-4o-mini',
#     'type': 'EXTERNAL_MODEL',
#     'external_model': {'provider': 'openai',
#      'name': 'gpt-4o-mini',
#      'task': 'llm/v1/chat',
#      'openai_config': {}},
#     'state': {'deployment': 'DEPLOYMENT_READY',
#      'deployment_state_message': ''},
#     'creator': 'daniel.liden@databricks.com',
#     'creation_timestamp': 1729531568000}],
#   'traffic_config': {'routes': [{'served_model_name': 'gpt-4o-mini',
#      'traffic_percentage': 100}]},
#   'config_version': 1},
#  'id': '44b258fb39804564b37603d8d14b853e',
#  'permission_level': 'CAN_MANAGE',
#  'tags': [{'key': 'project', 'value': 'test'}],
#  'route_optimized': False,
#  'task': 'llm/v1/chat',
#  'endpoint_type': 'EXTERNAL_MODEL',
#  'creator_display_name': 'Daniel Liden',
#  'creator_kind': 'User'}

# update Tags
name = "test"
tags = {"add_tags": [{"key": "project", "value": "test"}]}
updated_tags = client.update_endpoint_tags(endpoint=name, config=tags)

updated_tags

# {'tags': [{'key': 'project', 'value': 'test'}]}

# Rate Limits
name = "databricks-dbrx-instruct"
rate_limits = {"rate_limits": [{"calls": 10, "key": "endpoint", "renewal_period": "minute"}]}
updated_rate_limits = client.update_endpoint_rate_limits(endpoint=name, config=rate_limits)
updated_rate_limits

# {'rate_limits': [{'calls': 10, 'key': 'endpoint', 'renewal_period': 'minute'}]}

# Update ai gateway

name = "test"
gateway_config = {
    "usage_tracking_config": {"enabled": True},
    "inference_table_config": {
        "enabled": True,
        "catalog_name": CATALOG_NAME,
        "schema_name": SCHEMA_NAME,
    },
}
updated_gateway = client.update_endpoint_ai_gateway(endpoint=name, config=gateway_config)
updated_gateway

name = "test"

# gateway_config = {
#     "usage_tracking_config": {"enabled": True},
#     "inference_table_config": {
#         "enabled": True,
#         "catalog_name": CATALOG_NAME,
#         "schema_name": SCHEMA_NAME,
#     },
# }

updated_gateway = client.update_endpoint_ai_gateway(endpoint=name, config=gateway_config)

updated_gateway

```
### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [X] Examples
  - [X] API references
  - [ ] Instructions

(Just the automatically-generated documentation)

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds support for configuring Mosaic AI Gateway in Databricks Model Serving to MLflow Deployments. Adds support for passing entire API request payload to `create_endpoint`. Adds new `update_endpoint_xxx` methods corresponding to the Databricks model serving update endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [X] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
