### PR TITLE
Revert "Fix langchain pyfunc predict input conversion (#13652)"

### DIFF
--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -103,31 +103,22 @@ class APIRequest:
     results: list[tuple[int, str]]
     errors: dict
     convert_chat_responses: bool
+    did_perform_chat_conversion: bool
     stream: bool
     params: dict[str, Any]
     prediction_context: Optional[Context] = None
 
-    def _predict_single_input(self, single_input: dict, callback_handlers, **kwargs):
+    def _predict_single_input(self, single_input, callback_handlers, **kwargs):
         config = kwargs.pop("config", {})
         config["callbacks"] = config.get("callbacks", []) + (callback_handlers or [])
-        # update self.request_json to make sure error message is accurate
-        self.request_json, did_perform_chat_conversion = (
-            transform_request_json_for_chat_if_necessary(single_input, self.lc_model)
-        )
-
         if self.stream:
-            result = self.lc_model.stream(self.request_json, config=config, **kwargs)
+            return self.lc_model.stream(single_input, config=config, **kwargs)
+        if hasattr(self.lc_model, "invoke"):
+            return self.lc_model.invoke(single_input, config=config, **kwargs)
         else:
-            if hasattr(self.lc_model, "invoke"):
-                result = self.lc_model.invoke(self.request_json, config=config, **kwargs)
-            else:
-                # for backwards compatibility, __call__ is deprecated and will be removed in 0.3.0
-                # kwargs shouldn't have config field if invoking with __call__
-                result = self.lc_model(self.request_json, callbacks=callback_handlers, **kwargs)
-
-        if did_perform_chat_conversion or self.convert_chat_responses:
-            return self._try_convert_response(result)
-        return result
+            # for backwards compatibility, __call__ is deprecated and will be removed in 0.3.0
+            # kwargs shouldn't have config field if invoking with __call__
+            return self.lc_model(single_input, callbacks=callback_handlers, **kwargs)
 
     def _try_convert_response(self, response):
         if self.stream:
@@ -152,24 +143,34 @@ class APIRequest:
                 # does not accept dictionaries as input, it leads to errors like
                 # Expected Scalar value for String field 'query_text'
                 try:
-                    original_request = self.request_json
                     response = self._predict_single_input(
                         self.request_json, callback_handlers, **self.params
                     )
                 except TypeError as e:
-                    _logger.debug(
+                    _logger.warning(
                         f"Failed to invoke {self.lc_model.__class__.__name__} "
                         f"with {self.request_json}. Error: {e!r}. Trying to "
                         "invoke with the first value of the dictionary."
                     )
-                    self.request_json = next(iter(original_request.values()))
+                    self.request_json = next(iter(self.request_json.values()))
+                    (
+                        prepared_request_json,
+                        did_perform_chat_conversion,
+                    ) = transform_request_json_for_chat_if_necessary(
+                        self.request_json, self.lc_model
+                    )
+                    self.did_perform_chat_conversion = did_perform_chat_conversion
+
                     response = self._predict_single_input(
-                        self.request_json, callback_handlers, **self.params
+                        prepared_request_json, callback_handlers, **self.params
                     )
             else:
                 response = self._predict_single_input(
                     self.request_json, callback_handlers, **self.params
                 )
+
+            if self.did_perform_chat_conversion or self.convert_chat_responses:
+                response = self._try_convert_response(response)
         else:
             # return_only_outputs is invalid for stream call
             if isinstance(self.lc_model, langchain.chains.base.Chain) and not self.stream:
@@ -179,12 +180,11 @@ class APIRequest:
             kwargs.update(**self.params)
             response = self._predict_single_input(self.request_json, callback_handlers, **kwargs)
 
-            # for backwards compatibility, only return the value for single-output chains
-            if (
-                not self.convert_chat_responses
-                and isinstance(response, dict)
-                and len(response) == 1
-            ):
+            if self.did_perform_chat_conversion or self.convert_chat_responses:
+                response = self._try_convert_response(response)
+            elif isinstance(response, dict) and len(response) == 1:
+                # to maintain existing code, single output chains will still return
+                # only the result
                 response = response.popitem()[1]
 
         return convert_to_serializable(response)
@@ -230,7 +230,17 @@ def process_api_requests(
 
     results = []
     errors = {}
-    requests_iter = enumerate(requests)
+
+    # Note: we should call `transform_request_json_for_chat_if_necessary`
+    # for the whole batch data, because the conversion should obey the rule
+    # that if any record in the batch can't be converted, then all the record
+    # in this batch can't be converted.
+    (
+        converted_chat_requests,
+        did_perform_chat_conversion,
+    ) = transform_request_json_for_chat_if_necessary(requests, lc_model)
+
+    requests_iter = enumerate(converted_chat_requests)
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         while True:
             # get next request (if one is not already waiting for capacity)
@@ -239,14 +249,15 @@ def process_api_requests(
                 _logger.warning(f"Retrying request {next_request.index}: {next_request}")
             elif req := next(requests_iter, None):
                 # get new request
-                index, request_json = req
+                index, converted_chat_request_json = req
                 next_request = APIRequest(
                     index=index,
                     lc_model=lc_model,
-                    request_json=request_json,
+                    request_json=converted_chat_request_json,
                     results=results,
                     errors=errors,
                     convert_chat_responses=convert_chat_responses,
+                    did_perform_chat_conversion=did_perform_chat_conversion,
                     stream=False,
                     prediction_context=get_prediction_context(),
                     params=params,
@@ -297,13 +308,19 @@ def process_stream_request(
             "No `stream` method found."
         )
 
+    (
+        converted_chat_requests,
+        did_perform_chat_conversion,
+    ) = transform_request_json_for_chat_if_necessary(request_json, lc_model)
+
     api_request = APIRequest(
         index=0,
         lc_model=lc_model,
-        request_json=request_json,
+        request_json=converted_chat_requests,
         results=None,
         errors=None,
         convert_chat_responses=convert_chat_responses,
+        did_perform_chat_conversion=did_perform_chat_conversion,
         stream=True,
         prediction_context=get_prediction_context(),
         params=params,

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -4,6 +4,7 @@ import time
 from typing import Literal, Optional
 
 import pydantic
+from langchain.agents import AgentExecutor
 from langchain.schema import AIMessage, HumanMessage, SystemMessage
 from langchain.schema import ChatMessage as LangChainChatMessage
 from packaging.version import Version
@@ -214,15 +215,6 @@ def try_transform_response_iter_to_chat_format(chunk_iter):
 
 
 def _convert_chat_request_or_throw(chat_request: dict):
-    try:
-        from langchain_core.messages.utils import convert_to_messages
-
-        return convert_to_messages(chat_request["messages"])
-    except ImportError:
-        pass
-
-    # it's safe to drop below when langchain >= 0.1.20
-    # TODO: drop this once we updated minimum supported langchain version
     if IS_PYDANTIC_V1:
         model = _ChatRequest.parse_obj(chat_request)
     else:
@@ -245,6 +237,11 @@ def _get_lc_model_input_fields(lc_model) -> set[str]:
 
 
 def should_transform_requst_json_for_chat(lc_model):
+    # Avoid converting the request to LangChain's Message format if the chain
+    # is an AgentExecutor, as LangChainChatMessage might not be accepted by the chain
+    if isinstance(lc_model, AgentExecutor):
+        return False
+
     input_fields = _get_lc_model_input_fields(lc_model)
     if "messages" in input_fields:
         # If the chain accepts a "messages" field directly, don't attempt to convert
@@ -255,14 +252,12 @@ def should_transform_requst_json_for_chat(lc_model):
     return True
 
 
-def transform_request_json_for_chat_if_necessary(request_json: dict, lc_model):
+def transform_request_json_for_chat_if_necessary(request_json, lc_model):
     """
     Convert the input request JSON to LangChain's Message format if the LangChain model
     accepts ChatMessage objects (e.g. AIMessage, HumanMessage, SystemMessage) as input.
-
-    Args:
-        request_json: The input request JSON. Must be a dictionary
-        lc_model: The LangChain model.
+    # TODO: this function should identify if the lc_model accepts ChatMessage objects,
+    # and only converts if it does. ChatModels inputs should be converted.
 
     Returns:
         A 2-element tuple containing:
@@ -271,6 +266,8 @@ def transform_request_json_for_chat_if_necessary(request_json: dict, lc_model):
             2. A boolean indicating whether or not the request was transformed from the OpenAI
             chat format.
     """
+    if not should_transform_requst_json_for_chat(lc_model):
+        return request_json, False
 
     def json_dict_might_be_chat_request(json_message: dict):
         return (
@@ -280,33 +277,22 @@ def transform_request_json_for_chat_if_necessary(request_json: dict, lc_model):
             # Additional keys can't be specified when calling LangChain invoke() / batch()
             # with chat messages
             len(json_message) == 1
-            # messages field should be a list
-            and isinstance(json_message["messages"], list)
         )
 
-    if not should_transform_requst_json_for_chat(lc_model):
-        return request_json, False
-
-    if json_dict_might_be_chat_request(request_json):
+    if isinstance(request_json, dict) and json_dict_might_be_chat_request(request_json):
         try:
-            result = _convert_chat_request_or_throw(request_json)
-            if hasattr(lc_model, "input_schema"):
-                # sometimes the input schema is not reliable and we should try
-                # to invoke the model with the request instead, restricting the check to only
-                # string input schemas to reduce the blast radius
-                # example: test_save_load_chain_as_code
-                if lc_model.input_schema.schema().get("type", "string") == "string":
-                    # TODO: migrate this logic inside APIRequest to avoid invoke twice
-                    lc_model.invoke(result)
-                    return result, True
-                else:
-                    lc_model.input_schema.validate(result)
-                    return result, True
+            return _convert_chat_request_or_throw(request_json), True
+        except pydantic.ValidationError:
             return request_json, False
-        # we should catch all exceptions here including pydantic validation errors
-        # if the model's input schema cannot validate the request
-        # we should not attempt to convert the request to LangChain's Message format
-        except Exception:
+    elif isinstance(request_json, list) and all(
+        json_dict_might_be_chat_request(json) for json in request_json
+    ):
+        try:
+            return (
+                [_convert_chat_request_or_throw(json_dict) for json_dict in request_json],
+                True,
+            )
+        except pydantic.ValidationError:
             return request_json, False
     else:
         return request_json, False

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2192,7 +2192,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
             expected_chat_response,
         ]
 
-    with pytest.raises(MlflowException, match="Invalid input type"):
+    with pytest.raises(MlflowException, match="Unrecognized chat message role"):
         pyfunc_loaded_model.predict({"messages": [{"role": "foobar", "content": "test content"}]})
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13742?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13742/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13742
```

</p>
</details>

This reverts commit 269730e5df2f887878cf9c4f06e94a0915bdc20a.

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Revert this change to avoid duplicate call, will file another fix later

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
