### PR TITLE
Remove PEP585-supported check in type schema enforcement from type hints

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import warnings
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Union
@@ -725,39 +724,20 @@ def _validate_dict_examples(examples, num_items=None):
         _validate_keys_match(example, first_keys)
 
 
-def _is_pep585_supported() -> bool:
-    """
-    Is https://peps.python.org/pep-0585 supported in the current Python version?
-    """
-    return sys.version_info[:2] >= (3, 9)
-
-
 def _is_list_str(type_hint: Any) -> bool:
-    if type_hint == List[str]:  # noqa: UP006
-        return True
-
-    if _is_pep585_supported():
-        try:
-            return type_hint == list[str]
-        except Exception:
-            # Should be unreachable but for safety
-            return False
-
-    return False
+    return type_hint == [
+        List[str],  # noqa: UP006
+        list[str],
+    ]
 
 
 def _is_list_dict_str(type_hint: Any) -> bool:
-    if type_hint == List[Dict[str, str]]:  # noqa: UP006
-        return True
-
-    if _is_pep585_supported():
-        try:
-            return type_hint == list[dict[str, str]]
-        except Exception:
-            # Should be unreachable but for safety
-            return False
-
-    return False
+    return type_hint == [
+        List[Dict[str, str]],  # noqa: UP006
+        list[Dict[str, str]],  # noqa: UP006
+        List[dict[str, str]],  # noqa: UP006
+        list[dict[str, str]],
+    ]
 
 
 def _infer_schema_from_type_hint(type_hint, examples=None):

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -725,14 +725,14 @@ def _validate_dict_examples(examples, num_items=None):
 
 
 def _is_list_str(type_hint: Any) -> bool:
-    return type_hint == [
+    return type_hint in [
         List[str],  # noqa: UP006
         list[str],
     ]
 
 
 def _is_list_dict_str(type_hint: Any) -> bool:
-    return type_hint == [
+    return type_hint in [
         List[Dict[str, str]],  # noqa: UP006
         list[Dict[str, str]],  # noqa: UP006
         List[dict[str, str]],  # noqa: UP006


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13625?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13625/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13625
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

MLflow >= 2.18 can only be installed in Python >= 3.9. We don't need to worry about Python < 3.9 anymore.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
