### PR TITLE
Run pyfunc tests in Python 3.9

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -301,9 +301,6 @@ jobs:
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
-          # debug
-          pytest tests/pyfunc/test_model_export_with_class_and_artifacts.py -k pep585
-
           pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --durations=30 \
             tests/pyfunc --ignore tests/pyfunc/test_spark_connect.py
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -287,6 +287,9 @@ jobs:
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/setup-python
+        with:
+          # TODO: Remove this once Python 3.8 support is dropped
+          python-version: 3.9
       - uses: ./.github/actions/setup-pyenv
       - uses: ./.github/actions/setup-java
       - name: Install dependencies
@@ -298,6 +301,9 @@ jobs:
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
+          # debug
+          pytest tests/pyfunc/test_model_export_with_class_and_artifacts.py -k pep585
+
           pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --durations=30 \
             tests/pyfunc --ignore tests/pyfunc/test_spark_connect.py
 

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -312,7 +312,7 @@ def _extract_type_hints(f, input_arg_index):
         hints = get_type_hints(f)
     except (
         TypeError,
-        NameError,  # Handles this issue: https://github.com/python/typing/issues/797
+        NameError,  # To handle this issue: https://github.com/python/typing/issues/797
     ):
         # ---
         # from __future__ import annotations # postpones evaluation of 'list[str]'

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -310,7 +310,10 @@ def _extract_type_hints(f, input_arg_index):
     arg_name = _get_arg_names(f)[input_arg_index]
     try:
         hints = get_type_hints(f)
-    except TypeError:
+    except (
+        TypeError,
+        NameError,  # Handles this issue: https://github.com/python/typing/issues/797
+    ):
         # ---
         # from __future__ import annotations # postpones evaluation of 'list[str]'
         #

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -27,6 +27,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.pyfunc.utils.input_converter import _hydrate_dataclass
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.llm import ChatMessage, ChatParams, ChatResponse
+from mlflow.types.utils import _is_list_dict_str, _is_list_str
 from mlflow.utils.annotations import experimental
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -587,7 +588,7 @@ class _PythonModelPyfuncWrapper:
         import pandas as pd
 
         hints = self.python_model._get_type_hints()
-        if hints.input == List[str]:
+        if _is_list_str(hints.input):
             if isinstance(model_input, pd.DataFrame):
                 first_string_column = _get_first_string_column(model_input)
                 if first_string_column is None:
@@ -600,7 +601,7 @@ class _PythonModelPyfuncWrapper:
                     return [next(iter(d.values())) for d in model_input]
                 elif all(isinstance(x, str) for x in model_input):
                     return model_input
-        elif hints.input == List[Dict[str, str]]:
+        elif _is_list_dict_str(hints.input):
             if isinstance(model_input, pd.DataFrame):
                 if (
                     len(self.signature.inputs) == 1

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import warnings
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Union
@@ -724,17 +725,52 @@ def _validate_dict_examples(examples, num_items=None):
         _validate_keys_match(example, first_keys)
 
 
+def _is_pep585_supported() -> bool:
+    """
+    Is https://peps.python.org/pep-0585 supported in the current Python version?
+    """
+    return sys.version_info[:2] >= (3, 9)
+
+
+def _is_list_str(type_hint: Any) -> bool:
+    if type_hint == List[str]:
+        return True
+
+    if _is_pep585_supported():
+        try:
+            return type_hint == list[str]
+        except TypeError:
+            # Should be unreachable but for safety
+            return False
+
+    return False
+
+
+def _is_list_dict_str(type_hint: Any) -> bool:
+    if type_hint == List[Dict[str, str]]:
+        return True
+
+    if _is_pep585_supported():
+        try:
+            return type_hint == list[dict[str, str]]
+        except TypeError:
+            # Should be unreachable but for safety
+            return False
+
+    return False
+
+
 def _infer_schema_from_type_hint(type_hint, examples=None):
     has_examples = examples is not None
     if has_examples:
         _validate_is_list(examples)
         _validate_non_empty(examples)
 
-    if type_hint == List[str]:
+    if _is_list_str(type_hint):
         if has_examples:
             _validate_is_all_string(examples)
         return Schema([ColSpec(type="string", name=None)])
-    elif type_hint == List[Dict[str, str]]:
+    elif _is_list_dict_str(type_hint):
         if has_examples:
             _validate_dict_examples(examples)
             return Schema([ColSpec(type="string", name=name) for name in examples[0]])

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -739,7 +739,7 @@ def _is_list_str(type_hint: Any) -> bool:
     if _is_pep585_supported():
         try:
             return type_hint == list[str]
-        except TypeError:
+        except Exception:
             # Should be unreachable but for safety
             return False
 
@@ -753,7 +753,7 @@ def _is_list_dict_str(type_hint: Any) -> bool:
     if _is_pep585_supported():
         try:
             return type_hint == list[dict[str, str]]
-        except TypeError:
+        except Exception:
             # Should be unreachable but for safety
             return False
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1552,7 +1552,7 @@ def test_pyfunc_model_infer_signature_from_type_hints(model_path):
     assert pyfunc_model.metadata.get_input_schema().to_dict() == [
         {"type": "string", "required": True}
     ]
-    pd.testing.assert_frame_equal(pyfunc_model.predict(["a", "b"]), pd.DataFrame(["a", "b"]))
+    assert pyfunc_model.predict(["a", "b"]) == ["a", "b"]
 
 
 def test_streamable_model_save_load(iris_data, tmp_path):

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -230,7 +230,7 @@ def test_spark_udf_env_manager_can_restore_env(spark, model_path, sklearn_versio
         pip_requirements=[
             f"pyspark=={pyspark.__version__}",
             f"scikit-learn=={sklearn_version}",
-            # pytest test is required to load the custom model from this file
+            # pytest is required to load the custom model from this file
             f"pytest=={pytest.__version__}",
         ],
     )

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -210,7 +210,7 @@ def test_spark_udf(spark, model_path):
                 assert expected == actual
 
 
-@pytest.mark.parametrize("sklearn_version", ["0.22.1", "0.24.0"])
+@pytest.mark.parametrize("sklearn_version", ["1.3.2", "1.4.2"])
 @pytest.mark.parametrize("env_manager", ["virtualenv", "conda"])
 def test_spark_udf_env_manager_can_restore_env(spark, model_path, sklearn_version, env_manager):
     class EnvRestoringTestModel(mlflow.pyfunc.PythonModel):
@@ -228,10 +228,10 @@ def test_spark_udf_env_manager_can_restore_env(spark, model_path, sklearn_versio
         path=model_path,
         python_model=EnvRestoringTestModel(),
         pip_requirements=[
-            "pyspark==3.2.0",
-            "pandas==1.3.0",
+            f"pyspark=={pyspark.__version__}",
             f"scikit-learn=={sklearn_version}",
-            "pytest==6.2.5",
+            # pytest test is required to load the custom model from this file
+            f"pytest=={pytest.__version__}",
         ],
     )
     # tests/helper_functions.py


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13541?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13541/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13541
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Another `py39` PR. Updates the pyfunc tests to use python 3.9.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
