### PR TITLE
Add a custom linter for preventing global imports in certain files

### DIFF
--- a/dev/clint/src/clint/__init__.py
+++ b/dev/clint/src/clint/__init__.py
@@ -35,7 +35,7 @@ def main():
     args = Args.parse()
     with ProcessPoolExecutor() as pool:
         futures = [
-            pool.submit(lint_file, Path(f))
+            pool.submit(lint_file, Path(f), config)
             for f in args.files
             if not EXCLUDE_REGEX.match(f) and os.path.exists(f)
         ]

--- a/dev/clint/src/clint/config.py
+++ b/dev/clint/src/clint/config.py
@@ -9,12 +9,12 @@ import tomli
 class Config:
     exclude: list[str]
     # Path -> List of modules that should not be imported globally under that path
-    forbidden_global_imports: dict[str, list[str]]
+    forbidden_top_level_imports: dict[str, list[str]]
 
     @classmethod
     def load(cls) -> Config:
         with open("pyproject.toml", "rb") as f:
             data = tomli.load(f)
             exclude = data["tool"]["clint"]["exclude"]
-            forbidden_global_imports = data["tool"]["clint"]["forbidden-global-imports"]
-            return cls(exclude, forbidden_global_imports)
+            forbidden_imports = data["tool"]["clint"]["forbidden-top-level-imports"]
+            return cls(exclude, forbidden_imports)

--- a/dev/clint/src/clint/config.py
+++ b/dev/clint/src/clint/config.py
@@ -8,10 +8,13 @@ import tomli
 @dataclass
 class Config:
     exclude: list[str]
+    # Path -> List of modules that should not be imported globally under that path
+    forbidden_global_imports: dict[str, list[str]]
 
     @classmethod
     def load(cls) -> Config:
         with open("pyproject.toml", "rb") as f:
             data = tomli.load(f)
             exclude = data["tool"]["clint"]["exclude"]
-            return cls(exclude)
+            forbidden_global_imports = data["tool"]["clint"]["forbidden-global-imports"]
+            return cls(exclude, forbidden_global_imports)

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -184,3 +184,17 @@ class OsEnvironDeleteInTest(Rule):
 
     def _message(self) -> str:
         return "Do not delete `os.environ` in test directly. Use `monkeypatch.delenv` (https://docs.pytest.org/en/stable/reference/reference.html#pytest.MonkeyPatch.delenv)."
+
+
+class ForbiddenGlobalImport(Rule):
+    def __init__(self, imported) -> None:
+        self.imported = imported
+
+    def _id(self) -> str:
+        return "MLF0013"
+
+    def _message(self) -> str:
+        return (
+            f"Globally importing module `{self.imported}` is not allowed in this file. "
+            "Use lazy import instead."
+        )

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -186,15 +186,15 @@ class OsEnvironDeleteInTest(Rule):
         return "Do not delete `os.environ` in test directly. Use `monkeypatch.delenv` (https://docs.pytest.org/en/stable/reference/reference.html#pytest.MonkeyPatch.delenv)."
 
 
-class ForbiddenGlobalImport(Rule):
-    def __init__(self, imported) -> None:
-        self.imported = imported
+class ForbiddenTopLevelImport(Rule):
+    def __init__(self, module: str) -> None:
+        self.module = module
 
     def _id(self) -> str:
         return "MLF0013"
 
     def _message(self) -> str:
         return (
-            f"Globally importing module `{self.imported}` is not allowed in this file. "
-            "Use lazy import instead."
+            f"Importing module `{self.module}` at the top level is not allowed "
+            "in this file. Use lazy import instead."
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,5 +271,5 @@ exclude = [
   "tests/protos",
 ]
 
-[tool.clint.forbidden-global-imports]
+[tool.clint.forbidden-top-level-imports]
 "mlflow/gateway/providers/*" = ["fastapi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,3 +270,6 @@ exclude = [
   "mlflow/store/db_migrations",
   "tests/protos",
 ]
+
+[tool.clint.forbidden-global-imports]
+"mlflow/gateway/providers/*" = ["fastapi"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13733?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13733/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13733
```

</p>
</details>

### Related Issues/PRs

Follow-up for https://github.com/mlflow/mlflow/pull/13721#issuecomment-2463666760

### What changes are proposed in this pull request?

Add a custom linter to prohibit global imports for certain modules in certain files. For example, we can block importing `fastapi` globally within `mlflow/gateway/providers` directory by adding this configuration to `pyproject.toml`.

```
[tool.clint.forbidden-global-imports]
"mlflow/gateway/providers/*" = ["fastapi"]
```

Then either `import fastapi` or `from fastapi import xyz` at top level will raise an lint error:

```
# mlflow/gateway/providers/anthropic.py

from fastapi import HTTPException  # noqa: F401
```

```
# mlflow/gateway/providers/togetherai.py

import fastapi  # noqa: F401
```

<img width="928" alt="Screenshot 2024-11-11 at 13 40 57" src="https://github.com/user-attachments/assets/a0e2bf88-8d87-4307-a346-cd8c90884dfd">

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (see above screenshot)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
