### PR TITLE
Add new UC tool extraction support

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -739,6 +739,10 @@ langchain:
           "uvicorn",
           # Required for testing Databricks dependency extraction
           "databricks-vectorsearch",
+          # Required for testing uc tools
+          "git+https://github.com/unitycatalog/unitycatalog.git#subdirectory=ai/core",
+          # TODO: update this to unitycatalog repo before merge
+          "git+https://github.com/serena-ruan/unitycatalog.git@tools#subdirectory=ai/integrations/langchain",
         ]
       # langchain-openai 0.1.22 is imcomptible with earlier langchain-core due to
       # https://github.com/langchain-ai/langchain/commit/b83f1eb0d56dbf99605a1fce93953ee09d77aabf

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -739,10 +739,6 @@ langchain:
           "uvicorn",
           # Required for testing Databricks dependency extraction
           "databricks-vectorsearch",
-          # Required for testing uc tools
-          "git+https://github.com/unitycatalog/unitycatalog.git#subdirectory=ai/core",
-          # TODO: update this to unitycatalog repo before merge
-          "git+https://github.com/serena-ruan/unitycatalog.git@tools#subdirectory=ai/integrations/langchain",
         ]
       # langchain-openai 0.1.22 is imcomptible with earlier langchain-core due to
       # https://github.com/langchain-ai/langchain/commit/b83f1eb0d56dbf99605a1fce93953ee09d77aabf
@@ -751,6 +747,10 @@ langchain:
           "langchain-huggingface",
           # Install langchain-databricks from the main branch
           "git+https://github.com/langchain-ai/langchain-databricks.git@main#egg=langchain-databricks&subdirectory=libs/databricks",
+          # Required for testing uc tools
+          "git+https://github.com/unitycatalog/unitycatalog.git#subdirectory=ai/core",
+          # TODO: update this to unitycatalog repo before merge
+          "git+https://github.com/serena-ruan/unitycatalog.git@tools#subdirectory=ai/integrations/langchain",
         ]
     run: |
       # Run all langchain tests except autologging

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -749,8 +749,7 @@ langchain:
           "git+https://github.com/langchain-ai/langchain-databricks.git@main#egg=langchain-databricks&subdirectory=libs/databricks",
           # Required for testing uc tools
           "git+https://github.com/unitycatalog/unitycatalog.git#subdirectory=ai/core",
-          # TODO: update this to unitycatalog repo before merge
-          "git+https://github.com/serena-ruan/unitycatalog.git@tools#subdirectory=ai/integrations/langchain",
+          "git+https://github.com/unitycatalog/unitycatalog.git#subdirectory=ai/integrations/langchain",
         ]
     run: |
       # Run all langchain tests except autologging

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -748,6 +748,7 @@ langchain:
           # Install langchain-databricks from the main branch
           "git+https://github.com/langchain-ai/langchain-databricks.git@main#egg=langchain-databricks&subdirectory=libs/databricks",
           # Required for testing uc tools
+          # TODO: replace to package names once they are released to PyPI
           "git+https://github.com/unitycatalog/unitycatalog.git#subdirectory=ai/core",
           "git+https://github.com/unitycatalog/unitycatalog.git#subdirectory=ai/integrations/langchain",
         ]

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -522,12 +522,8 @@ def test_parsing_unitycatalog_tool_as_dependency(monkeypatch: pytest.MonkeyPatch
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain.agents import initialize_agent
     from langchain_openai.llms import OpenAI
-
-    try:
-        from unitycatalog.ai.core.databricks import DatabricksFunctionClient
-        from unitycatalog.ai.langchain.toolkit import UCFunctionToolkit
-    except Exception:
-        return
+    from unitycatalog.ai.core.databricks import DatabricksFunctionClient
+    from unitycatalog.ai.langchain.toolkit import UCFunctionToolkit
 
     # When get is called return a function
     def mock_function_get(self, function_name):

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -512,3 +512,66 @@ def test_parsing_dependency_from_databricks(monkeypatch, use_partner_package):
         DatabricksServingEndpoint(endpoint_name="embedding-model"),
         DatabricksServingEndpoint(endpoint_name="databricks-llama-2-70b-chat"),
     ]
+
+
+def test_parsing_unitycatalog_tool_as_dependency(monkeypatch: pytest.MonkeyPatch):
+    from databricks.sdk.service.catalog import FunctionInfo
+    from langchain.agents import initialize_agent
+    from langchain_openai.llms import OpenAI
+
+    try:
+        from unitycatalog.ai.core.databricks import DatabricksFunctionClient
+        from unitycatalog.ai.langchain.toolkit import UCFunctionToolkit
+    except Exception:
+        return
+
+    # When get is called return a function
+    def mock_function_get(self, function_name):
+        components = function_name.split(".")
+        # Initialize agent used below requires functions to take in exactly one parameter
+        param_dict = {
+            "parameters": [
+                {
+                    "name": "param",
+                    "parameter_type": "PARAM",
+                    "position": 0,
+                    "type_json": '{"name":"param","type":"string","nullable":true,"metadata":{}}',
+                    "type_name": "STRING",
+                    "type_precision": 0,
+                    "type_scale": 0,
+                    "type_text": "string",
+                }
+            ]
+        }
+        # Add the catalog, schema and name to the function Info followed by the parameter
+        return FunctionInfo.from_dict(
+            {
+                "catalog_name": components[0],
+                "schema_name": components[1],
+                "name": components[2],
+                "input_params": param_dict,
+            }
+        )
+
+    monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
+    monkeypatch.setattr("databricks.sdk.service.catalog.FunctionsAPI.get", mock_function_get)
+
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient._validate_warehouse_type",
+        return_value=None,
+    ):
+        client = DatabricksFunctionClient(warehouse_id="testId1")
+    toolkit = UCFunctionToolkit(function_names=["rag.test.test_function"], client=client)
+    llm = OpenAI(temperature=0)
+    agent = initialize_agent(
+        toolkit.tools,
+        llm,
+        verbose=True,
+    )
+
+    resources = list(_extract_dependency_list_from_lc_model(agent))
+    assert resources == [
+        DatabricksFunction(function_name="rag.test.test_function"),
+        DatabricksSQLWarehouse(warehouse_id="testId1"),
+    ]

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -514,6 +514,10 @@ def test_parsing_dependency_from_databricks(monkeypatch, use_partner_package):
     ]
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="unitycatalog-langchain depends on langchain>=0.2.0",
+)
 def test_parsing_unitycatalog_tool_as_dependency(monkeypatch: pytest.MonkeyPatch):
     from databricks.sdk.service.catalog import FunctionInfo
     from langchain.agents import initialize_agent


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13567?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13567/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13567
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support extraction of new UC tools as databricks dependency.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
