### PR TITLE
Avoid global import of fastapi in Gateway Adapters.

### DIFF
--- a/mlflow/gateway/app.py
+++ b/mlflow/gateway/app.py
@@ -1,3 +1,4 @@
+import functools
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -83,6 +84,7 @@ def _translate_http_exception(func):
     Decorator for translating MLflow exceptions to HTTP exceptions
     """
 
+    @functools.wraps(func)
     async def wrapper(*args, **kwargs):
         try:
             return await func(*args, **kwargs)

--- a/mlflow/gateway/exceptions.py
+++ b/mlflow/gateway/exceptions.py
@@ -1,2 +1,14 @@
 class AIGatewayConfigException(Exception):
     pass
+
+
+class AIGatewayException(Exception):
+    """
+    A custom exception class for handling exceptions raised by the AI Gateway.
+    This will be transformed into an HTTPException before being returned to the client.
+    """
+
+    def __init__(self, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(detail)

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -1,9 +1,7 @@
 import time
 
-from fastapi import HTTPException
-from fastapi.encoders import jsonable_encoder
-
 from mlflow.gateway.config import AI21LabsConfig, RouteConfig
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request
 from mlflow.gateway.schemas import completions
@@ -22,6 +20,8 @@ class AI21LabsProvider(BaseProvider):
         self.base_url = f"https://api.ai21.com/studio/v1/{self.config.model.name}/"
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         key_mapping = {
@@ -31,11 +31,11 @@ class AI21LabsProvider(BaseProvider):
         }
         for k1, k2 in key_mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         if payload.get("stream", False):
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail="Setting the 'stream' parameter to 'true' is not supported with the MLflow "
                 "Gateway.",

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -1,10 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import AsyncIterable
 
-from fastapi import HTTPException
-
 from mlflow.gateway.base_models import ConfigModel
 from mlflow.gateway.config import RouteConfig
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.schemas import chat, completions, embeddings
 from mlflow.utils.annotations import developer_stable
 
@@ -37,13 +36,13 @@ class BaseProvider(ABC):
     async def chat_stream(
         self, payload: chat.RequestPayload
     ) -> AsyncIterable[chat.StreamResponsePayload]:
-        raise HTTPException(
+        raise AIGatewayException(
             status_code=501,
             detail=f"The chat streaming route is not implemented for {self.NAME} models.",
         )
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
-        raise HTTPException(
+        raise AIGatewayException(
             status_code=501,
             detail=f"The chat route is not implemented for {self.NAME} models.",
         )
@@ -51,29 +50,27 @@ class BaseProvider(ABC):
     async def completions_stream(
         self, payload: completions.RequestPayload
     ) -> AsyncIterable[completions.StreamResponsePayload]:
-        raise HTTPException(
+        raise AIGatewayException(
             status_code=501,
             detail=f"The completions streaming route is not implemented for {self.NAME} models.",
         )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
-        raise HTTPException(
+        raise AIGatewayException(
             status_code=501,
             detail=f"The completions route is not implemented for {self.NAME} models.",
         )
 
     async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
-        raise HTTPException(
+        raise AIGatewayException(
             status_code=501,
             detail=f"The embeddings route is not implemented for {self.NAME} models.",
         )
 
     @staticmethod
     def check_for_model_field(payload):
-        from fastapi import HTTPException
-
         if "model" in payload:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail="The parameter 'model' is not permitted to be passed. The route being "
                 "queried already defines a model instance.",
@@ -131,6 +128,6 @@ class ProviderAdapter(ABC):
     def check_keys_against_mapping(cls, mapping, payload):
         for k1, k2 in mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=400, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -2,17 +2,11 @@ import json
 import time
 from enum import Enum
 
-import boto3
-import botocore.config
-import botocore.exceptions
-from fastapi import HTTPException
-from fastapi.encoders import jsonable_encoder
-
 from mlflow.gateway.config import AmazonBedrockConfig, AWSIdAndKey, AWSRole, RouteConfig
 from mlflow.gateway.constants import (
     MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
 )
-from mlflow.gateway.exceptions import AIGatewayConfigException
+from mlflow.gateway.exceptions import AIGatewayConfigException, AIGatewayException
 from mlflow.gateway.providers.anthropic import AnthropicAdapter
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.cohere import CohereAdapter
@@ -48,7 +42,7 @@ class AWSTitanAdapter(ProviderAdapter):
     def completions_to_model(cls, payload, config):
         n = payload.pop("n", 1)
         if n != 1:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail=f"'n' must be '1' for AWS Titan models. Received value: '{n}'.",
             )
@@ -186,6 +180,9 @@ class AmazonBedrockProvider(BaseProvider):
         )
 
     def get_bedrock_client(self):
+        import boto3
+        import botocore.exceptions
+
         if self._client is not None and not self._client_expired():
             return self._client
 
@@ -249,19 +246,21 @@ class AmazonBedrockProvider(BaseProvider):
     def underlying_provider_adapter(self) -> ProviderAdapter:
         provider = self._underlying_provider
         if not provider:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail=f"Unknown Amazon Bedrock model type {self._underlying_provider}",
             )
         adapter = provider.adapter
         if not adapter:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail=f"Don't know how to handle {self._underlying_provider} for Amazon Bedrock",
             )
         return adapter
 
     def _request(self, body):
+        import botocore.exceptions
+
         try:
             response = self.get_bedrock_client().invoke_model(
                 body=json.dumps(body).encode(),
@@ -278,9 +277,11 @@ class AmazonBedrockProvider(BaseProvider):
         #     raise HTTPException(status_code=422, detail=str(e)) from e
 
         except botocore.exceptions.ReadTimeoutError as e:
-            raise HTTPException(status_code=408) from e
+            raise AIGatewayException(status_code=408) from e
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         self.check_for_model_field(payload)
         payload = jsonable_encoder(payload, exclude_none=True, exclude_defaults=True)
         payload = self.underlying_provider_adapter.completions_to_model(payload, self.config)

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -2,10 +2,8 @@ import json
 import time
 from typing import Any, AsyncGenerator, AsyncIterable
 
-from fastapi import HTTPException
-from fastapi.encoders import jsonable_encoder
-
 from mlflow.gateway.config import CohereConfig, RouteConfig
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
 from mlflow.gateway.schemas import chat, completions, embeddings
@@ -174,7 +172,7 @@ class CohereAdapter(ProviderAdapter):
         key_mapping = {"input": "texts"}
         for k1, k2 in key_mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         return rename_payload_keys(payload, key_mapping)
@@ -182,14 +180,14 @@ class CohereAdapter(ProviderAdapter):
     @classmethod
     def chat_to_model(cls, payload, config):
         if payload["n"] != 1:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail=f"Parameter n must be 1 for Cohere chat, got {payload['n']}.",
             )
         del payload["n"]
 
         if "stop" in payload:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail="Parameter stop is not supported for Cohere chat.",
             )
@@ -198,7 +196,7 @@ class CohereAdapter(ProviderAdapter):
         messages = payload.pop("messages")
         last_message = messages.pop()  # pydantic enforces min_items=1
         if last_message["role"] != "user":
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail=f"Last message must be from user, got {last_message['role']}.",
             )
@@ -364,6 +362,8 @@ class CohereProvider(BaseProvider):
     async def chat_stream(
         self, payload: chat.RequestPayload
     ) -> AsyncIterable[chat.StreamResponsePayload]:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         stream = self._stream_request(
@@ -383,6 +383,8 @@ class CohereProvider(BaseProvider):
             yield CohereAdapter.model_to_chat_streaming(resp, self.config)
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         resp = await self._request(
@@ -397,6 +399,8 @@ class CohereProvider(BaseProvider):
     async def completions_stream(
         self, payload: completions.RequestPayload
     ) -> AsyncIterable[completions.StreamResponsePayload]:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         stream = self._stream_request(
@@ -414,6 +418,8 @@ class CohereProvider(BaseProvider):
             yield CohereAdapter.model_to_completions_streaming(resp, self.config)
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         resp = await self._request(
@@ -426,6 +432,8 @@ class CohereProvider(BaseProvider):
         return CohereAdapter.model_to_completions(resp, self.config)
 
     async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         resp = await self._request(

--- a/mlflow/gateway/providers/huggingface.py
+++ b/mlflow/gateway/providers/huggingface.py
@@ -1,10 +1,8 @@
 import time
 from typing import Any
 
-from fastapi import HTTPException
-from fastapi.encoders import jsonable_encoder
-
 from mlflow.gateway.config import HuggingFaceTextGenerationInferenceConfig, RouteConfig
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.utils import (
     rename_payload_keys,
@@ -35,6 +33,8 @@ class HFTextGenerationInferenceServerProvider(BaseProvider):
         )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         key_mapping = {
@@ -42,14 +42,14 @@ class HFTextGenerationInferenceServerProvider(BaseProvider):
         }
         for k1, k2 in key_mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
 
         # HF TGI does not support generating multiple candidates.
         n = payload.pop("n", 1)
         if n != 1:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail="'n' must be '1' for the Text Generation Inference provider."
                 f"Received value: '{n}'.",

--- a/mlflow/gateway/providers/mistral.py
+++ b/mlflow/gateway/providers/mistral.py
@@ -1,8 +1,6 @@
 import time
 from typing import Any
 
-from fastapi.encoders import jsonable_encoder
-
 from mlflow.gateway.config import MistralConfig, RouteConfig
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.utils import send_request
@@ -141,6 +139,8 @@ class MistralProvider(BaseProvider):
         )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         resp = await self._request(
@@ -153,6 +153,8 @@ class MistralProvider(BaseProvider):
         return MistralAdapter.model_to_completions(resp, self.config)
 
     async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         resp = await self._request(

--- a/mlflow/gateway/providers/mosaicml.py
+++ b/mlflow/gateway/providers/mosaicml.py
@@ -2,11 +2,9 @@ import time
 from contextlib import contextmanager
 from typing import Any
 
-from fastapi import HTTPException
-from fastapi.encoders import jsonable_encoder
-
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import MosaicMLConfig, RouteConfig
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request
 from mlflow.gateway.schemas import chat, completions, embeddings
@@ -83,6 +81,8 @@ class MosaicMLProvider(BaseProvider):
         return prompt
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         # Extract the List[RequestMessage] from the RequestPayload
         messages = payload.messages
         payload = jsonable_encoder(payload, exclude_none=True)
@@ -94,7 +94,7 @@ class MosaicMLProvider(BaseProvider):
         }
         for k1, k2 in key_mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         payload = rename_payload_keys(payload, key_mapping)
@@ -103,7 +103,7 @@ class MosaicMLProvider(BaseProvider):
         try:
             prompt = [self._parse_chat_messages_to_prompt(messages)]
         except MlflowException as e:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422, detail=f"An invalid request structure was submitted. {e.message}"
             )
         # Construct final payload structure
@@ -151,6 +151,8 @@ class MosaicMLProvider(BaseProvider):
         )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         key_mapping = {
@@ -158,7 +160,7 @@ class MosaicMLProvider(BaseProvider):
         }
         for k1, k2 in key_mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         payload = rename_payload_keys(payload, key_mapping)
@@ -216,12 +218,14 @@ class MosaicMLProvider(BaseProvider):
         )
 
     async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         key_mapping = {"input": "inputs"}
         for k1, k2 in key_mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         payload = rename_payload_keys(payload, key_mapping)
@@ -273,6 +277,7 @@ def custom_token_allowance_exceeded_handling():
     Context manager handler for specific error messages that are incorrectly set as server-side
     errors, but are in actuality an issue with the request sent to the external provider.
     """
+    from fastapi import HTTPException
 
     try:
         yield

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -2,11 +2,10 @@ import json
 import os
 from typing import TYPE_CHECKING, AsyncIterable
 
-from fastapi import HTTPException
-
 from mlflow.environment_variables import MLFLOW_ENABLE_UC_FUNCTIONS
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import OpenAIAPIType, OpenAIConfig, RouteConfig
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat, completions, embeddings
@@ -33,7 +32,7 @@ def _get_workspace_client():
 
         return WorkspaceClient()
     except ImportError:
-        raise HTTPException(
+        raise AIGatewayException(
             message="Databricks SDK is required to use Unity Catalog integration",
             error_code=404,
         )
@@ -168,7 +167,7 @@ class OpenAIProvider(BaseProvider):
         workspace_client = _get_workspace_client()
         warehouse_id = os.environ.get("DATABRICKS_WAREHOUSE_ID")
         if warehouse_id is None:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=400,
                 detail="DATABRICKS_WAREHOUSE_ID environment variable is not set",
             )
@@ -320,7 +319,7 @@ class OpenAIProvider(BaseProvider):
                     resp["choices"][0]["message"]["tool_calls"] = user_tool_calls
                     break
             else:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=500,
                     detail="Max iterations reached",
                 )

--- a/mlflow/gateway/providers/palm.py
+++ b/mlflow/gateway/providers/palm.py
@@ -1,10 +1,8 @@
 import time
 from typing import Any
 
-from fastapi import HTTPException
-from fastapi.encoders import jsonable_encoder
-
 from mlflow.gateway.config import PaLMConfig, RouteConfig
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request
 from mlflow.gateway.schemas import chat, completions, embeddings
@@ -30,10 +28,12 @@ class PaLMProvider(BaseProvider):
         )
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         if "max_tokens" in payload or "maxOutputTokens" in payload:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422, detail="Max tokens is not supported for PaLM chat."
             )
         key_mapping = {
@@ -42,7 +42,7 @@ class PaLMProvider(BaseProvider):
         }
         for k1, k2 in key_mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         payload = rename_payload_keys(payload, key_mapping)
@@ -103,6 +103,8 @@ class PaLMProvider(BaseProvider):
         )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         key_mapping = {
@@ -112,7 +114,7 @@ class PaLMProvider(BaseProvider):
         }
         for k1, k2 in key_mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         payload = rename_payload_keys(payload, key_mapping)
@@ -164,6 +166,8 @@ class PaLMProvider(BaseProvider):
         )
 
     async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         key_mapping = {
@@ -171,7 +175,7 @@ class PaLMProvider(BaseProvider):
         }
         for k1, k2 in key_mapping.items():
             if k2 in payload:
-                raise HTTPException(
+                raise AIGatewayException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         payload = rename_payload_keys(payload, key_mapping)

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -1,11 +1,9 @@
 import json
 from typing import Any, AsyncGenerator, AsyncIterable
 
-from fastapi import HTTPException
-from fastapi.encoders import jsonable_encoder
-
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import RouteConfig, TogetherAIConfig
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
 from mlflow.gateway.schemas import chat as chat_schema
@@ -148,7 +146,7 @@ class TogetherAIAdapter(ProviderAdapter):
         )
 
         if logprobs_in_payload_condition:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail="Wrong type for logprobs. It should be an 32bit integer.",
             )
@@ -158,7 +156,7 @@ class TogetherAIAdapter(ProviderAdapter):
         )
 
         if openai_top_logprobs_in_payload_condition:
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail="Wrong type for top_logprobs. It should a 32bit integer.",
             )
@@ -334,6 +332,8 @@ class TogetherAIProvider(BaseProvider):
     async def embeddings(
         self, payload: embeddings_schema.RequestPayload
     ) -> embeddings_schema.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
 
         resp = await self._request(
@@ -349,10 +349,12 @@ class TogetherAIProvider(BaseProvider):
     async def completions_stream(
         self, payload: completions_schema.RequestPayload
     ) -> AsyncIterable[completions_schema.StreamResponsePayload]:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
 
         if not payload.get("max_tokens"):
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail=(
                     "max_tokens is not present in payload."
@@ -383,10 +385,12 @@ class TogetherAIProvider(BaseProvider):
     async def completions(
         self, payload: completions_schema.RequestPayload
     ) -> completions_schema.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
 
         if not payload.get("max_tokens"):
-            raise HTTPException(
+            raise AIGatewayException(
                 status_code=422,
                 detail=(
                     "max_tokens is not present in payload."
@@ -405,6 +409,8 @@ class TogetherAIProvider(BaseProvider):
         return TogetherAIAdapter.model_to_completions(resp, self.config)
 
     async def chat_stream(self, payload: chat_schema.RequestPayload) -> chat_schema.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
 
         stream = await self._stream_request(
@@ -428,6 +434,8 @@ class TogetherAIProvider(BaseProvider):
             yield TogetherAIAdapter.model_to_chat_streaming(resp, self.config)
 
     async def chat(self, payload: chat_schema.RequestPayload) -> chat_schema.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
 
         resp = await self._request(

--- a/tests/gateway/providers/test_cohere.py
+++ b/tests/gateway/providers/test_cohere.py
@@ -2,12 +2,12 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
@@ -155,7 +155,7 @@ async def test_chat_throws_if_parameter_not_permitted(params):
     provider = CohereProvider(RouteConfig(**config))
     payload = chat_payload()
     payload.update(params)
-    with pytest.raises(HTTPException, match=r".*") as e:
+    with pytest.raises(AIGatewayException, match=r".*") as e:
         await provider.chat(chat.RequestPayload(**payload))
     assert e.value.status_code == 422
 
@@ -579,7 +579,7 @@ async def test_param_model_is_not_permitted():
         "max_tokens": 5000,
         "model": "something-else",
     }
-    with pytest.raises(HTTPException, match=r".*") as e:
+    with pytest.raises(AIGatewayException, match=r".*") as e:
         await provider.completions(completions.RequestPayload(**payload))
     assert "The parameter 'model' is not permitted" in e.value.detail
     assert e.value.status_code == 422

--- a/tests/gateway/providers/test_mistral.py
+++ b/tests/gateway/providers/test_mistral.py
@@ -3,12 +3,12 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.mistral import MistralProvider
 from mlflow.gateway.schemas import completions, embeddings
 
@@ -267,7 +267,7 @@ async def test_param_model_is_not_permitted():
         "max_tokens": 5000,
         "model": "something-else",
     }
-    with pytest.raises(HTTPException, match=r".*") as e:
+    with pytest.raises(AIGatewayException, match=r".*") as e:
         await provider.completions(completions.RequestPayload(**payload))
     assert "The parameter 'model' is not permitted" in e.value.detail
     assert e.value.status_code == 422

--- a/tests/gateway/providers/test_mosaicml.py
+++ b/tests/gateway/providers/test_mosaicml.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from mlflow import MlflowException
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.mosaicml import MosaicMLProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 from mlflow.gateway.schemas.chat import RequestMessage
@@ -340,7 +341,7 @@ async def test_param_model_is_not_permitted():
         "max_tokens": 5000,
         "model": "something-else",
     }
-    with pytest.raises(HTTPException, match=r".*") as e:
+    with pytest.raises(AIGatewayException, match=r".*") as e:
         await provider.completions(completions.RequestPayload(**payload))
     assert "The parameter 'model' is not permitted" in e.value.detail
     assert e.value.status_code == 422

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -2,13 +2,13 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import OpenAIConfig, RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.openai import OpenAIProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
@@ -702,7 +702,7 @@ async def test_param_model_is_not_permitted():
         "max_tokens": 5000,
         "model": "something-else",
     }
-    with pytest.raises(HTTPException, match=r".*") as e:
+    with pytest.raises(AIGatewayException, match=r".*") as e:
         await provider.completions(completions.RequestPayload(**payload))
     assert "The parameter 'model' is not permitted" in e.value.detail
     assert e.value.status_code == 422

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -2,12 +2,12 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.palm import PaLMProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
@@ -344,7 +344,7 @@ async def test_param_model_is_not_permitted():
         "max_tokens": 5000,
         "model": "something-else",
     }
-    with pytest.raises(HTTPException, match=r".*") as e:
+    with pytest.raises(AIGatewayException, match=r".*") as e:
         await provider.completions(completions.RequestPayload(**payload))
     assert "The parameter 'model' is not permitted" in e.value.detail
     assert e.value.status_code == 422
@@ -377,7 +377,7 @@ async def test_completions_throws_if_prompt_contains_non_string(prompt):
 async def test_param_max_tokens_for_chat_is_not_permitted(payload):
     config = chat_config()
     provider = PaLMProvider(RouteConfig(**config))
-    with pytest.raises(HTTPException, match=r".*") as e:
+    with pytest.raises(AIGatewayException, match=r".*") as e:
         await provider.chat(chat.RequestPayload(**payload))
     assert "Max tokens is not supported for PaLM chat." in e.value.detail
     assert e.value.status_code == 422

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -3,11 +3,11 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.togetherai import TogetherAIProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
@@ -248,8 +248,8 @@ async def test_max_tokens_missing_error():
             "max_tokens is not present in payload."
             "It is a required parameter for TogetherAI completions."
         )
-        # Test whether HTTPException is raised when max_tokens is missing
-        with pytest.raises(HTTPException, match=error_string) as exc_info:
+        # Test whether AIGatewayException is raised when max_tokens is missing
+        with pytest.raises(AIGatewayException, match=error_string) as exc_info:
             await provider.completions(completions.RequestPayload(**payload))
 
         # Check if the raised exception has correct status code and detail
@@ -283,8 +283,8 @@ async def test_wrong_logprobs_type_error():
             "logprobs": "invalid_type",
         }
         error_string = "Wrong type for logprobs. It should be an 32bit integer."
-        # Test whether HTTPException is raised when max_tokens is missing
-        with pytest.raises(HTTPException, match=error_string) as exc_info:
+        # Test whether AIGatewayException is raised when max_tokens is missing
+        with pytest.raises(AIGatewayException, match=error_string) as exc_info:
             await provider.completions(completions.RequestPayload(**payload))
 
         # Check if the raised exception has correct status code and detail


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13721?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13721/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13721
```

</p>
</details>

### What changes are proposed in this pull request?

Currently, all LLM provider module for MLflow Gateway imports `fastapi` at globally and use its `HTTPException` class within the adapter implementation. This is fine for normal gateway usage where `fastapi` is always installed.

Then, now we are trying to re-use adapters implementation for other use cases, e.g. support non-OAI LLM models as a judge in MLflow evaluation. By using existing adapters, we can significantly reduce the implementation effort and duplication in our code base (see [design doc](https://docs.google.com/document/d/1OJj5cwFSGH2W76PE7nUmoBPQj7zt8ks1mhsqz9b6RSE/edit?tab=t.0#heading=h.9yq8unor1ydo) for more detailed discussion). However, `fastapi` should not be a hard dependency for such use cases where we don't need to spin up a web server but just want to convert requests and responses.

Therefore, this PR removes this needs by 
1. Move global `fastapi` import to lazy load in each provider.
2. Add a new custom exception and use it instead of `HTTPException`, which will be translated to `HTTPException` in the API handler.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
