### PR TITLE
Add numpy to requirement when pandas is found

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -541,6 +541,11 @@ def _infer_requirements(model_uri, flavor, raise_on_error=False, extra_env_vars=
             unrecognized_packages,
         )
 
+    # for pandas<2.1.0, we need to pin numpy as pandas is not compatible with numpy 2.x
+    # pinning numpy to the current version used should be safe
+    if any(package == "pandas" for package in packages):
+        packages.add("numpy")
+
     return sorted(map(_get_pinned_requirement, packages))
 
 

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -541,18 +541,18 @@ def _infer_requirements(model_uri, flavor, raise_on_error=False, extra_env_vars=
             unrecognized_packages,
         )
 
-    packages = set(map(_get_pinned_requirement, packages))
-
     # Handle pandas incompatibility issue with numpy 2.x https://github.com/pandas-dev/pandas/issues/55519
     # pandas == 2.2.*: compatible with numpy >= 2
     # pandas >= 2.1.2: incompatible with numpy >= 2, but it pins numpy < 2
     # pandas < 2.1.2: incompatible with numpy >= 2 and doesn't pin numpy, so we need to pin numpy
     if any(
-        package.startswith("pandas") and Version(package.split("==")[1]) < Version("2.1.2")
+        package == "pandas"
+        and Version(_get_pinned_requirement(package).split("==")[1]) < Version("2.1.2")
         for package in packages
     ):
-        packages.add(_get_pinned_requirement("numpy"))
-    return sorted(packages)
+        packages.add("numpy")
+
+    return sorted(map(_get_pinned_requirement, packages))
 
 
 def _get_local_version_label(version):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -541,9 +541,11 @@ def _infer_requirements(model_uri, flavor, raise_on_error=False, extra_env_vars=
             unrecognized_packages,
         )
 
-    # for pandas < 2.1.0, we need to pin numpy < 2 as pandas is not compatible with numpy 2.x
-    # in general, we just pin numpy to the current version
-    if any(package == "pandas" for package in packages):
+    # for pandas < 2.1.2, we need to pin numpy < 2 as pandas is not compatible with numpy 2.x
+    if any(
+        package == "pandas" and _get_pinned_requirement(package).split("==")[1] < "2.1.2"
+        for package in packages
+    ):
         packages.add("numpy")
 
     return sorted(map(_get_pinned_requirement, packages))

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -541,7 +541,10 @@ def _infer_requirements(model_uri, flavor, raise_on_error=False, extra_env_vars=
             unrecognized_packages,
         )
 
-    # for pandas < 2.1.2, we need to pin numpy < 2 as pandas is not compatible with numpy 2.x
+    # Fix pandas incompatibility issue with numpy 2.x
+    # pandas == 2.2.*: compatible with numpy >= 2
+    # pandas >= 2.1.2: incompatible with numpy >= 2, but it pins numpy < 2
+    # pandas < 2.1.2: incompatible with numpy >= 2 and doesn't pin numpy, so we need to pin numpy
     if any(
         package == "pandas" and _get_pinned_requirement(package).split("==")[1] < "2.1.2"
         for package in packages

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -541,17 +541,18 @@ def _infer_requirements(model_uri, flavor, raise_on_error=False, extra_env_vars=
             unrecognized_packages,
         )
 
-    # Fix pandas incompatibility issue with numpy 2.x
+    packages = set(map(_get_pinned_requirement, packages))
+
+    # Handle pandas incompatibility issue with numpy 2.x https://github.com/pandas-dev/pandas/issues/55519
     # pandas == 2.2.*: compatible with numpy >= 2
     # pandas >= 2.1.2: incompatible with numpy >= 2, but it pins numpy < 2
     # pandas < 2.1.2: incompatible with numpy >= 2 and doesn't pin numpy, so we need to pin numpy
     if any(
-        package == "pandas" and _get_pinned_requirement(package).split("==")[1] < "2.1.2"
+        package.startswith("pandas") and Version(package.split("==")[1]) < Version("2.1.2")
         for package in packages
     ):
-        packages.add("numpy")
-
-    return sorted(map(_get_pinned_requirement, packages))
+        packages.add(_get_pinned_requirement("numpy"))
+    return sorted(packages)
 
 
 def _get_local_version_label(version):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -541,8 +541,8 @@ def _infer_requirements(model_uri, flavor, raise_on_error=False, extra_env_vars=
             unrecognized_packages,
         )
 
-    # for pandas<2.1.0, we need to pin numpy as pandas is not compatible with numpy 2.x
-    # pinning numpy to the current version used should be safe
+    # for pandas < 2.1.0, we need to pin numpy < 2 as pandas is not compatible with numpy 2.x
+    # in general, we just pin numpy to the current version
     if any(package == "pandas" for package in packages):
         packages.add("numpy")
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2050,9 +2050,9 @@ def test_model_pip_requirements_pin_numpy_when_pandas_included():
 
     # no numpy when pandas > 2.1.2
     with mlflow.start_run():
-        mlflow.pyfunc.log_model("model", python_model=TestModel(), input_example="abc")
+        model_info = mlflow.pyfunc.log_model("model", python_model=TestModel(), input_example="abc")
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [
                 expected_mlflow_version,
                 f"cloudpickle=={cloudpickle.__version__}",
@@ -2076,9 +2076,9 @@ def test_model_pip_requirements_pin_numpy_when_pandas_included():
             side_effect=mock_get_installed_version,
         ),
     ):
-        mlflow.pyfunc.log_model("model", python_model=TestModel(), input_example="abc")
+        model_info = mlflow.pyfunc.log_model("model", python_model=TestModel(), input_example="abc")
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [
                 expected_mlflow_version,
                 "pandas==2.1.0",
@@ -2090,9 +2090,9 @@ def test_model_pip_requirements_pin_numpy_when_pandas_included():
 
     # no input_example, so pandas not included in requirements
     with mlflow.start_run():
-        mlflow.pyfunc.log_model("model", python_model=TestModel())
+        model_info = mlflow.pyfunc.log_model("model", python_model=TestModel())
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, f"cloudpickle=={cloudpickle.__version__}"],
             strict=True,
         )

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2050,5 +2050,19 @@ def test_model_pip_requirements_pin_numpy_when_pandas_included():
         expected_mlflow_version = _mlflow_major_version_string()
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
-            [expected_mlflow_version, f"pandas=={pandas.__version__}", f"numpy=={np.__version__}"],
+            [
+                expected_mlflow_version,
+                f"pandas=={pandas.__version__}",
+                f"numpy=={np.__version__}",
+                f"cloudpickle=={cloudpickle.__version__}",
+            ],
+            strict=True,
+        )
+
+    with mlflow.start_run():
+        mlflow.pyfunc.log_model("model", python_model=TestModel())
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"),
+            [expected_mlflow_version, f"cloudpickle=={cloudpickle.__version__}"],
+            strict=True,
         )

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2038,3 +2038,17 @@ def test_model_as_code_pycache_cleaned_up():
 
     path = _download_artifact_from_uri(model_info.model_uri)
     assert list(Path(path).rglob("__pycache__")) == []
+
+
+def test_model_pip_requirements_pin_numpy_when_pandas_included():
+    class TestModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
+    with mlflow.start_run():
+        mlflow.pyfunc.log_model("model", python_model=TestModel(), input_example="abc")
+        expected_mlflow_version = _mlflow_major_version_string()
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"),
+            [expected_mlflow_version, f"pandas=={pandas.__version__}", f"numpy=={np.__version__}"],
+        )

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2069,9 +2069,12 @@ def test_model_pip_requirements_pin_numpy_when_pandas_included():
         return original_get_installed_version(package, module)
 
     # include numpy when pandas < 2.1.2
-    with mlflow.start_run(), mock.patch(
-        "mlflow.utils.requirements_utils._get_installed_version",
-        side_effect=mock_get_installed_version,
+    with (
+        mlflow.start_run(),
+        mock.patch(
+            "mlflow.utils.requirements_utils._get_installed_version",
+            side_effect=mock_get_installed_version,
+        ),
     ):
         mlflow.pyfunc.log_model("model", python_model=TestModel(), input_example="abc")
         _assert_pip_requirements(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13580?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13580/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13580
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Pandas < 2.1.0 is not compatible with numpy 2.x, so if pandas is included in the pip requirement file, we should pin numpy to the current version as well to make sure it won't cause exception in serving.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
