### PR TITLE
Fix mlflow.models.predict on serverless

### DIFF
--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -1,15 +1,20 @@
 import json
 import logging
 import os
-from datetime import datetime
+import shutil
 from io import StringIO
 from typing import ForwardRef, get_args, get_origin
 
 from mlflow.exceptions import MlflowException
 from mlflow.models.flavor_backend_registry import get_flavor_backend
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import env_manager as _EnvManager
+from mlflow.utils.annotations import experimental
+from mlflow.utils.databricks_utils import (
+    is_databricks_connect,
+    is_in_databricks_runtime,
+)
 from mlflow.utils.file_utils import TempDir
-from mlflow.utils.proto_json_utils import dump_input_data
 
 _logger = logging.getLogger(__name__)
 
@@ -94,6 +99,7 @@ _CONTENT_TYPE_CSV = "csv"
 _CONTENT_TYPE_JSON = "json"
 
 
+@experimental
 def predict(
     model_uri,
     input_data=None,
@@ -113,6 +119,10 @@ def predict(
         model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
         input_data: Input data for prediction. Must be valid input for the PyFunc model. Refer
             to the :py:func:`mlflow.pyfunc.PyFuncModel.predict()` for the supported input types.
+
+            .. note::
+                Use `mlflow.models.convert_input_example_to_serving_input` to manually validate
+                your input data.
         input_path: Path to a file containing input data. If provided, 'input_data' must be None.
         content_type: Content type of the input data. Can be one of {‘json’, ‘csv’}.
         output_path: File to output results to as json. If not provided, output to stdout.
@@ -128,6 +138,12 @@ def predict(
         pip_requirements_override: If specified, install the specified python dependencies to the
             model inference environment. This is particularly useful when you want to add extra
             dependencies or try different versions of the dependencies defined in the logged model.
+
+            .. note::
+                After validating the pip requirements override works as expected, you can update
+                the logged model's dependency using `mlflow.models.update_model_requirements` API.
+                Note that a registered model is immutable, so you need to register a new model
+                version with the updated logged model.
 
     Code example:
 
@@ -152,14 +168,55 @@ def predict(
         )
 
     """
+    # to avoid circular imports
+    from mlflow.pyfunc import (
+        _PREBUILD_ENV_ROOT_LOCATION,
+        _create_model_downloading_tmp_dir,
+        _gen_prebuilt_env_archive_name,
+    )
+
     if content_type not in [_CONTENT_TYPE_JSON, _CONTENT_TYPE_CSV]:
         raise MlflowException.invalid_parameter_value(
             f"Content type must be one of {_CONTENT_TYPE_JSON} or {_CONTENT_TYPE_CSV}."
         )
 
+    spark_session = None
+    if is_in_databricks_runtime():
+        try:
+            # if in Databricks, fetch the current active session
+            from databricks.sdk.runtime import spark
+
+            spark_session = spark
+        except Exception:
+            pass
+    is_dbconnect_mode = is_databricks_connect(spark_session)
+    if is_dbconnect_mode:
+        if env_manager != _EnvManager.VIRTUALENV:
+            raise MlflowException(
+                "Databricks Connect only supports virtualenv as the environment manager. "
+                f"Got {env_manager}."
+            )
+        local_model_path = _download_artifact_from_uri(
+            artifact_uri=model_uri,
+            output_path=_create_model_downloading_tmp_dir(should_use_nfs=False),
+        )
+        archive_name = _gen_prebuilt_env_archive_name(spark_session, local_model_path)
+        env_root_dir = os.path.join(_PREBUILD_ENV_ROOT_LOCATION, archive_name)
+        if os.path.exists(env_root_dir):
+            shutil.rmtree(env_root_dir)
+        pyfunc_backend_env_root_config = {
+            "create_env_root_dir": False,
+            "env_root_dir": env_root_dir,
+        }
+    else:
+        pyfunc_backend_env_root_config = {"create_env_root_dir": True}
+
     def _predict(_input_path: str):
         return get_flavor_backend(
-            model_uri, env_manager=env_manager, install_mlflow=install_mlflow
+            model_uri,
+            env_manager=env_manager,
+            install_mlflow=install_mlflow,
+            **pyfunc_backend_env_root_config,
         ).predict(
             model_uri=model_uri,
             input_path=_input_path,
@@ -210,6 +267,10 @@ def _serialize_input_data(input_data, content_type):
     # so we shouldn't import pandas at the top level
     import pandas as pd
 
+    # this introduces numpy as dependency, we shouldn't import it at the top level
+    # as it is not available in mlflow-skinny
+    from mlflow.models.utils import convert_input_example_to_serving_input
+
     valid_input_types = {
         _CONTENT_TYPE_CSV: (str, list, dict, pd.DataFrame),
         _CONTENT_TYPE_JSON: _get_pyfunc_supported_input_types(),
@@ -221,54 +282,36 @@ def _serialize_input_data(input_data, content_type):
             f"but got {type(input_data)}."
         )
 
-    # If the input is already string, check if the input string can be deserialized correctly
-    if isinstance(input_data, str):
-        _validate_string(input_data, content_type)
-        return input_data
+    if content_type == _CONTENT_TYPE_CSV:
+        if isinstance(input_data, str):
+            _validate_string(input_data, content_type)
+            return input_data
+        else:
+            try:
+                return pd.DataFrame(input_data).to_csv(index=False)
+            except Exception as e:
+                raise MlflowException.invalid_parameter_value(
+                    "Failed to serialize input data to CSV format."
+                ) from e
 
     try:
-        if content_type == _CONTENT_TYPE_CSV:
-            # We should not set header=False here because the scoring server expects the
-            # first row to be the header
-            return pd.DataFrame(input_data).to_csv(index=False)
-        else:
-            return _serialize_to_json(input_data)
+        # we do not need to validate string input here
+        # as the model can accept arbitrary string inputs
+        return convert_input_example_to_serving_input(input_data)
     except Exception as e:
         raise MlflowException.invalid_parameter_value(
-            message=f"Input data could not be serialized to {content_type}."
+            "Invalid input data, please make sure the data is acceptable by the "
+            "loaded pyfunc model. Use `mlflow.models.convert_input_example_to_serving_input` "
+            "to manually validate your input data."
         ) from e
 
 
-def _serialize_to_json(input_data):
-    # imported inside function to avoid circular import
-    from mlflow.pyfunc.scoring_server import SUPPORTED_FORMATS
-    from mlflow.pyfunc.utils.serving_data_parser import SUPPORTED_LLM_FORMATS
-
-    if isinstance(input_data, dict) and any(
-        key in input_data for key in SUPPORTED_FORMATS | SUPPORTED_LLM_FORMATS
-    ):
-        return json.dumps(input_data)
-    else:
-        original_input_data = input_data
-
-        if isinstance(input_data, (datetime, bool, bytes, float, int, str)):
-            input_data = [input_data]
-
-        input_data = dump_input_data(input_data)
-
-        _logger.info(
-            f"Your input data has been transformed to comply with the expected input format for "
-            "the MLflow scoring server. If you want to deploy the model to online serving, make "
-            "sure to apply the same preprocessing in your inference client. Please also refer to "
-            "https://www.mlflow.org/docs/latest/deployment/deploy-model-locally.html#json-input "
-            "for more details on the supported input format."
-            f"\n\nOriginal input data:\n{original_input_data}"
-            f"\n\nTransformed input data:\n{input_data}"
-        )
-        return input_data
-
-
 def _validate_string(input_data: str, content_type: str):
+    """
+    Validate the input data is compatible with the content_type.
+    If content_type is 'csv', the string must be the path to a CSV file.
+    If content_type is 'json', the string must be a valid JSON string.
+    """
     try:
         if content_type == _CONTENT_TYPE_CSV:
             import pandas as pd

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -177,10 +177,9 @@ def predict(
     spark_session = None
     if is_in_databricks_runtime():
         try:
-            # if in Databricks, fetch the current active session
-            from databricks.sdk.runtime import spark
+            from pyspark.sql import SparkSession
 
-            spark_session = spark
+            spark_session = SparkSession.getActiveSession()
         except Exception:
             pass
     is_dbconnect_mode = is_databricks_connect(spark_session)

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -160,7 +160,7 @@ def predict(
         # Run prediction with additional pip dependencies
         mlflow.models.predict(
             model_uri=f"runs:/{run_id}/model",
-            input_data='{"x": 1, "y": 2}',
+            input_data={"x": 1, "y": 2},
             content_type="json",
             pip_requirements_override=["scikit-learn==0.23.2"],
         )

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -280,8 +280,8 @@ def _serialize_input_data(input_data, content_type):
                 ) from e
 
     try:
-        # we do not need to validate string input here
-        # as the model can accept arbitrary string inputs
+        # rely on convert_input_example_to_serving_input to validate
+        # the input_data is valid type for the loaded pyfunc model
         return convert_input_example_to_serving_input(input_data)
     except Exception as e:
         raise MlflowException.invalid_parameter_value(

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -353,8 +353,8 @@ class _Example:
             else:
                 example_type = "sparse_matrix_csr"
             self.info["type"] = example_type
+            self.serving_input = {INPUTS: model_input.toarray()}
             model_input = _handle_sparse_matrix(model_input)
-            self.serving_input = None
         elif isinstance(model_input, pd.DataFrame):
             model_input = _convert_dataframe_to_split_dict(model_input)
             self.serving_input = {DF_SPLIT: model_input}
@@ -365,7 +365,7 @@ class _Example:
                     "pandas_orient": orient,
                 }
             )
-        elif np.isscalar(model_input):
+        elif np.isscalar(model_input) or isinstance(model_input, dt.datetime):
             self.info["type"] = "json_object"
             self.serving_input = {INPUTS: model_input}
         else:
@@ -379,6 +379,7 @@ class _Example:
                 "- dict\n"
                 "- list\n"
                 "- scalars\n"
+                "- datetime.datetime\n"
                 f"but got '{type(model_input)}'",
             )
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -474,7 +474,9 @@ def _predict(model_uri, input_path, output_path, content_type):
             with open(input_path) as f:
                 input_str = f.read()
         data, params = _split_data_and_params(input_str)
-        df = infer_and_parse_data(data)
+        # schema needs to be passed to correctly match the behavior
+        # of schema enforcement during pyfunc predict
+        df = infer_and_parse_data(data, schema=pyfunc_model.metadata.get_input_schema())
     elif content_type == "csv":
         df = parse_csv_input(input_path) if input_path is not None else parse_csv_input(sys.stdin)
         params = None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13516?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13516/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13516
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
1. Fix predict issue on serverless compute
2. Fix scoring_server _predict bug about data parsing


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

With serverless compute
<img width="1069" alt="image" src="https://github.com/user-attachments/assets/e5477f78-9a3f-4359-ac3a-35f1f3a9bfba">

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
