### PR TITLE
Fix Langchain Dependency Detection

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -279,6 +279,8 @@ def _get_deps_from_closures(lc_model):
     `inspect.getsource(func)` can fail. This causes deps of RunnableLambda to be empty.
     Therefore this method adds an additional way of getting dependencies through
     closure variables.
+
+    TODO: Remove when issue gets resolved: https://github.com/langchain-ai/langchain/issues/27970
     """
     import inspect
 
@@ -292,10 +294,8 @@ def _get_deps_from_closures(lc_model):
         candidates = {**closure.globals, **closure.nonlocals}
         deps = []
 
-        for (
-            _,
-            v,
-        ) in candidates.items():
+        # This code is taken from Langchain deps here: https://github.com/langchain-ai/langchain/blob/14f182795312f01985344576b5199681683641e1/libs/core/langchain_core/runnables/base.py#L4481
+        for _, v in candidates.items():
             if isinstance(v, Runnable):
                 deps.append(v)
             elif isinstance(getattr(v, "__self__", None), Runnable):

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -273,6 +273,39 @@ def _traverse_runnable(
         pass
 
 
+def _get_deps_from_closures(lc_model):
+    """
+    In some cases, the dependency extraction of Runnable Lambda fails because the call
+    `inspect.getsource(func)` can fail. This causes deps of RunnableLambda to be empty.
+    Therefore this method adds an additional way of getting dependencies through
+    closure variables.
+    """
+    import inspect
+
+    if not hasattr(lc_model, "func"):
+        return []
+
+    try:
+        from langchain_core.runnables import Runnable
+
+        closure = inspect.getclosurevars(lc_model.func)
+        candidates = {**closure.globals, **closure.nonlocals}
+        deps = []
+
+        for (
+            _,
+            v,
+        ) in candidates.items():
+            if isinstance(v, Runnable):
+                deps.append(v)
+            elif isinstance(getattr(v, "__self__", None), Runnable):
+                deps.append(v.__self__)
+
+        return deps
+    except Exception:
+        return []
+
+
 def _get_nodes_from_runnable_lambda(lc_model):
     """
     This is a workaround for the LangGraph issue: https://github.com/langchain-ai/langgraph/issues/1856
@@ -294,7 +327,8 @@ def _get_nodes_from_runnable_lambda(lc_model):
     from the original get_graph() function, dropping the input/output related logic.
     https://github.com/langchain-ai/langchain/blob/2ea5f60cc5747a334550273a5dba1b70b11414c1/libs/core/langchain_core/runnables/base.py#L4493C1-L4512C46
     """
-    if deps := lc_model.deps:
+
+    if deps := lc_model.deps or _get_deps_from_closures(lc_model):
         nodes = []
         for dep in deps:
             dep_graph = dep.get_graph()

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -282,8 +282,6 @@ def _get_deps_from_closures(lc_model):
 
     TODO: Remove when issue gets resolved: https://github.com/langchain-ai/langchain/issues/27970
     """
-    import inspect
-
     if not hasattr(lc_model, "func"):
         return []
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aravind-segu/mlflow/pull/13693?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13693/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13693
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Previously the playground code was using `createReactAgent`. Recently this was switched to workflow graphs. Langchain currently [uses](https://github.com/langchain-ai/langchain/blob/81f7daa4580aaee45314e31b3461f23520f79bd1/libs/core/langchain_core/runnables/utils.py#L401) `inspect.getsource(func)` in order to get the dependencies of a runnable lambda. However in mlflow, with the current playground setup this is causing a `OSError: cannot get source function`, preventing us from getting the dependencies correctly. 

This PR gets the dependencies of a function from the closure variables if the RunnableLambda method fails. This will act as a fail safe in case the RunnableLambda.deps returns an empty list.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

#### No Tools Added - Previously
- [Notebook Link](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/2489125455867543?o=6051921418418893)
- [ML Model File](https://e2-dogfood.staging.cloud.databricks.com/explore/data/models/ml/aravind_segu/no-tools-mlflow-master?o=6051921418418893)
- No Resources:
<img width="855" alt="image" src="https://github.com/user-attachments/assets/96adb105-1e7e-4ce8-837c-85d79817c6aa">


#### No Tools Added
- [Notebook Link](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/2489125455864143?o=6051921418418893)
- [ML Model File](https://e2-dogfood.staging.cloud.databricks.com/explore/data/models/ml/aravind_segu/no-tool-agent?o=6051921418418893)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/469c6768-f9ee-4eda-91f7-1582d2afce29">

#### Tools Added
- [Notebook Link](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/2489125455864806?o=6051921418418893)
- [ML Model File ](https://e2-dogfood.staging.cloud.databricks.com/explore/data/models/ml/aravind_segu/tools_agent?o=6051921418418893)
- 
<img width="419" alt="image" src="https://github.com/user-attachments/assets/b00fb59b-c04c-49cc-a277-b8a35288a2af">


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
