### PR TITLE
Fix langchain inputs conversion

### DIFF
--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -554,12 +554,10 @@ For a complete example of a LangGraph model that works with this evaluation exam
 How to control whether my input is converted to List[langchain.schema.BaseMessage] in PyFunc predict?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If user provides inputs like ``{"messages": [{"role": "user", "content": "some_question"}]}``, MLflow internally tries to
-convert the input to List[langchain.schema.BaseMessage] like ``[HumanMessage(content="some_question")]``. If the model is
-AgentExecutor or the model's input_schema contains "messages" field, then MLflow doesn't convert the inputs.
-There're some edge cases where user wants to provide the input as is, in such cases user can set the environment variable
-``MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN`` to ``False``. This will prevent MLflow from 
-implementing such conversion.
+By default, MLflow converts chat request format input ``{"messages": [{"role": "user", "content": "some_question"}]}`` to
+List[langchain.schema.BaseMessage] like ``[HumanMessage(content="some_question")]`` for certain model types.
+To force the conversion, set the environment variable ``MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN`` to ``True``.
+To disable this behavior, set the environment variable ``MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN`` to ``False`` as demonstrated below:
 
 .. code-block:: python
 
@@ -585,7 +583,7 @@ implementing such conversion.
     assert model.invoke(input_example) == "Hello"
 
     # set this environment variable to avoid input conversion
-    os.environ["MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN"] = "false"
+    os.environ["MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN"] = "false"
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(model, "model", input_example=input_example)
 

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -558,7 +558,7 @@ If user provides inputs like ``{"messages": [{"role": "user", "content": "some_q
 convert the input to List[langchain.schema.BaseMessage] like ``[HumanMessage(content="some_question")]``. If the model is
 AgentExecutor or the model's input_schema contains "messages" field, then MLflow doesn't convert the inputs.
 There're some edge cases where user wants to provide the input as is, in such cases user can set the environment variable
-``MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN`` to ``False``. This will prevent MLflow from 
+``MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN`` to ``False``. This will prevent MLflow from 
 implementing such conversion.
 
 .. code-block:: python
@@ -585,9 +585,7 @@ implementing such conversion.
     assert model.invoke(input_example) == "Hello"
 
     # set this environment variable to avoid input conversion
-    os.environ[
-        "MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN"
-    ] = "false"
+    os.environ["MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN"] = "false"
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(model, "model", input_example=input_example)
 

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -550,3 +550,46 @@ string response, which can be compared to the `"ground_truth"` column.
 
 For a complete example of a LangGraph model that works with this evaluation example, see the 
 `MLflow LangGraph blog <https://mlflow.org/blog/langgraph-model-from-code>`_.
+
+How to control whether my input is converted to List[langchain.schema.BaseMessage] in PyFunc predict?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If user provides inputs like ``{"messages": [{"role": "user", "content": "some_question"}]}``, MLflow internally tries to
+convert the input to List[langchain.schema.BaseMessage] like ``[HumanMessage(content="some_question")]``. If the model is
+AgentExecutor or the model's input_schema contains "messages" field, then MLflow doesn't convert the inputs.
+There're some edge cases where user wants to provide the input as is, in such cases user can set the environment variable
+``MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN`` to ``False``. This will prevent MLflow from 
+implementing such conversion.
+
+.. code-block:: python
+
+    import json
+    import mlflow
+    import os
+    from operator import itemgetter
+    from langchain.schema.runnable import RunnablePassthrough
+
+    model = RunnablePassthrough.assign(
+        problem=lambda x: json.loads(x["messages"][-1]["content"])["problem"]
+    ) | itemgetter("problem")
+
+    input_example = {
+        "messages": [
+            {
+                "role": "user",
+                "content": json.dumps({"problem": "Hello"}),
+            }
+        ]
+    }
+    # this model accepts the input_example
+    assert model.invoke(input_example) == "Hello"
+
+    # set this environment variable to avoid input conversion
+    os.environ[
+        "MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN"
+    ] = "false"
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(model, "model", input_example=input_example)
+
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert pyfunc_model.predict(input_example) == ["Hello"]

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -568,14 +568,14 @@ To disable this behavior, set the environment variable ``MLFLOW_CONVERT_MESSAGES
     from langchain.schema.runnable import RunnablePassthrough
 
     model = RunnablePassthrough.assign(
-        problem=lambda x: json.loads(x["messages"][-1]["content"])["problem"]
+        problem=lambda x: x["messages"][-1]["content"]
     ) | itemgetter("problem")
 
     input_example = {
         "messages": [
             {
                 "role": "user",
-                "content": json.dumps({"problem": "Hello"}),
+                "content": "Hello",
             }
         ]
     }

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -677,6 +677,6 @@ MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING = _BooleanEnvironmentVariable(
 # to a List[BaseMessage] object when invoking a PyFunc model saved with langchain flavor.
 # This takes precedence over the default behavior of trying such conversion if the model
 # is not an AgentExecutor and the input schema doesn't contain a 'messages' field.
-MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN = _BooleanEnvironmentVariable(
-    "MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN", None
+MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN = _BooleanEnvironmentVariable(
+    "MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN", None
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -677,6 +677,6 @@ MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING = _BooleanEnvironmentVariable(
 # to a List[BaseMessage] object when invoking a PyFunc model saved with langchain flavor.
 # This takes precedence over the default behavior of trying such conversion if the model
 # is not an AgentExecutor and the input schema doesn't contain a 'messages' field.
-MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN = _BooleanEnvironmentVariable(
-    "MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN", None
+MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN = _BooleanEnvironmentVariable(
+    "MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN", None
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -668,7 +668,15 @@ MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR = _EnvironmentVariable(
     "MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR", str, None
 )
 
-# Specifies weather to log environment variable names used during model logging.
+# Specifies whether to log environment variable names used during model logging.
 MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING = _BooleanEnvironmentVariable(
     "MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING", True
+)
+
+# Specifies whether to convert a {"messages": [{"role": "...", "content": "..."}]} input
+# to a List[BaseMessage] object when invoking a PyFunc model saved with langchain flavor.
+# This takes precedence over the default behavior of trying such conversion if the model
+# is not an AgentExecutor and the input schema doesn't contain a 'messages' field.
+MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN = _BooleanEnvironmentVariable(
+    "MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN", None
 )

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -147,7 +147,7 @@ class APIRequest:
                         self.request_json, callback_handlers, **self.params
                     )
                 except TypeError as e:
-                    _logger.warning(
+                    _logger.debug(
                         f"Failed to invoke {self.lc_model.__class__.__name__} "
                         f"with {self.request_json}. Error: {e!r}. Trying to "
                         "invoke with the first value of the dictionary."

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -301,12 +301,22 @@ def transform_request_json_for_chat_if_necessary(request_json, lc_model):
         should_convert = should_transform_requst_json_for_chat(lc_model) and (
             json_dict_might_be_chat_request(request_json) or is_list_of_chat_messages(request_json)
         )
+        if should_convert:
+            _logger.debug(
+                "Converting the request JSON to LangChain's Message format. "
+                "To disable this conversion, set the environment variable "
+                f"`{MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN}` to 'false'."
+            )
 
     if should_convert:
         try:
             return convert_chat_request(request_json), True
-        # we should catch all exceptions here including pydantic validation errors
         except pydantic.ValidationError:
+            _logger.debug(
+                "Failed to convert the request JSON to LangChain's Message format. "
+                "The request will be passed to the LangChain model as-is. ",
+                exc_info=True,
+            )
             return request_json, False
     else:
         return request_json, False

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -218,15 +218,6 @@ def try_transform_response_iter_to_chat_format(chunk_iter):
 
 
 def _convert_chat_request_or_throw(chat_request: dict):
-    try:
-        from langchain_core.messages.utils import convert_to_messages
-
-        return convert_to_messages(chat_request["messages"])
-    except ImportError:
-        pass
-
-    # it's safe to drop below when langchain >= 0.1.20
-    # TODO: drop this once we updated minimum supported langchain version
     if IS_PYDANTIC_V1:
         model = _ChatRequest.parse_obj(chat_request)
     else:
@@ -315,7 +306,7 @@ def transform_request_json_for_chat_if_necessary(request_json, lc_model):
         try:
             return convert_chat_request(request_json), True
         # we should catch all exceptions here including pydantic validation errors
-        except Exception:
+        except pydantic.ValidationError:
             return request_json, False
     else:
         return request_json, False

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -10,7 +10,7 @@ from langchain.schema import ChatMessage as LangChainChatMessage
 from packaging.version import Version
 
 from mlflow.environment_variables import (
-    MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN,
+    MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.types.schema import Array, ColSpec, DataType, Schema
@@ -296,7 +296,7 @@ def transform_request_json_for_chat_if_necessary(request_json, lc_model):
             json_dict_might_be_chat_request(message) for message in json_message
         )
 
-    should_convert = MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN.get()
+    should_convert = MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN.get()
     if should_convert is None:
         should_convert = should_transform_requst_json_for_chat(lc_model) and (
             json_dict_might_be_chat_request(request_json) or is_list_of_chat_messages(request_json)
@@ -305,7 +305,7 @@ def transform_request_json_for_chat_if_necessary(request_json, lc_model):
             _logger.debug(
                 "Converting the request JSON to LangChain's Message format. "
                 "To disable this conversion, set the environment variable "
-                f"`{MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN}` to 'false'."
+                f"`{MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN}` to 'false'."
             )
 
     if should_convert:

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -10,7 +10,7 @@ from langchain.schema import ChatMessage as LangChainChatMessage
 from packaging.version import Version
 
 from mlflow.environment_variables import (
-    MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN,
+    MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.types.schema import Array, ColSpec, DataType, Schema
@@ -305,7 +305,7 @@ def transform_request_json_for_chat_if_necessary(request_json, lc_model):
             json_dict_might_be_chat_request(message) for message in json_message
         )
 
-    should_convert = MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN.get()
+    should_convert = MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN.get()
     if should_convert is None:
         should_convert = should_transform_requst_json_for_chat(lc_model) and (
             json_dict_might_be_chat_request(request_json) or is_list_of_chat_messages(request_json)

--- a/tests/langchain/test_chat_utils.py
+++ b/tests/langchain/test_chat_utils.py
@@ -85,14 +85,16 @@ def test_transform_response_iter_to_chat_format_ai_message():
 def test_transform_request_json_for_chat_if_necessary_no_conversion():
     model = MagicMock(spec=AgentExecutor)
     request_json = {"messages": [{"role": "user", "content": "some_input"}]}
-    assert transform_request_json_for_chat_if_necessary(request_json, model) == (
-        request_json,
-        False,
-    )
+    with patch.object(model.input_schema, "validate", side_effect=Exception):
+        assert transform_request_json_for_chat_if_necessary(request_json, model) == (
+            request_json,
+            False,
+        )
 
 
 def test_transform_request_json_for_chat_if_necessary_conversion():
     model = MagicMock(spec=SimpleChatModel)
+    model.input_schema = MagicMock()
     request_json = {"messages": [{"role": "user", "content": "some_input"}]}
 
     with patch("mlflow.langchain.utils.chat._get_lc_model_input_fields", return_value={"messages"}):
@@ -112,12 +114,22 @@ def test_transform_request_json_for_chat_if_necessary_conversion():
         {"messages": [{"role": "assistant", "content": "What would you like to ask?"}]},
         {"messages": [{"role": "user", "content": "Who owns MLflow?"}]},
     ]
-    with patch(
-        "mlflow.langchain.utils.chat._get_lc_model_input_fields",
-        return_value={},
+    with (
+        patch(
+            "mlflow.langchain.utils.chat._get_lc_model_input_fields",
+            return_value={},
+        ),
+        patch.object(model.input_schema, "schema", return_value={}),
+        patch.object(model.input_schema, "validate", return_value=None),
     ):
-        transformed_request = transform_request_json_for_chat_if_necessary(request_json, model)
-        assert transformed_request[0][0][0] == SystemMessage(content="You are a helpful assistant.")
-        assert transformed_request[0][1][0] == AIMessage(content="What would you like to ask?")
-        assert transformed_request[0][2][0] == HumanMessage(content="Who owns MLflow?")
-        assert transformed_request[1] is True
+        transformed_requests = []
+        for request_dict in request_json:
+            transformed_requests.append(
+                transform_request_json_for_chat_if_necessary(request_dict, model)
+            )
+        assert transformed_requests[0][0][0] == SystemMessage(
+            content="You are a helpful assistant."
+        )
+        assert transformed_requests[1][0][0] == AIMessage(content="What would you like to ask?")
+        assert transformed_requests[2][0][0] == HumanMessage(content="Who owns MLflow?")
+        assert transformed_requests[1][1] is True

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -26,7 +26,7 @@ from langchain.chains.qa_with_sources import load_qa_with_sources_chain
 from langchain.evaluation.qa import QAEvalChain
 
 from mlflow.environment_variables import (
-    MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN,
+    MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN,
 )
 from mlflow.tracing.export.inference_table import pop_trace
 from mlflow.tracing.provider import reset_tracer_setup
@@ -3652,7 +3652,7 @@ def test_pyfunc_converts_chat_request_correctly(
 
     if needs_env_var:
         monkeypatch.setenv(
-            MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN.name,
+            MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN.name,
             str(should_convert),
         )
     # pyfunc model can accepts chat request format even the chain

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3643,8 +3643,6 @@ def chain_accepts_list_messages():
 def test_pyfunc_converts_chat_request_correctly(
     model, should_convert, input_example, needs_env_var, monkeypatch
 ):
-    # making sure the model infer_pip_requirements work when logging model
-    monkeypatch.setenv("MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS", "true")
     request = (
         transform_request_json_for_chat_if_necessary(model, input_example)
         if should_convert

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3610,6 +3610,9 @@ def chain_accepts_list_messages():
     return prompt | fake_chat_model | StrOutputParser()
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.1.20"), reason="feature not existing"
+)
 @pytest.mark.parametrize(
     ("model", "should_convert", "input_example", "needs_env_var"),
     [

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3625,16 +3625,14 @@ def chain_accepts_list_messages():
         (
             # This model is an example when the model expects a chat request
             # format input, but the input should not be converted to List[BaseMessage]
-            RunnablePassthrough.assign(
-                problem=lambda x: json.loads(x["messages"][-1]["content"])["problem"]
-            )
+            RunnablePassthrough.assign(problem=lambda x: x["messages"][-1]["content"])
             | itemgetter("problem"),
             False,
             {
                 "messages": [
                     {
                         "role": "user",
-                        "content": json.dumps({"problem": "Databricks"}),
+                        "content": "Databricks",
                     }
                 ]
             },

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2198,7 +2198,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
             expected_chat_response,
         ]
 
-    with pytest.raises(MlflowException, match="Invalid input type"):
+    with pytest.raises(MlflowException, match="Unrecognized chat message role"):
         pyfunc_loaded_model.predict({"messages": [{"role": "foobar", "content": "test content"}]})
 
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3640,6 +3640,8 @@ def chain_accepts_list_messages():
 def test_pyfunc_converts_chat_request_correctly(
     model, should_convert, input_example, needs_env_var, monkeypatch
 ):
+    # making sure the model infer_pip_requirements work when logging model
+    monkeypatch.setenv("MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS", "true")
     request = (
         transform_request_json_for_chat_if_necessary(model, input_example)
         if should_convert

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -26,7 +26,7 @@ from langchain.chains.qa_with_sources import load_qa_with_sources_chain
 from langchain.evaluation.qa import QAEvalChain
 
 from mlflow.environment_variables import (
-    MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN,
+    MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN,
 )
 from mlflow.tracing.export.inference_table import pop_trace
 from mlflow.tracing.provider import reset_tracer_setup
@@ -3623,6 +3623,8 @@ def chain_accepts_list_messages():
             False,
         ),
         (
+            # This model is an example when the model expects a chat request
+            # format input, but the input should not be converted to List[BaseMessage]
             RunnablePassthrough.assign(
                 problem=lambda x: json.loads(x["messages"][-1]["content"])["problem"]
             )
@@ -3652,7 +3654,7 @@ def test_pyfunc_converts_chat_request_correctly(
 
     if needs_env_var:
         monkeypatch.setenv(
-            MLFLOW_CONVERT_MESSAGES_DICT_TO_FOR_LANGCHAIN.name,
+            MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN.name,
             str(should_convert),
         )
     # pyfunc model can accepts chat request format even the chain

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -25,6 +25,9 @@ from langchain.chains.base import Chain
 from langchain.chains.qa_with_sources import load_qa_with_sources_chain
 from langchain.evaluation.qa import QAEvalChain
 
+from mlflow.environment_variables import (
+    MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN,
+)
 from mlflow.tracing.export.inference_table import pop_trace
 from mlflow.tracing.provider import reset_tracer_setup
 
@@ -76,7 +79,10 @@ from mlflow.langchain.utils import (
     IS_PICKLE_SERIALIZATION_RESTRICTED,
     lc_runnables_types,
 )
-from mlflow.langchain.utils.chat import try_transform_response_to_chat_format
+from mlflow.langchain.utils.chat import (
+    transform_request_json_for_chat_if_necessary,
+    try_transform_response_to_chat_format,
+)
 from mlflow.models import Model
 from mlflow.models.dependencies_schemas import DependenciesSchemasType
 from mlflow.models.resources import (
@@ -2192,7 +2198,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
             expected_chat_response,
         ]
 
-    with pytest.raises(MlflowException, match="Unrecognized chat message role"):
+    with pytest.raises(MlflowException, match="Invalid input type"):
         pyfunc_loaded_model.predict({"messages": [{"role": "foobar", "content": "test content"}]})
 
 
@@ -3591,3 +3597,83 @@ def test_custom_resources(chain_model_signature, tmp_path):
         model_path = _download_artifact_from_uri(model_uri)
         reloaded_model = Model.load(os.path.join(model_path, "MLmodel"))
         assert reloaded_model.resources == expected_resources
+
+
+def chain_accepts_list_messages():
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", "You are a chatbot that can answer questions about Databricks."),
+            ("user", "{question}"),
+        ]
+    )
+    fake_chat_model = get_fake_chat_model()
+    return prompt | fake_chat_model | StrOutputParser()
+
+
+@pytest.mark.parametrize(
+    ("model", "should_convert", "input_example", "needs_env_var"),
+    [
+        (
+            chain_accepts_list_messages(),
+            True,
+            {"messages": [{"role": "user", "content": "Hello"}]},
+            False,
+        ),
+        (
+            RunnablePassthrough.assign(
+                problem=lambda x: json.loads(x["messages"][-1]["content"])["problem"]
+            )
+            | itemgetter("problem"),
+            False,
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": json.dumps({"problem": "Databricks"}),
+                    }
+                ]
+            },
+            True,
+        ),
+    ],
+)
+def test_pyfunc_converts_chat_request_correctly(
+    model, should_convert, input_example, needs_env_var, monkeypatch
+):
+    request = (
+        transform_request_json_for_chat_if_necessary(model, input_example)
+        if should_convert
+        else input_example
+    )
+    assert model.invoke(request) == "Databricks"
+
+    if needs_env_var:
+        monkeypatch.setenv(
+            MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN.name,
+            str(should_convert),
+        )
+    # pyfunc model can accepts chat request format even the chain
+    # itself does not accept it, but we need to use the correct
+    # input example to infer model signature
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            model,
+            "model",
+            input_example=input_example,
+        )
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    result = pyfunc_model.predict(input_example)
+    if should_convert:
+        # output are converted to chatResponse format if input is converted
+        assert result[0]["choices"][0]["message"]["content"] == "Databricks"
+    else:
+        assert result == ["Databricks"]
+
+    # Test stream output
+    response = pyfunc_model.predict_stream(input_example)
+    if should_convert:
+        assert isinstance(response, map)
+        assert list(response)[0]["choices"][0]["delta"]["content"] == "Databricks"
+    else:
+        assert inspect.isgenerator(response)
+        assert list(response) == ["Databricks"], list(response)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13744?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13744/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13744
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Apply https://github.com/mlflow/mlflow/pull/13652 again and fix issue that previously mentioned in https://github.com/mlflow/mlflow/pull/13725.

In this PR I keep the original logic for deciding when to convert the input request to List[message], and added an environment variable `MLFLOW_CONVERT_MESSAGES_DICT_TO_LIST_OF_BASEMESSAGES_FOR_LANGCHAIN` for overriding the behavior. 
The reason I didn't add such param inside predict function is because of the params schema enforcement, if we add it in predict function then we need either customers to add this parameter when logging the model or opt-out params schema enforcement in pyfunc predict, neither of them are good practice.
Newly added test case fails on master (second example) and succeeds in this PR.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
