### PR TITLE
Fix test_autolog_text_vec_model test

### DIFF
--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1007,13 +1007,11 @@ def get_text_vec_model(train_samples):
 
 
 @pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.3.0") or Version(tf.keras.__version__) >= Version("3.7"),
+    Version(tf.__version__) < Version("2.3.0"),
     reason=(
         "Deserializing a model with `TextVectorization` and `Embedding` "
         "fails in tensorflow < 2.3.0. See this issue: "
         "https://github.com/tensorflow/tensorflow/issues/38250."
-        "Keras >= 3.7 is incompatible with Sequential mdoel with text vectorization layer,"
-        "see this issue: https://github.com/keras-team/keras/issues/20479."
     ),
 )
 def test_autolog_text_vec_model(tmp_path):
@@ -1022,7 +1020,7 @@ def test_autolog_text_vec_model(tmp_path):
     """
     mlflow.tensorflow.autolog()
 
-    train_samples = np.array(["this is an example", "another example"], dtype=object)
+    train_samples = tf.convert_to_tensor(["this is an example", "another example"])
     train_labels = np.array([0.4, 0.2])
     model = get_text_vec_model(train_samples)
 

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1007,11 +1007,13 @@ def get_text_vec_model(train_samples):
 
 
 @pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.3.0"),
+    Version(tf.__version__) < Version("2.3.0") or Version(tf.keras.__version__) >= Version("3.7"),
     reason=(
         "Deserializing a model with `TextVectorization` and `Embedding` "
         "fails in tensorflow < 2.3.0. See this issue: "
-        "https://github.com/tensorflow/tensorflow/issues/38250"
+        "https://github.com/tensorflow/tensorflow/issues/38250."
+        "Keras >= 3.7 is incompatible with Sequential mdoel with text vectorization layer,"
+        "see this issue: https://github.com/keras-team/keras/issues/20479."
     ),
 )
 def test_autolog_text_vec_model(tmp_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/13745?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13745/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13745
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix test_autolog_text_vec_model
See https://github.com/keras-team/keras/issues/20479#issuecomment-2468703602 for details

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
