### PR TITLE
Support custom chat endpoint without endpoint type set as llm judge

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -99,12 +99,16 @@ def _extract_score_and_justification(text):
 
 
 def _score_model_on_one_payload(
-    payload,
-    eval_model,
-    parameters,
+    payload: str,
+    eval_model: str,
+    parameters: Optional[Dict[str, Any]],
 ):
     try:
-        raw_result = model_utils.score_model_on_payload(eval_model, payload, parameters)
+        # If the endpoint does not specify type, default to chat format
+        endpoint_type = model_utils.get_endpoint_type(eval_model) or "llm/v1/chat"
+        raw_result = model_utils.score_model_on_payload(
+            eval_model, payload, parameters, endpoint_type
+        )
         return _extract_score_and_justification(raw_result)
     except ImportError:
         raise

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -235,7 +235,9 @@ def _construct_payload_from_str(prompt: str, endpoint_type: str) -> Dict[str, An
         )
 
 
-def _parse_response(response: Dict[str, Any], endpoint_type: Optional[str]) -> str:
+def _parse_response(
+    response: Dict[str, Any], endpoint_type: Optional[str]
+) -> Union[Optional[str], Dict[str, Any]]:
     if endpoint_type == "llm/v1/completions":
         return _parse_completions_response_format(response)
     elif endpoint_type == "llm/v1/chat":

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import urllib.parse
+from typing import Any, Dict, Optional, Union
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -9,9 +10,32 @@ from mlflow.utils.openai_utils import REQUEST_URL_CHAT
 _logger = logging.getLogger(__name__)
 
 
+def get_endpoint_type(endpoint_uri: str) -> Optional[str]:
+    """
+    Get the type of the endpoint if it is MLflow deployment
+    endpoint. For other endpoints e.g. OpenAI, or if the
+    endpoint does not specify type, return None.
+    """
+    schema, path = _parse_model_uri(endpoint_uri)
+
+    if schema != "endpoints":
+        return None
+
+    from pydantic import BaseModel
+
+    from mlflow.deployments import get_deploy_client
+
+    client = get_deploy_client()
+
+    endpoint = client.get_endpoint(path)
+    # TODO: Standardize the return type of `get_endpoint` and remove this check
+    endpoint = endpoint.dict() if isinstance(endpoint, BaseModel) else endpoint
+    return endpoint.get("task", endpoint.get("endpoint_type"))
+
+
 # TODO: improve this name
-def score_model_on_payload(model_uri, payload, eval_parameters=None):
-    """Call the model identified by the given uri with the given payload."""
+def score_model_on_payload(model_uri, payload, eval_parameters=None, endpoint_type=None):
+    """Call the model identified by the given uri with the given string prompt."""
 
     if eval_parameters is None:
         eval_parameters = {}
@@ -22,7 +46,7 @@ def score_model_on_payload(model_uri, payload, eval_parameters=None):
     elif prefix == "gateway":
         return _call_gateway_api(suffix, payload, eval_parameters)
     elif prefix == "endpoints":
-        return _call_deployments_api(suffix, payload, eval_parameters)
+        return call_deployments_api(suffix, payload, eval_parameters, endpoint_type)
     elif prefix in ("model", "runs"):
         # TODO: call _load_model_or_server
         raise NotImplementedError
@@ -121,72 +145,51 @@ is set correctly and the input payload is valid.\n
 - Input payload: {payload}"""
 
 
-def _call_deployments_api(deployment_uri, payload, eval_parameters, wrap_payload=True):
+def call_deployments_api(
+    deployment_uri: str,
+    input_data: Union[str, Dict[str, Any]],
+    eval_parameters: Optional[Dict[str, Any]] = None,
+    endpoint_type: Optional[str] = None,
+):
     """Call the deployment endpoint with the given payload and parameters.
 
     Args:
         deployment_uri: The URI of the deployment endpoint.
-        payload: The input payload to send to the endpoint.
+        input_data: The input string or dictionary to send to the endpoint.
+            - If it is a string, MLflow tries to construct the payload based on the endpoint type.
+            - If it is a dictionary, MLflow directly sends it to the endpoint.
         eval_parameters: The evaluation parameters to send to the endpoint.
-        wrap_payload: Whether to wrap the payload in a expected key by the endpoint,
-            e.g. "prompt" for completions or "messages" for chat. If False, the specified
-            payload is directly sent to the endpoint combined with the eval_parameters.
+        endpoint_type: The type of the endpoint. If specified, must be 'llm/v1/completions'
+            or 'llm/v1/chat'. If not specified, MLflow tries to get the endpoint type
+            from the endpoint, and if not found, directly sends the payload to the endpoint.
 
     Returns:
         The unpacked response from the endpoint.
     """
-    from pydantic import BaseModel
-
     from mlflow.deployments import get_deploy_client
 
     client = get_deploy_client()
 
-    endpoint = client.get_endpoint(deployment_uri)
-    # TODO: Standardize the return type of `get_endpoint` and remove this check
-    endpoint = endpoint.dict() if isinstance(endpoint, BaseModel) else endpoint
-    endpoint_type = endpoint.get("task", endpoint.get("endpoint_type"))
-
-    if endpoint_type == "llm/v1/completions":
-        if wrap_payload:
-            payload = {"prompt": payload}
-        chat_inputs = {**payload, **eval_parameters}
-        try:
-            response = client.predict(endpoint=deployment_uri, inputs=chat_inputs)
-        except Exception as e:
-            raise MlflowException(
-                _PREDICT_ERROR_MSG.format(e=e, uri=deployment_uri, payload=chat_inputs)
-            ) from e
-        return _parse_completions_response_format(response)
-    elif endpoint_type == "llm/v1/chat":
-        if wrap_payload:
-            payload = {"messages": [{"role": "user", "content": payload}]}
-        completion_inputs = {**payload, **eval_parameters}
-        try:
-            response = client.predict(endpoint=deployment_uri, inputs=completion_inputs)
-        except Exception as e:
-            raise MlflowException(
-                _PREDICT_ERROR_MSG.format(e=e, uri=deployment_uri, payload=completion_inputs)
-            ) from e
-        return _parse_chat_response_format(response)
-    elif endpoint_type is None:
-        # If the endpoint type is not specified, we don't assume any format
-        # and directly send the payload to the endpoint. This is primary for Databricks
-        # Managed Agent Evaluation, where the endpoint type may not be specified but the
-        # eval harness ensures that the payload is formatted to the chat format, as well
-        # as parsing the response.
-        inputs = {**payload, **eval_parameters}
-        try:
-            return client.predict(endpoint=deployment_uri, inputs=inputs)
-        except Exception as e:
-            raise MlflowException(
-                _PREDICT_ERROR_MSG.format(e=e, uri=deployment_uri, payload=inputs)
-            ) from e
+    if isinstance(input_data, str):
+        payload = _construct_payload_from_str(input_data, endpoint_type)
+    elif isinstance(input_data, dict):
+        # If the input is a dictionary, we assume it is already in the correct format
+        payload = input_data
     else:
         raise MlflowException(
-            f"Unsupported endpoint type: {endpoint_type}. Endpoint type, if specified, "
-            "must be 'llm/v1/completions' or 'llm/v1/chat'.",
+            f"Invalid input data type {type(input_data)}. Must be a string or a dictionary.",
             error_code=INVALID_PARAMETER_VALUE,
         )
+    payload = {**payload, **(eval_parameters or {})}
+
+    try:
+        response = client.predict(endpoint=deployment_uri, inputs=payload)
+    except Exception as e:
+        raise MlflowException(
+            _PREDICT_ERROR_MSG.format(e=e, uri=deployment_uri, payload=payload)
+        ) from e
+
+    return _parse_response(response, endpoint_type)
 
 
 def _call_gateway_api(gateway_uri, payload, eval_parameters):
@@ -213,6 +216,32 @@ def _call_gateway_api(gateway_uri, payload, eval_parameters):
             "route of type 'llm/v1/completions' or 'llm/v1/chat' instead.",
             error_code=INVALID_PARAMETER_VALUE,
         )
+
+
+def _construct_payload_from_str(prompt: str, endpoint_type: str) -> Dict[str, Any]:
+    """
+    Construct the payload from the input string based on the endpoint type.
+    If the endpoint type is not specified or unsupported one, raise an exception.
+    """
+    if endpoint_type == "llm/v1/completions":
+        return {"prompt": prompt}
+    elif endpoint_type == "llm/v1/chat":
+        return {"messages": [{"role": "user", "content": prompt}]}
+    else:
+        raise MlflowException(
+            f"Unsupported endpoint type: {endpoint_type}. If string input is provided, "
+            "the endpoint type must be 'llm/v1/completions' or 'llm/v1/chat'.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+
+def _parse_response(response: Dict[str, Any], endpoint_type: Optional[str]) -> str:
+    if endpoint_type == "llm/v1/completions":
+        return _parse_completions_response_format(response)
+    elif endpoint_type == "llm/v1/chat":
+        return _parse_chat_response_format(response)
+    else:
+        return response
 
 
 def _parse_chat_response_format(response):

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -2182,15 +2182,18 @@ def test_evaluate_on_model_endpoint_invalid_payload(mock_deploy_client):
     ],
 )
 def test_evaluate_on_model_endpoint_invalid_input_data(input_data, error_message):
-    with pytest.raises(MlflowException, match=error_message):
-        with mlflow.start_run():
-            mlflow.evaluate(
-                model="endpoints:/chat",
-                data=input_data,
-                model_type="question-answering",
-                targets="ground_truth",
-                inference_params={"max_tokens": 10, "temperature": 0.5},
-            )
+    with mock.patch("mlflow.deployments.get_deploy_client") as mock_deploy_client:
+        mock_deploy_client.return_value.get_endpoint.return_value = {"task": "llm/v1/chat"}
+
+        with pytest.raises(MlflowException, match=error_message):
+            with mlflow.start_run():
+                mlflow.evaluate(
+                    model="endpoints:/chat",
+                    data=input_data,
+                    model_type="question-answering",
+                    targets="ground_truth",
+                    inference_params={"max_tokens": 10, "temperature": 0.5},
+                )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13538?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13538/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13538
```

</p>
</details>

### What changes are proposed in this pull request?

Support using a custom serving endpoint as a LLM judge for GenAI metrics like `answer_similarity`. Today, MLflow only supports serving endpoint that has endpoint type or task defined to be `llm/v1/chat` or `llm/v1/completion`. This works for FMAPI or some flavors, but not for model that does not have task concept e.g. LangChain.

This PR addresses this issue by defaulting to a chat task if the 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Test data: 
```
import pandas as pd

eval_data = pd.DataFrame({
        "inputs": ["What is MLflow?"],
        "ground_truth": ["MLflow is an OSS platform for managing ML lifecycle."],
})
```

**Case 1. Custom Chat Endpoint**:

(The serving service is down so I cannot test it right now, instead, I validated the change by mocking `get_endpoint` API of the deploy client)

```
# Custom chat model (mocking with FMAPI until model serving service recovers)
from unittest import mock
from mlflow.deployments import get_deploy_client

real_client = get_deploy_client()
mock_client = mock.MagicMock(spec=real_client.__class__)
mock_client.get_endpoint.return_value = {}
mock_client.predict = real_client.predict

with mock.patch("mlflow.deployments.get_deploy_client", return_value=mock_client) as mock_get_deploy_client:
    mock_get_deploy_client.return_value = mock_client

    # Validate the mocking works
    from mlflow.deployments import get_deploy_client
    from mlflow.metrics.genai.model_utils import get_endpoint_type
    client = get_deploy_client()
    endpoint_details = client.get_endpoint("endpoints:/databricks-meta-llama-3-1-70b-instruct")
    assert "task" not in endpoint_details
    assert "endpoint_type" not in endpoint_details
    assert get_endpoint_type("endpoints:/databricks-meta-llama-3-1-70b-instruct") is None

    # Run evaluation
    with mlflow.start_run():
        results = mlflow.evaluate(
            "runs:/f71fc47873394a35843724165b772644/model",
            eval_data,
            targets="ground_truth",
            extra_metrics=[
                answer_similarity(model="endpoints:/databricks-meta-llama-3-1-70b-instruct"),
                answer_correctness(model="endpoints:/databricks-mixtral-8x7b-instruct")
            ]
        )
        print(f"Aggregated evaluation results: \n{results.metrics}")
```

> Aggregated evaluation results: 
{'answer_similarity/v1/mean': 4.0, 'answer_similarity/v1/variance': 0.0, 'answer_similarity/v1/p90': 4.0, 'answer_correctness/v1/mean': 5.0, 'answer_correctness/v1/variance': 0.0, 'answer_correctness/v1/p90': 5.0}

This should properly emulate the requirement, as the same code fails with MLflow 2.17.0:

> Aggregated evaluation results: 
{'answer_similarity/v1/mean': nan, 'answer_similarity/v1/variance': nan, 'answer_correctness/v1/mean': nan, 'answer_correctness/v1/variance': nan}

**Case 2. OpenAI**:
```
with mlflow.start_run():
    results = mlflow.evaluate(
        "runs:/f71fc47873394a35843724165b772644/model",
        eval_data,
        targets="ground_truth",
        extra_metrics=[
            answer_similarity(), # Default
            answer_correctness(model="openai:/gpt-4o-mini"),
        ]
    )
    print(f"Aggregated evaluation results: \n{results.metrics}")
```
> Aggregated evaluation results: 
{'answer_similarity/v1/mean': 4.0, 'answer_similarity/v1/variance': 0.0, 'answer_similarity/v1/p90': 4.0, 'answer_correctness/v1/mean': 5.0, 'answer_correctness/v1/variance': 0.0, 'answer_correctness/v1/p90': 5.0}

**Case 3: FMAPI**:
```
with mlflow.start_run():
    results = mlflow.evaluate(
        "runs:/f71fc47873394a35843724165b772644/model",
        eval_data,
        targets="ground_truth",
        extra_metrics=[
            answer_similarity(model="endpoints:/databricks-meta-llama-3-1-70b-instruct"),
            answer_correctness(model="endpoints:/databricks-mixtral-8x7b-instruct")
        ]
    )
    print(f"Aggregated evaluation results: \n{results.metrics}")
```
> Aggregated evaluation results: 
{'answer_similarity/v1/mean': 4.0, 'answer_similarity/v1/variance': 0.0, 'answer_similarity/v1/p90': 4.0, 'answer_correctness/v1/mean': 5.0, 'answer_correctness/v1/variance': 0.0, 'answer_correctness/v1/p90': 5.0}

**Case 4: External Model (proxy)**
```
# External Model
with mlflow.start_run():
    results = mlflow.evaluate(
        "runs:/f71fc47873394a35843724165b772644/model",
        eval_data,
        targets="ground_truth",
        extra_metrics=[
            answer_similarity(model="endpoints:/yuki-watanabe-openai-proxy-endpoint"),
            answer_correctness(model="endpoints:/yuki-watanabe-openai-proxy-endpoint"),
        ]
    )
    print(f"Aggregated evaluation results: \n{results.metrics}")
```
> Aggregated evaluation results: 
{'answer_similarity/v1/mean': 4.0, 'answer_similarity/v1/variance': 0.0, 'answer_similarity/v1/p90': 4.0, 'answer_correctness/v1/mean': 5.0, 'answer_correctness/v1/variance': 0.0, 'answer_correctness/v1/p90': 5.0}

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support custom chat endpoint without endpoint type set as llm judge

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
