### PR TITLE
Test ubuntu-24.04

### DIFF
--- a/.github/workflows/advice.yml
+++ b/.github/workflows/advice.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   notify:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       pull-requests: write # advice.js comments on PRs

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   check-comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'autoformat') }}
     permissions:
@@ -51,7 +51,7 @@ jobs:
             return { ...pullInfo, shouldAutoformat };
 
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: check-comment
     if: ${{ needs.check-comment.outputs.should_autoformat == 'true' }}
@@ -154,7 +154,7 @@ jobs:
           path: ${{ github.run_id }}.diff
 
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: [check-comment, format]
     if: ${{ needs.format.outputs.reformatted == 'true' }}
@@ -188,7 +188,7 @@ jobs:
           git push
 
   update-status:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [check-comment, format, push]
     if: always() && needs.check-comment.outputs.should_autoformat == 'true'

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -33,7 +33,7 @@ defaults:
 jobs:
   build:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   cancel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       actions: write # to cancel workflow runs

--- a/.github/workflows/cherry-picks-warn.yml
+++ b/.github/workflows/cherry-picks-warn.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       pull-requests: write # to post a comment on the PR

--- a/.github/workflows/closing-pr.yml
+++ b/.github/workflows/closing-pr.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   closing-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       pull-requests: read # closing-pr.js reads the PR body

--- a/.github/workflows/cross-version-test-runner.yml
+++ b/.github/workflows/cross-version-test-runner.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: ${{ github.event.issue.pull_request && github.event.comment.body }}
     permissions:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -56,7 +56,7 @@ env:
 
 jobs:
   set-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     permissions:

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -26,7 +26,7 @@ defaults:
 jobs:
   deployments:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -42,7 +42,7 @@ defaults:
 
 jobs:
   linux-env-setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: github.event_name != 'schedule' || github.repository == 'mlflow-automation/mlflow'
     steps:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   devcontainer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     if: github.repository == 'mlflow/mlflow'
     permissions:
@@ -100,7 +100,7 @@ jobs:
       repo: ${{ steps.image.outputs.name }}
 
   devcontainer-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: devcontainer
     if: github.event_name == 'push'
     permissions:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -43,7 +43,7 @@ env:
 
 jobs:
   examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     strategy:
@@ -99,7 +99,7 @@ jobs:
           df -h
 
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     steps:

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   gateway:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -20,7 +20,7 @@ defaults:
 jobs:
   labeling:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write # harupy/auto-labeling
       issues: write # harupy/auto-labeling

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,7 +41,7 @@ jobs:
   # while also verifying certain dependencies are omitted.
   python-skinny:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
 
   python:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -99,7 +99,7 @@ jobs:
 
   database:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
@@ -149,7 +149,7 @@ jobs:
 
   java:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -170,7 +170,7 @@ jobs:
 
   flavors:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -203,7 +203,7 @@ jobs:
   # run these tests in a separate job.
   models:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -236,7 +236,7 @@ jobs:
   # be removed.
   evaluate:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -267,7 +267,7 @@ jobs:
 
   pyfunc:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -301,7 +301,7 @@ jobs:
 
   sagemaker:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   patch:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     timeout-minutes: 120

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   main:
     if: github.repository == 'mlflow/mlflow'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       statuses: read # preview_docs.py checks PR statuses
       pull-requests: write # preview_docs.py comments on PRs

--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -20,7 +20,7 @@ jobs:
     # This job prevents accidental auto-merging of PRs when jobs that are conditionally
     # triggered (for example, those defined in `cross-version-tests.yml`) are either still
     # in the process of running or have resulted in failures.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/protobuf-cross-test.yml
+++ b/.github/workflows/protobuf-cross-test.yml
@@ -40,7 +40,7 @@ env:
 jobs:
   core_tests:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/protos.yml
+++ b/.github/workflows/protos.yml
@@ -32,7 +32,7 @@ defaults:
 jobs:
   protos:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   push-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       packages: write # to push to ghcr.io

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   r:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     if: github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     defaults:

--- a/.github/workflows/recipe-template.yml
+++ b/.github/workflows/recipe-template.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
           cd ${{ github.event.inputs.repository }}
           pre-commit run --all-files
   recipe:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/recipe.yml
+++ b/.github/workflows/recipe.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   recipes:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -30,7 +30,7 @@ defaults:
 jobs:
   validate-labeled:
     if: github.event.pull_request.draft == false && github.event.action != 'closed'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: read # validateLabeled looks at PR's labels
     timeout-minutes: 5
@@ -49,7 +49,7 @@ jobs:
 
   post-merge:
     if: github.event.action == 'closed' && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       pull-requests: write # postMerge labels PRs

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -34,7 +34,7 @@ defaults:
 
 jobs:
   skinny:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     steps:
@@ -58,7 +58,7 @@ jobs:
           ./dev/run-python-skinny-tests.sh
 
   core:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     if: (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     steps:

--- a/.github/workflows/rerun-cross-version-tests.yml
+++ b/.github/workflows/rerun-cross-version-tests.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   set-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: github.repository == 'mlflow-automation/mlflow'
     permissions:

--- a/.github/workflows/rerun-workflow-run.yml
+++ b/.github/workflows/rerun-workflow-run.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   rerun:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       actions: write # to rerun github action workflows

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: github.event.review.state == 'approved' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
     steps:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     if: (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     strategy:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: github.event_name != 'schedule' || github.repository == 'mlflow/mlflow'
     permissions:

--- a/.github/workflows/team-review.yml
+++ b/.github/workflows/team-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event.requested_reviewer.login == 'mlflow-automation'}}
     permissions:
       pull-requests: write

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -327,7 +327,7 @@ def get_runs_on(runs_on: Optional[dict[str, str]], version: str) -> str:
     if runs_on and (match := next(_find_matches(runs_on, version), None)):
         return match
 
-    return "ubuntu-latest"
+    return "ubuntu-24.04"
 
 
 def remove_comments(s):

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -370,9 +370,6 @@ spark:
   autologging:
     minimum: "3.1.2"
     maximum: "3.5.3"
-    runs_on:
-      # TODO: Remove this once ubuntu 24 is fully rolled out: https://github.com/actions/runner-images/issues/10636
-      "== 3.3.4": "ubuntu-24.04"
     java:
       ">= 3.4.1": "17"
     # NB: Allow unreleased maximum versions for the pyspark package to support models and


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13681?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13681/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13681
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

GitHub will start migrating the `ubuntu-latest` label to ubuntu 24. This PR 

https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
