### PR TITLE
Add environment variable detection in model logging

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -667,3 +667,8 @@ MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC = _BooleanEnvironmentVaria
 MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR = _EnvironmentVariable(
     "MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR", str, None
 )
+
+# Specifies weather to log environment variables used during model logging.
+MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING = _BooleanEnvironmentVariable(
+    "MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING", True
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -668,7 +668,7 @@ MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR = _EnvironmentVariable(
     "MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR", str, None
 )
 
-# Specifies weather to log environment variables used during model logging.
+# Specifies weather to log environment variable names used during model logging.
 MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING = _BooleanEnvironmentVariable(
     "MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING", True
 )

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -869,16 +869,16 @@ class Model:
                     env_var_path, mlflow_model.artifact_path, run_id
                 )
                 if len(model_info.env_vars) <= 3:
-                    env_var_info = ", ".join(model_info.env_vars)
+                    env_var_info = "[" + ", ".join(model_info.env_vars) + "]"
                 else:
-                    env_var_info = ", ".join(model_info.env_vars[:3]) + ", ... "
+                    env_var_info = "[" + ", ".join(model_info.env_vars[:3]) + ", ... " + "]"
                     f"(check file {ENV_VAR_FILE_NAME} in the model's artifact folder for full list"
                     " of environment variable names)"
                 _logger.info(
-                    "Found the following environment variables used during model logging: "
+                    "Found the following environment variables used during model inference: "
                     f"{env_var_info}. Please check if you need to set them when deploying the "
-                    "model. To disable logging environment variable names, set environment variable"
-                    f" `{MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name}` to `false`."
+                    "model. To disable this message, set environment variable "
+                    f"`{MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name}` to `false`."
                 )
 
         return model_info

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -75,6 +75,7 @@ MODEL_CODE_PATH = "model_code_path"
 SET_MODEL_ERROR = (
     "Model should either be an instance of PyFuncModel, Langchain type, or LlamaIndex index."
 )
+ENV_VAR_FILE_NAME = "environment_variables.txt"
 
 
 class ModelInfo:
@@ -96,6 +97,7 @@ class ModelInfo:
         signature_dict: Optional[dict[str, Any]] = None,
         metadata: Optional[dict[str, Any]] = None,
         registered_model_version: Optional[int] = None,
+        env_vars: Optional[list[str]] = None,
     ):
         self._artifact_path = artifact_path
         self._flavors = flavors
@@ -109,6 +111,7 @@ class ModelInfo:
         self._mlflow_version = mlflow_version
         self._metadata = metadata
         self._registered_model_version = registered_model_version
+        self._env_vars = env_vars
 
     @property
     def artifact_path(self) -> str:
@@ -241,6 +244,22 @@ class ModelInfo:
         """
         return self._mlflow_version
 
+    @property
+    def env_vars(self):
+        """
+        Environment variables used during the model logging process.
+
+        :getter: Gets the environment variables used during the model logging process.
+        :type: Optional[List[str]]
+        """
+        return self._env_vars
+
+    @env_vars.setter
+    def env_vars(self, value: Optional[list[str]]) -> None:
+        if value and not (isinstance(value, list) and all(isinstance(x, str) for x in value)):
+            raise TypeError(f"env_vars must be a list of strings. Got: {value}")
+        self._env_vars = value
+
     @experimental
     @property
     def metadata(self) -> Optional[dict[str, Any]]:
@@ -321,6 +340,7 @@ class Model:
         metadata: Optional[dict[str, Any]] = None,
         model_size_bytes: Optional[int] = None,
         resources: Optional[Union[str, list[Resource]]] = None,
+        env_vars: Optional[list[str]] = None,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -335,6 +355,7 @@ class Model:
         self.metadata = metadata
         self.model_size_bytes = model_size_bytes
         self.resources = resources
+        self.env_vars = env_vars
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -537,6 +558,16 @@ class Model:
             serialized_resource = value
         self._resources = serialized_resource
 
+    @property
+    def env_vars(self) -> Optional[list[str]]:
+        return self._env_vars
+
+    @env_vars.setter
+    def env_vars(self, value: Optional[list[str]]) -> None:
+        if value and not (isinstance(value, list) and all(isinstance(x, str) for x in value)):
+            raise TypeError(f"env_vars must be a list of strings. Got: {value}")
+        self._env_vars = value
+
     def get_model_info(self) -> ModelInfo:
         """
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
@@ -651,10 +682,20 @@ class Model:
             )
 
         path = download_artifacts(artifact_uri=path)
+        env_vars = None
         if os.path.isdir(path):
             path = os.path.join(path, MLMODEL_FILE_NAME)
+            env_var_path = os.path.join(path, ENV_VAR_FILE_NAME)
+        elif os.path.isfile(path):
+            env_var_path = os.path.join(os.path.dirname(path), ENV_VAR_FILE_NAME)
+        else:
+            env_var_path = None
+        if os.path.exists(env_var_path):
+            env_vars = Path(env_var_path).read_text().splitlines()
         with open(path) as f:
-            return cls.from_dict(yaml.safe_load(f.read()))
+            model_dict = yaml.safe_load(f.read())
+        model_dict["env_vars"] = env_vars
+        return cls.from_dict(model_dict)
 
     @classmethod
     def from_dict(cls, model_dict) -> "Model":
@@ -799,22 +840,31 @@ class Model:
             # validate input example works for serving when logging the model
             if serving_input and kwargs.get("validate_serving_input", True):
                 from mlflow.models import validate_serving_input
+                from mlflow.utils.model_utils import env_var_tracker
 
-                try:
-                    validate_serving_input(model_info.model_uri, serving_input)
-                except Exception as e:
-                    _logger.warning(
-                        f"Failed to validate serving input example {serving_input}. "
-                        "Alternatively, you can avoid passing input example and pass model "
-                        "signature instead when logging the model. To ensure the input example "
-                        "is valid prior to serving, please try calling "
-                        "`mlflow.models.validate_serving_input` on the model uri and serving "
-                        "input example. A serving input example can be generated from model "
-                        "input example using "
-                        "`mlflow.models.convert_input_example_to_serving_input` function.\n"
-                        f"Got error: {e}",
-                        exc_info=_logger.isEnabledFor(logging.DEBUG),
-                    )
+                with env_var_tracker() as env:
+                    try:
+                        validate_serving_input(model_info.model_uri, serving_input)
+                    except Exception as e:
+                        _logger.warning(
+                            f"Failed to validate serving input example {serving_input}. "
+                            "Alternatively, you can avoid passing input example and pass model "
+                            "signature instead when logging the model. To ensure the input example "
+                            "is valid prior to serving, please try calling "
+                            "`mlflow.models.validate_serving_input` on the model uri and serving "
+                            "input example. A serving input example can be generated from model "
+                            "input example using "
+                            "`mlflow.models.convert_input_example_to_serving_input` function.\n"
+                            f"Got error: {e}",
+                            exc_info=_logger.isEnabledFor(logging.DEBUG),
+                        )
+                    model_info.env_vars = list(env.get_env_vars()) or None
+            if model_info.env_vars:
+                env_var_path = Path(local_path, ENV_VAR_FILE_NAME)
+                env_var_path.write_text("\n".join(model_info.env_vars) + "\n")
+                mlflow.tracking.fluent.log_artifact(
+                    env_var_path, mlflow_model.artifact_path, run_id
+                )
 
         return model_info
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -79,7 +79,8 @@ SET_MODEL_ERROR = (
 ENV_VAR_FILE_NAME = "environment_variables.txt"
 ENV_VAR_FILE_HEADER = (
     "# This file records environment variable names that are used during model inference\n"
-    "# make sure you set them when creating a serving endpoint from this model.\n"
+    "# they might need to be set when creating a serving endpoint from this model\n"
+    "# note: it is not guaranteed that all environment variables listed here are required\n"
 )
 
 
@@ -697,8 +698,9 @@ class Model:
         else:
             env_var_path = None
         if os.path.exists(env_var_path):
-            # the first two items are headers in ENV_VAR_FILE_HEADER
-            env_vars = Path(env_var_path).read_text().splitlines()[2:]
+            # comments start with `#` such as ENV_VAR_FILE_HEADER
+            lines = Path(env_var_path).read_text().splitlines()
+            env_vars = [line for line in lines if line and not line.startswith("#")]
         with open(path) as f:
             model_dict = yaml.safe_load(f.read())
         model_dict["env_vars"] = env_vars
@@ -799,7 +801,7 @@ class Model:
                 with env_var_tracker() as env:
                     try:
                         validate_serving_input(
-                            model_uri=f"runs:/{run_id}/{mlflow_model.artifact_path}",
+                            model_uri=local_path,
                             serving_input=serving_input,
                         )
                     except Exception as e:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -865,6 +865,11 @@ class Model:
                 mlflow.tracking.fluent.log_artifact(
                     env_var_path, mlflow_model.artifact_path, run_id
                 )
+                _logger.info(
+                    f"Logged environment variables to file {ENV_VAR_FILE_NAME} in "
+                    "the model's artifact folder, please check if you need to set these "
+                    "environment variables when serving the model.",
+                )
 
         return model_info
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -860,20 +860,25 @@ class Model:
                             f"Got error: {e}",
                             exc_info=_logger.isEnabledFor(logging.DEBUG),
                         )
-                    if hasattr(env, "get_env_vars"):
-                        model_info.env_vars = list(env.get_env_vars()) or None
+                    if hasattr(env, "get_tracked_env_names"):
+                        model_info.env_vars = list(env.get_tracked_env_names()) or None
             if model_info.env_vars:
                 env_var_path = Path(local_path, ENV_VAR_FILE_NAME)
                 env_var_path.write_text("\n".join(model_info.env_vars) + "\n")
                 mlflow.tracking.fluent.log_artifact(
                     env_var_path, mlflow_model.artifact_path, run_id
                 )
+                if len(model_info.env_vars) <= 3:
+                    env_var_info = ", ".join(model_info.env_vars)
+                else:
+                    env_var_info = ", ".join(model_info.env_vars[:3]) + ", ... "
+                    f"(check file {ENV_VAR_FILE_NAME} in the model's artifact folder for full list"
+                    " of environment variable names)"
                 _logger.info(
-                    "Logged environment variables used during model logging to file "
-                    f"{ENV_VAR_FILE_NAME} in the model's artifact folder, please check "
-                    "if you need to set these environment variables when deploying the model. "
-                    "To disable logging them, set environment variable "
-                    f"`{MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name}` to `false`."
+                    "Found the following environment variables used during model logging: "
+                    f"{env_var_info}. Please check if you need to set them when deploying the "
+                    "model. To disable logging environment variable names, set environment variable"
+                    f" `{MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name}` to `false`."
                 )
 
         return model_info

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -689,7 +689,6 @@ class Model:
             )
 
         path = download_artifacts(artifact_uri=path)
-        env_vars = None
         if os.path.isdir(path):
             path = os.path.join(path, MLMODEL_FILE_NAME)
             env_var_path = os.path.join(path, ENV_VAR_FILE_NAME)
@@ -697,6 +696,7 @@ class Model:
             env_var_path = os.path.join(os.path.dirname(path), ENV_VAR_FILE_NAME)
         else:
             env_var_path = None
+        env_vars = None
         if os.path.exists(env_var_path):
             # comments start with `#` such as ENV_VAR_FILE_HEADER
             lines = Path(env_var_path).read_text().splitlines()

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -872,7 +872,7 @@ class Model:
                     "Logged environment variables used during model logging to file "
                     f"{ENV_VAR_FILE_NAME} in the model's artifact folder, please check "
                     "if you need to set these environment variables when deploying the model. "
-                    "To disable logging them, set environmenv variable "
+                    "To disable logging them, set environment variable "
                     f"`{MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name}` to `false`."
                 )
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -78,9 +78,9 @@ SET_MODEL_ERROR = (
 )
 ENV_VAR_FILE_NAME = "environment_variables.txt"
 ENV_VAR_FILE_HEADER = (
-    "# This file records environment variable names that are used during model inference\n"
-    "# they might need to be set when creating a serving endpoint from this model\n"
-    "# note: it is not guaranteed that all environment variables listed here are required\n"
+    "# This file records environment variable names that are used during model inference.\n"
+    "# They might need to be set when creating a serving endpoint from this model.\n"
+    "# Note: it is not guaranteed that all environment variables listed here are required\n"
 )
 
 
@@ -251,7 +251,7 @@ class ModelInfo:
         return self._mlflow_version
 
     @property
-    def env_vars(self):
+    def env_vars(self) -> Optional[list[str]]:
         """
         Environment variables used during the model logging process.
 
@@ -817,11 +817,14 @@ class Model:
                             f"Got error: {e}",
                             exc_info=_logger.isEnabledFor(logging.DEBUG),
                         )
-                    env_vars = [
-                        x
-                        for x in tracked_env_names
-                        if any(env_var in x for env_var in RECORD_ENV_VAR_ALLOWLIST)
-                    ] or None
+                    env_vars = (
+                        sorted(
+                            x
+                            for x in tracked_env_names
+                            if any(env_var in x for env_var in RECORD_ENV_VAR_ALLOWLIST)
+                        )
+                        or None
+                    )
             if env_vars:
                 env_var_path = Path(local_path, ENV_VAR_FILE_NAME)
                 env_var_path.write_text(ENV_VAR_FILE_HEADER + "\n".join(env_vars) + "\n")

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -446,10 +446,9 @@ class EnvTracker(dict):
         self.env_vars.add(key)
 
     def __getitem__(self, key):
-        result = super().__getitem__(key)
-        if result is not None:
+        if key in self:
             self.env_vars.add(key)
-        return result
+        return super().__getitem__(key)
 
     def get(self, key, *args, **kwargs):
         if key in self:

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -466,16 +466,21 @@ def env_var_tracker():
 
         def updated_get_item(self, key):
             result = original_getitem(self, key)
-            if any(env_var in key for env_var in RECORD_ENV_VAR_ALLOWLIST):
-                tracked_env_names.add(key)
+            tracked_env_names.add(key)
             return result
 
         def updated_get(self, key, *args, **kwargs):
-            if key in self and any(env_var in key for env_var in RECORD_ENV_VAR_ALLOWLIST):
+            if key in self:
                 tracked_env_names.add(key)
             return original_get(self, key, *args, **kwargs)
 
         def get_tracked_env_names(self):
+            nonlocal tracked_env_names
+            tracked_env_names = {
+                x
+                for x in tracked_env_names
+                if any(env_var in x for env_var in RECORD_ENV_VAR_ALLOWLIST)
+            }
             return tracked_env_names
 
         try:

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -431,7 +431,23 @@ def _validate_pyfunc_model_config(model_config):
         )
 
 
-ALLOWED_ENV_VARS = {"API_KEY", "DATABRICKS"}
+RECORD_ENV_VARS = {
+    # api key related
+    "API_KEY",
+    # databricks auth related
+    "DATABRICKS_HOST",
+    "DATABRICKS_USERNAME",
+    "DATABRICKS_PASSWORD",
+    "DATABRICKS_TOKEN",
+    "DATABRICKS_INSECURE",
+    "DATABRICKS_CLIENT_ID",
+    "DATABRICKS_CLIENT_SECRET",
+    "_DATABRICKS_WORKSPACE_HOST",
+    "_DATABRICKS_WORKSPACE_ID",
+    # dbconnect related
+    "SPARK_REMOTE",
+    "SPARK_LOCAL_REMOTE",
+}
 
 
 class EnvTracker(dict):
@@ -446,16 +462,16 @@ class EnvTracker(dict):
 
     def __setitem__(self, key, value):
         super().__setitem__(key, value)
-        if any(env_var in key for env_var in ALLOWED_ENV_VARS):
+        if any(env_var in key for env_var in RECORD_ENV_VARS):
             self.env_vars.add(key)
 
     def __getitem__(self, key):
-        if key in self and any(env_var in key for env_var in ALLOWED_ENV_VARS):
+        if key in self and any(env_var in key for env_var in RECORD_ENV_VARS):
             self.env_vars.add(key)
         return super().__getitem__(key)
 
     def get(self, key, *args, **kwargs):
-        if key in self and any(env_var in key for env_var in ALLOWED_ENV_VARS):
+        if key in self and any(env_var in key for env_var in RECORD_ENV_VARS):
             self.env_vars.add(key)
         return super().get(key, *args, **kwargs)
 

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -433,7 +433,8 @@ def _validate_pyfunc_model_config(model_config):
 
 class EnvTracker(dict):
     """
-    Track environment variables accessed.
+    Track environment variables set and accessed during the context manager's lifetime.
+    Note that if the environment variable does not exist, it will not be tracked.
     """
 
     def __init__(self, *args, **kwargs):
@@ -445,11 +446,14 @@ class EnvTracker(dict):
         self.env_vars.add(key)
 
     def __getitem__(self, key):
-        self.env_vars.add(key)
-        return super().__getitem__(key)
+        result = super().__getitem__(key)
+        if result is not None:
+            self.env_vars.add(key)
+        return result
 
     def get(self, key, *args, **kwargs):
-        self.env_vars.add(key)
+        if key in self:
+            self.env_vars.add(key)
         return super().get(key, *args, **kwargs)
 
     def get_env_vars(self):

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2104,6 +2104,11 @@ def test_environment_variables_used_during_model_logging(monkeypatch):
         def predict(self, context, model_input, params=None):
             monkeypatch.setenv("TEST_API_KEY", "test_env")
             monkeypatch.setenv("INVALID_ENV_VAR", "var")
+            # existing env var is tracked
+            os.environ["TEST_API_KEY"]
+            # existing env var not in allowlist is not tracked
+            os.environ.get("INVALID_ENV_VAR")
+            # non-existing env var is not tracked
             os.environ.get("INVALID_API_KEY")
             return model_input
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2103,9 +2103,12 @@ def test_environment_variables_used_during_model_logging(monkeypatch):
     class MyModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
             monkeypatch.setenv("TEST_API_KEY", "test_env")
+            monkeypatch.setenv("ANOTHER_API_KEY", "test_env")
             monkeypatch.setenv("INVALID_ENV_VAR", "var")
             # existing env var is tracked
             os.environ["TEST_API_KEY"]
+            # existing env var fetched by getenv is tracked
+            os.getenv("ANOTHER_API_KEY")
             # existing env var not in allowlist is not tracked
             os.environ.get("INVALID_ENV_VAR")
             # non-existing env var is not tracked
@@ -2115,6 +2118,7 @@ def test_environment_variables_used_during_model_logging(monkeypatch):
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model("model", python_model=MyModel(), input_example="data")
     assert "TEST_API_KEY" in model_info.env_vars
+    assert "ANOTHER_API_KEY" in model_info.env_vars
     assert "INVALID_ENV_VAR" not in model_info.env_vars
     assert "INVALID_API_KEY" not in model_info.env_vars
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2107,7 +2107,8 @@ def test_environment_variables_used_during_model_logging(monkeypatch):
 
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model("model", python_model=MyModel(), input_example="data")
-    assert all(x in model_info.env_vars for x in ["TEST_ENV", "TRY_GET_ENV"])
+    assert "TEST_ENV" in model_info.env_vars
+    assert "TRY_GET_ENV" not in model_info.env_vars
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_model.metadata.env_vars == model_info.env_vars
 

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -133,14 +133,14 @@ def test_env_var_tracker(monkeypatch):
         os.environ.get("INVALID_API_KEY", "abc")
         assert "INVALID_API_KEY" not in os.environ.get_env_vars()
         try:
-            os.environ["DATABRICKS_CLIENT"]
+            os.environ["ANOTHER_API_KEY"]
         except KeyError:
             pass
-        assert "DATABRICKS_CLIENT" not in os.environ.get_env_vars()
+        assert "ANOTHER_API_KEY" not in os.environ.get_env_vars()
 
     assert not hasattr(os.environ, "get_env_vars")
     assert all(x in os.environ for x in ["DATABRICKS_HOST", "TEST_API_KEY"])
-    assert all(x not in os.environ for x in ["INVALID_API_KEY", "DATABRICKS_CLIENT"])
+    assert all(x not in os.environ for x in ["INVALID_API_KEY", "ANOTHER_API_KEY"])
 
     monkeypatch.setenv(MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name, "false")
     with env_var_tracker() as env:

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -126,23 +126,27 @@ def test_env_var_tracker(monkeypatch):
 
     with env_var_tracker():
         assert os.environ["DATABRICKS_HOST"] == "host"
-        assert "DATABRICKS_HOST" in os.environ.get_env_vars()
-        assert "TEST_API_KEY" not in os.environ.get_env_vars()
+        assert "DATABRICKS_HOST" in os.environ.get_tracked_env_names()
+        assert "TEST_API_KEY" not in os.environ.get_tracked_env_names()
+        # test set env var can be tracked
         monkeypatch.setenv("TEST_API_KEY", "key")
-        assert "TEST_API_KEY" in os.environ.get_env_vars()
+        assert "TEST_API_KEY" in os.environ.get_tracked_env_names()
+        # test non-existing env vars fetched by `get` are not tracked
         os.environ.get("INVALID_API_KEY", "abc")
-        assert "INVALID_API_KEY" not in os.environ.get_env_vars()
+        assert "INVALID_API_KEY" not in os.environ.get_tracked_env_names()
+        # test non-existing env vars are not tracked
         try:
             os.environ["ANOTHER_API_KEY"]
         except KeyError:
             pass
-        assert "ANOTHER_API_KEY" not in os.environ.get_env_vars()
+        assert "ANOTHER_API_KEY" not in os.environ.get_tracked_env_names()
 
-    assert not hasattr(os.environ, "get_env_vars")
+    assert isinstance(os.environ, os._Environ)
+    assert not hasattr(os.environ, "get_tracked_env_names")
     assert all(x in os.environ for x in ["DATABRICKS_HOST", "TEST_API_KEY"])
     assert all(x not in os.environ for x in ["INVALID_API_KEY", "ANOTHER_API_KEY"])
 
     monkeypatch.setenv(MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name, "false")
     with env_var_tracker() as env:
         monkeypatch.setenv("ANOTHER_TEST_API_KEY", "key")
-        assert not hasattr(env, "get_env_vars")
+        assert not hasattr(env, "get_tracked_env_names")

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -128,8 +128,11 @@ def test_env_var_tracker(monkeypatch):
         assert os.environ["DATABRICKS_HOST"] == "host"
         assert "DATABRICKS_HOST" in os.environ.get_tracked_env_names()
         assert "TEST_API_KEY" not in os.environ.get_tracked_env_names()
-        # test set env var can be tracked
+        # test set un-used env var not tracked
         monkeypatch.setenv("TEST_API_KEY", "key")
+        assert "TEST_API_KEY" not in os.environ.get_tracked_env_names()
+        # accessed env var is tracked
+        assert os.environ.get("TEST_API_KEY") == "key"
         assert "TEST_API_KEY" in os.environ.get_tracked_env_names()
         # test non-existing env vars fetched by `get` are not tracked
         os.environ.get("INVALID_API_KEY", "abc")

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -129,8 +129,14 @@ def test_env_var_tracker(monkeypatch):
         assert "ENV2" not in os.environ.get_env_vars()
         monkeypatch.setenv("ENV2", "env2")
         assert "ENV2" in os.environ.get_env_vars()
-        os.environ.get("ENV3")
-        assert "ENV3" in os.environ.get_env_vars()
+        os.environ.get("ENV3", "abc")
+        assert "ENV3" not in os.environ.get_env_vars()
+        try:
+            os.environ["ENV4"]
+        except KeyError:
+            pass
+        assert "ENV4" not in os.environ.get_env_vars()
 
     assert not hasattr(os.environ, "get_env_vars")
     assert all(x in os.environ for x in ["ENV1", "ENV2"])
+    assert all(x not in os.environ for x in ["ENV3", "ENV4"])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13584?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13584/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13584
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
If the model is logged with an input example, we capture environment variables used during `validate_serving_input` stage and save it into `environment_variables.txt` file in the model's folder. This is useful for letting people know what environment variables are used and could be necessary for model deployment. But since not all accessed environment variables are essential, MLflow doesn't add any constraint here, it's more of a `REMINDER` to the user.

Tested in databricks
<img width="823" alt="image" src="https://github.com/user-attachments/assets/b769e8dc-d762-4615-980e-05bc2b42e6dc">


**UPDATE** 
we decide to go with a whitelist and only record keys containing certain keywords, we start with `API_KEY` and databricks auth related keywords + dbconnect keys
<img width="843" alt="image" src="https://github.com/user-attachments/assets/7446754f-5040-4d46-9e1c-38c32b86a85f">


Known limitation:
We **cannot** detect `DATABRICKS_HOST` or `DATABRICKS_TOKEN` as part of env vars in dbr by default, proof:
<img width="837" alt="image" src="https://github.com/user-attachments/assets/b304cc99-7728-405b-87f5-5940abd4f2fe">
The initialization of WorkspaceClient doesn't require these env vars existing, but they're required in databricks serving because serving is an isolated environment. Even though, I think the issue should be fixed in databricks serving instead of here, as for other users who use env vars as auth, these env vars can be captured.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
