### PR TITLE
Enable merge queue for pull request merge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - master
       - branch-[0-9]+.[0-9]+
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
   merge_group:
+    types:
+      - checks_requested
 
 permissions:
   contents: read

--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -1,3 +1,6 @@
+# This job prevents accidental auto-merging of PRs when jobs that are conditionally
+# triggered (for example, those defined in `cross-version-tests.yml`) are either still
+# in the process of running or have resulted in failures.
 name: Protect
 
 on:
@@ -18,9 +21,8 @@ concurrency:
 
 jobs:
   protect:
-    # This job prevents accidental auto-merging of PRs when jobs that are conditionally
-    # triggered (for example, those defined in `cross-version-tests.yml`) are either still
-    # in the process of running or have resulted in failures.
+    # Skip this job in a merge queue
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -29,7 +31,6 @@ jobs:
           sparse-checkout: |
             .github
       - uses: actions/github-script@v7
-        if: github.event_name == 'pull_request'
         with:
           script: |
             const script = require('./.github/workflows/protect.js');

--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -11,6 +11,8 @@ on:
       - reopened
       - ready_for_review
   merge_group:
+    types:
+      - checks_requested
 
 permissions:
   contents: read

--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  merge_group:
 
 permissions:
   contents: read
@@ -28,6 +29,7 @@ jobs:
           sparse-checkout: |
             .github
       - uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
         with:
           script: |
             const script = require('./.github/workflows/protect.js');


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Imagine we have two pull requests, A and B. A adds a new lint check and B has a line that violates the rule but is not aware of that. In the following scenario, the lint check starts failing on master. This has happened several (not many) times before:

```
- A passes all CI checks, ready to be merged
- B passes all CI checks, ready to be merged
- Merge A (B still can be merged)
- Merge B -> lint starts failing on master
```

**Merge queue** can help prevent this by running checks before merge. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue for details.

> Once a pull request has passed all required branch protection checks, a user with write access to the repository can add the pull request to the queue. The merge queue will ensure the pull request's changes pass all required status checks when applied to the latest version of the target branch and any pull requests already in the queue.

This PR marks the lint check as a required check for merge queue to prevent the issue above.

### Why only lint?

Good question. There are several reasons:

1. It's stable.
2. It's fast.

We can run more checks/tests in a merge queue, but it does slow down PR merge velocity or blocks us when we have flaky tests. We're not familiar with merge queue at all, and not even sure if it really works **for us**. Start small, fail small, and quit fast if it doesn't work for us.

### Can we disable merge queue in emergency?

Yes, we can disable merge queue in emergency from the repo settings.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
