### PR TITLE
Attempt to unflake system metrics test for Windows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -59,7 +59,7 @@ jobs:
   python:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -323,7 +323,7 @@ jobs:
   windows:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-latest
-    timeout-minutes: 360
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -374,10 +374,9 @@ jobs:
           export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
           export PATH=$PATH:$HADOOP_HOME/bin
           # Run Windows tests
-          pytest tests/system_metrics/test_system_metrics_logging.py
-          # pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
-          #   --ignore-flavors --ignore=tests/projects --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate --ignore tests/deployments/server \
-          #   tests
+          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
+            --ignore-flavors --ignore=tests/projects --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate --ignore tests/deployments/server \
+            tests
           # MLeap is incompatible on Windows with PySpark3.4 release.
           # Reinstate tests when MLeap has released a fix. [ML-30491]
           # pytest tests/mleap

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -59,7 +59,7 @@ jobs:
   python:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -93,9 +93,10 @@ jobs:
         run: |
           source .venv/bin/activate
           source dev/setup-ssh.sh
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
-            --ignore-flavors --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate \
-            --ignore tests/deployments/server tests
+          pytest tests/system_metrics/test_system_metrics_logging.py
+          # pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
+          #   --ignore-flavors --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate \
+          #   --ignore tests/deployments/server tests
 
   database:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
@@ -322,7 +323,7 @@ jobs:
   windows:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-latest
-    timeout-minutes: 120
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -373,9 +374,10 @@ jobs:
           export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
           export PATH=$PATH:$HADOOP_HOME/bin
           # Run Windows tests
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
-            --ignore-flavors --ignore=tests/projects --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate --ignore tests/deployments/server \
-            tests
+          pytest tests/system_metrics/test_system_metrics_logging.py
+          # pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
+          #   --ignore-flavors --ignore=tests/projects --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate --ignore tests/deployments/server \
+          #   tests
           # MLeap is incompatible on Windows with PySpark3.4 release.
           # Reinstate tests when MLeap has released a fix. [ML-30491]
           # pytest tests/mleap

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -93,10 +93,9 @@ jobs:
         run: |
           source .venv/bin/activate
           source dev/setup-ssh.sh
-          pytest tests/system_metrics/test_system_metrics_logging.py
-          # pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
-          #   --ignore-flavors --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate \
-          #   --ignore tests/deployments/server tests
+          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
+            --ignore-flavors --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate \
+            --ignore tests/deployments/server tests
 
   database:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -16,6 +16,7 @@ def disable_system_metrics_logging():
     mlflow.set_system_metrics_samples_before_logging(None)
     mlflow.set_system_metrics_node_id(None)
 
+
 @pytest.fixture
 def wait_for_condition():
     def _wait(condition_func):
@@ -29,22 +30,21 @@ def wait_for_condition():
 
     return _wait
 
+
 @pytest.mark.parametrize("x", range(200))
-def test_manual_system_metrics_monitor(wait_for_condition, x:int):
+def test_manual_system_metrics_monitor(wait_for_condition, x: int):
     with mlflow.start_run(log_system_metrics=False) as run:
         system_monitor = SystemMetricsMonitor(
             run.info.run_id,
             sampling_interval=0.1,
-            samples_before_logging=5,
+            samples_before_logging=1,
         )
         system_monitor.start()
         thread_names = [thread.name for thread in threading.enumerate()]
         # Check the system metrics monitoring thread has been started.
         assert "SystemMetricsMonitor" in thread_names
 
-        assert wait_for_condition(
-            lambda: len(mlflow.get_run(run.info.run_id).data.metrics) >= 7
-        )
+        assert wait_for_condition(lambda: len(mlflow.get_run(run.info.run_id).data.metrics) >= 7)
 
     assert wait_for_condition(
         lambda: "SystemMetricsMonitor" not in [thread.name for thread in threading.enumerate()]
@@ -74,7 +74,7 @@ def test_manual_system_metrics_monitor(wait_for_condition, x:int):
 
 
 @pytest.mark.parametrize("x", range(200))
-def test_automatic_system_metrics_monitor(wait_for_condition, x:int):
+def test_automatic_system_metrics_monitor(wait_for_condition, x: int):
     mlflow.enable_system_metrics_logging()
     mlflow.set_system_metrics_sampling_interval(0.2)
     mlflow.set_system_metrics_samples_before_logging(2)
@@ -83,9 +83,7 @@ def test_automatic_system_metrics_monitor(wait_for_condition, x:int):
         # Check the system metrics monitoring thread has been started.
         assert "SystemMetricsMonitor" in thread_names
 
-        assert wait_for_condition(
-            lambda: len(mlflow.get_run(run.info.run_id).data.metrics) >= 7
-        )
+        assert wait_for_condition(lambda: len(mlflow.get_run(run.info.run_id).data.metrics) >= 7)
 
     assert wait_for_condition(
         lambda: "SystemMetricsMonitor" not in [thread.name for thread in threading.enumerate()]
@@ -169,7 +167,10 @@ def test_system_metrics_monitor_with_multi_node(wait_for_condition):
         mlflow.set_system_metrics_node_id(node_id)
         with mlflow.start_run(run_id=run_id, log_system_metrics=True):
             assert wait_for_condition(
-                lambda: any(k.startswith(f"system/{node_id}/") for k in mlflow.get_run(run_id).data.metrics.keys())
+                lambda: any(
+                    k.startswith(f"system/{node_id}/")
+                    for k in mlflow.get_run(run_id).data.metrics.keys()
+                )
             )
 
     mlflow_run = mlflow.get_run(run_id)

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -31,8 +31,7 @@ def wait_for_condition():
     return _wait
 
 
-@pytest.mark.parametrize("x", range(200))
-def test_manual_system_metrics_monitor(wait_for_condition, x: int):
+def test_manual_system_metrics_monitor(wait_for_condition):
     metric_test = "system/cpu_utilization_percentage"
     with mlflow.start_run(log_system_metrics=False) as run:
         system_monitor = SystemMetricsMonitor(
@@ -73,8 +72,7 @@ def test_manual_system_metrics_monitor(wait_for_condition, x: int):
     assert metrics_history[-1].step > 0
 
 
-@pytest.mark.parametrize("x", range(200))
-def test_automatic_system_metrics_monitor(wait_for_condition, x: int):
+def test_automatic_system_metrics_monitor(wait_for_condition):
     metric_test = "system/cpu_utilization_percentage"
     mlflow.enable_system_metrics_logging()
     mlflow.set_system_metrics_sampling_interval(0.2)
@@ -109,9 +107,7 @@ def test_automatic_system_metrics_monitor(wait_for_condition, x: int):
         assert name in metrics
 
     # Check the step is correctly logged.
-    metrics_history = mlflow.MlflowClient().get_metric_history(
-        run.info.run_id, metric_test
-    )
+    metrics_history = mlflow.MlflowClient().get_metric_history(run.info.run_id, metric_test)
     assert metrics_history[-1].step > 0
 
 

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -30,7 +30,7 @@ def wait_for_condition():
     return _wait
 
 @pytest.mark.parametrize("x", range(200))
-def test_manual_system_metrics_monitor(wait_for_condition):
+def test_manual_system_metrics_monitor(wait_for_condition, x:int):
     with mlflow.start_run(log_system_metrics=False) as run:
         system_monitor = SystemMetricsMonitor(
             run.info.run_id,
@@ -74,7 +74,7 @@ def test_manual_system_metrics_monitor(wait_for_condition):
 
 
 @pytest.mark.parametrize("x", range(200))
-def test_automatic_system_metrics_monitor(wait_for_condition):
+def test_automatic_system_metrics_monitor(wait_for_condition, x:int):
     mlflow.enable_system_metrics_logging()
     mlflow.set_system_metrics_sampling_interval(0.2)
     mlflow.set_system_metrics_samples_before_logging(2)

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -19,7 +19,7 @@ def disable_system_metrics_logging():
 
 
 def wait_for_condition(
-    condition_func: Callable[..., Any], timeout: int = 10, check_interval: int = 1
+    condition_func: Callable[[], Any], timeout: int = 10, check_interval: int = 1
 ) -> None:
     start_time = time.time()
     while time.time() - start_time < timeout:

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -35,7 +35,7 @@ def test_manual_system_metrics_monitor(wait_for_condition, x:int):
         system_monitor = SystemMetricsMonitor(
             run.info.run_id,
             sampling_interval=0.1,
-            samples_before_logging=2,
+            samples_before_logging=5,
         )
         system_monitor.start()
         thread_names = [thread.name for thread in threading.enumerate()]

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -17,21 +17,15 @@ def disable_system_metrics_logging():
     mlflow.set_system_metrics_node_id(None)
 
 
-@pytest.fixture
-def wait_for_condition():
-    def _wait(condition_func):
-        timeout = 10
-        check_interval = 1
-        for _ in range(timeout // check_interval):
-            if condition_func():
-                return True
-            time.sleep(check_interval)
-        return False
-
-    return _wait
+def wait_for_condition(condition_func, timeout=10, check_interval=1):
+    for _ in range(timeout // check_interval):
+        if condition_func():
+            return True
+        time.sleep(check_interval)
+    return False
 
 
-def test_manual_system_metrics_monitor(wait_for_condition):
+def test_manual_system_metrics_monitor():
     metric_test = "system/cpu_utilization_percentage"
     with mlflow.start_run(log_system_metrics=False) as run:
         system_monitor = SystemMetricsMonitor(
@@ -72,7 +66,7 @@ def test_manual_system_metrics_monitor(wait_for_condition):
     assert metrics_history[-1].step > 0
 
 
-def test_automatic_system_metrics_monitor(wait_for_condition):
+def test_automatic_system_metrics_monitor():
     metric_test = "system/cpu_utilization_percentage"
     mlflow.enable_system_metrics_logging()
     mlflow.set_system_metrics_sampling_interval(0.2)
@@ -111,7 +105,7 @@ def test_automatic_system_metrics_monitor(wait_for_condition):
     assert metrics_history[-1].step > 0
 
 
-def test_automatic_system_metrics_monitor_resume_existing_run(wait_for_condition):
+def test_automatic_system_metrics_monitor_resume_existing_run():
     mlflow.enable_system_metrics_logging()
     mlflow.set_system_metrics_sampling_interval(0.2)
     mlflow.set_system_metrics_samples_before_logging(2)
@@ -153,7 +147,7 @@ def test_automatic_system_metrics_monitor_resume_existing_run(wait_for_condition
     assert metrics_history[-1].step > last_step
 
 
-def test_system_metrics_monitor_with_multi_node(wait_for_condition):
+def test_system_metrics_monitor_with_multi_node():
     mlflow.enable_system_metrics_logging()
     mlflow.set_system_metrics_sampling_interval(0.2)
     mlflow.set_system_metrics_samples_before_logging(2)

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -36,15 +36,15 @@ def test_manual_system_metrics_monitor(wait_for_condition, x: int):
     with mlflow.start_run(log_system_metrics=False) as run:
         system_monitor = SystemMetricsMonitor(
             run.info.run_id,
-            sampling_interval=0.1,
-            samples_before_logging=1,
+            sampling_interval=0.2,
+            samples_before_logging=2,
         )
         system_monitor.start()
         thread_names = [thread.name for thread in threading.enumerate()]
         # Check the system metrics monitoring thread has been started.
         assert "SystemMetricsMonitor" in thread_names
 
-        assert wait_for_condition(lambda: len(mlflow.get_run(run.info.run_id).data.metrics) >= 7)
+        assert wait_for_condition(lambda: len(mlflow.get_run(run.info.run_id).data.metrics) > 7)
 
     assert wait_for_condition(
         lambda: "SystemMetricsMonitor" not in [thread.name for thread in threading.enumerate()]
@@ -83,7 +83,7 @@ def test_automatic_system_metrics_monitor(wait_for_condition, x: int):
         # Check the system metrics monitoring thread has been started.
         assert "SystemMetricsMonitor" in thread_names
 
-        assert wait_for_condition(lambda: len(mlflow.get_run(run.info.run_id).data.metrics) >= 7)
+        assert wait_for_condition(lambda: len(mlflow.get_run(run.info.run_id).data.metrics) > 7)
 
     assert wait_for_condition(
         lambda: "SystemMetricsMonitor" not in [thread.name for thread in threading.enumerate()]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/13773?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13773/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13773
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The `test_automatic_system_metrics_monitor` suite has been flaky in Windows. Attempt slightly longer delay configurations for Windows due to the different VM runner config for Windows on GHA and the different behavior that Windows has with thread process management as compared to Linux.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
