### PR TITLE
Unflake `test_system_metrics_monitor_with_multi_node`

### DIFF
--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -158,7 +158,7 @@ def test_system_metrics_monitor_with_multi_node():
         with mlflow.start_run(run_id=run_id, log_system_metrics=True):
             for _ in range(10):
                 run = mlflow.get_run(run_id)
-                if run.data.metrics:
+                if any(k.startswith(f"system/{node_id}/") for k in run.data.metrics.keys()):
                     break
                 time.sleep(1)
             else:

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -156,7 +156,13 @@ def test_system_metrics_monitor_with_multi_node():
     for node_id in node_ids:
         mlflow.set_system_metrics_node_id(node_id)
         with mlflow.start_run(run_id=run_id, log_system_metrics=True):
-            time.sleep(1)
+            for _ in range(10):
+                run = mlflow.get_run(run_id)
+                if run.data.metrics:
+                    break
+                time.sleep(1)
+            else:
+                raise pytest.fail("No system metrics are logged within 10 seconds.")
 
     mlflow_run = mlflow.get_run(run_id)
     metrics = mlflow_run.data.metrics


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13692?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13692/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13692
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://github.com/mlflow/mlflow/actions/runs/11697467185/job/32576245628:

```
_________________ test_system_metrics_monitor_with_multi_node __________________

    def test_system_metrics_monitor_with_multi_node():
        mlflow.enable_system_metrics_logging()
        mlflow.set_system_metrics_sampling_interval(0.2)
        mlflow.set_system_metrics_samples_before_logging(2)
    
        with mlflow.start_run() as run:
            run_id = run.info.run_id
    
        node_ids = ["0", "1", "2", "3"]
        for node_id in node_ids:
            mlflow.set_system_metrics_node_id(node_id)
            with mlflow.start_run(run_id=run_id, log_system_metrics=True):
                time.sleep(1)
    
        mlflow_run = mlflow.get_run(run_id)
        metrics = mlflow_run.data.metrics
    
        for node_id in node_ids:
            expected_metric_name = f"system/{node_id}/cpu_utilization_percentage"
>           assert expected_metric_name in metrics.keys()
E           AssertionError: assert 'system/0/cpu_utilization_percentage' in dict_keys(['system/1/cpu_utilization_percentage', 'system/1/system_memory_usage_megabytes', 'system/1/system_memory_us...es', 'system/3/disk_available_megabytes', 'system/3/network_receive_megabytes', 'system/3/network_transmit_megabytes'])
E            +  where dict_keys(['system/1/cpu_utilization_percentage', 'system/1/system_memory_usage_megabytes', 'system/1/system_memory_us...es', 'system/3/disk_available_megabytes', 'system/3/network_receive_megabytes', 'system/3/network_transmit_megabytes']) = <built-in method keys of dict object at 0x7ffa88af5340>()
E            +    where <built-in method keys of dict object at 0x7ffa88af5340> = {'system/1/cpu_utilization_percentage': 1.2, 'system/1/disk_available_megabytes': 25122.6, 'system/1/disk_usage_megabytes': 52711.9, 'system/1/disk_usage_percentage': 67.7, ...}.keys
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
