### PR TITLE
Cherry-pick #13741 to branch-2.18

### DIFF
--- a/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
+++ b/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
@@ -1,0 +1,67 @@
+"""add cascading deletion to datasets from experiments
+
+Revision ID: 0584bdc529eb
+Revises: f5a4f2784254
+Create Date: 2024-11-11 15:27:53.189685
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from mlflow.store.tracking.dbmodels.models import SqlDataset, SqlExperiment
+
+
+# revision identifiers, used by Alembic.
+revision = '0584bdc529eb'
+down_revision = 'f5a4f2784254'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    dialect_name = op.get_context().dialect.name
+
+    # standardize the constraint to sqlite naming convention
+    new_fk_constraint_name = f"fk_{SqlDataset.__tablename__}_experiment_id_{SqlExperiment.__tablename__}"
+
+    if dialect_name == "sqlite":
+        # Only way to drop unnamed fk constraint in sqllite
+        # See https://alembic.sqlalchemy.org/en/latest/batch.html#dropping-unnamed-or-named-foreign-key-constraints
+        with op.batch_alter_table(
+            SqlDataset.__tablename__,
+            schema=None,
+            naming_convention={
+                "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            },
+        ) as batch_op:
+            batch_op.drop_constraint(new_fk_constraint_name, type_="foreignkey")
+            # Need to explicitly name the fk constraint with batch alter table
+            batch_op.create_foreign_key(
+                new_fk_constraint_name,
+                SqlExperiment.__tablename__,
+                ["experiment_id"],
+                ["experiment_id"],
+                ondelete="CASCADE",
+            )
+    else:
+        if dialect_name == "postgresql":
+            fk_constraint_name = f"{SqlDataset.__tablename__}_experiment_id_fkey"
+        elif dialect_name == "mysql":
+            fk_constraint_name = f"{SqlDataset.__tablename__}_ibfk_1"
+        elif dialect_name == "mssql":
+            # mssql fk constraint name at f5a4f2784254
+            fk_constraint_name = f"FK__{SqlDataset.__tablename__}__experi__6477ECF3"
+
+        op.drop_constraint(fk_constraint_name, SqlDataset.__tablename__, type_="foreignkey")
+        op.create_foreign_key(
+            new_fk_constraint_name,
+            SqlDataset.__tablename__,
+            SqlExperiment.__tablename__,
+            ["experiment_id"],
+            ["experiment_id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade():
+    pass

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -494,7 +494,7 @@ class SqlDataset(Base):
     Dataset UUID: `String` (limit 36 characters). Defined as *Non-null* in schema.
     Part of *Primary Key* for ``datasets`` table.
     """
-    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id"))
+    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id", ondelete="CASCADE"))
     """
     Experiment ID to which this dataset belongs: *Foreign Key* into ``experiments`` table.
     """

--- a/tests/db/Dockerfile.mssql
+++ b/tests/db/Dockerfile.mssql
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM amd64/python:3.9
 
 ARG DEPENDENCIES
 

--- a/tests/db/compose.yml
+++ b/tests/db/compose.yml
@@ -74,6 +74,7 @@ services:
       - mssql
     extends:
       service: base
+    platform: linux/amd64
     image: mlflow-mssql
     build:
       context: .
@@ -87,6 +88,7 @@ services:
       - mssql
     extends:
       service: base
+    platform: linux/amd64
     image: mlflow-mssql
     build:
       context: .

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -53,7 +53,7 @@ CREATE TABLE datasets (
 	dataset_schema VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	dataset_profile VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	CONSTRAINT "FK__datasets__experi__6477ECF3" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -54,7 +54,7 @@ CREATE TABLE datasets (
 	dataset_schema MEDIUMTEXT,
 	dataset_profile MEDIUMTEXT,
 	PRIMARY KEY (experiment_id, name, digest),
-	CONSTRAINT datasets_ibfk_1 FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -55,7 +55,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	CONSTRAINT datasets_experiment_id_fkey FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -56,7 +56,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -56,7 +56,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/store/tracking/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/test_sqlalchemy_store_schema.py
@@ -120,7 +120,10 @@ def test_store_generated_schema_matches_base(tmp_path, db_url):
     # index metadata but `mc` does. Note this doesn't mean the MLflow database is missing indexes
     # as tested in `test_create_index_on_run_uuid`.
     diff = [d for d in diff if (d[0] not in ["remove_index", "add_index", "add_fk"])]
-    assert len(diff) == 0
+    assert len(diff) == 0, (
+        "if this test is failing after writing a DB migration, please make sure you've "
+        "updated the ORM definitions in `mlflow/store/tracking/dbmodels/models.py`."
+    )
 
 
 def test_create_index_on_run_uuid(tmp_path, db_url):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ from click.testing import CliRunner
 import mlflow
 from mlflow import pyfunc
 from mlflow.cli import doctor, gc, server
+from mlflow.data import numpy_dataset
 from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.server import handlers
@@ -595,3 +596,38 @@ def test_cli_with_python_mod():
 def test_doctor():
     res = CliRunner().invoke(doctor, catch_exceptions=False)
     assert res.exit_code == 0
+
+
+def test_mlflow_gc_with_datasets(sqlite_store):
+    store = sqlite_store[0]
+
+    mlflow.set_tracking_uri(sqlite_store[1])
+    mlflow.set_experiment("dataset")
+
+    dataset = numpy_dataset.from_numpy(np.array([1, 2, 3]))
+
+    with mlflow.start_run() as run:
+        experiment_id = run.info.experiment_id
+        mlflow.log_input(dataset)
+
+    experiments = store.search_experiments(view_type=ViewType.ALL)
+
+    # default and datasets
+    assert len(experiments) == 2
+
+    store.delete_experiment(experiment_id)
+
+    # the new experiment is only marked as deleted, not removed
+    experiments = store.search_experiments(view_type=ViewType.ALL)
+    assert len(experiments) == 2
+
+    subprocess.check_call(
+        [sys.executable, "-m", "mlflow", "gc", "--backend-store-uri", sqlite_store[1]]
+    )
+    experiments = store.search_experiments(view_type=ViewType.ALL)
+
+    # only default is left after GC
+    assert len(experiments) == 1
+    assert experiments[0].experiment_id == "0"
+    with pytest.raises(MlflowException, match=f"No Experiment with id={experiment_id} exists"):
+        store.get_experiment(experiment_id)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/13767?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13767/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13767
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR cherry picks #13741 to the 2.18 branch for inclusion in MLflow 2.18.0rc0. Please attribute this fix to @chilir. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where experiment deletion would not cascade to datasets, preventing experiments with datasets from being deleted. Please run `mlflow db upgrade <DB_URI>` to utilize the fix!

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
