### PR TITLE
Fix DSPy autologging for recent released version

### DIFF
--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -54,19 +54,23 @@ def autolog(
     from dspy.teleprompt import Teleprompter
 
     for cls in Teleprompter.__subclasses__():
+        compile_patch = "compile"
+        if hasattr(cls, compile_patch):
+            safe_patch(
+                FLAVOR_NAME,
+                cls,
+                "compile",
+                trace_disabled_fn,
+            )
+
+    call_patch = "__call__"
+    if hasattr(Evaluate, call_patch):
         safe_patch(
             FLAVOR_NAME,
-            cls,
-            "compile",
+            Evaluate,
+            call_patch,
             trace_disabled_fn,
         )
-
-    safe_patch(
-        FLAVOR_NAME,
-        Evaluate,
-        "__call__",
-        trace_disabled_fn,
-    )
 
 
 @autologging_integration(FLAVOR_NAME)

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -53,16 +53,16 @@ def autolog(
     from dspy.evaluate import Evaluate
     from dspy.teleprompt import Teleprompter
 
+    compile_patch = "compile"
     for cls in Teleprompter.__subclasses__():
-        compile_patch = "compile"
         # NB: This is to avoid the abstraction inheritance of superclasses that are defined
-        # only for the purposes of abstraction. The recursion behavior of the __subclasses__ dunder method
-        # will target the appropriate subclasses we need to patch.
+        # only for the purposes of abstraction. The recursion behavior of the
+        # __subclasses__ dunder method will target the appropriate subclasses we need to patch.
         if hasattr(cls, compile_patch):
             safe_patch(
                 FLAVOR_NAME,
                 cls,
-                "compile",
+                compile_patch,
                 trace_disabled_fn,
             )
 

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -55,6 +55,9 @@ def autolog(
 
     for cls in Teleprompter.__subclasses__():
         compile_patch = "compile"
+        # NB: This is to avoid the abstraction inheritance of superclasses that are defined
+        # only for the purposes of abstraction. The recursion behavior of the __subclasses__ dunder method
+        # will target the appropriate subclasses we need to patch.
         if hasattr(cls, compile_patch):
             safe_patch(
                 FLAVOR_NAME,

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -106,7 +106,10 @@ def test_mlflow_callback_exception():
             raise ValueError("Error")
 
     dspy.settings.configure(
-        lm=ErrorLM({"How are you?": {"answer": "test output", "reasoning": "No more responses"}}),
+        lm=ErrorLM(
+            model="invalid",
+            prompt={"How are you?": {"answer": "test output", "reasoning": "No more responses"}},
+        ),
     )
 
     cot = dspy.ChainOfThought("question -> answer", n=3)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/13755?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13755/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13755
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adjusts the safe patch logic to only apply patching for valid subclasses, ignoring type class definitions that do not contain patch-compatible logic. 
Also, update a test that utilizes a constructor that performs validation of the instantiated object when called.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
