### PR TITLE
add monkeypatching for setting env var in test deployment

### DIFF
--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -168,3 +168,19 @@ class ImplicitOptional(Rule):
         Returns True if `value` represents `None`.
         """
         return isinstance(value, ast.Constant) and value.value is None
+
+
+class OsEnvironSetInTest(Rule):
+    def _id(self) -> str:
+        return "MLF0011"
+
+    def _message(self) -> str:
+        return "Do not set `os.environ` in test directly. Use `monkeypatch.setenv` (https://docs.pytest.org/en/stable/reference/reference.html#pytest.MonkeyPatch.setenv)."
+
+
+class OsEnvironDeleteInTest(Rule):
+    def _id(self) -> str:
+        return "MLF0012"
+
+    def _message(self) -> str:
+        return "Do not delete `os.environ` in test directly. Use `monkeypatch.delenv` (https://docs.pytest.org/en/stable/reference/reference.html#pytest.MonkeyPatch.delenv)."

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1,7 +1,6 @@
 import abc
 import copy
 import inspect
-import os
 from collections import namedtuple
 from contextlib import nullcontext as does_not_raise
 from unittest import mock
@@ -155,21 +154,15 @@ def mock_event_logger():
         AutologgingEventLogger.set_logger(prev_logger)
 
 
-def test_is_testing_respects_environment_variable():
-    prev_env_var_value = os.environ.pop("MLFLOW_AUTOLOGGING_TESTING", None)
-    try:
-        assert not is_testing()
+def test_is_testing_respects_environment_variable(monkeypatch):
+    monkeypatch.delenv("MLFLOW_AUTOLOGGING_TESTING", raising=False)
+    assert not is_testing()
 
-        os.environ["MLFLOW_AUTOLOGGING_TESTING"] = "false"
-        assert not is_testing()
+    monkeypatch.setenv("MLFLOW_AUTOLOGGING_TESTING", "false")
+    assert not is_testing()
 
-        os.environ["MLFLOW_AUTOLOGGING_TESTING"] = "true"
-        assert is_testing()
-    finally:
-        if prev_env_var_value:
-            os.environ["MLFLOW_AUTOLOGGING_TESTING"] = prev_env_var_value
-        else:
-            del os.environ["MLFLOW_AUTOLOGGING_TESTING"]
+    monkeypatch.setenv("MLFLOW_AUTOLOGGING_TESTING", "true")
+    assert is_testing()
 
 
 def test_safe_patch_forwards_expected_arguments_to_function_based_patch_implementation(

--- a/tests/deployments/test_deployments.py
+++ b/tests/deployments/test_deployments.py
@@ -1,4 +1,3 @@
-import os
 from unittest import mock
 
 import pytest
@@ -101,7 +100,6 @@ def test_plugin_raising_error(monkeypatch):
     monkeypatch.setenv("raiseError", "True")
     with pytest.raises(RuntimeError, match="Error requested"):
         client.list_deployments()
-    os.environ["raiseError"] = "False"
 
 
 def test_target_uri_parsing():

--- a/tests/deployments/test_deployments.py
+++ b/tests/deployments/test_deployments.py
@@ -95,10 +95,10 @@ def test_plugin_doesnot_have_required_attrib():
         plugin_manager["dummy"]
 
 
-def test_plugin_raising_error():
+def test_plugin_raising_error(monkeypatch):
     client = deployments.get_deploy_client(f_target)
     # special case to raise error
-    os.environ["raiseError"] = "True"
+    monkeypatch.setenv("raiseError", "True")
     with pytest.raises(RuntimeError, match="Error requested"):
         client.list_deployments()
     os.environ["raiseError"] = "False"

--- a/tests/models/test_wheeled_model.py
+++ b/tests/models/test_wheeled_model.py
@@ -365,7 +365,7 @@ def test_wheel_download_works(tmp_path):
     assert simple_dependency in wheels[0]  # Cloudpickle wheel downloaded
 
 
-def test_wheel_download_override_option_works(tmp_path):
+def test_wheel_download_override_option_works(tmp_path, monkeypatch):
     dependency = "pyspark"
     requirements_file = os.path.join(tmp_path, "req.txt")
     wheel_dir = os.path.join(tmp_path, "wheels")
@@ -379,7 +379,7 @@ def test_wheel_download_override_option_works(tmp_path):
         WheeledModel._download_wheels(requirements_file, wheel_dir)
 
     # Set option override
-    os.environ["MLFLOW_WHEELED_MODEL_PIP_DOWNLOAD_OPTIONS"] = "--prefer-binary"
+    monkeypatch.setenv("MLFLOW_WHEELED_MODEL_PIP_DOWNLOAD_OPTIONS", "--prefer-binary")
     WheeledModel._download_wheels(requirements_file, wheel_dir)
     assert len(os.listdir(wheel_dir))  # Wheel dir is not empty
 

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -212,7 +212,9 @@ def test_spark_udf(spark, model_path):
 
 @pytest.mark.parametrize("sklearn_version", ["1.3.2", "1.4.2"])
 @pytest.mark.parametrize("env_manager", ["virtualenv", "conda"])
-def test_spark_udf_env_manager_can_restore_env(spark, model_path, sklearn_version, env_manager):
+def test_spark_udf_env_manager_can_restore_env(
+    spark, model_path, sklearn_version, env_manager, monkeypatch
+):
     class EnvRestoringTestModel(mlflow.pyfunc.PythonModel):
         def __init__(self):
             pass
@@ -237,7 +239,7 @@ def test_spark_udf_env_manager_can_restore_env(spark, model_path, sklearn_versio
     # tests/helper_functions.py
     from tests.helper_functions import _get_mlflow_home
 
-    os.environ["MLFLOW_HOME"] = _get_mlflow_home()
+    monkeypatch.setenv("MLFLOW_HOME", _get_mlflow_home())
     python_udf = mlflow.pyfunc.spark_udf(
         spark, model_path, env_manager=env_manager, result_type="string"
     )

--- a/tests/recipes/test_pipeline.py
+++ b/tests/recipes/test_pipeline.py
@@ -77,13 +77,13 @@ def test_create_recipe_fails_with_path_containing_space(tmp_path):
 @pytest.mark.usefixtures("enter_recipe_example_directory")
 @pytest.mark.parametrize("custom_execution_directory", [None, "custom"])
 def test_recipes_execution_directory_is_managed_as_expected(
-    custom_execution_directory, enter_recipe_example_directory, tmp_path
+    custom_execution_directory, enter_recipe_example_directory, tmp_path, monkeypatch
 ):
     if custom_execution_directory is not None:
         custom_execution_directory = tmp_path / custom_execution_directory
 
     if custom_execution_directory is not None:
-        os.environ["MLFLOW_RECIPES_EXECUTION_DIRECTORY"] = str(custom_execution_directory)
+        monkeypatch.setenv("MLFLOW_RECIPES_EXECUTION_DIRECTORY", str(custom_execution_directory))
 
     expected_execution_directory_location = (
         pathlib.Path(custom_execution_directory)

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -45,13 +45,12 @@ def mock_client():
         os.environ["AZURE_STORAGE_CONNECTION_STRING"] = old_conn_string
 
 
-def test_artifact_uri_factory(mock_client):
+def test_artifact_uri_factory(mock_client, monkeypatch):
     # We pass in the mock_client here to clear Azure environment variables, but we don't use it;
     # We do need to set up a fake access key for the code to run though
-    os.environ["AZURE_STORAGE_ACCESS_KEY"] = ""
+    monkeypatch.setenv("AZURE_STORAGE", "")
     repo = get_artifact_repository(TEST_URI)
     assert isinstance(repo, AzureBlobArtifactRepository)
-    del os.environ["AZURE_STORAGE_ACCESS_KEY"]
 
 
 @mock.patch("azure.identity.DefaultAzureCredential")

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -61,11 +61,12 @@ def test_log_artifact_viewfs(hdfs_system_mock):
 @mock.patch(
     "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
 )
-def test_log_artifact_with_kerberos_setup(hdfs_system_mock):
+def test_log_artifact_with_kerberos_setup(hdfs_system_mock, monkeypatch):
     if sys.platform == "win32":
         pytest.skip()
-    os.environ["MLFLOW_KERBEROS_TICKET_CACHE"] = "/tmp/krb5cc_22222222"
-    os.environ["MLFLOW_KERBEROS_USER"] = "some_kerberos_user"
+
+    monkeypatch.setenv("MLFLOW_KERBEROS_TICKET_CACHE", "/tmp/krb5cc_22222222")
+    monkeypatch.setenv("MLFLOW_KERBEROS_USER", "some_kerberos_user")
 
     repo = HdfsArtifactRepository("hdfs:/some/maybe/path")
 
@@ -99,9 +100,9 @@ def test_log_artifact_with_invalid_local_dir(_):
 @mock.patch(
     "mlflow.store.artifact.hdfs_artifact_repo.HadoopFileSystem", spec=pyarrow.fs.HadoopFileSystem
 )
-def test_log_artifacts(hdfs_system_mock):
-    os.environ["MLFLOW_KERBEROS_TICKET_CACHE"] = "/tmp/krb5cc_22222222"
-    os.environ["MLFLOW_KERBEROS_USER"] = "some_kerberos_user"
+def test_log_artifacts(hdfs_system_mock, monkeypatch):
+    monkeypatch.setenv("MLFLOW_KERBEROS_TICKET_CACHE", "/tmp/krb5cc_22222222")
+    monkeypatch.setenv("MLFLOW_KERBEROS_USER", "some_kerberos_user")
 
     repo = HdfsArtifactRepository("hdfs:/some_path/maybe/path")
 

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -64,7 +64,6 @@ def test_log_artifact_viewfs(hdfs_system_mock):
 def test_log_artifact_with_kerberos_setup(hdfs_system_mock, monkeypatch):
     if sys.platform == "win32":
         pytest.skip()
-
     monkeypatch.setenv("MLFLOW_KERBEROS_TICKET_CACHE", "/tmp/krb5cc_22222222")
     monkeypatch.setenv("MLFLOW_KERBEROS_USER", "some_kerberos_user")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/parag-shendye/mlflow/pull/13657?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13657/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13657
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #13651 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
