### PR TITLE
Fix langchain input conversion

### DIFF
--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -32,7 +32,7 @@ from langchain.callbacks.base import BaseCallbackHandler
 import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.langchain.utils.chat import (
-    _convert_chat_request_or_throw,
+    _convert_chat_request_to_messages_or_throw,
     json_dict_might_be_chat_request,
     try_transform_response_iter_to_chat_format,
     try_transform_response_to_chat_format,
@@ -137,7 +137,7 @@ class APIRequest:
             # Note: we cannot rely on the model's input_schema to validate the request
             # because lots of cases the input_schema is not reliable.
             try:
-                request_json = _convert_chat_request_or_throw(self.request_json)
+                request_json = _convert_chat_request_to_messages_or_throw(self.request_json)
                 if self.stream:
                     # validate if the model accepts list[BaseMessage] as input
                     # as stream doesn't calculate the result immediately

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -136,6 +136,8 @@ class APIRequest:
             # If the conversion fails, call the model with the original request
             # Note: we cannot rely on the model's input_schema to validate the request
             # because lots of cases the input_schema is not reliable.
+            # e.g. model defined in test test_pyfunc_converts_chat_request_correctly
+            # accepts list[BaseMessage] but the input_schema cannot validate it.
             try:
                 request_json = _convert_chat_request_to_messages_or_throw(self.request_json)
                 if self.stream:
@@ -155,7 +157,7 @@ class APIRequest:
             # TODO: what if the model accepts the messages input but just fails?
             except Exception as e:
                 _logger.debug(
-                    f"Invoking model with chat messages failed. Error: {e!r}. ", stack_info=True
+                    f"Invoking model with chat messages failed. Error: {e!r}. ", exc_info=True
                 )
                 result = self._call_model(
                     self.request_json, config, callback_handlers, stream=self.stream, **kwargs

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -213,7 +213,13 @@ def try_transform_response_iter_to_chat_format(chunk_iter):
     return map(_convert, chunk_iter)
 
 
-def _convert_chat_request_or_throw(chat_request: dict) -> list[BaseMessage]:
+def _convert_chat_request_to_messages_or_throw(chat_request: dict) -> list[BaseMessage]:
+    """
+    This function tries to convert a chat request dictionary
+    e.g. {"messages": [{"role": "user", "content": "Hello"}]}
+    to a list of langchain_core.messages.BaseMessage objects.
+    e.g. [HumanMessage(content="Hello")]
+    """
     try:
         from langchain_core.messages.utils import convert_to_messages
 
@@ -232,6 +238,9 @@ def _convert_chat_request_or_throw(chat_request: dict) -> list[BaseMessage]:
 
 
 def json_dict_might_be_chat_request(json_message: dict):
+    """
+    Check if the given JSON message might be a chat request.
+    """
     return (
         isinstance(json_message, dict)
         and "messages" in json_message

--- a/tests/langchain/test_chat_utils.py
+++ b/tests/langchain/test_chat_utils.py
@@ -1,12 +1,7 @@
-from unittest.mock import MagicMock, patch
-
-from langchain.agents import AgentExecutor
-from langchain.chat_models.base import SimpleChatModel
-from langchain.schema import AIMessage, HumanMessage, SystemMessage
+from langchain.schema import AIMessage
 from langchain_core.messages.ai import AIMessageChunk
 
 from mlflow.langchain.utils.chat import (
-    transform_request_json_for_chat_if_necessary,
     try_transform_response_iter_to_chat_format,
     try_transform_response_to_chat_format,
 )
@@ -80,56 +75,3 @@ def test_transform_response_iter_to_chat_format_ai_message():
             converted_response[i]["choices"][0]["finish_reason"]
             == response[i].response_metadata["finish_reason"]
         )
-
-
-def test_transform_request_json_for_chat_if_necessary_no_conversion():
-    model = MagicMock(spec=AgentExecutor)
-    request_json = {"messages": [{"role": "user", "content": "some_input"}]}
-    with patch.object(model.input_schema, "validate", side_effect=Exception):
-        assert transform_request_json_for_chat_if_necessary(request_json, model) == (
-            request_json,
-            False,
-        )
-
-
-def test_transform_request_json_for_chat_if_necessary_conversion():
-    model = MagicMock(spec=SimpleChatModel)
-    model.input_schema = MagicMock()
-    request_json = {"messages": [{"role": "user", "content": "some_input"}]}
-
-    with patch("mlflow.langchain.utils.chat._get_lc_model_input_fields", return_value={"messages"}):
-        transformed_request = transform_request_json_for_chat_if_necessary(request_json, model)
-        assert transformed_request == (request_json, False)
-
-    with patch(
-        "mlflow.langchain.utils.chat._get_lc_model_input_fields",
-        return_value={},
-    ):
-        transformed_request = transform_request_json_for_chat_if_necessary(request_json, model)
-        assert transformed_request[0][0] == HumanMessage(content="some_input")
-        assert transformed_request[1] is True
-
-    request_json = [
-        {"messages": [{"role": "system", "content": "You are a helpful assistant."}]},
-        {"messages": [{"role": "assistant", "content": "What would you like to ask?"}]},
-        {"messages": [{"role": "user", "content": "Who owns MLflow?"}]},
-    ]
-    with (
-        patch(
-            "mlflow.langchain.utils.chat._get_lc_model_input_fields",
-            return_value={},
-        ),
-        patch.object(model.input_schema, "schema", return_value={}),
-        patch.object(model.input_schema, "validate", return_value=None),
-    ):
-        transformed_requests = []
-        for request_dict in request_json:
-            transformed_requests.append(
-                transform_request_json_for_chat_if_necessary(request_dict, model)
-            )
-        assert transformed_requests[0][0][0] == SystemMessage(
-            content="You are a helpful assistant."
-        )
-        assert transformed_requests[1][0][0] == AIMessage(content="What would you like to ask?")
-        assert transformed_requests[2][0][0] == HumanMessage(content="Who owns MLflow?")
-        assert transformed_requests[1][1] is True


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13725?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13725/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13725
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix langchain input data conversion, as there's a bug report showing that langchain model's input_schema is not reliable for validating if the model can accept List[BaseMessage] as input:
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/0637619a-ff1d-476f-afa3-88a1265053b6">
Updated the logic to happen inside APIRequest, so we always try invoking with the List[BaseMessage] input if the input is likely a ChatCompletionRequest. If it fails we fallback to original request.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests
The added test fails on master branch

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
