### PR TITLE
Keras output conversion for serving purpose

### DIFF
--- a/mlflow/keras/load.py
+++ b/mlflow/keras/load.py
@@ -45,8 +45,8 @@ class KerasModelWrapper:
                 f"received type: {type(data)}.",
                 INVALID_PARAMETER_VALUE,
             )
-        # Return value must be json serializable, so we convert the Tensor output to a list.
-        return keras.ops.convert_to_numpy(model_call(data)).tolist()
+        # Return numpy array for serving purposes.
+        return keras.ops.convert_to_numpy(model_call(data))
 
 
 def _load_keras_model(path, model_conf, custom_objects=None, **load_model_kwargs):

--- a/mlflow/keras/load.py
+++ b/mlflow/keras/load.py
@@ -45,7 +45,8 @@ class KerasModelWrapper:
                 f"received type: {type(data)}.",
                 INVALID_PARAMETER_VALUE,
             )
-        return model_call(data)
+        # Return value must be json serializable, so we convert the Tensor output to a list.
+        return keras.ops.convert_to_numpy(model_call(data)).tolist()
 
 
 def _load_keras_model(path, model_conf, custom_objects=None, **load_model_kwargs):

--- a/tests/keras/test_save.py
+++ b/tests/keras/test_save.py
@@ -55,10 +55,10 @@ def test_keras_save_model_export():
     logged_model = f"runs:/{run.info.run_id}/{model_path}"
     loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model)
     predict_outputs = loaded_pyfunc_model.predict(test_input)
-    assert isinstance(predict_outputs, list)
+    assert isinstance(predict_outputs, np.ndarray)
     np.testing.assert_allclose(
         keras.ops.convert_to_numpy(model(test_input)),
-        np.array(predict_outputs),
+        predict_outputs,
     )
 
 

--- a/tests/keras/test_save.py
+++ b/tests/keras/test_save.py
@@ -54,9 +54,11 @@ def test_keras_save_model_export():
     # Test the loaded pyfunc model produces the same output for the same input as the model.
     logged_model = f"runs:/{run.info.run_id}/{model_path}"
     loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model)
+    predict_outputs = loaded_pyfunc_model.predict(test_input)
+    assert isinstance(predict_outputs, list)
     np.testing.assert_allclose(
         keras.ops.convert_to_numpy(model(test_input)),
-        loaded_pyfunc_model.predict(test_input),
+        np.array(predict_outputs),
     )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/13535?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13535/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13535
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently the wrapper returns a tensor, which is not compatible with Databricks serving (which requries json serializable). This PR converts the output to a list.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
