### PR TITLE
Rerun failed github action workflows on PR approval

### DIFF
--- a/.github/workflows/rerun-workflow-run.yml
+++ b/.github/workflows/rerun-workflow-run.yml
@@ -1,0 +1,41 @@
+# Triggered by rerun.yml on PR approval.
+name: rerun-workflow-run
+on:
+  workflow_run:
+    workflows: [rerun]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rerun:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write # to rerun github action workflows
+    steps:
+      - uses: actions/checkout@v4 # checks out the default branch (master), not the PR branch
+      - name: Download PR number
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const rerun = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/rerun.js`);
+            await rerun.download({ context, github });
+
+      - name: Unzip PR number
+        run: unzip pr_number.zip
+
+      - name: Rerun workflows
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const rerun = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/rerun.js`);
+            await rerun.rerun({ context, github });

--- a/.github/workflows/rerun.js
+++ b/.github/workflows/rerun.js
@@ -1,19 +1,36 @@
-module.exports = async ({ github, context }) => {
+const fs = require("fs");
+
+async function download({ github, context }) {
+  const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    run_id: context.payload.workflow_run.id,
+  });
+
+  const matchArtifact = allArtifacts.data.artifacts.find((artifact) => {
+    return artifact.name == "pr_number";
+  });
+
+  const download = await github.rest.actions.downloadArtifact({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    artifact_id: matchArtifact.id,
+    archive_format: "zip",
+  });
+
+  fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+}
+
+async function rerun({ github, context }) {
+  const pull_number = Number(fs.readFileSync("./pr_number"));
   const {
     repo: { owner, repo },
   } = context;
 
-  await github.rest.reactions.createForIssueComment({
-    owner,
-    repo,
-    comment_id: context.payload.comment.id,
-    content: "rocket",
-  });
-
   const { data: pr } = await github.rest.pulls.get({
     owner,
     repo,
-    pull_number: context.issue.number,
+    pull_number,
   });
 
   const checkRuns = await github.paginate(github.rest.checks.listForRef, {
@@ -41,11 +58,20 @@ module.exports = async ({ github, context }) => {
   const uniqueRunIds = [...new Set(runIdsToRerun)];
   const promises = uniqueRunIds.map(async (run_id) => {
     console.log(`Rerunning https://github.com/${owner}/${repo}/actions/runs/${run_id}`);
-    await github.rest.actions.reRunWorkflowFailedJobs({
-      repo,
-      owner,
-      run_id,
-    });
+    try {
+      await github.rest.actions.reRunWorkflowFailedJobs({
+        repo,
+        owner,
+        run_id,
+      });
+    } catch (error) {
+      console.error(`Failed to rerun workflow for run_id ${run_id}:`, error);
+    }
   });
   await Promise.all(promises);
+}
+
+module.exports = {
+  download,
+  rerun,
 };

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -17,7 +17,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event.review.state == 'approved'
+    if: github.event.review.state == 'approved' && contains(github.event.review.author_association, 'MEMBER,OWNER,COLLABORATOR')
     steps:
       - name: Upload PR number
         env:

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,8 +1,10 @@
+# Triggers rerun-workflow-run.yml on PR approval.
+# See https://stackoverflow.com/questions/67247752/how-to-use-secret-in-pull-request-review-similar-to-pull-request-target for why we need this approach and how it works.
 name: rerun
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -12,21 +14,18 @@ permissions:
   contents: read
 
 jobs:
-  rerun:
+  upload:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      pull-requests: write # to create a reaction to the comment
-      actions: write # to rerun github action workflows
-    if: github.event.issue.pull_request && (github.event.comment.body == '/rerun' || github.event.comment.body == '/rr')
+    if: github.event.review.state == 'approved'
     steps:
-      - uses: actions/checkout@v4
+      - name: Upload PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p /tmp/pr
+          echo $PR_NUMBER > /tmp/pr/pr_number
+      - uses: actions/upload-artifact@v4
         with:
-          sparse-checkout: |
-            .github
-      - uses: ./.github/actions/validate-author
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            const rerun = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/rerun.js`);
-            await rerun({ context, github });
+          name: pr_number
+          path: /tmp/pr/

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -17,7 +17,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event.review.state == 'approved' && contains(github.event.review.author_association, 'MEMBER,OWNER,COLLABORATOR')
+    if: github.event.review.state == 'approved' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
     steps:
       - name: Upload PR number
         env:


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Currently, we need to comment `/rerun` to run failed jobs after a PR is approved. This PR eliminates this process to rerun failed jobs **when** the PR is approved.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Tested in https://github.com/harupy/mlflow/pull/95.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
