### PR TITLE
Add taskRunID to mlflow databricks tags and fix bugged jobRunID

### DIFF
--- a/mlflow/tracking/context/databricks_job_context.py
+++ b/mlflow/tracking/context/databricks_job_context.py
@@ -5,6 +5,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_DATABRICKS_JOB_ID,
     MLFLOW_DATABRICKS_JOB_RUN_ID,
     MLFLOW_DATABRICKS_JOB_TYPE,
+    MLFLOW_DATABRICKS_TASK_RUN_ID,
     MLFLOW_DATABRICKS_WEBAPP_URL,
     MLFLOW_DATABRICKS_WORKSPACE_ID,
     MLFLOW_DATABRICKS_WORKSPACE_URL,
@@ -20,6 +21,7 @@ class DatabricksJobRunContext(RunContextProvider):
     def tags(self):
         job_id = databricks_utils.get_job_id()
         job_run_id = databricks_utils.get_job_run_id()
+        task_run_id = databricks_utils.get_task_run_id()
         job_type = databricks_utils.get_job_type()
         webapp_url = databricks_utils.get_webapp_url()
         workspace_url = databricks_utils.get_workspace_url()
@@ -36,6 +38,8 @@ class DatabricksJobRunContext(RunContextProvider):
             tags[MLFLOW_DATABRICKS_JOB_ID] = job_id
         if job_run_id is not None:
             tags[MLFLOW_DATABRICKS_JOB_RUN_ID] = job_run_id
+        if task_run_id is not None:
+            tags[MLFLOW_DATABRICKS_TASK_RUN_ID] = task_run_id
         if job_type is not None:
             tags[MLFLOW_DATABRICKS_JOB_TYPE] = job_type
         if webapp_url is not None:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -493,8 +493,16 @@ def get_job_id():
         return _get_context_tag("jobId")
 
 
-@_use_repl_context_if_available("idInJob")
+@_use_repl_context_if_available("jobRunId")
 def get_job_run_id():
+    try:
+        return _get_command_context().jobRunId().get()
+    except Exception:
+        return _get_context_tag("jobRunId")
+
+
+@_use_repl_context_if_available("idInJob")
+def get_task_run_id():
     try:
         return _get_command_context().idInJob().get()
     except Exception:

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -49,6 +49,7 @@ MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID = "mlflow.databricks.shellJobRunID"
 # when MLflow Tracking APIs are used within a Databricks Job
 MLFLOW_DATABRICKS_JOB_ID = "mlflow.databricks.jobID"
 MLFLOW_DATABRICKS_JOB_RUN_ID = "mlflow.databricks.jobRunID"
+MLFLOW_DATABRICKS_TASK_RUN_ID = "mlflow.databricks.taskRunID"
 # Here MLFLOW_DATABRICKS_JOB_TYPE means the job task type and MLFLOW_DATABRICKS_JOB_TYPE_INFO
 # implies the job type which could be normal, ephemeral, etc.
 MLFLOW_DATABRICKS_JOB_TYPE = "mlflow.databricks.jobType"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/yanivshahar/mlflow/pull/13654?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13654/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13654
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->

### What changes are proposed in this pull request?

Using mlflow in databricks is currently saving the `taskRunID` instead of the `jobRunID` which is actually expected in the tag named `mlflow.databricks.jobRunID`.
In this PR we propose a fix by adding an additional tag for the task run id - `mlflow.databricks.taskRunID` as well as fixing the original `mlflow.databricks.jobRunID` value with the correct one.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
