### PR TITLE
fix recipes test

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -421,7 +421,6 @@ from urllib.parse import urlparse
 import numpy as np
 import pandas
 import yaml
-from databricks.sdk import WorkspaceClient
 from packaging.version import Version
 
 import mlflow
@@ -1767,6 +1766,8 @@ def _download_prebuilt_env_if_needed(prebuilt_env_uri):
             return local_model_env_path
 
         try:
+            from databricks.sdk import WorkspaceClient
+
             ws = WorkspaceClient()
             # Download model env file from UC volume.
             with ws.files.download(model_env_uc_path).contents as rf, open(

--- a/mlflow/recipes/recipe.py
+++ b/mlflow/recipes/recipe.py
@@ -433,9 +433,9 @@ class Recipe:
                 ) from None
             else:
                 raise MlflowException(
-                    f"Failed to construct Recipe {class_name}. Error: {e!r}",
+                    f"Failed to construct Recipe {class_name}",
                     error_code=INTERNAL_ERROR,
-                ) from None
+                ) from e
 
         recipe_name = get_recipe_name(recipe_root_path)
         _logger.info(f"Creating MLflow Recipe '{recipe_name}' with profile: '{profile}'")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13539?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13539/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13539
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix regression introduced by https://github.com/mlflow/mlflow/commit/892a1a5d17fa716cfad9c7805467b0f43049ccbb

The error was:
```
File ~/.pyenv/versions/3.8.20/lib/python3.8/site-packages/mlflow/recipes/recipe.py:435, in Recipe.__new__(cls, profile)
    429         raise MlflowException(
    430             f"Failed to find Recipe {class_name}."
    431             f"Please check the correctness of the recipe template setting: {recipe}",
    432             error_code=INVALID_PARAMETER_VALUE,
    433         ) from None
    434     else:
--> 435         raise MlflowException(
    436             f"Failed to construct Recipe {class_name}. Error: {e!r}",
    437             error_code=INTERNAL_ERROR,
    438         ) from None
    440 recipe_name = get_recipe_name(recipe_root_path)
    441 _logger.info(f"Creating MLflow Recipe '{recipe_name}' with profile: '{profile}'")

MlflowException: Failed to construct Recipe mlflow.recipes.regression.v1.RecipeImpl. Error: MlflowException('Failed to construct Recipe mlflow.recipes.regression.v1.RecipeImpl. Error: AttributeError("partially initialized module \'mlflow.recipes.regression.v1\' has no attribute \'RecipeImpl\' (most likely due to a circular import)")')
```
https://app.circleci.com/pipelines/github/mlflow/mlflow/42138/workflows/c9ed3402-9800-438c-b738-c712e659b2ff/jobs/127641

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
