### PR TITLE
[1/x] Support custom headers and proxy URL for LLM-as-a-Judge model

### DIFF
--- a/mlflow/metrics/genai/metric_definitions.py
+++ b/mlflow/metrics/genai/metric_definitions.py
@@ -16,6 +16,9 @@ def answer_similarity(
     metric_version: Optional[str] = None,
     examples: Optional[list[EvaluationExample]] = None,
     metric_metadata: Optional[dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
+    extra_headers: Optional[dict[str, str]] = None,
+    proxy_url: Optional[str] = None,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the answer similarity of an LLM
@@ -41,6 +44,14 @@ def answer_similarity(
         metric_metadata: (Optional) Dictionary of metadata to be attached to the
             EvaluationMetric object. Useful for model evaluators that require additional
             information to determine how to evaluate this metric.
+        parameters: (Optional) Dictionary of parameters to be passed to the judge model,
+            e.g., {"temperature": 0.5}. When specified, these parameters will override
+            the default parameters defined in the metric implementation.
+        extra_headers: (Optional) Dictionary of extra headers to be passed to the judge model.
+        proxy_url: (Optional) Proxy URL to be used for the judge model. This is useful when the
+            judge model is served via a proxy endpoint, not directly via LLM provider services.
+            If not specified, the default URL for the LLM provider will be used
+            (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
 
     Returns:
         A metric object
@@ -76,10 +87,12 @@ def answer_similarity(
         version=metric_version,
         model=model,
         grading_context_columns=answer_similarity_class_module.grading_context_columns,
-        parameters=answer_similarity_class_module.parameters,
+        parameters=parameters or answer_similarity_class_module.parameters,
         aggregations=["mean", "variance", "p90"],
         greater_is_better=True,
         metric_metadata=metric_metadata,
+        extra_headers=extra_headers,
+        proxy_url=proxy_url,
     )
 
 
@@ -89,6 +102,9 @@ def answer_correctness(
     metric_version: Optional[str] = None,
     examples: Optional[list[EvaluationExample]] = None,
     metric_metadata: Optional[dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
+    extra_headers: Optional[dict[str, str]] = None,
+    proxy_url: Optional[str] = None,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the answer correctness of an LLM
@@ -114,6 +130,14 @@ def answer_correctness(
         metric_metadata: (Optional) Dictionary of metadata to be attached to the
             EvaluationMetric object. Useful for model evaluators that require additional
             information to determine how to evaluate this metric.
+        parameters: (Optional) Dictionary of parameters to be passed to the judge model,
+            e.g., {"temperature": 0.5}. When specified, these parameters will override
+            the default parameters defined in the metric implementation.
+        extra_headers: (Optional) Dictionary of extra headers to be passed to the judge model.
+        proxy_url: (Optional) Proxy URL to be used for the judge model. This is useful when the
+            judge model is served via a proxy endpoint, not directly via LLM provider services.
+            If not specified, the default URL for the LLM provider will be used
+            (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
 
     Returns:
         A metric object
@@ -148,10 +172,12 @@ def answer_correctness(
         version=metric_version,
         model=model,
         grading_context_columns=answer_correctness_class_module.grading_context_columns,
-        parameters=answer_correctness_class_module.parameters,
+        parameters=parameters or answer_correctness_class_module.parameters,
         aggregations=["mean", "variance", "p90"],
         greater_is_better=True,
         metric_metadata=metric_metadata,
+        extra_headers=extra_headers,
+        proxy_url=proxy_url,
     )
 
 
@@ -161,6 +187,9 @@ def faithfulness(
     metric_version: Optional[str] = _get_latest_metric_version(),
     examples: Optional[list[EvaluationExample]] = None,
     metric_metadata: Optional[dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
+    extra_headers: Optional[dict[str, str]] = None,
+    proxy_url: Optional[str] = None,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the faithfullness of an LLM using the
@@ -186,6 +215,14 @@ def faithfulness(
         metric_metadata: (Optional) Dictionary of metadata to be attached to the
             EvaluationMetric object. Useful for model evaluators that require additional
             information to determine how to evaluate this metric.
+        parameters: (Optional) Dictionary of parameters to be passed to the judge model,
+            e.g., {"temperature": 0.5}. When specified, these parameters will override
+            the default parameters defined in the metric implementation.
+        extra_headers: (Optional) Dictionary of extra headers to be passed to the judge model.
+        proxy_url: (Optional) Proxy URL to be used for the judge model. This is useful when the
+            judge model is served via a proxy endpoint, not directly via LLM provider services.
+            If not specified, the default URL for the LLM provider will be used
+            (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
 
     Returns:
         A metric object
@@ -218,11 +255,13 @@ def faithfulness(
         examples=examples,
         version=metric_version,
         model=model,
-        grading_context_columns=faithfulness_class_module.grading_context_columns,
+        grading_context_columns=parameters or faithfulness_class_module.grading_context_columns,
         parameters=faithfulness_class_module.parameters,
         aggregations=["mean", "variance", "p90"],
         greater_is_better=True,
         metric_metadata=metric_metadata,
+        extra_headers=extra_headers,
+        proxy_url=proxy_url,
     )
 
 
@@ -232,6 +271,9 @@ def answer_relevance(
     metric_version: Optional[str] = _get_latest_metric_version(),
     examples: Optional[list[EvaluationExample]] = None,
     metric_metadata: Optional[dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
+    extra_headers: Optional[dict[str, str]] = None,
+    proxy_url: Optional[str] = None,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the answer relevance of an LLM
@@ -253,6 +295,14 @@ def answer_relevance(
         metric_metadata: (Optional) Dictionary of metadata to be attached to the
             EvaluationMetric object. Useful for model evaluators that require additional
             information to determine how to evaluate this metric.
+        parameters: (Optional) Dictionary of parameters to be passed to the judge model,
+            e.g., {"temperature": 0.5}. When specified, these parameters will override
+            the default parameters defined in the metric implementation.
+        extra_headers: (Optional) Dictionary of extra headers to be passed to the judge model.
+        proxy_url: (Optional) Proxy URL to be used for the judge model. This is useful when the
+            judge model is served via a proxy endpoint, not directly via LLM provider services.
+            If not specified, the default URL for the LLM provider will be used
+            (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
 
     Returns:
         A metric object
@@ -284,10 +334,12 @@ def answer_relevance(
         examples=examples,
         version=metric_version,
         model=model,
-        parameters=answer_relevance_class_module.parameters,
+        parameters=parameters or answer_relevance_class_module.parameters,
         aggregations=["mean", "variance", "p90"],
         greater_is_better=True,
         metric_metadata=metric_metadata,
+        extra_headers=extra_headers,
+        proxy_url=proxy_url,
     )
 
 
@@ -296,6 +348,9 @@ def relevance(
     metric_version: Optional[str] = None,
     examples: Optional[list[EvaluationExample]] = None,
     metric_metadata: Optional[dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
+    extra_headers: Optional[dict[str, str]] = None,
+    proxy_url: Optional[str] = None,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the evaluate the relevance of an
@@ -321,6 +376,14 @@ def relevance(
         metric_metadata: (Optional) Dictionary of metadata to be attached to the
             EvaluationMetric object. Useful for model evaluators that require additional
             information to determine how to evaluate this metric.
+        parameters: (Optional) Dictionary of parameters to be passed to the judge model,
+            e.g., {"temperature": 0.5}. When specified, these parameters will override
+            the default parameters defined in the metric implementation.
+        extra_headers: (Optional) Dictionary of extra headers to be passed to the judge model.
+        proxy_url: (Optional) Proxy URL to be used for the judge model. This is useful when the
+            judge model is served via a proxy endpoint, not directly via LLM provider services.
+            If not specified, the default URL for the LLM provider will be used
+            (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
 
     Returns:
         A metric object
@@ -355,8 +418,10 @@ def relevance(
         version=metric_version,
         model=model,
         grading_context_columns=relevance_class_module.grading_context_columns,
-        parameters=relevance_class_module.parameters,
+        parameters=parameters or relevance_class_module.parameters,
         aggregations=["mean", "variance", "p90"],
         greater_is_better=True,
         metric_metadata=metric_metadata,
+        extra_headers=extra_headers,
+        proxy_url=proxy_url,
     )

--- a/mlflow/openai/api_request_parallel_processor.py
+++ b/mlflow/openai/api_request_parallel_processor.py
@@ -27,6 +27,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from typing import Optional
 
 import requests
 import tiktoken
@@ -232,6 +233,7 @@ def process_api_requests(
     max_attempts: int = 5,
     max_workers: int = 10,
     throw_original_error=False,
+    extra_headers: Optional[dict[str, str]] = None,
 ):
     """Processes API requests in parallel, throttling to stay under rate limits."""
     # constants
@@ -241,6 +243,9 @@ def process_api_requests(
     retry_queue = queue.Queue()
     status_tracker = StatusTracker()  # single instance to track a collection of variables
     next_request = None  # variable to hold the next request to call
+
+    # Additional headers to be passed in the request
+    extra_headers = extra_headers or {}
 
     # initialize available capacity counts
     available_request_capacity = max_requests_per_minute
@@ -309,7 +314,7 @@ def process_api_requests(
                         next_request.call_api,
                         retry_queue=retry_queue,
                         status_tracker=status_tracker,
-                        headers=api_token.auth_headers(),
+                        headers={**api_token.auth_headers(), **extra_headers},
                     )
                     next_request = None  # reset next_request to empty
                 else:


### PR DESCRIPTION
### What changes are proposed in this pull request?

Some customers serve an OpenAI model behind their proxy server for security reason. However, currently we don't have a way to use proxy URL and custom headers for LLM-as-a-Judge metrics. This PR adds those parameters to the GenAI metrics to unblock this use case.

```
    similarity_metric = answer_similarity(
        model="openai:/gpt-4o-mini",
        proxy_url="https://my-proxy/chat",
        extra_headers={"my-group-id": "xyz"}
    )
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (to-be-done)

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support passing custom headers and setting a proxy endpoint for a judge model of GenAI metrics.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
