### PR TITLE
Update databricks env when running mlflow.models.predict

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -70,6 +70,7 @@ from mlflow.utils.autologging_utils import (
     safe_patch,
 )
 from mlflow.utils.databricks_utils import (
+    _get_databricks_serverless_env_vars,
     is_in_databricks_model_serving_environment,
     is_in_databricks_serverless_runtime,
     is_mlflow_tracing_enabled_in_model_serving,
@@ -126,28 +127,6 @@ def get_default_conda_env():
         :func:`save_model()` and :func:`log_model()`.
     """
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
-
-
-def _get_databricks_serverless_env_vars():
-    """
-    Returns the environment variables required to to initialize WorkspaceClient in a subprocess
-    with serverless compute.
-
-    Note:
-        Databricks authentication related environment variables are set in the
-        _capture_imported_modules function.
-    """
-    envs = {}
-    if "SPARK_REMOTE" in os.environ:
-        envs["SPARK_LOCAL_REMOTE"] = os.environ["SPARK_REMOTE"]
-    else:
-        logger.warning(
-            "Missing required environment variable `SPARK_LOCAL_REMOTE` or `SPARK_REMOTE`."
-            "These are necessary to initialize the WorkspaceClient with serverless compute in "
-            "a subprocess in Databricks for UC function execution. Setting the value to 'true'."
-        )
-        envs["SPARK_LOCAL_REMOTE"] = "true"
-    return envs
 
 
 @experimental

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -105,6 +105,7 @@ def predict(
     env_manager=_EnvManager.VIRTUALENV,
     install_mlflow=False,
     pip_requirements_override=None,
+    # TODO: add an option to force recreating the env
 ):
     """
     Generate predictions in json format using a saved MLflow model. For information about the input

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -9,7 +9,6 @@ from mlflow.utils import env_manager as _EnvManager
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
     is_databricks_connect,
-    is_in_databricks_runtime,
 )
 from mlflow.utils.file_utils import TempDir
 
@@ -174,15 +173,7 @@ def predict(
             f"Content type must be one of {_CONTENT_TYPE_JSON} or {_CONTENT_TYPE_CSV}."
         )
 
-    spark_session = None
-    if is_in_databricks_runtime():
-        try:
-            from pyspark.sql import SparkSession
-
-            spark_session = SparkSession.getActiveSession()
-        except Exception:
-            pass
-    is_dbconnect_mode = is_databricks_connect(spark_session)
+    is_dbconnect_mode = is_databricks_connect()
     if is_dbconnect_mode:
         if env_manager != _EnvManager.VIRTUALENV:
             raise MlflowException(

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -476,16 +476,20 @@ def init(model: PyFuncModel):
 def _predict(model_uri, input_path, output_path, content_type):
     pyfunc_model = load_model(model_uri)
 
+    should_parse_as_unified_llm_input = False
     if content_type == "json":
         if input_path is None:
             input_str = sys.stdin.read()
         else:
             with open(input_path) as f:
                 input_str = f.read()
-        data, params = _split_data_and_params(input_str)
-        # schema needs to be passed to correctly match the behavior
-        # of schema enforcement during pyfunc predict
-        df = infer_and_parse_data(data, schema=pyfunc_model.metadata.get_input_schema())
+        parsed_json_input = _parse_json_data(
+            data=input_str,
+            metadata=pyfunc_model.metadata,
+            input_schema=pyfunc_model.metadata.get_input_schema(),
+        )
+        df = parsed_json_input.data
+        should_parse_as_unified_llm_input = parsed_json_input.is_unified_llm_input
     elif content_type == "csv":
         df = parse_csv_input(input_path) if input_path is not None else parse_csv_input(sys.stdin)
         params = None
@@ -498,11 +502,15 @@ def _predict(model_uri, input_path, output_path, content_type):
         _log_warning_if_params_not_in_predict_signature(_logger, params)
         raw_predictions = pyfunc_model.predict(df)
 
+    parse_output_func = (
+        unwrapped_predictions_to_json if should_parse_as_unified_llm_input else predictions_to_json
+    )
+
     if output_path is None:
-        predictions_to_json(raw_predictions, sys.stdout)
+        parse_output_func(raw_predictions, sys.stdout)
     else:
         with open(output_path, "w") as fout:
-            predictions_to_json(raw_predictions, fout)
+            parse_output_func(raw_predictions, fout)
 
 
 def _serve(model_uri, port, host):

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -489,6 +489,7 @@ def _predict(model_uri, input_path, output_path, content_type):
             input_schema=pyfunc_model.metadata.get_input_schema(),
         )
         df = parsed_json_input.data
+        params = parsed_json_input.params
         should_parse_as_unified_llm_input = parsed_json_input.is_unified_llm_input
     elif content_type == "csv":
         df = parse_csv_input(input_path) if input_path is not None else parse_csv_input(sys.stdin)

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -277,7 +277,7 @@ def is_in_databricks_shared_cluster_runtime():
     )
 
 
-def is_databricks_connect(spark):
+def is_databricks_connect(spark=None):
     """
     Return True if current Spark-connect client connects to Databricks cluster.
     """
@@ -289,6 +289,8 @@ def is_databricks_connect(spark):
     if is_in_databricks_serverless_runtime() or is_in_databricks_shared_cluster_runtime():
         return True
     try:
+        if spark is None:
+            spark = _get_active_spark_session()
         # TODO: Remove the `spark.client._builder` attribute usage once
         #  Spark-connect has public attribute for this information.
         return is_spark_connect_mode() and any(
@@ -1102,6 +1104,28 @@ def get_databricks_env_vars(tracking_uri):
         env_vars.update(workspace_info.to_environment())
 
     return env_vars
+
+
+def _get_databricks_serverless_env_vars():
+    """
+    Returns the environment variables required to to initialize WorkspaceClient in a subprocess
+    with serverless compute.
+
+    Note:
+        Databricks authentication related environment variables are set in the
+        _capture_imported_modules function.
+    """
+    envs = {}
+    if "SPARK_REMOTE" in os.environ:
+        envs["SPARK_LOCAL_REMOTE"] = os.environ["SPARK_REMOTE"]
+    else:
+        _logger.warning(
+            "Missing required environment variable `SPARK_LOCAL_REMOTE` or `SPARK_REMOTE`."
+            "These are necessary to initialize the WorkspaceClient with serverless compute in "
+            "a subprocess in Databricks for UC function execution. Setting the value to 'true'."
+        )
+        envs["SPARK_LOCAL_REMOTE"] = "true"
+    return envs
 
 
 class DatabricksRuntimeVersion(NamedTuple):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1106,21 +1106,21 @@ def get_databricks_env_vars(tracking_uri):
     return env_vars
 
 
-def _get_databricks_serverless_env_vars():
+def _get_databricks_serverless_env_vars() -> dict[str, str]:
     """
     Returns the environment variables required to to initialize WorkspaceClient in a subprocess
     with serverless compute.
 
     Note:
-        Databricks authentication related environment variables are set in the
-        _capture_imported_modules function.
+        Databricks authentication related environment variables such as DATABRICKS_HOST are
+        set in the are set in the _capture_imported_modules function.
     """
     envs = {}
     if "SPARK_REMOTE" in os.environ:
         envs["SPARK_LOCAL_REMOTE"] = os.environ["SPARK_REMOTE"]
     else:
         _logger.warning(
-            "Missing required environment variable `SPARK_LOCAL_REMOTE` or `SPARK_REMOTE`."
+            "Missing required environment variable `SPARK_LOCAL_REMOTE` or `SPARK_REMOTE`. "
             "These are necessary to initialize the WorkspaceClient with serverless compute in "
             "a subprocess in Databricks for UC function execution. Setting the value to 'true'."
         )

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -19,7 +19,14 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.tracking import get_tracking_uri
 from mlflow.utils import PYTHON_VERSION, insecure_hash
+from mlflow.utils.databricks_utils import (
+    _get_databricks_serverless_env_vars,
+    get_databricks_env_vars,
+    is_databricks_connect,
+    is_in_databricks_runtime,
+)
 from mlflow.utils.os import is_windows
 from mlflow.utils.process import _exec_cmd
 from mlflow.utils.requirements_utils import (
@@ -829,6 +836,10 @@ class Environment:
         if command_env is None:
             command_env = os.environ.copy()
         command_env = {**self._extra_env, **command_env}
+        if is_in_databricks_runtime():
+            command_env.update(get_databricks_env_vars(get_tracking_uri()))
+        if is_databricks_connect():
+            command_env.update(_get_databricks_serverless_env_vars())
         if not isinstance(command, list):
             command = [command]
 

--- a/tests/models/test_python_api.py
+++ b/tests/models/test_python_api.py
@@ -46,6 +46,12 @@ from mlflow.utils.env_manager import CONDA, VIRTUALENV
             np.array([[1, 2], [3, 4]]),
             _CONTENT_TYPE_JSON,
         ),
+        (
+            # uLLM input, no change
+            {"input": "some_data"},
+            {"input": "some_data"},
+            _CONTENT_TYPE_JSON,
+        ),
     ],
 )
 def test_predict(input_data, expected_data, content_type):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13569?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13569/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13569
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
1. If in dbruntime, we should include databricks configs into environment variables for running `mlflow.models.predict` as they might be necessary to run model prediction in a subprocess.
2. Fix _predict used in `mlflow.models.predict` to be consistent with scoring_server's predict. We should accept uLLM input and has same parsing logic.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manual validation on an agent that requires databricks auth
<img width="849" alt="image" src="https://github.com/user-attachments/assets/4c688f15-863b-4f8b-aead-5b07a3fab3d2">


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
