### PR TITLE
Fix dspy tests

### DIFF
--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -4,6 +4,7 @@ from unittest import mock
 import dspy
 import dspy.teleprompt
 import pytest
+from dspy.utils import DSPDummyLM, dummy_rm
 
 import mlflow
 from mlflow.models import Model, ModelSignature
@@ -65,7 +66,7 @@ def test_save_compiled_model():
         return 1.0
 
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DSPDummyLM(answers=random_answers)
+    lm = DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     dspy_model = CoT()
@@ -110,8 +111,8 @@ def test_dspy_save_preserves_object_state():
         return 1.0
 
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DSPDummyLM(answers=random_answers)
-    rm = dspy.utils.dummy_rm(passages=["dummy1", "dummy2", "dummy3"])
+    lm = DSPDummyLM(answers=random_answers)
+    rm = dummy_rm(passages=["dummy1", "dummy2", "dummy3"])
     dspy.settings.configure(lm=lm, rm=rm)
 
     train_data = ["What is 2 + 2?", "What is 3 + 3?", "What is 4 + 4?", "What is 5 + 5?"]
@@ -181,7 +182,7 @@ def test_load_logged_model_in_native_dspy():
         "What is 5 + 5?",
     ]
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DSPDummyLM(answers=random_answers)
+    lm = DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     with mlflow.start_run() as run:
@@ -206,7 +207,7 @@ def test_serving_logged_model():
 
     dspy_model = CoT()
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DSPDummyLM(answers=random_answers)
+    lm = DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     input_examples = {"inputs": ["What is 2 + 2?"]}
@@ -256,7 +257,7 @@ def test_save_chat_model_with_string_output():
 
     dspy_model = CoT()
     random_answers = ["4", "4", "4", "4"]
-    lm = dspy.utils.DSPDummyLM(answers=random_answers)
+    lm = DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     input_examples = {"messages": [{"role": "user", "content": "What is 2 + 2?"}]}
@@ -291,7 +292,7 @@ def test_serve_chat_model():
 
     dspy_model = CoT()
     random_answers = ["4", "6", "8", "10"]
-    lm = dspy.utils.DSPDummyLM(answers=random_answers)
+    lm = DSPDummyLM(answers=random_answers)
     dspy.settings.configure(lm=lm)
 
     input_examples = {"messages": [{"role": "user", "content": "What is 2 + 2?"}]}
@@ -356,7 +357,7 @@ def test_infer_signature_from_input_examples():
     artifact_path = "model"
     dspy_model = CoT()
     random_answers = ["4", "6", "8", "10"]
-    dspy.settings.configure(lm=dspy.utils.DSPDummyLM(answers=random_answers))
+    dspy.settings.configure(lm=DSPDummyLM(answers=random_answers))
     with mlflow.start_run():
         mlflow.dspy.log_model(dspy_model, artifact_path, input_example="what is 2 + 2?")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13562?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13562/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13562
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Dspy's latest release changes the `dspy.utils` routing to `dspy.signatures.utils`, so the tests are broken. Filed issue https://github.com/stanfordnlp/dspy/issues/1706

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
