### PR TITLE
Backtick delta table name when loading

### DIFF
--- a/mlflow/data/delta_dataset_source.py
+++ b/mlflow/data/delta_dataset_source.py
@@ -18,6 +18,7 @@ from mlflow.utils.rest_utils import (
     call_endpoint,
     extract_api_info_for_service,
 )
+from mlflow.utils.string_utils import _is_backticked
 
 DATABRICKS_HIVE_METASTORE_NAME = "hive_metastore"
 # these two catalog names both points to the workspace local default HMS (hive metastore).
@@ -27,10 +28,6 @@ DATABRICKS_LOCAL_METASTORE_NAMES = [DATABRICKS_HIVE_METASTORE_NAME, "spark_catal
 DATABRICKS_SAMPLES_CATALOG_NAME = "samples"
 
 _logger = logging.getLogger(__name__)
-
-
-def _is_backticked(s: str) -> bool:
-    return s.startswith("`") and s.endswith("`")
 
 
 class DeltaDatasetSource(DatasetSource):

--- a/mlflow/data/delta_dataset_source.py
+++ b/mlflow/data/delta_dataset_source.py
@@ -83,7 +83,7 @@ class DeltaDatasetSource(DatasetSource):
             return spark_read_op.load(self._path)
         else:
             backticked_delta_table_name = ".".join(
-                f"`{part}`" if not _is_backticked(part) else part
+                part if _is_backticked(part) else f"`{part}`"
                 for part in self._delta_table_name.split(".")
             )
             return spark_read_op.table(backticked_delta_table_name)

--- a/mlflow/data/delta_dataset_source.py
+++ b/mlflow/data/delta_dataset_source.py
@@ -78,7 +78,9 @@ class DeltaDatasetSource(DatasetSource):
         if self._path:
             return spark_read_op.load(self._path)
         else:
-            backticked_delta_table_name = '.'.join(f'`{part}`' for part in self._delta_table_name.split('.'))
+            backticked_delta_table_name = ".".join(
+                f"`{part}`" for part in self._delta_table_name.split(".")
+            )
             return spark_read_op.table(backticked_delta_table_name)
 
     @property

--- a/mlflow/data/delta_dataset_source.py
+++ b/mlflow/data/delta_dataset_source.py
@@ -29,6 +29,10 @@ DATABRICKS_SAMPLES_CATALOG_NAME = "samples"
 _logger = logging.getLogger(__name__)
 
 
+def _is_backticked(s: str) -> bool:
+    return s.startswith("`") and s.endswith("`")
+
+
 class DeltaDatasetSource(DatasetSource):
     """
     Represents the source of a dataset stored at in a delta table.
@@ -79,7 +83,8 @@ class DeltaDatasetSource(DatasetSource):
             return spark_read_op.load(self._path)
         else:
             backticked_delta_table_name = ".".join(
-                f"`{part}`" for part in self._delta_table_name.split(".")
+                f"`{part}`" if not _is_backticked(part) else part
+                for part in self._delta_table_name.split(".")
             )
             return spark_read_op.table(backticked_delta_table_name)
 

--- a/mlflow/data/delta_dataset_source.py
+++ b/mlflow/data/delta_dataset_source.py
@@ -18,7 +18,7 @@ from mlflow.utils.rest_utils import (
     call_endpoint,
     extract_api_info_for_service,
 )
-from mlflow.utils.string_utils import _is_backticked
+from mlflow.utils.string_utils import _backtick_quote
 
 DATABRICKS_HIVE_METASTORE_NAME = "hive_metastore"
 # these two catalog names both points to the workspace local default HMS (hive metastore).
@@ -80,8 +80,7 @@ class DeltaDatasetSource(DatasetSource):
             return spark_read_op.load(self._path)
         else:
             backticked_delta_table_name = ".".join(
-                part if _is_backticked(part) else f"`{part}`"
-                for part in self._delta_table_name.split(".")
+                map(_backtick_quote, self._delta_table_name.split("."))
             )
             return spark_read_op.table(backticked_delta_table_name)
 

--- a/mlflow/data/delta_dataset_source.py
+++ b/mlflow/data/delta_dataset_source.py
@@ -78,7 +78,8 @@ class DeltaDatasetSource(DatasetSource):
         if self._path:
             return spark_read_op.load(self._path)
         else:
-            return spark_read_op.table(self._delta_table_name)
+            backticked_delta_table_name = '.'.join(f'`{part}`' for part in self._delta_table_name.split('.'))
+            return spark_read_op.table(backticked_delta_table_name)
 
     @property
     def path(self) -> Optional[str]:

--- a/mlflow/data/spark_delta_utils.py
+++ b/mlflow/data/spark_delta_utils.py
@@ -87,9 +87,7 @@ def _try_get_delta_table_latest_version_from_table_name(table_name: str) -> Opti
 
     try:
         spark = SparkSession.builder.getOrCreate()
-        backticked_table_name = ".".join(
-            part if _is_backticked(part) else f"`{part}`" for part in table_name.split(".")
-        )
+        backticked_table_name = ".".join(map(_is_backticked, table_name.split(".")))
         j_delta_table = spark._jvm.io.delta.tables.DeltaTable.forName(
             spark._jsparkSession, backticked_table_name
         )

--- a/mlflow/data/spark_delta_utils.py
+++ b/mlflow/data/spark_delta_utils.py
@@ -86,6 +86,7 @@ def _try_get_delta_table_latest_version_from_table_name(table_name: str) -> Opti
     try:
         spark = SparkSession.builder.getOrCreate()
         backticked_table_name = ".".join(f"`{part}`" for part in table_name.split("."))
+        print(backticked_table_name)
         j_delta_table = spark._jvm.io.delta.tables.DeltaTable.forName(
             spark._jsparkSession, backticked_table_name
         )
@@ -95,7 +96,7 @@ def _try_get_delta_table_latest_version_from_table_name(table_name: str) -> Opti
             "Failed to obtain version information for Delta table with name '%s'. Version"
             " information may not be included in the dataset source for MLflow Tracking."
             " Exception: %s",
-            table_name,
+            backticked_table_name,
             e,
         )
 

--- a/mlflow/data/spark_delta_utils.py
+++ b/mlflow/data/spark_delta_utils.py
@@ -86,7 +86,6 @@ def _try_get_delta_table_latest_version_from_table_name(table_name: str) -> Opti
     try:
         spark = SparkSession.builder.getOrCreate()
         backticked_table_name = ".".join(f"`{part}`" for part in table_name.split("."))
-        print(backticked_table_name)
         j_delta_table = spark._jvm.io.delta.tables.DeltaTable.forName(
             spark._jsparkSession, backticked_table_name
         )
@@ -96,7 +95,7 @@ def _try_get_delta_table_latest_version_from_table_name(table_name: str) -> Opti
             "Failed to obtain version information for Delta table with name '%s'. Version"
             " information may not be included in the dataset source for MLflow Tracking."
             " Exception: %s",
-            backticked_table_name,
+            table_name,
             e,
         )
 

--- a/mlflow/data/spark_delta_utils.py
+++ b/mlflow/data/spark_delta_utils.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import Optional
 
-from mlflow.utils.string_utils import _is_backticked
+from mlflow.utils.string_utils import _backtick_quote
 
 _logger = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ def _try_get_delta_table_latest_version_from_table_name(table_name: str) -> Opti
 
     try:
         spark = SparkSession.builder.getOrCreate()
-        backticked_table_name = ".".join(map(_is_backticked, table_name.split(".")))
+        backticked_table_name = ".".join(map(_backtick_quote, table_name.split(".")))
         j_delta_table = spark._jvm.io.delta.tables.DeltaTable.forName(
             spark._jsparkSession, backticked_table_name
         )

--- a/mlflow/data/spark_delta_utils.py
+++ b/mlflow/data/spark_delta_utils.py
@@ -85,8 +85,9 @@ def _try_get_delta_table_latest_version_from_table_name(table_name: str) -> Opti
 
     try:
         spark = SparkSession.builder.getOrCreate()
+        backticked_table_name = ".".join(f"`{part}`" for part in table_name.split("."))
         j_delta_table = spark._jvm.io.delta.tables.DeltaTable.forName(
-            spark._jsparkSession, table_name
+            spark._jsparkSession, backticked_table_name
         )
         return _get_delta_table_latest_version(j_delta_table)
     except Exception as e:

--- a/mlflow/data/spark_delta_utils.py
+++ b/mlflow/data/spark_delta_utils.py
@@ -2,6 +2,8 @@ import logging
 import os
 from typing import Optional
 
+from mlflow.utils.string_utils import _is_backticked
+
 _logger = logging.getLogger(__name__)
 
 
@@ -85,7 +87,9 @@ def _try_get_delta_table_latest_version_from_table_name(table_name: str) -> Opti
 
     try:
         spark = SparkSession.builder.getOrCreate()
-        backticked_table_name = ".".join(f"`{part}`" for part in table_name.split("."))
+        backticked_table_name = ".".join(
+            part if _is_backticked(part) else f"`{part}`" for part in table_name.split(".")
+        )
         j_delta_table = spark._jvm.io.delta.tables.DeltaTable.forName(
             spark._jsparkSession, backticked_table_name
         )

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -131,8 +131,8 @@ def quote(s):
     return mslex_quote(s) if is_windows() else shlex.quote(s)
 
 
-def _is_backticked(s: str) -> bool:
+def _backtick_quote(s: str) -> str:
     """
-    Returns True if the given string is enclosed in backticks.
+    Quotes the given string with backticks.
     """
-    return s.startswith("`") and s.endswith("`")
+    return f"`{s}`" if not (s.startswith("`") and s.endswith("`")) else s

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -133,6 +133,6 @@ def quote(s):
 
 def _backtick_quote(s: str) -> str:
     """
-    Quotes the given string with backticks.
+    Quotes the given string with backticks if it is not already quoted with backticks.
     """
     return f"`{s}`" if not (s.startswith("`") and s.endswith("`")) else s

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -129,3 +129,10 @@ def mslex_quote(s, for_cmd=True):
 
 def quote(s):
     return mslex_quote(s) if is_windows() else shlex.quote(s)
+
+
+def _is_backticked(s: str) -> bool:
+    """
+    Returns True if the given string is enclosed in backticks.
+    """
+    return s.startswith("`") and s.endswith("`")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/13718?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13718/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13718
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- Backtick table name when loading

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:
<img width="1200" alt="Screenshot 2024-11-08 at 3 23 57 PM" src="https://github.com/user-attachments/assets/41af69d7-cf8e-44f1-8976-3581290a48d3">

After:
<img width="1029" alt="Screenshot 2024-11-08 at 3 22 45 PM" src="https://github.com/user-attachments/assets/6009eed1-e864-4175-8845-51db6ed1b4b4">



### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
