### PR TITLE
Move langchain related evaluation tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -766,6 +766,8 @@ langchain:
       echo "Testing langchain autolog and evaluation with langchain-community"
       # Install with 'langchain' to ensure the compatible version is installed
       pip install langchain langchain-community
+
+      # TODO: an unexpected issue happens when autolog test and evaluation test are run together, which need investigations
       pytest tests/langchain/test_langchain_autolog.py
       pytest tests/langchain/test_langchain_evaluation.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -721,13 +721,13 @@ langchain:
         ]
     run: |
       # Run all langchain tests except autologging and evaluation
-      pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
+      pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py --ignore tests/langchain/test_langchain_evaluation.py
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
       if [[ $PYDANTIC_VERSION == 1.* ]]; then
         pip install 'pydantic>2' 'fastapi>=0.100.0'
         echo "Testing langchain model export with pydantic v2"
-        pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
+        pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py --ignore tests/langchain/test_langchain_evaluation.py
       fi
   autologging:
     minimum: "0.1.0"
@@ -766,7 +766,7 @@ langchain:
       echo "Testing langchain autolog with langchain-community"
       # Install with 'langchain' to ensure the compatible version is installed
       pip install langchain langchain-community
-      pytest tests/langchain/test_langchain_autolog.py
+      pytest tests/langchain/test_langchain_autolog.py tests/langchain/test_langchain_evaluation.py
 
 llama_index:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -720,7 +720,7 @@ langchain:
           "git+https://github.com/unitycatalog/unitycatalog.git#subdirectory=ai/integrations/langchain",
         ]
     run: |
-      # Run all langchain tests except autologging
+      # Run all langchain tests except autologging and evaluation
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -763,10 +763,11 @@ langchain:
         pytest tests/langchain/test_langchain_autolog.py
       fi
 
-      echo "Testing langchain autolog with langchain-community"
+      echo "Testing langchain autolog and evaluation with langchain-community"
       # Install with 'langchain' to ensure the compatible version is installed
       pip install langchain langchain-community
-      pytest tests/langchain/test_langchain_autolog.py tests/langchain/test_langchain_evaluation.py
+      pytest tests/langchain/test_langchain_autolog.py
+      pytest tests/langchain/test_langchain_evaluation.py
 
 llama_index:
   package_info:

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1,5 +1,4 @@
 import hashlib
-import inspect
 import io
 import json
 import os
@@ -20,8 +19,6 @@ import sklearn.impute
 import sklearn.linear_model
 import sklearn.pipeline
 import sklearn.preprocessing
-from langchain.prompts import PromptTemplate
-from langchain_community.llms import FakeListLLM
 from mlflow_test_plugin.dummy_evaluator import Array2DEvaluationArtifact, DummyEvaluator
 from PIL import Image, ImageChops
 from pyspark.ml.linalg import Vectors
@@ -54,15 +51,10 @@ from mlflow.models.evaluation.base import (
     resolve_evaluators_and_configs,
 )
 from mlflow.models.evaluation.evaluator_registry import _model_evaluation_registry
-from mlflow.models.evaluation.evaluators.default import DefaultEvaluator
 from mlflow.pyfunc import _ServedPyFuncModel
 from mlflow.pyfunc.scoring_server.client import ScoringServerClient
 from mlflow.tracing.constant import TraceMetadataKey
-from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracking.artifact_utils import get_artifact_uri
-from mlflow.utils.autologging_utils import (
-    MLFLOW_EVALUATE_RESTRICT_LANGCHAIN_AUTOLOG_TO_TRACES_CONFIG,
-)
 from mlflow.utils.file_utils import TempDir
 
 from tests.tracing.helper import create_test_trace_info, get_traces
@@ -394,172 +386,6 @@ def test_pyfunc_evaluate_logs_traces():
     assert len(get_traces()) == 1
     assert len(get_traces()[0].data.spans) == 2
     assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
-
-
-def test_langchain_evaluate_autologs_traces():
-    # Check langchain autolog parameters are restored after evaluation
-    mlflow.langchain.autolog(log_models=True)
-
-    prompt = PromptTemplate(
-        input_variables=["input"],
-        template="Test Prompt {input}",
-    )
-    llm = FakeListLLM(responses=["response"])
-    chain = prompt | llm
-
-    with mock.patch("mlflow.langchain.log_model") as log_model_mock:
-
-        def model(inputs):
-            return [chain.invoke({"input": input}) for input in inputs["inputs"]]
-
-        eval_data = pd.DataFrame(
-            {
-                "inputs": [
-                    "What is MLflow?",
-                    "What is Spark?",
-                ],
-                "ground_truth": ["What is MLflow?", "Not what is Spark?"],
-            }
-        )
-
-        with mlflow.start_run() as run:
-            evaluate(
-                model,
-                eval_data,
-                targets="ground_truth",
-                extra_metrics=[mlflow.metrics.exact_match()],
-            )
-        log_model_mock.assert_not_called()
-
-    assert len(get_traces()) == 2
-    for trace in get_traces():
-        assert len(trace.data.spans) == 3
-    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
-
-    # Test original langchain autolog configs is restored
-    with mock.patch("mlflow.langchain.log_model") as log_model_mock:
-        with mlflow.start_run() as run:
-            chain.invoke("text")
-
-        log_model_mock.assert_called_once()
-        assert len(get_traces()) == 3
-        assert len(get_traces()[0].data.spans) == 3
-
-
-def test_langchain_pyfunc_autologs_traces():
-    prompt = PromptTemplate(
-        input_variables=["inputs"],
-        template="Test Prompt {inputs}",
-    )
-    llm = FakeListLLM(responses=["response"])
-    chain = prompt | llm
-
-    eval_data = pd.DataFrame(
-        {
-            "inputs": ["What is MLflow?"],
-            "ground_truth": ["What is MLflow?"],
-        }
-    )
-
-    with mlflow.start_run() as run:
-        model_info = mlflow.langchain.log_model(chain, "model")
-        evaluate(
-            model_info.model_uri,
-            eval_data,
-            targets="ground_truth",
-            extra_metrics=[mlflow.metrics.exact_match()],
-        )
-    assert len(get_traces()) == 1
-    assert len(get_traces()[0].data.spans) == 3
-    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
-
-
-def test_langchain_evaluate_fails_with_an_exception():
-    # Check langchain autolog parameters are restored after evaluation
-    mlflow.langchain.autolog(log_models=True)
-
-    prompt = PromptTemplate(
-        input_variables=["input"],
-        template="Test Prompt {input}",
-    )
-    llm = FakeListLLM(responses=["response"])
-    chain = prompt | llm
-
-    with (
-        mock.patch("mlflow.langchain.log_model") as log_model_mock,
-        mock.patch.object(
-            DefaultEvaluator, "evaluate", side_effect=MlflowException("evaluate mock error")
-        ),
-    ):
-
-        def model(inputs):
-            return [chain.invoke({"input": input}) for input in inputs["inputs"]]
-
-        eval_data = pd.DataFrame(
-            {
-                "inputs": [
-                    "What is MLflow?",
-                    "What is Spark?",
-                ],
-                "ground_truth": ["What is MLflow?", "Not what is Spark?"],
-            }
-        )
-        with mlflow.start_run():
-            with pytest.raises(MlflowException, match="evaluate mock error"):
-                evaluate(
-                    model,
-                    eval_data,
-                    targets="ground_truth",
-                    extra_metrics=[mlflow.metrics.exact_match()],
-                )
-            log_model_mock.assert_not_called()
-
-    assert len(get_traces()) == 0
-
-    TRACE_BUFFER.clear()
-
-    # Test original langchain autolog configs is restored
-    with mock.patch("mlflow.langchain.log_model") as log_model_mock:
-        with mlflow.start_run():
-            chain.invoke("text")
-
-        log_model_mock.assert_called_once()
-        assert len(get_traces()) == 1
-        assert len(get_traces()[0].data.spans) == 3
-
-
-def test_langchain_autolog_parameters_matches_default_parameters():
-    # The custom config is to restrict langchain autologging to only log traces.
-    # The parameters in this configuration should match the signature of
-    # mlflow.langchain.autolog exactly. The values of the parameters should be set
-    # in a way that disables logging anything but traces.
-    params = inspect.signature(mlflow.langchain.autolog).parameters
-    for name in params:
-        assert name in MLFLOW_EVALUATE_RESTRICT_LANGCHAIN_AUTOLOG_TO_TRACES_CONFIG
-    for name in MLFLOW_EVALUATE_RESTRICT_LANGCHAIN_AUTOLOG_TO_TRACES_CONFIG:
-        assert name in params
-
-
-def test_evaluate_works_with_no_langchain_installed():
-    with mock.patch.dict("sys.modules", {"langchain": None}):
-        # Import within the test context
-        with pytest.raises(ImportError, match="import of langchain halted"):
-            import langchain  # noqa: F401
-        eval_data = pd.DataFrame(
-            {
-                "inputs": [1],
-                "ground_truth": [1],
-            }
-        )
-
-        @mlflow.trace
-        def model(inputs):
-            return inputs
-
-        evaluate(
-            model, eval_data, targets="ground_truth", extra_metrics=[mlflow.metrics.exact_match()]
-        )
-        assert len(get_traces()) == 1
 
 
 def test_classifier_evaluate(multiclass_logistic_regressor_model_uri, iris_dataset):

--- a/tests/langchain/test_langchain_evaluation.py
+++ b/tests/langchain/test_langchain_evaluation.py
@@ -1,0 +1,187 @@
+import inspect
+from unittest import mock
+
+import pandas as pd
+import pytest
+from langchain.prompts import PromptTemplate
+from langchain_community.llms import FakeListLLM
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.models.evaluation import evaluate
+from mlflow.models.evaluation.evaluators.default import DefaultEvaluator
+from mlflow.tracing.constant import TraceMetadataKey
+from mlflow.tracing.fluent import TRACE_BUFFER
+from mlflow.utils.autologging_utils import (
+    MLFLOW_EVALUATE_RESTRICT_LANGCHAIN_AUTOLOG_TO_TRACES_CONFIG,
+)
+
+from tests.tracing.helper import get_traces
+
+INFERENCE_FILE_NAME = "inference_inputs_outputs.json"
+
+
+def test_langchain_evaluate_autologs_traces():
+    # Check langchain autolog parameters are restored after evaluation
+    mlflow.langchain.autolog(log_models=True)
+
+    prompt = PromptTemplate(
+        input_variables=["input"],
+        template="Test Prompt {input}",
+    )
+    llm = FakeListLLM(responses=["response"])
+    chain = prompt | llm
+
+    with mock.patch("mlflow.langchain.log_model") as log_model_mock:
+
+        def model(inputs):
+            return [chain.invoke({"input": input}) for input in inputs["inputs"]]
+
+        eval_data = pd.DataFrame(
+            {
+                "inputs": [
+                    "What is MLflow?",
+                    "What is Spark?",
+                ],
+                "ground_truth": ["What is MLflow?", "Not what is Spark?"],
+            }
+        )
+
+        with mlflow.start_run() as run:
+            evaluate(
+                model,
+                eval_data,
+                targets="ground_truth",
+                extra_metrics=[mlflow.metrics.exact_match()],
+            )
+        log_model_mock.assert_not_called()
+
+    assert len(get_traces()) == 2
+    for trace in get_traces():
+        assert len(trace.data.spans) == 3
+    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
+
+    # Test original langchain autolog configs is restored
+    with mock.patch("mlflow.langchain.log_model") as log_model_mock:
+        with mlflow.start_run() as run:
+            chain.invoke("text")
+
+        log_model_mock.assert_called_once()
+        assert len(get_traces()) == 3
+        assert len(get_traces()[0].data.spans) == 3
+
+
+def test_langchain_pyfunc_autologs_traces():
+    prompt = PromptTemplate(
+        input_variables=["inputs"],
+        template="Test Prompt {inputs}",
+    )
+    llm = FakeListLLM(responses=["response"])
+    chain = prompt | llm
+
+    eval_data = pd.DataFrame(
+        {
+            "inputs": ["What is MLflow?"],
+            "ground_truth": ["What is MLflow?"],
+        }
+    )
+
+    with mlflow.start_run() as run:
+        model_info = mlflow.langchain.log_model(chain, "model")
+        evaluate(
+            model_info.model_uri,
+            eval_data,
+            targets="ground_truth",
+            extra_metrics=[mlflow.metrics.exact_match()],
+        )
+    assert len(get_traces()) == 1
+    assert len(get_traces()[0].data.spans) == 3
+    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
+
+
+def test_langchain_evaluate_fails_with_an_exception():
+    # Check langchain autolog parameters are restored after evaluation
+    mlflow.langchain.autolog(log_models=True)
+
+    prompt = PromptTemplate(
+        input_variables=["input"],
+        template="Test Prompt {input}",
+    )
+    llm = FakeListLLM(responses=["response"])
+    chain = prompt | llm
+
+    with (
+        mock.patch("mlflow.langchain.log_model") as log_model_mock,
+        mock.patch.object(
+            DefaultEvaluator, "evaluate", side_effect=MlflowException("evaluate mock error")
+        ),
+    ):
+
+        def model(inputs):
+            return [chain.invoke({"input": input}) for input in inputs["inputs"]]
+
+        eval_data = pd.DataFrame(
+            {
+                "inputs": [
+                    "What is MLflow?",
+                    "What is Spark?",
+                ],
+                "ground_truth": ["What is MLflow?", "Not what is Spark?"],
+            }
+        )
+        with mlflow.start_run():
+            with pytest.raises(MlflowException, match="evaluate mock error"):
+                evaluate(
+                    model,
+                    eval_data,
+                    targets="ground_truth",
+                    extra_metrics=[mlflow.metrics.exact_match()],
+                )
+            log_model_mock.assert_not_called()
+
+    assert len(get_traces()) == 0
+
+    TRACE_BUFFER.clear()
+
+    # Test original langchain autolog configs is restored
+    with mock.patch("mlflow.langchain.log_model") as log_model_mock:
+        with mlflow.start_run():
+            chain.invoke("text")
+
+        log_model_mock.assert_called_once()
+        assert len(get_traces()) == 1
+        assert len(get_traces()[0].data.spans) == 3
+
+
+def test_langchain_autolog_parameters_matches_default_parameters():
+    # The custom config is to restrict langchain autologging to only log traces.
+    # The parameters in this configuration should match the signature of
+    # mlflow.langchain.autolog exactly. The values of the parameters should be set
+    # in a way that disables logging anything but traces.
+    params = inspect.signature(mlflow.langchain.autolog).parameters
+    for name in params:
+        assert name in MLFLOW_EVALUATE_RESTRICT_LANGCHAIN_AUTOLOG_TO_TRACES_CONFIG
+    for name in MLFLOW_EVALUATE_RESTRICT_LANGCHAIN_AUTOLOG_TO_TRACES_CONFIG:
+        assert name in params
+
+
+def test_evaluate_works_with_no_langchain_installed():
+    with mock.patch.dict("sys.modules", {"langchain": None}):
+        # Import within the test context
+        with pytest.raises(ImportError, match="import of langchain halted"):
+            import langchain  # noqa: F401
+        eval_data = pd.DataFrame(
+            {
+                "inputs": [1],
+                "ground_truth": [1],
+            }
+        )
+
+        @mlflow.trace
+        def model(inputs):
+            return inputs
+
+        evaluate(
+            model, eval_data, targets="ground_truth", extra_metrics=[mlflow.metrics.exact_match()]
+        )
+        assert len(get_traces()) == 1

--- a/tests/langchain/test_langchain_evaluation.py
+++ b/tests/langchain/test_langchain_evaluation.py
@@ -64,7 +64,7 @@ def test_langchain_evaluate_autologs_traces():
     # Test original langchain autolog configs is restored
     with mock.patch("mlflow.langchain.log_model") as log_model_mock:
         with mlflow.start_run() as run:
-            chain.invoke("text")
+            chain.invoke({"input": "text"})
 
         log_model_mock.assert_called_once()
         assert len(get_traces()) == 3
@@ -146,7 +146,7 @@ def test_langchain_evaluate_fails_with_an_exception():
     # Test original langchain autolog configs is restored
     with mock.patch("mlflow.langchain.log_model") as log_model_mock:
         with mlflow.start_run():
-            chain.invoke("text")
+            chain.invoke({"input": "text"})
 
         log_model_mock.assert_called_once()
         assert len(get_traces()) == 1


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/13728?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13728/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13728
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
The test_evaluation.py included langchain specific tests and they are moved to tests/langchain folder.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
