### PR TITLE
Add doc on how to use code paths for custom library

### DIFF
--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -329,8 +329,14 @@ code like ``from utils import my_func``. You can also specify a directory path a
 Use of ``code_paths`` Option for a Custom Library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To include custom libraries or libraries from a private mirror server when logging your model, use the ``code_paths`` option. 
+To include custom libraries or libraries from a private mirror server when logging your model, the ``code_paths`` option can be used. 
 This option allows you to upload .whl files or other dependencies alongside your model, ensuring all required libraries are available during serving.
+
+.. note::
+
+    The following example demonstrates a quick method for including custom libraries for development purposes. 
+    This approach is not recommended for production environments. 
+    For production usage, upload libraries to a custom PyPI server or a cloud storage to ensure reliable and secure access.
 
 ::
 

--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -329,10 +329,10 @@ code like ``from utils import my_func``. You can also specify a directory path a
 Use of ``code_paths`` Option for a Custom Library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To include custom libraries or libraries from a private mirror server when logging your model, the ``code_paths`` option can be used. 
+To include custom libraries that are not publicly available on PyPI when logging your model, the ``code_paths`` argument can be used. 
 This option allows you to upload .whl files or other dependencies alongside your model, ensuring all required libraries are available during serving.
 
-.. note::
+.. warning::
 
     The following example demonstrates a quick method for including custom libraries for development purposes. 
     This approach is not recommended for production environments. 

--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -330,13 +330,15 @@ Use of ``code_paths`` Option for a Custom Library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To include custom libraries that are not publicly available on PyPI when logging your model, the ``code_paths`` argument can be used. 
-This option allows you to upload .whl files or other dependencies alongside your model, ensuring all required libraries are available during serving.
+This option allows you to upload ``.whl`` files or other dependencies alongside your model, ensuring all required libraries are available during serving.
 
 .. warning::
 
     The following example demonstrates a quick method for including custom libraries for development purposes. 
     This approach is not recommended for production environments. 
     For production usage, upload libraries to a custom PyPI server or a cloud storage to ensure reliable and secure access.
+
+For example, suppose your project has the following file structure:
 
 ::
 

--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -326,6 +326,44 @@ Then MLflow will save ``utils.py`` under ``code/`` directory in the model direct
 When MLflow loads the model for serving, the ``code`` directory will be added to the system path so that you can use the module in your model
 code like ``from utils import my_func``. You can also specify a directory path as ``code_paths`` to save multiple files under the directory:
 
+Use of ``code_paths`` Option for a Custom Library
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To include custom libraries or libraries from a private mirror server when logging your model, use the ``code_paths`` option. 
+This option allows you to upload .whl files or other dependencies alongside your model, ensuring all required libraries are available during serving.
+
+::
+
+    my_project/
+    |── train.py
+    └── custom_package.whl
+
+Then the following code can log your model with the custom package:
+
+.. code-block:: python
+    :caption: train.py
+
+    import mlflow
+    from custom_package import my_func
+
+
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input):
+            x = my_func(model_input)
+            # .. your prediction logic
+            return prediction
+
+
+    # Log the model
+    with mlflow.start_run() as run:
+        mlflow.pyfunc.log_model(
+            python_model=MyModel(),
+            artifact_path="model",
+            extra_pip_requirements=["code/custom_package.whl"],
+            input_example=input_data,
+            code_paths=["custom_package.whl"],
+        )
+
 Caveats of ``code_paths`` Option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/13702?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13702/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13702
```

</p>
</details>

### Related Issues/PRs
N/A

### What changes are proposed in this pull request?

- Add documentation on how to use code paths for custom library

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
