### PR TITLE
Update deprecation annotation to support classes

### DIFF
--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -55,7 +55,7 @@ def experimental(api_or_type: Union[C, str]) -> C:
 
 
 def _experimental(api: C, api_type: str) -> C:
-    indent = _get_min_indent_of_docstring(api.__doc__)
+    indent = _get_min_indent_of_docstring(api.__doc__) if api.__doc__ else ""
     notice = (
         indent + f".. Note:: Experimental: This {api_type} may change or "
         "be removed in a future release without warning.\n\n"
@@ -187,7 +187,7 @@ def keyword_only(func):
             raise TypeError(f"Method {func.__name__} only takes keyword arguments.")
         return func(**kwargs)
 
-    indent = _get_min_indent_of_docstring(str(wrapper.__doc__))
+    indent = _get_min_indent_of_docstring(wrapper.__doc__) if wrapper.__doc__ else ""
     notice = indent + ".. note:: This method requires all argument be specified by keyword.\n"
     wrapper.__doc__ = notice + wrapper.__doc__ if wrapper.__doc__ else notice
 

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -138,7 +138,7 @@ def deprecated(
         if alternative and alternative.strip():
             notice += f" Use ``{alternative}`` instead."
 
-        if isinstance(obj, type):
+        if inspect.isclass(obj):
             original_init = obj.__init__
 
             @wraps(original_init)

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -3,7 +3,7 @@ import re
 import types
 import warnings
 from functools import wraps
-from typing import Any, Callable, TypeVar, Union
+from typing import Any, Callable, Optional, TypeVar, Union
 
 C = TypeVar("C", bound=Callable[..., Any])
 
@@ -111,16 +111,18 @@ def is_marked_deprecated(func):
     return getattr(func, _DEPRECATED_MARK_ATTR_NAME, False)
 
 
-def deprecated(alternative=None, since=None, impact=None):
+def deprecated(
+    alternative: Optional[str] = None, since: Optional[str] = None, impact: Optional[str] = None
+):
     """Annotation decorator for marking APIs as deprecated in docstrings and raising a warning if
     called.
 
     Args:
-        alternative: (Optional string) The name of a superseded replacement function, method,
+        alternative: The name of a superseded replacement function, method,
             or class to use in place of the deprecated one.
-        since: (Optional string) A version designator defining during which release the function,
+        since: A version designator defining during which release the function,
             method, or class was marked as deprecated.
-        impact: (Optional string) Indication of whether the method, function, or class will be
+        impact: Indication of whether the method, function, or class will be
             removed in a future release.
 
     Returns:

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -107,14 +107,18 @@ def test_deprecated_method():
     msg = "``tests.utils.test_annotations.MyClass.method`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         assert MyClass().method() == 0
-    assert msg in MyClass.method.__doc__
+    docstring = MyClass.method.__doc__
+    assert docstring is not None
+    assert msg in docstring
 
 
 def test_deprecated_function():
     msg = "``tests.utils.test_annotations.function`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         assert function() == 1
-    assert msg in function.__doc__
+    docstring = function.__doc__
+    assert docstring is not None
+    assert msg in docstring
 
 
 def test_empty_docstring():
@@ -157,7 +161,8 @@ def test_multi_line_docstring_second_line():
 
 
 def test_deprecated_and_keyword_first():
-    docstring = str(deprecated_and_keyword_only_first.__doc__)
+    docstring = deprecated_and_keyword_only_first.__doc__
+    assert docstring is not None
     assert docstring.rstrip() == (
         """    .. note:: This method requires all argument be specified by keyword.
     .. Warning:: ``tests.utils.test_annotations.deprecated_and_keyword_only_first`` is deprecated since 0.0.0. This method will be removed in a future release.
@@ -172,7 +177,8 @@ Description
 
 
 def test_deprecated_and_keyword_second():
-    docstring = str(deprecated_and_keyword_only_second.__doc__)
+    docstring = deprecated_and_keyword_only_second.__doc__
+    assert docstring is not None
     assert docstring.rstrip() == (
         """    .. Warning:: ``tests.utils.test_annotations.deprecated_and_keyword_only_second`` is deprecated since 0.0.0. This method will be removed in a future release.
     .. note:: This method requires all argument be specified by keyword.
@@ -191,7 +197,9 @@ def test_deprecated_class():
     msg = "``tests.utils.test_annotations.DeprecatedClass`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         DeprecatedClass()
-    assert msg in DeprecatedClass.__doc__
+    docstring = DeprecatedClass.__doc__
+    assert docstring is not None
+    assert msg in docstring
 
 
 def test_deprecated_class_method():
@@ -199,14 +207,18 @@ def test_deprecated_class_method():
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         instance = DeprecatedClass()
     assert instance.greet() == "Hello"
-    assert msg in DeprecatedClass.__doc__
+    docstring = DeprecatedClass.__doc__
+    assert docstring is not None
+    assert msg in docstring
 
 
 def test_deprecated_dataclass():
     msg = "``tests.utils.test_annotations.DeprecatedDataClass`` is deprecated since 1.0.0"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         DeprecatedDataClass(x=10, y=20)
-    assert msg in DeprecatedDataClass.__doc__
+    docstring = DeprecatedDataClass.__doc__
+    assert docstring is not None
+    assert msg in docstring
 
 
 def test_deprecated_dataclass_fields():
@@ -215,7 +227,9 @@ def test_deprecated_dataclass_fields():
         instance = DeprecatedDataClass(x=5, y=15)
     assert instance.x == 5
     assert instance.y == 15
-    assert msg in DeprecatedDataClass.__doc__
+    docstring = DeprecatedDataClass.__doc__
+    assert docstring is not None
+    assert msg in docstring
 
 
 def test_deprecated_dataclass_method():
@@ -223,14 +237,18 @@ def test_deprecated_dataclass_method():
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         instance = AnotherDeprecatedDataClass(a=3, b=4)
     assert instance.add() == 7
-    assert msg in AnotherDeprecatedDataClass.__doc__
+    docstring = AnotherDeprecatedDataClass.__doc__
+    assert docstring is not None
+    assert msg in docstring
 
 
 def test_deprecated_dataclass_different_order():
     msg = "``tests.utils.test_annotations.AnotherDeprecatedDataClassOrder`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         AnotherDeprecatedDataClassOrder(m=7, n=8)
-    assert msg in AnotherDeprecatedDataClassOrder.__doc__
+    docstring = AnotherDeprecatedDataClassOrder.__doc__
+    assert docstring is not None
+    assert msg in docstring
 
 
 def test_deprecated_dataclass_dunder_methods():

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -281,7 +281,7 @@ def test_deprecated_dataclass_dunder_methods_not_mutated():
 
     assert instance.add() == 15
 
-    allowed_attrs = {"x", "y", "add", "__module__", "__doc__", "__annotations__"}
+    allowed_attrs = {"x", "y", "add"}
     for attr in dir(instance):
         if not attr.startswith("__"):
             assert attr in allowed_attrs
@@ -303,7 +303,7 @@ def test_deprecated_dataclass_special_methods_integrity():
 
     assert instance.add() == 126
 
-    allowed_attrs = {"x", "y", "add", "__module__", "__doc__", "__annotations__"}
+    allowed_attrs = {"x", "y", "add"}
     for attr in dir(instance):
         if not attr.startswith("__"):
             assert attr in allowed_attrs

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -282,9 +282,7 @@ def test_deprecated_dataclass_dunder_methods_not_mutated():
     assert instance.add() == 15
 
     allowed_attrs = {"x", "y", "add"}
-    for attr in dir(instance):
-        if not attr.startswith("__"):
-            assert attr in allowed_attrs
+    assert {attr for attr in dir(instance) if not attr.startswith("__")}.issubset(allowed_attrs)
 
 
 def test_deprecated_dataclass_special_methods_integrity():
@@ -304,6 +302,4 @@ def test_deprecated_dataclass_special_methods_integrity():
     assert instance.add() == 126
 
     allowed_attrs = {"x", "y", "add"}
-    for attr in dir(instance):
-        if not attr.startswith("__"):
-            assert attr in allowed_attrs
+    assert {attr for attr in dir(instance) if not attr.startswith("__")}.issubset(allowed_attrs)

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -282,7 +282,8 @@ def test_deprecated_dataclass_dunder_methods_not_mutated():
     assert instance.add() == 15
 
     allowed_attrs = {"x", "y", "add"}
-    assert {attr for attr in dir(instance) if not attr.startswith("__")}.issubset(allowed_attrs)
+    attrs = {attr for attr in dir(instance) if not attr.startswith("__")}
+    assert attrs == allowed_attrs
 
 
 def test_deprecated_dataclass_special_methods_integrity():
@@ -302,4 +303,5 @@ def test_deprecated_dataclass_special_methods_integrity():
     assert instance.add() == 126
 
     allowed_attrs = {"x", "y", "add"}
-    assert {attr for attr in dir(instance) if not attr.startswith("__")}.issubset(allowed_attrs)
+    attrs = {attr for attr in dir(instance) if not attr.startswith("__")}
+    assert attrs == allowed_attrs

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -190,7 +190,7 @@ def test_deprecated_and_keyword_second():
 def test_deprecated_class():
     msg = "``tests.utils.test_annotations.DeprecatedClass`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
-        _ = DeprecatedClass()
+        DeprecatedClass()
     assert msg in str(DeprecatedClass.__doc__)
 
 
@@ -205,7 +205,7 @@ def test_deprecated_class_method():
 def test_deprecated_dataclass():
     msg = "``tests.utils.test_annotations.DeprecatedDataClass`` is deprecated since 1.0.0"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
-        _ = DeprecatedDataClass(x=10, y=20)
+        DeprecatedDataClass(x=10, y=20)
     assert msg in str(DeprecatedDataClass.__doc__)
 
 
@@ -229,7 +229,7 @@ def test_deprecated_dataclass_method():
 def test_deprecated_dataclass_different_order():
     msg = "``tests.utils.test_annotations.AnotherDeprecatedDataClassOrder`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
-        _ = AnotherDeprecatedDataClassOrder(m=7, n=8)
+        AnotherDeprecatedDataClassOrder(m=7, n=8)
     assert msg in str(AnotherDeprecatedDataClassOrder.__doc__)
 
 

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -107,14 +107,14 @@ def test_deprecated_method():
     msg = "``tests.utils.test_annotations.MyClass.method`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         assert MyClass().method() == 0
-    assert msg in str(MyClass.method.__doc__)
+    assert msg in MyClass.method.__doc__
 
 
 def test_deprecated_function():
     msg = "``tests.utils.test_annotations.function`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         assert function() == 1
-    assert msg in str(function.__doc__)
+    assert msg in function.__doc__
 
 
 def test_empty_docstring():
@@ -191,7 +191,7 @@ def test_deprecated_class():
     msg = "``tests.utils.test_annotations.DeprecatedClass`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         DeprecatedClass()
-    assert msg in str(DeprecatedClass.__doc__)
+    assert msg in DeprecatedClass.__doc__
 
 
 def test_deprecated_class_method():
@@ -199,14 +199,14 @@ def test_deprecated_class_method():
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         instance = DeprecatedClass()
         assert instance.greet() == "Hello"
-    assert msg in str(DeprecatedClass.__doc__)
+    assert msg in DeprecatedClass.__doc__
 
 
 def test_deprecated_dataclass():
     msg = "``tests.utils.test_annotations.DeprecatedDataClass`` is deprecated since 1.0.0"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         DeprecatedDataClass(x=10, y=20)
-    assert msg in str(DeprecatedDataClass.__doc__)
+    assert msg in DeprecatedDataClass.__doc__
 
 
 def test_deprecated_dataclass_fields():
@@ -215,7 +215,7 @@ def test_deprecated_dataclass_fields():
         instance = DeprecatedDataClass(x=5, y=15)
         assert instance.x == 5
         assert instance.y == 15
-    assert msg in str(DeprecatedDataClass.__doc__)
+    assert msg in DeprecatedDataClass.__doc__
 
 
 def test_deprecated_dataclass_method():
@@ -223,14 +223,14 @@ def test_deprecated_dataclass_method():
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         instance = AnotherDeprecatedDataClass(a=3, b=4)
         assert instance.add() == 7
-    assert msg in str(AnotherDeprecatedDataClass.__doc__)
+    assert msg in AnotherDeprecatedDataClass.__doc__
 
 
 def test_deprecated_dataclass_different_order():
     msg = "``tests.utils.test_annotations.AnotherDeprecatedDataClassOrder`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         AnotherDeprecatedDataClassOrder(m=7, n=8)
-    assert msg in str(AnotherDeprecatedDataClassOrder.__doc__)
+    assert msg in AnotherDeprecatedDataClassOrder.__doc__
 
 
 def test_deprecated_dataclass_dunder_methods():

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -198,7 +198,7 @@ def test_deprecated_class_method():
     msg = "``tests.utils.test_annotations.DeprecatedClass`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         instance = DeprecatedClass()
-        assert instance.greet() == "Hello"
+    assert instance.greet() == "Hello"
     assert msg in DeprecatedClass.__doc__
 
 
@@ -213,8 +213,8 @@ def test_deprecated_dataclass_fields():
     msg = "``tests.utils.test_annotations.DeprecatedDataClass`` is deprecated since 1.0.0"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         instance = DeprecatedDataClass(x=5, y=15)
-        assert instance.x == 5
-        assert instance.y == 15
+    assert instance.x == 5
+    assert instance.y == 15
     assert msg in DeprecatedDataClass.__doc__
 
 
@@ -222,7 +222,7 @@ def test_deprecated_dataclass_method():
     msg = "``tests.utils.test_annotations.AnotherDeprecatedDataClass`` is deprecated since 1.0.0"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         instance = AnotherDeprecatedDataClass(a=3, b=4)
-        assert instance.add() == 7
+    assert instance.add() == 7
     assert msg in AnotherDeprecatedDataClass.__doc__
 
 

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import dataclass, fields
 
 import pytest
 
@@ -51,18 +52,69 @@ def deprecated_and_keyword_only_second(x):
     return 1
 
 
+@deprecated()
+class DeprecatedClass:
+    """
+    A deprecated class.
+    """
+
+    def __init__(self):
+        pass
+
+    def greet(self):
+        """
+        Greets the user.
+        """
+        return "Hello"
+
+
+@deprecated(since="1.0.0")
+@dataclass
+class DeprecatedDataClass:
+    """
+    A deprecated dataclass.
+    """
+
+    x: int
+    y: int
+
+    def add(self):
+        return self.x + self.y
+
+
+@deprecated(since="1.0.0")
+@dataclass
+class AnotherDeprecatedDataClass:
+    a: int
+    b: int
+
+    def add(self):
+        return self.a + self.b
+
+
+@deprecated()
+@dataclass
+class AnotherDeprecatedDataClassOrder:
+    """
+    A deprecated dataclass with decorators in different order.
+    """
+
+    m: int
+    n: int
+
+
 def test_deprecated_method():
     msg = "``tests.utils.test_annotations.MyClass.method`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         assert MyClass().method() == 0
-    assert msg in MyClass.method.__doc__
+    assert msg in str(MyClass.method.__doc__)
 
 
 def test_deprecated_function():
     msg = "``tests.utils.test_annotations.function`` is deprecated"
     with pytest.warns(FutureWarning, match=re.escape(msg)):
         assert function() == 1
-    assert msg in function.__doc__
+    assert msg in str(function.__doc__)
 
 
 def test_empty_docstring():
@@ -105,7 +157,7 @@ def test_multi_line_docstring_second_line():
 
 
 def test_deprecated_and_keyword_first():
-    docstring = deprecated_and_keyword_only_first.__doc__
+    docstring = str(deprecated_and_keyword_only_first.__doc__)
     assert docstring.rstrip() == (
         """    .. note:: This method requires all argument be specified by keyword.
     .. Warning:: ``tests.utils.test_annotations.deprecated_and_keyword_only_first`` is deprecated since 0.0.0. This method will be removed in a future release.
@@ -120,7 +172,7 @@ Description
 
 
 def test_deprecated_and_keyword_second():
-    docstring = deprecated_and_keyword_only_second.__doc__
+    docstring = str(deprecated_and_keyword_only_second.__doc__)
     assert docstring.rstrip() == (
         """    .. Warning:: ``tests.utils.test_annotations.deprecated_and_keyword_only_second`` is deprecated since 0.0.0. This method will be removed in a future release.
     .. note:: This method requires all argument be specified by keyword.
@@ -133,3 +185,125 @@ def test_deprecated_and_keyword_second():
     Returns:
         y"""  # noqa: E501
     )
+
+
+def test_deprecated_class():
+    msg = "``tests.utils.test_annotations.DeprecatedClass`` is deprecated"
+    with pytest.warns(FutureWarning, match=re.escape(msg)):
+        _ = DeprecatedClass()
+    assert msg in str(DeprecatedClass.__doc__)
+
+
+def test_deprecated_class_method():
+    msg = "``tests.utils.test_annotations.DeprecatedClass`` is deprecated"
+    with pytest.warns(FutureWarning, match=re.escape(msg)):
+        instance = DeprecatedClass()
+        assert instance.greet() == "Hello"
+    assert msg in str(DeprecatedClass.__doc__)
+
+
+def test_deprecated_dataclass():
+    msg = "``tests.utils.test_annotations.DeprecatedDataClass`` is deprecated since 1.0.0"
+    with pytest.warns(FutureWarning, match=re.escape(msg)):
+        _ = DeprecatedDataClass(x=10, y=20)
+    assert msg in str(DeprecatedDataClass.__doc__)
+
+
+def test_deprecated_dataclass_fields():
+    msg = "``tests.utils.test_annotations.DeprecatedDataClass`` is deprecated since 1.0.0"
+    with pytest.warns(FutureWarning, match=re.escape(msg)):
+        instance = DeprecatedDataClass(x=5, y=15)
+        assert instance.x == 5
+        assert instance.y == 15
+    assert msg in str(DeprecatedDataClass.__doc__)
+
+
+def test_deprecated_dataclass_method():
+    msg = "``tests.utils.test_annotations.AnotherDeprecatedDataClass`` is deprecated since 1.0.0"
+    with pytest.warns(FutureWarning, match=re.escape(msg)):
+        instance = AnotherDeprecatedDataClass(a=3, b=4)
+        assert instance.add() == 7
+    assert msg in str(AnotherDeprecatedDataClass.__doc__)
+
+
+def test_deprecated_dataclass_different_order():
+    msg = "``tests.utils.test_annotations.AnotherDeprecatedDataClassOrder`` is deprecated"
+    with pytest.warns(FutureWarning, match=re.escape(msg)):
+        _ = AnotherDeprecatedDataClassOrder(m=7, n=8)
+    assert msg in str(AnotherDeprecatedDataClassOrder.__doc__)
+
+
+def test_deprecated_dataclass_dunder_methods():
+    instance = DeprecatedDataClass(x=1, y=2)
+
+    assert instance.x == 1
+    assert instance.y == 2
+
+    expected_repr = "DeprecatedDataClass(x=1, y=2)"
+    assert repr(instance) == expected_repr
+
+    instance2 = DeprecatedDataClass(x=1, y=2)
+    instance3 = DeprecatedDataClass(x=2, y=3)
+    assert instance == instance2
+    assert instance != instance3
+
+
+def test_deprecated_dataclass_preserves_fields():
+    instance = DeprecatedDataClass(x=100, y=200)
+    field_names = {f.name for f in fields(DeprecatedDataClass)}
+    assert field_names == {"x", "y"}
+    assert instance.x == 100
+    assert instance.y == 200
+
+
+def test_deprecated_dataclass_preserves_methods():
+    instance = DeprecatedDataClass(x=10, y=20)
+    assert instance.add() == 30
+
+
+def test_deprecated_dataclass_preserves_class_attributes():
+    assert DeprecatedDataClass.__module__ == "tests.utils.test_annotations"
+    assert DeprecatedDataClass.__qualname__ == "DeprecatedDataClass"
+
+
+def test_deprecated_dataclass_dunder_methods_not_mutated():
+    instance = DeprecatedDataClass(x=5, y=10)
+    assert instance.x == 5
+    assert instance.y == 10
+
+    expected_repr = "DeprecatedDataClass(x=5, y=10)"
+    assert repr(instance) == expected_repr
+
+    same_instance = DeprecatedDataClass(x=5, y=10)
+    different_instance = DeprecatedDataClass(x=1, y=2)
+    assert instance == same_instance
+    assert instance != different_instance
+
+    assert instance.add() == 15
+
+    allowed_attrs = {"x", "y", "add", "__module__", "__doc__", "__annotations__"}
+    for attr in dir(instance):
+        if not attr.startswith("__"):
+            assert attr in allowed_attrs
+
+
+def test_deprecated_dataclass_special_methods_integrity():
+    instance = DeprecatedDataClass(x=42, y=84)
+
+    assert instance.x == 42
+    assert instance.y == 84
+
+    expected_repr = "DeprecatedDataClass(x=42, y=84)"
+    assert repr(instance) == expected_repr
+
+    same_instance = DeprecatedDataClass(x=42, y=84)
+    different_instance = DeprecatedDataClass(x=1, y=2)
+    assert instance == same_instance
+    assert instance != different_instance
+
+    assert instance.add() == 126
+
+    allowed_attrs = {"x", "y", "add", "__module__", "__doc__", "__annotations__"}
+    for attr in dir(instance):
+        if not attr.startswith("__"):
+            assert attr in allowed_attrs


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/13712?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13712/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13712
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This fixes a bug in using the existing deprecation warning decorator when used on dataclasses and some class definitions. Expanded test coverage to validate the proper behavior.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
