### PR TITLE
Fix tool span inputs/outputs format in LangChain autolog

### DIFF
--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -371,6 +371,10 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         parent_run_id: Optional[UUID] = None,
         metadata: Optional[Dict[str, Any]] = None,
         name: Optional[str] = None,
+        # We don't use inputs here because LangChain override the original inputs
+        # with None for some cases. In order to avoid losing the original inputs,
+        # we try to parse the input_str instead.
+        # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/tools/base.py#L636-L640
         inputs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ):

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -80,7 +80,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         parent_run_id: Optional[UUID],
         span_type: str,
         run_id: UUID,
-        inputs: Optional[Dict[str, Any]] = None,
+        inputs: Optional[Union[str, Dict[str, Any]]] = None,
         attributes: Optional[Dict[str, Any]] = None,
     ) -> LiveSpan:
         """Start MLflow Span (or Trace if it is root component)"""

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -1,4 +1,4 @@
-import json
+import ast
 import logging
 from typing import Any, Dict, List, Optional, Sequence, Set, Union
 from uuid import UUID
@@ -378,11 +378,11 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         if metadata:
             kwargs.update({"metadata": metadata})
 
-        # Input string should be JSON-like (it is json with single quotes)
-        # for function calling. We try parsing it for better rendering,
+        # For function calling, input_str can be a stringified dictionary
+        # like "{'key': 'value'}". We try parsing it for better rendering,
         # but conservatively fallback to original if it fails.
         try:
-            inputs = json.loads(input_str.replace("'", '"'))
+            inputs = ast.literal_eval(input_str)
         except Exception:
             inputs = input_str
 

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -468,7 +468,7 @@ def test_tool_success(mock_databricks_serving_with_tracing_env):
     # Tool
     tool_span = spans[0]
     assert tool_span.span_type == "TOOL"
-    assert tool_span.inputs == str(tool_input)
+    assert tool_span.inputs == tool_input
     assert tool_span.outputs is not None
     tool_span_id = tool_span.span_id
 

--- a/tests/langchain/test_langgraph.py
+++ b/tests/langchain/test_langgraph.py
@@ -5,6 +5,8 @@ import pytest
 from packaging.version import Version
 
 import mlflow
+from mlflow.entities.span import SpanType
+from mlflow.entities.span_status import SpanStatusCode
 
 from tests.tracing.helper import get_traces
 
@@ -102,3 +104,11 @@ def test_langgraph_tracing():
     for msg, (type, expected_content) in zip(messages, expected_messages):
         assert msg["type"] == type
         assert msg["content"] == expected_content
+
+    # Validate tool span
+    tool_span = next(span for span in traces[0].data.spans if span.span_type == SpanType.TOOL)
+    assert tool_span.name == "get_weather"
+    assert tool_span.inputs == {"city": "sf"}
+    assert tool_span.outputs["content"] == "It's always sunny in sf"
+    assert tool_span.outputs["status"] == "success"
+    assert tool_span.status.status_code == SpanStatusCode.OK


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13527?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13527/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13527
```

</p>
</details>

### What changes are proposed in this pull request?

Fix a reported issue that the tool span in LangChain auto-tracing have inputs and outputs being raw string, rather than a proper JSON format.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Before:**
![Screenshot 2024-10-24 at 10 22 30](https://github.com/user-attachments/assets/8247dca3-b126-49cc-89db-636becc8e4bd)

**After:**
![Screenshot 2024-10-24 at 10 22 46](https://github.com/user-attachments/assets/1928bb94-bd52-484b-ad1a-eccda7f76ea1)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `TOOL` span inputs and outputs in LangChain auto-tracing to be rendered properly, instead of raw string.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
