### PR TITLE
Any type support

### DIFF
--- a/docs/source/python_api/mlflow.types.rst
+++ b/docs/source/python_api/mlflow.types.rst
@@ -9,7 +9,8 @@ mlflow.types
     :members:
 
 .. automodule:: mlflow.types.schema
-    :members: Array, Map, Object
+    :members: Array, Map, Object, Property, AnyType
+    :undoc-members:
 
 .. automodule:: mlflow.types.llm._BaseDataclass
     :undoc-members:

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1267,11 +1267,9 @@ def _enforce_array(data: Any, arr: Array, required=True):
     If the field is required, then the data must be provided.
     If Array's internal dtype is AnyType, then None and empty lists are also accepted.
     """
-    if not required or arr.dtype == AnyType():
-        if data is None:
-            return None
-        if isinstance(data, list) and not data:
-            return []
+    if not required or isinstance(arr.dtype, AnyType):
+        if data is None or data == []:
+            return data
         if isinstance(data, np.ndarray) and not data.tolist():
             return np.array([])
 
@@ -1292,11 +1290,8 @@ def _enforce_property(data: Any, property: Property):
 
 
 def _enforce_object(data: dict[str, Any], obj: Object, required=True):
-    if not required:
-        if data is None:
-            return None
-        if isinstance(data, dict) and not data:
-            return {}
+    if not required and (data is None or data == {}):
+        return data
     if HAS_PYSPARK and isinstance(data, Row):
         data = data.asDict(True)
     if not isinstance(data, dict):
@@ -1331,11 +1326,8 @@ def _enforce_object(data: dict[str, Any], obj: Object, required=True):
 
 
 def _enforce_map(data: Any, map_type: Map, required=True):
-    if not required:
-        if data is None:
-            return None
-        if isinstance(data, dict) and not data:
-            return {}
+    if (not required or isinstance(map_type.value_type, AnyType)) and (data is None or data == {}):
+        return data
 
     if not isinstance(data, dict):
         raise MlflowException(f"Expected data to be a dict, got {type(data).__name__}")

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1268,10 +1268,8 @@ def _enforce_array(data: Any, arr: Array, required=True):
     If Array's internal dtype is AnyType, then None and empty lists are also accepted.
     """
     if not required or isinstance(arr.dtype, AnyType):
-        if data is None or data == []:
+        if data is None or (isinstance(data, (list, np.ndarray)) and len(data) == 0):
             return data
-        if isinstance(data, np.ndarray) and not data.tolist():
-            return np.array([])
 
     if not isinstance(data, (list, np.ndarray)):
         raise MlflowException(f"Expected data to be list or numpy array, got {type(data).__name__}")

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1249,7 +1249,6 @@ def _enforce_datatype(data: Any, dtype: DataType, required=True):
     if not isinstance(dtype, DataType):
         raise MlflowException(f"Expected dtype to be DataType, got {type(dtype).__name__}")
     if not np.isscalar(data):
-        # raise Exception(f"{_is_none_or_nan(data)}, {data}, {required}")
         raise MlflowException(f"Expected data to be scalar, got {type(data).__name__}")
     # Reuse logic in _enforce_mlflow_datatype for type conversion
     pd_series = pd.Series(data)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1288,10 +1288,10 @@ def _enforce_property(data: Any, property: Property):
 
 
 def _enforce_object(data: dict[str, Any], obj: Object, required=True):
+    if HAS_PYSPARK and isinstance(data, Row):
+        data = None if len(data) == 0 else data.asDict(True)
     if not required and (data is None or data == {}):
         return data
-    if HAS_PYSPARK and isinstance(data, Row):
-        data = data.asDict(True)
     if not isinstance(data, dict):
         raise MlflowException(
             f"Failed to enforce schema of '{data}' with type '{obj}'. "

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1263,7 +1263,12 @@ def _enforce_datatype(data: Any, dtype: DataType, required=True):
 
 
 def _enforce_array(data: Any, arr: Array, required=True):
-    if not required:
+    """
+    Enforce data against an Array type.
+    If the field is required, then the data must be provided.
+    If Array's internal dtype is AnyType, then None and empty lists are also accepted.
+    """
+    if not required or arr.dtype == AnyType():
         if data is None:
             return None
         if isinstance(data, list) and not data:

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -25,10 +25,11 @@ from mlflow.models.model_config import _set_model_config
 from mlflow.store.artifact.utils.models import get_model_name_and_version
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType, ParamSchema, ParamSpec, Schema, TensorSpec
-from mlflow.types.schema import Array, Map, Object, Property
+from mlflow.types.schema import AnyType, Array, Map, Object, Property
 from mlflow.types.utils import (
     TensorsNotSupportedException,
     _infer_param_schema,
+    _is_none_or_nan,
     clean_tensor_type,
 )
 from mlflow.utils.annotations import experimental
@@ -1242,12 +1243,13 @@ def _enforce_pyspark_dataframe_schema(
 
 
 def _enforce_datatype(data: Any, dtype: DataType, required=True):
-    if not required and data is None:
+    if not required and _is_none_or_nan(data):
         return None
 
     if not isinstance(dtype, DataType):
         raise MlflowException(f"Expected dtype to be DataType, got {type(dtype).__name__}")
     if not np.isscalar(data):
+        # raise Exception(f"{_is_none_or_nan(data)}, {data}, {required}")
         raise MlflowException(f"Expected data to be scalar, got {type(data).__name__}")
     # Reuse logic in _enforce_mlflow_datatype for type conversion
     pd_series = pd.Series(data)
@@ -1261,13 +1263,18 @@ def _enforce_datatype(data: Any, dtype: DataType, required=True):
 
 
 def _enforce_array(data: Any, arr: Array, required=True):
-    if not required and data is None:
-        return None
+    if not required:
+        if data is None:
+            return None
+        if isinstance(data, list) and not data:
+            return []
+        if isinstance(data, np.ndarray) and not data.tolist():
+            return np.array([])
 
     if not isinstance(data, (list, np.ndarray)):
         raise MlflowException(f"Expected data to be list or numpy array, got {type(data).__name__}")
 
-    data_enforced = [_enforce_type(x, arr.dtype) for x in data]
+    data_enforced = [_enforce_type(x, arr.dtype, required=required) for x in data]
 
     # Keep input data type
     if isinstance(data, np.ndarray):
@@ -1277,12 +1284,15 @@ def _enforce_array(data: Any, arr: Array, required=True):
 
 
 def _enforce_property(data: Any, property: Property):
-    return _enforce_type(data, property.dtype)
+    return _enforce_type(data, property.dtype, required=property.required)
 
 
 def _enforce_object(data: dict[str, Any], obj: Object, required=True):
-    if not required and data is None:
-        return None
+    if not required:
+        if data is None:
+            return None
+        if isinstance(data, dict) and not data:
+            return {}
     if HAS_PYSPARK and isinstance(data, Row):
         data = data.asDict(True)
     if not isinstance(data, dict):
@@ -1317,8 +1327,11 @@ def _enforce_object(data: dict[str, Any], obj: Object, required=True):
 
 
 def _enforce_map(data: Any, map_type: Map, required=True):
-    if not required and data is None:
-        return None
+    if not required:
+        if data is None:
+            return None
+        if isinstance(data, dict) and not data:
+            return {}
 
     if not isinstance(data, dict):
         raise MlflowException(f"Expected data to be a dict, got {type(data).__name__}")
@@ -1326,7 +1339,7 @@ def _enforce_map(data: Any, map_type: Map, required=True):
     if not all(isinstance(k, str) for k in data):
         raise MlflowException("Expected all keys in the map type data are string type.")
 
-    return {k: _enforce_type(v, map_type.value_type) for k, v in data.items()}
+    return {k: _enforce_type(v, map_type.value_type, required=required) for k, v in data.items()}
 
 
 def _enforce_type(data: Any, data_type: Union[DataType, Array, Object, Map], required=True):
@@ -1338,6 +1351,8 @@ def _enforce_type(data: Any, data_type: Union[DataType, Array, Object, Map], req
         return _enforce_object(data, data_type, required=required)
     if isinstance(data_type, Map):
         return _enforce_map(data, data_type, required=required)
+    if isinstance(data_type, AnyType):
+        return data
     raise MlflowException(f"Invalid data type: {data_type!r}")
 
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -302,10 +302,7 @@ class Property:
                 return Property(name=self.name, dtype=self.dtype, required=required)
             raise MlflowException(f"Properties are incompatible for {self.dtype} and {other.dtype}")
 
-        if (
-            isinstance(self.dtype, (Array, Object, Map, AnyType))
-            and self.dtype.__class__ is other.dtype.__class__
-        ):
+        if isinstance(self.dtype, (Array, Object, Map, AnyType)):
             obj = self.dtype._merge(other.dtype)
             return Property(name=self.name, dtype=obj, required=required)
 
@@ -547,10 +544,7 @@ class Array:
                 f"{other} with dtype={other.dtype}"
             )
 
-        if (
-            isinstance(self.dtype, (Array, Object, Map, AnyType))
-            and self.dtype.__class__ is other.dtype.__class__
-        ):
+        if isinstance(self.dtype, (Array, Object, Map, AnyType)):
             return Array(dtype=self.dtype._merge(other.dtype))
 
         raise MlflowException(f"Array type {self!r} and {other!r} are incompatible")
@@ -664,10 +658,7 @@ class Map:
                 f"{map_type} with value_type={map_type.value_type}"
             )
 
-        if (
-            isinstance(self.value_type, (Array, Object, Map))
-            and self.value_type.__class__ is map_type.value_type.__class__
-        ):
+        if isinstance(self.value_type, (Array, Object, Map, AnyType)):
             return Map(value_type=self.value_type._merge(map_type.value_type))
 
         raise MlflowException(f"Map type {self!r} and {map_type!r} are incompatible")
@@ -693,19 +684,6 @@ class AnyType:
 
     def to_dict(self):
         return {"type": ANY_TYPE}
-
-    # @classmethod
-    # def from_json_dict(cls, **kwargs):
-    #     """
-    #     Deserialize from a json loaded dictionary.
-    #     The dictionary is expected to contain `type` keys
-    #     Example: {"type": "any"}
-    #     """
-    #     if not {"type"} <= set(kwargs.keys()):
-    #         raise MlflowException("Missing keys in Array JSON. Expected to find key `type`")
-    #     if kwargs["type"] != ANY_TYPE:
-    #         raise MlflowException(f"Type mismatch, Any expects `{ANY_TYPE}` as the type")
-    #     return cls()
 
     def _merge(
         self, another_type: Union["AnyType", Array, Object, Map, DataType]

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -21,7 +21,7 @@ OBJECT_TYPE = "object"
 MAP_TYPE = "map"
 ANY_TYPE = "any"
 SPARKML_VECTOR_TYPE = "sparkml_vector"
-SUPPORTED_TYPES = Union["Array", "DataType", "Map", "Object", "AnyType", str]
+ALOWWED_DTYPES = Union["Array", "DataType", "Map", "Object", "AnyType", str]
 EXPECTED_TYPE_MESSAGE = (
     "Expected mlflow.types.schema.Datatype, mlflow.types.schema.Array, "
     "mlflow.types.schema.Object, mlflow.types.schema.Map, mlflow.types.schema.AnyType "
@@ -151,18 +151,30 @@ class DataType(Enum):
 class BaseType(ABC):
     @abstractmethod
     def __eq__(self, other) -> bool:
+        """
+        Determine if two objects are equal.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def __repr__(self) -> str:
+        """
+        The string representation of the object.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def to_dict(self) -> dict:
+        """
+        Dictionary representation of the object.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def _merge(self, other: BaseType) -> BaseType:
+        """
+        Merge two objects and return the updated object if they're compatible.
+        """
         raise NotImplementedError
 
 
@@ -174,7 +186,7 @@ class Property(BaseType):
     def __init__(
         self,
         name: str,
-        dtype: SUPPORTED_TYPES,
+        dtype: ALOWWED_DTYPES,
         required: bool = True,
     ) -> None:
         """
@@ -483,7 +495,7 @@ class Array(BaseType):
 
     def __init__(
         self,
-        dtype: SUPPORTED_TYPES,
+        dtype: ALOWWED_DTYPES,
     ) -> None:
         try:
             self._dtype = DataType[dtype] if isinstance(dtype, str) else dtype
@@ -601,7 +613,7 @@ class Map(BaseType):
     Specification used to represent a json-convertible map with string type keys.
     """
 
-    def __init__(self, value_type: SUPPORTED_TYPES):
+    def __init__(self, value_type: ALOWWED_DTYPES):
         try:
             self._value_type = DataType[value_type] if isinstance(value_type, str) else value_type
         except KeyError:
@@ -735,7 +747,7 @@ class ColSpec:
 
     def __init__(
         self,
-        type: SUPPORTED_TYPES,
+        type: ALOWWED_DTYPES,
         name: Optional[str] = None,
         required: bool = True,
     ):

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -717,9 +717,12 @@ class AnyType:
     def _merge(self, another_type: BaseType) -> BaseType:
         if self == another_type:
             return deepcopy(self)
+        if isinstance(another_type, DataType):
+            return another_type
         if not isinstance(another_type, BaseType):
             raise MlflowException(
-                f"Can't merge AnyType with {type(another_type).__name__}, it must be a BaseType"
+                f"Can't merge AnyType with {type(another_type).__name__}, "
+                "it must be a BaseType or DataType"
             )
         # Merging AnyType with another type makes the other type optional
         return another_type._merge(self)

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -670,10 +670,11 @@ class AnyType:
         AnyType can store any json-serializable data including None values.
 
         .. Note::
-            AnyType should not be used to host variant types in a schema.
-            It should only be used when the field is None, or the type is not known
-            at the time of data creation. e.g. for GenAI flavors, the model output
-            could contain `None` values, and `AnyType` can be used to represent them.
+            AnyType should not be used to host union types in a schema.
+            It should only be used when the field is None, the type is not known
+            at the time of data creation, or the field can have multiple types.
+            e.g. for GenAI flavors, the model output could contain `None` values,
+            and `AnyType` can be used to represent them.
         """
 
     def __repr__(self) -> str:

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -302,8 +302,8 @@ def _infer_schema(data: Any) -> Schema:
                 col_data_mapping[k].append(v)
         requiredness = {}
         for col in col_data_mapping:
-            # if col exists in item but its value is empty, then it is not required
-            requiredness[col] = all(item.get(col) for item in data)
+            # if col exists in item but its value is None, then it is not required
+            requiredness[col] = all(item.get(col) is not None for item in data)
 
         schema = Schema(
             [

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -24,8 +24,9 @@ from mlflow.types.schema import (
 )
 
 MULTIPLE_TYPES_ERROR_MSG = (
-    "Expected all values in list to be of same type; if the list contains multiple types, "
-    "use Array(AnyType()) in mlflow.models.schema to represent list of mixed types explicitly."
+    "Expected all values in the list to be of the same type. To specify a model signature "
+    "with a list containing elements of multiple types, define the signature manually "
+    "using the Array(AnyType()) type from mlflow.models.schema."
 )
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -23,6 +23,10 @@ from mlflow.types.schema import (
     TensorSpec,
 )
 
+MULTIPLE_TYPES_ERROR_MSG = (
+    "Expected all values in list to be of same type; if the list contains multiple types, "
+    "use Array(AnyType()) in mlflow.models.schema to represent list of mixed types explicitly."
+)
 _logger = logging.getLogger(__name__)
 
 
@@ -178,14 +182,10 @@ def _infer_array_datatype(data: Union[list, np.ndarray]) -> Optional[Array]:
             try:
                 result = Array(result.dtype._merge(dtype))
             except MlflowException as e:
-                raise MlflowException.invalid_parameter_value(
-                    "Expected all values in list to be of same type"
-                ) from e
+                raise MlflowException.invalid_parameter_value(MULTIPLE_TYPES_ERROR_MSG) from e
         elif isinstance(result.dtype, DataType):
             if not isinstance(dtype, AnyType) and dtype != result.dtype:
-                raise MlflowException.invalid_parameter_value(
-                    "Expected all values in list to be of same type"
-                )
+                raise MlflowException.invalid_parameter_value(MULTIPLE_TYPES_ERROR_MSG)
         else:
             raise MlflowException.invalid_parameter_value(
                 f"{dtype} is not a valid type for an item of a list or numpy array."

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -107,7 +107,7 @@ def _infer_colspec_type(data: Any) -> Union[DataType, Array, Object, AnyType]:
     return dtype
 
 
-def _infer_datatype(data: Any) -> Union[DataType, Array, Object, AnyType]:
+def _infer_datatype(data: Any) -> Optional[Union[DataType, Array, Object, AnyType]]:
     """
     Infer the datatype of input data.
     Data type and inferred schema type mapping:
@@ -118,9 +118,10 @@ def _infer_datatype(data: Any) -> Union[DataType, Array, Object, AnyType]:
         - None, emty dictionary/list -> AnyType
 
     .. Note::
-        Empty numpy arrays are inferred as None
+        Empty numpy arrays are inferred as None to keep the backward compatibility, as numpy
+        arrays are used by some traditional ML flavors.
         e.g. numpy.array([]) -> None, numpy.array([[], []]) -> None
-        While empty lists are inferred as AnyType
+        While empty lists are inferred as AnyType instead of None after the support of AnyType.
         e.g. [] -> AnyType, [[], []] -> Array(Any)
     """
 

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -133,7 +133,9 @@ def _infer_datatype(data: Any) -> Union[DataType, Array, Object, AnyType]:
             dtype = _infer_datatype(v)
             if dtype is None:
                 raise MlflowException("Dictionary value must not be an empty numpy array.")
-            properties.append(Property(name=k, dtype=dtype))
+            properties.append(
+                Property(name=k, dtype=dtype, required=not isinstance(dtype, AnyType))
+            )
         return Object(properties=properties)
 
     if isinstance(data, (list, np.ndarray)):

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -214,7 +214,7 @@ def cast_df_types_according_to_schema(pdf, schema):
     import numpy as np
 
     from mlflow.models.utils import _enforce_array, _enforce_map, _enforce_object
-    from mlflow.types.schema import Array, DataType, Map, Object
+    from mlflow.types.schema import AnyType, Array, DataType, Map, Object
 
     actual_cols = set(pdf.columns)
     if schema.has_input_names():
@@ -224,6 +224,7 @@ def cast_df_types_according_to_schema(pdf, schema):
     else:
         n = min(len(schema.input_types()), len(pdf.columns))
         dtype_list = zip(pdf.columns[:n], schema.input_types()[:n])
+    required_input_names = set(schema.required_input_names())
 
     for col_name, col_type_spec in dtype_list:
         if isinstance(col_type_spec, DataType):
@@ -231,6 +232,7 @@ def cast_df_types_according_to_schema(pdf, schema):
         else:
             col_type = col_type_spec
         if col_name in actual_cols:
+            required = col_name in required_input_names
             try:
                 if isinstance(col_type_spec, DataType) and col_type_spec == DataType.binary:
                     # NB: We expect binary data to be passed base64 encoded
@@ -247,11 +249,19 @@ def cast_df_types_according_to_schema(pdf, schema):
                     # `PyFuncModel.predict` being called.
                     pass
                 elif isinstance(col_type_spec, Array):
-                    pdf[col_name] = pdf[col_name].map(lambda x: _enforce_array(x, col_type_spec))
+                    pdf[col_name] = pdf[col_name].map(
+                        lambda x: _enforce_array(x, col_type_spec, required=required)
+                    )
                 elif isinstance(col_type_spec, Object):
-                    pdf[col_name] = pdf[col_name].map(lambda x: _enforce_object(x, col_type_spec))
+                    pdf[col_name] = pdf[col_name].map(
+                        lambda x: _enforce_object(x, col_type_spec, required=required)
+                    )
                 elif isinstance(col_type_spec, Map):
-                    pdf[col_name] = pdf[col_name].map(lambda x: _enforce_map(x, col_type_spec))
+                    pdf[col_name] = pdf[col_name].map(
+                        lambda x: _enforce_map(x, col_type_spec, required=required)
+                    )
+                elif isinstance(col_type_spec, AnyType):
+                    pass
                 else:
                     pdf[col_name] = pdf[col_name].astype(col_type, copy=False)
             except Exception as ex:
@@ -380,7 +390,7 @@ def convert_data_type(data, spec):
     import numpy as np
 
     from mlflow.models.utils import _enforce_array, _enforce_map, _enforce_object
-    from mlflow.types.schema import Array, ColSpec, DataType, Map, Object, TensorSpec
+    from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, TensorSpec
 
     try:
         if spec is None:
@@ -396,11 +406,13 @@ def convert_data_type(data, spec):
                 )
             elif isinstance(spec.type, Array):
                 # convert to numpy array for backwards compatibility
-                return np.array(_enforce_array(data, spec.type))
+                return np.array(_enforce_array(data, spec.type, required=spec.required))
             elif isinstance(spec.type, Object):
-                return _enforce_object(data, spec.type)
+                return _enforce_object(data, spec.type, required=spec.required)
             elif isinstance(spec.type, Map):
-                return _enforce_map(data, spec.type)
+                return _enforce_map(data, spec.type, required=spec.required)
+            elif isinstance(spec.type, AnyType):
+                return data
     except MlflowException as e:
         raise MlflowInvalidInputException(e.message)
     except Exception as ex:

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -3003,7 +3003,7 @@ def test_zero_or_one_longs_convert_to_floats():
         ),
         (
             {"a": {"x": None}},
-            Schema([ColSpec(type=Object([Property("x", AnyType())]), name="a")]),
+            Schema([ColSpec(type=Object([Property("x", AnyType(), required=False)]), name="a")]),
             {"a": {"x": 234}},
         ),
         (
@@ -3050,11 +3050,11 @@ def test_zero_or_one_longs_convert_to_floats():
                             Object(
                                 properties=[
                                     Property("content", DataType.string),
-                                    Property("additional_kwargs", AnyType()),
-                                    Property("response_metadata", AnyType()),
+                                    Property("additional_kwargs", AnyType(), required=False),
+                                    Property("response_metadata", AnyType(), required=False),
                                     Property("type", DataType.string),
-                                    Property("name", AnyType()),
-                                    Property("id", AnyType()),
+                                    Property("name", AnyType(), required=False),
+                                    Property("id", AnyType(), required=False),
                                     Property("example", DataType.boolean, required=False),
                                     Property("tool_calls", AnyType(), required=False),
                                     Property("invalid_tool_calls", AnyType(), required=False),

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -30,7 +30,7 @@ from mlflow.pyfunc import PyFuncModel
 from mlflow.pyfunc.scoring_server import is_unified_llm_input
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import ColSpec, DataType, ParamSchema, ParamSpec, Schema, TensorSpec
-from mlflow.types.schema import Array, Map, Object, Property
+from mlflow.types.schema import AnyType, Array, Map, Object, Property
 from mlflow.utils.proto_json_utils import dump_input_data
 
 from tests.helper_functions import pyfunc_scoring_endpoint, pyfunc_serve_and_score_model
@@ -2980,3 +2980,115 @@ def test_zero_or_one_longs_convert_to_floats():
     pd.testing.assert_series_equal(
         data["temperature"], pd.Series([0.0, 0.9, 1.0, np.nan], dtype=np.float64), check_names=False
     )
+
+
+@pytest.mark.parametrize(
+    ("input_example", "expected_schema"),
+    [
+        ({"a": None}, Schema([ColSpec(type=AnyType(), name="a", required=False)])),
+        ([[None], []], Schema([ColSpec(Array(AnyType()))])),
+        ({"a": [None]}, Schema([ColSpec(type=Array(AnyType()), name="a", required=False)])),
+        (
+            {"a": [None, "string"]},
+            Schema([ColSpec(type=Array(DataType.string), name="a", required=False)]),
+        ),
+        (
+            {"a": {"x": None}},
+            Schema([ColSpec(type=Object([Property("x", AnyType())]), name="a")]),
+        ),
+        (
+            [
+                {
+                    "messages": [
+                        {
+                            "content": "You are a helpful assistant.",
+                            "additional_kwargs": {},
+                            "response_metadata": {},
+                            "type": "system",
+                            "name": None,
+                            "id": None,
+                        },
+                        {
+                            "content": "What would you like to ask?",
+                            "additional_kwargs": {},
+                            "response_metadata": {},
+                            "type": "ai",
+                            "name": None,
+                            "id": None,
+                            "example": False,
+                            "tool_calls": [],
+                            "invalid_tool_calls": [],
+                            "usage_metadata": None,
+                        },
+                        {
+                            "content": "Who owns MLflow?",
+                            "additional_kwargs": {},
+                            "response_metadata": {},
+                            "type": "human",
+                            "name": None,
+                            "id": None,
+                            "example": False,
+                        },
+                    ],
+                    "text": "Hello?",
+                }
+            ],
+            Schema(
+                [
+                    ColSpec(
+                        Array(
+                            Object(
+                                properties=[
+                                    Property("content", DataType.string),
+                                    Property("additional_kwargs", AnyType()),
+                                    Property("response_metadata", AnyType()),
+                                    Property("type", DataType.string),
+                                    Property("name", AnyType()),
+                                    Property("id", AnyType()),
+                                    Property("example", DataType.boolean, required=False),
+                                    Property("tool_calls", AnyType(), required=False),
+                                    Property("invalid_tool_calls", AnyType(), required=False),
+                                    Property("usage_metadata", AnyType(), required=False),
+                                ]
+                            )
+                        ),
+                        name="messages",
+                    ),
+                    ColSpec(DataType.string, name="text"),
+                ]
+            ),
+        ),
+    ],
+)
+def test_schema_enforcement_for_anytype(input_example, expected_schema):
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "test_model",
+            python_model=MyModel(),
+            input_example=input_example,
+        )
+    assert model_info.signature.inputs == expected_schema
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    prediction = loaded_model.predict(input_example)
+    df = (
+        pd.DataFrame(input_example)
+        if isinstance(input_example, list)
+        else pd.DataFrame([input_example])
+    )
+    pd.testing.assert_frame_equal(prediction, df)
+
+    data = convert_input_example_to_serving_input(input_example)
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=data,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert response.status_code == 200, response.content
+    result = json.loads(response.content.decode("utf-8"))["predictions"]
+    expected_result = df.to_dict(orient="records")
+    np.testing.assert_equal(result, expected_result)

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -30,6 +30,7 @@ from mlflow.types.schema import (
     convert_dataclass_to_schema,
 )
 from mlflow.types.utils import (
+    MULTIPLE_TYPES_ERROR_MSG,
     _get_tensor_shape,
     _infer_colspec_type,
     _infer_param_schema,
@@ -349,7 +350,7 @@ def test_schema_inference_on_dictionary_of_strings(data, schema):
 
 def test_schema_inference_on_list_with_errors():
     data = [{"a": 1, "b": "c"}, {"a": 1, "b": ["a", "b"]}]
-    with pytest.raises(MlflowException, match=r"Expected all values in list to be of same type"):
+    with pytest.raises(MlflowException, match=re.escape(MULTIPLE_TYPES_ERROR_MSG)):
         _infer_schema(data)
 
 
@@ -360,10 +361,10 @@ def test_schema_inference_validating_dictionary_keys():
 
 
 def test_schema_inference_on_lists_with_errors():
-    with pytest.raises(MlflowException, match="Expected all values in list to be of same type"):
+    with pytest.raises(MlflowException, match=re.escape(MULTIPLE_TYPES_ERROR_MSG)):
         _infer_schema(["a", 1])
 
-    with pytest.raises(MlflowException, match="Expected all values in list to be of same type"):
+    with pytest.raises(MlflowException, match=re.escape(MULTIPLE_TYPES_ERROR_MSG)):
         _infer_schema(["a", ["b", "c"]])
 
 

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1871,7 +1871,70 @@ def test_convert_dataclass_to_schema_invalid():
         ),
         (
             {"a": {"x": None}},
-            Schema([ColSpec(type=Object([Property("x", AnyType())]), name="a")]),
+            Schema([ColSpec(type=Object([Property("x", AnyType(), required=False)]), name="a")]),
+        ),
+        (
+            [
+                {
+                    "id": None,
+                    "object": "chat.completion",
+                    "created": 1731491873,
+                    "model": None,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "MLflow",
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": None,
+                        "completion_tokens": None,
+                        "total_tokens": None,
+                    },
+                }
+            ],
+            Schema(
+                [
+                    ColSpec(type=AnyType(), name="id", required=False),
+                    ColSpec(type=DataType.string, name="object"),
+                    ColSpec(type=DataType.long, name="created"),
+                    ColSpec(type=AnyType(), name="model", required=False),
+                    ColSpec(
+                        type=Array(
+                            Object(
+                                properties=[
+                                    Property("index", dtype=DataType.long),
+                                    Property(
+                                        "message",
+                                        dtype=Object(
+                                            [
+                                                Property("role", DataType.string),
+                                                Property("content", DataType.string),
+                                            ]
+                                        ),
+                                    ),
+                                    Property("finish_reason", dtype=AnyType(), required=False),
+                                ]
+                            )
+                        ),
+                        name="choices",
+                    ),
+                    ColSpec(
+                        type=Object(
+                            [
+                                Property("prompt_tokens", AnyType(), required=False),
+                                Property("completion_tokens", AnyType(), required=False),
+                                Property("total_tokens", AnyType(), required=False),
+                            ]
+                        ),
+                        name="usage",
+                    ),
+                ]
+            ),
         ),
         (
             [
@@ -1917,11 +1980,11 @@ def test_convert_dataclass_to_schema_invalid():
                             Object(
                                 properties=[
                                     Property("content", DataType.string),
-                                    Property("additional_kwargs", AnyType()),
-                                    Property("response_metadata", AnyType()),
+                                    Property("additional_kwargs", AnyType(), required=False),
+                                    Property("response_metadata", AnyType(), required=False),
                                     Property("type", DataType.string),
-                                    Property("name", AnyType()),
-                                    Property("id", AnyType()),
+                                    Property("name", AnyType(), required=False),
+                                    Property("id", AnyType(), required=False),
                                     Property("example", DataType.boolean, required=False),
                                     Property("tool_calls", AnyType(), required=False),
                                     Property("invalid_tool_calls", AnyType(), required=False),

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1711,7 +1711,7 @@ def test_schema_inference_with_empty_lists():
 
     data = [{"data": {"key": []}}]
     assert _infer_schema(data) == Schema(
-        [ColSpec(Object([Property("key", AnyType())]), name="data")]
+        [ColSpec(Object([Property("key", AnyType(), required=False)]), name="data")]
     )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13766?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13766/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13766
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Introduce `AnyType` to host None values. If the field has to host multiple types, `AnyType` can also be used.
Note: its main usage is to avoid any exceptions to happen when the input example contains None values, or we have no idea what the field could contain; because `AnyType` does no data validation.

Verified model registry and deployment work in Databricks
<img width="970" alt="image" src="https://github.com/user-attachments/assets/f48a83f1-a4a0-4059-bf3d-822d35df4e8b">
<img width="890" alt="image" src="https://github.com/user-attachments/assets/c766c41e-b8c9-449b-bc48-2087b25297dd">


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
