### PR TITLE
Run transformers tests in Python 3.9

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -293,11 +293,6 @@ def infer_python_version(package: str, version: str) -> str:
     Infer the minimum Python version required by the package.
     """
     candidates = ("3.9", "3.10")
-
-    # TODO: Figure out how to fix transformers tests for Python 3.9 and remove this.
-    if package == "transformers":
-        candidates = ("3.8", *candidates)
-
     if rp := _requires_python(package, version):
         spec = SpecifierSet(rp)
         return next(filter(spec.contains, candidates), candidates[0])

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -597,7 +597,7 @@ transformers:
       # `accelerate>=0.32.0` and `peft>=0.13.0` are incompatible with `huggingface_hub==0.17.3`.
       "== 4.34.1": ["accelerate<0.32.0", "peft<0.13.0"]
       # Pin torchvision to <0.20.0 to avoid https://github.com/pytorch/torchchat/issues/1158
-      "< 4.38": ["tensorflow<2.18"] # Older versions of transformers are incompatible with tensorflow >= 2.18
+      "< 4.38": ["tensorflow<2.14"] # Older versions of transformers are incompatible with tensorflow >= 2.14
       ">= 4.38": ["tf-keras"] # Transformers doesn't support Keras 3.0. tf-keras needs to be installed.
     pre_test: |
       export PYTHONPATH=./
@@ -643,7 +643,7 @@ transformers:
       # Installing `transformers==4.34.1` with `datasets` results in installing `huggingface_hub==0.17.3`.
       # `accelerate>=0.32.0` is incompatible with `huggingface_hub==0.17.3`.
       "== 4.34.1": ["accelerate<0.32.0", "sentence-transformers<3.1.0"]
-      "< 4.38": ["tensorflow<2.18"] # Older versions of transformers are incompatible with tensorflow >= 2.18
+      "< 4.38": ["tensorflow<2.14"] # Older versions of transformers are incompatible with tensorflow >= 2.14
       ">= 4.38": ["tf-keras"] # Transformers doesn't support Keras 3.0. tf-keras needs to be installed.
     run: |
       pytest tests/transformers/test_transformers_autolog.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -598,7 +598,7 @@ transformers:
       "== 4.34.1": ["accelerate<0.32.0", "peft<0.13.0"]
       # Pin torchvision to <0.20.0 to avoid https://github.com/pytorch/torchchat/issues/1158
       ">= 4.42, < 4.46.0": ["torchvision<0.20.0"]
-      ">= 4.38": ["tf-keras"]
+      ">= 4.38": ["tf-keras", "tensorflow<2.18"]
     pre_test: |
       export PYTHONPATH=./
       python tests/transformers/helper.py
@@ -643,7 +643,7 @@ transformers:
       # Installing `transformers==4.34.1` with `datasets` results in installing `huggingface_hub==0.17.3`.
       # `accelerate>=0.32.0` is incompatible with `huggingface_hub==0.17.3`.
       "== 4.34.1": ["accelerate<0.32.0", "sentence-transformers<3.1.0"]
-      ">= 4.38": ["tf-keras"]
+      ">= 4.38": ["tf-keras", "tensorflow<2.18"]
     run: |
       pytest tests/transformers/test_transformers_autolog.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -588,7 +588,6 @@ transformers:
           "protobuf<=3.20.3", # fix error `Couldn't build proto file into descriptor pool: duplicate file name sentencepiece_model.proto`
           "typing_extensions>=4.6.0", # fix error for SqlAlchemy == 2.0.25 cannot import name 'TypeAliasType' from 'typing_extensions'
           "accelerate<1",
-          "tf-keras",
         ]
       # tensorflow 2.13.0 made all Keras private functions inaccessible. transformers versions
       # prior to 4.30.0 are incompatible with this breaking change in Keras.
@@ -599,7 +598,7 @@ transformers:
       "== 4.34.1": ["accelerate<0.32.0", "peft<0.13.0"]
       # Pin torchvision to <0.20.0 to avoid https://github.com/pytorch/torchchat/issues/1158
       ">= 4.42, < 4.46.0": ["torchvision<0.20.0"]
-      "== dev": ["tf-keras"]
+      ">= 4.38": ["tf-keras"]
     pre_test: |
       export PYTHONPATH=./
       python tests/transformers/helper.py
@@ -633,7 +632,6 @@ transformers:
           "setfit",
           "optuna",
           "accelerate<1",
-          "tf-keras",
         ]
       # sentence-transformers >= 2.4.0 relies on `transformers.utils.import_utils.is_nltk_available`
       # to check nltk availability. This function is only available in transformers>=4.34.0.
@@ -645,7 +643,7 @@ transformers:
       # Installing `transformers==4.34.1` with `datasets` results in installing `huggingface_hub==0.17.3`.
       # `accelerate>=0.32.0` is incompatible with `huggingface_hub==0.17.3`.
       "== 4.34.1": ["accelerate<0.32.0", "sentence-transformers<3.1.0"]
-      "== dev": ["tf-keras"]
+      ">= 4.38": ["tf-keras"]
     run: |
       pytest tests/transformers/test_transformers_autolog.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -588,6 +588,7 @@ transformers:
           "protobuf<=3.20.3", # fix error `Couldn't build proto file into descriptor pool: duplicate file name sentencepiece_model.proto`
           "typing_extensions>=4.6.0", # fix error for SqlAlchemy == 2.0.25 cannot import name 'TypeAliasType' from 'typing_extensions'
           "accelerate<1",
+          "tf-keras",
         ]
       # tensorflow 2.13.0 made all Keras private functions inaccessible. transformers versions
       # prior to 4.30.0 are incompatible with this breaking change in Keras.
@@ -632,6 +633,7 @@ transformers:
           "setfit",
           "optuna",
           "accelerate<1",
+          "tf-keras",
         ]
       # sentence-transformers >= 2.4.0 relies on `transformers.utils.import_utils.is_nltk_available`
       # to check nltk availability. This function is only available in transformers>=4.34.0.

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -597,8 +597,8 @@ transformers:
       # `accelerate>=0.32.0` and `peft>=0.13.0` are incompatible with `huggingface_hub==0.17.3`.
       "== 4.34.1": ["accelerate<0.32.0", "peft<0.13.0"]
       # Pin torchvision to <0.20.0 to avoid https://github.com/pytorch/torchchat/issues/1158
-      ">= 4.42, < 4.46.0": ["torchvision<0.20.0"]
-      ">= 4.38": ["tf-keras", "tensorflow<2.18"]
+      "< 4.38": ["tensorflow<2.18"] # Older versions of transformers are incompatible with tensorflow >= 2.18
+      ">= 4.38": ["tf-keras"] # Transformers doesn't support Keras 3.0. tf-keras needs to be installed.
     pre_test: |
       export PYTHONPATH=./
       python tests/transformers/helper.py
@@ -643,7 +643,8 @@ transformers:
       # Installing `transformers==4.34.1` with `datasets` results in installing `huggingface_hub==0.17.3`.
       # `accelerate>=0.32.0` is incompatible with `huggingface_hub==0.17.3`.
       "== 4.34.1": ["accelerate<0.32.0", "sentence-transformers<3.1.0"]
-      ">= 4.38": ["tf-keras", "tensorflow<2.18"]
+      "< 4.38": ["tensorflow<2.18"] # Older versions of transformers are incompatible with tensorflow >= 2.18
+      ">= 4.38": ["tf-keras"] # Transformers doesn't support Keras 3.0. tf-keras needs to be installed.
     run: |
       pytest tests/transformers/test_transformers_autolog.py
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -3265,12 +3265,12 @@ def test_evaluate_with_latency():
     assert all(isinstance(grade, float) for grade in logged_data["latency"])
 
 
+def pd_series_model(inputs: list[str]) -> pd.Series:
+    return pd.Series(inputs)
+
+
 def test_evaluate_with_latency_and_pd_series():
     with mlflow.start_run() as run:
-
-        def pd_series_model(inputs: list[str]) -> pd.Series:
-            return pd.Series(inputs)
-
         model_info = mlflow.pyfunc.log_model(
             "model", python_model=pd_series_model, input_example=["a", "b"]
         )

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -3265,12 +3265,12 @@ def test_evaluate_with_latency():
     assert all(isinstance(grade, float) for grade in logged_data["latency"])
 
 
-def pd_series_model(inputs: list[str]) -> pd.Series:
-    return pd.Series(inputs)
-
-
 def test_evaluate_with_latency_and_pd_series():
     with mlflow.start_run() as run:
+
+        def pd_series_model(inputs: list[str]) -> pd.Series:
+            return pd.Series(inputs)
+
         model_info = mlflow.pyfunc.log_model(
             "model", python_model=pd_series_model, input_example=["a", "b"]
         )

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -283,13 +283,13 @@ def transformers_hyperparameter_functional(tmp_path):
     )
 
 
-skip_transformer_dev_setfit_test = pytest.mark.skipif(
-    Version(transformers.__version__).is_devrelease,
+skip_setfit_issue_564 = pytest.mark.skipif(
+    Version(transformers.__version__) >= Version("4.46.0"),
     reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
 )
 
 
-@skip_transformer_dev_setfit_test
+@skip_setfit_issue_564
 def test_setfit_does_not_autolog(setfit_trainer):
     mlflow.autolog()
 
@@ -303,7 +303,7 @@ def test_setfit_does_not_autolog(setfit_trainer):
     assert len(preds) == 3
 
 
-@skip_transformer_dev_setfit_test
+@skip_setfit_issue_564
 def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     mlflow.sklearn.autolog()
 
@@ -327,7 +327,7 @@ def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     assert len(runs) == 1
 
 
-@skip_transformer_dev_setfit_test
+@skip_setfit_issue_564
 def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_trainer):
     mlflow.transformers.autolog(disable=False)
 
@@ -362,7 +362,7 @@ def test_transformers_autolog_adheres_to_global_behavior_using_trainer(transform
     assert len(runs) == 1
 
 
-@skip_transformer_dev_setfit_test
+@skip_setfit_issue_564
 def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog(
     iris_data, setfit_trainer
 ):
@@ -438,7 +438,7 @@ def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformer
     assert sklearn_run[0].info == logged_sklearn_data.info
 
 
-@skip_transformer_dev_setfit_test
+@skip_setfit_issue_564
 def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     iris_data, setfit_trainer
 ):

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -283,13 +283,13 @@ def transformers_hyperparameter_functional(tmp_path):
     )
 
 
-skip_setfit_issue_564 = pytest.mark.skipif(
+skip_setfit = pytest.mark.skipif(
     Version(transformers.__version__) >= Version("4.46.0"),
     reason="fails due to issue: https://github.com/huggingface/setfit/issues/564",
 )
 
 
-@skip_setfit_issue_564
+@skip_setfit
 def test_setfit_does_not_autolog(setfit_trainer):
     mlflow.autolog()
 
@@ -303,7 +303,7 @@ def test_setfit_does_not_autolog(setfit_trainer):
     assert len(preds) == 3
 
 
-@skip_setfit_issue_564
+@skip_setfit
 def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     mlflow.sklearn.autolog()
 
@@ -327,7 +327,7 @@ def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
     assert len(runs) == 1
 
 
-@skip_setfit_issue_564
+@skip_setfit
 def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_trainer):
     mlflow.transformers.autolog(disable=False)
 
@@ -362,7 +362,7 @@ def test_transformers_autolog_adheres_to_global_behavior_using_trainer(transform
     assert len(runs) == 1
 
 
-@skip_setfit_issue_564
+@skip_setfit
 def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog(
     iris_data, setfit_trainer
 ):
@@ -438,7 +438,7 @@ def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformer
     assert sklearn_run[0].info == logged_sklearn_data.info
 
 
-@skip_setfit_issue_564
+@skip_setfit
 def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     iris_data, setfit_trainer
 ):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13559?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13559/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13559
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Title

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
