### PR TITLE
Remove unnecessary python version specifier

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -10,16 +10,12 @@ sklearn:
     requirements:
       "< 1.3.0": ["numpy<2"]
       "< 1.0": ["scipy==1.7.3"]
-    python:
-      "== dev": "3.9"
     run: |
       pytest tests/sklearn/test_sklearn_model_export.py
 
   autologging:
     minimum: "0.24.1"
     maximum: "1.5.2"
-    python:
-      "== dev": "3.9"
     requirements:
       ">= 0.0.0": ["matplotlib"]
       "< 1.3.0": ["numpy<2"]
@@ -45,8 +41,6 @@ pytorch:
       ">= 0.0.0": ["torchvision", "scikit-learn"]
       ">= 1.8": ["transformers"]
       "< 2.3": ["numpy<2"]
-    python:
-      ">= 2.5.0": "3.9"
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 
@@ -55,8 +49,6 @@ pytorch:
     maximum: "2.4.1"
     requirements:
       ">= 0.0.0": ["tensorboard"]
-    python:
-      ">= 2.5.0": "3.9"
     run: |
       pytest tests/pytorch/test_tensorboard_autolog.py
 
@@ -84,8 +76,6 @@ keras:
   models:
     minimum: "3.0.2"
     maximum: "3.6.0"
-    python:
-      "== dev": "3.9"
     requirements:
       ">= 3.0.0": ["jax[cpu]>0.4"]
     run: |
@@ -95,8 +85,6 @@ keras:
   autologging:
     minimum: "3.0.2"
     maximum: "3.6.0"
-    python:
-      "== dev": "3.9"
     requirements:
       ">= 3.0.0": ["jax[cpu]>0.4"]
     run: |
@@ -112,8 +100,6 @@ tensorflow:
   models:
     minimum: "2.7.4"
     maximum: "2.17.0"
-    python:
-      "== dev": "3.9"
     requirements:
       # Requirements to run tests for keras
       ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1"]
@@ -133,8 +119,6 @@ tensorflow:
   autologging:
     minimum: "2.7.4"
     maximum: "2.17.0"
-    python:
-      "== dev": "3.9"
     requirements:
       "== dev": ["scikit-learn"]
       "< 2.12.0": ["numpy<2"]
@@ -308,9 +292,6 @@ spacy:
   models:
     minimum: "3.0.0"
     maximum: "3.8.2"
-    python:
-      "== dev": "3.9"
-      ">= 3.8.2": "3.9"
     requirements:
       ">= 0.0.0": ["scikit-learn", "click<8.1.0"]
       "<= 3.0.9": ["flask<2.1.0", "werkzeug<3"]
@@ -328,8 +309,6 @@ statsmodels:
   models:
     minimum: "0.12.2"
     maximum: "0.14.4"
-    python:
-      "== dev": "3.9"
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
       "== 0.13.*": ["numpy<2"]
@@ -339,8 +318,6 @@ statsmodels:
   autologging:
     minimum: "0.12.2"
     maximum: "0.14.4"
-    python:
-      "== dev": "3.9"
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
       "== 0.13.*": ["numpy<2"]
@@ -364,8 +341,6 @@ spark:
   models:
     minimum: "3.1.2"
     maximum: "3.5.3"
-    python:
-      "== dev": "3.9"
     java:
       "> 3.4.1": "17"
     # NB: Allow unreleased maximum versions for the pyspark package to support models and
@@ -398,8 +373,6 @@ spark:
     runs_on:
       # TODO: Remove this once ubuntu 24 is fully rolled out: https://github.com/actions/runner-images/issues/10636
       "== 3.3.4": "ubuntu-24.04"
-    python:
-      "== dev": "3.9"
     java:
       ">= 3.4.1": "17"
     # NB: Allow unreleased maximum versions for the pyspark package to support models and
@@ -559,8 +532,6 @@ transformers:
   models:
     minimum: "4.25.1"
     maximum: "4.45.2"
-    python:
-      "== dev": "3.9"
     unsupported: [
         # Avoid this patch: https://github.com/huggingface/transformers/pull/29032
         "4.38.0",
@@ -606,8 +577,6 @@ transformers:
   autologging:
     minimum: "4.25.1"
     maximum: "4.45.2"
-    python:
-      "== dev": "3.9"
     unsupported: [
         # Avoid this patch: https://github.com/huggingface/transformers/pull/29032
         "4.38.0",
@@ -716,8 +685,6 @@ langchain:
     # Where the large package update was made (langchain-core, community, ...)
     minimum: "0.0.354"
     maximum: "0.3.3"
-    python:
-      "== dev": "3.9"
     requirements:
       ">= 0.0.0": [
           "pyspark",
@@ -761,8 +728,6 @@ langchain:
   autologging:
     minimum: "0.1.0"
     maximum: "0.3.3"
-    python:
-      "== dev": "3.9"
     requirements:
       ">= 0.0.0": [
           "pyspark",
@@ -809,8 +774,6 @@ llama_index:
     # New event/span framework is fully implemented in 0.10.44
     minimum: "0.10.44"
     maximum: "0.11.17"
-    python:
-      "== dev": "3.9"
     requirements:
       ">= 0.0.0": [
           "openai",
@@ -829,8 +792,6 @@ llama_index:
   autologging:
     minimum: "0.10.44"
     maximum: "0.11.17"
-    python:
-      "== dev": "3.9"
     requirements:
       ">= 0.0.0": [
           "openai",


### PR DESCRIPTION
This is a final PR to complete Python 3.9 migration.

<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13614?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13614/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13614
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

We've migrated to Python 3.9. We can remove the following in the cross-version test config.

```
    python:
      ">= 2.5.0": "3.9"
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
