### PR TITLE
Make DSPy flavor able to take arbitrary `dependency_schema`

### DIFF
--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -7,6 +7,7 @@ from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
 import mlflow
 from mlflow.entities import SpanStatusCode, SpanType
 from mlflow.entities.span_event import SpanEvent
+from mlflow.pyfunc.context import Context, maybe_set_prediction_context
 
 _logger = logging.getLogger(__name__)
 
@@ -14,9 +15,10 @@ _logger = logging.getLogger(__name__)
 class MlflowCallback(BaseCallback):
     """Callback for generating MLflow traces for DSPy components"""
 
-    def __init__(self):
+    def __init__(self, prediction_context: Optional[Context] = None):
         self._client = mlflow.MlflowClient()
         self._call_id_to_span = {}
+        self._prediction_context = prediction_context
 
     def on_module_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         span_type = self._get_span_type_for_module(instance)
@@ -128,12 +130,15 @@ class MlflowCallback(BaseCallback):
             "attributes": attributes,
         }
 
-        if parent_span:
-            span = self._client.start_span(
-                request_id=parent_span.request_id, parent_id=parent_span.span_id, **common_params
-            )
-        else:
-            span = self._client.start_trace(**common_params)
+        with maybe_set_prediction_context(self._prediction_context):
+            if parent_span:
+                span = self._client.start_span(
+                    request_id=parent_span.request_id,
+                    parent_id=parent_span.span_id,
+                    **common_params,
+                )
+            else:
+                span = self._client.start_trace(**common_params)
 
         self._call_id_to_span[call_id] = span
 
@@ -160,10 +165,11 @@ class MlflowCallback(BaseCallback):
             "status": status,
         }
 
-        if span.parent_id:
-            self._client.end_span(span_id=span.span_id, **common_params)
-        else:
-            self._client.end_trace(**common_params)
+        with maybe_set_prediction_context(self._prediction_context):
+            if span.parent_id:
+                self._client.end_span(span_id=span.span_id, **common_params)
+            else:
+                self._client.end_trace(**common_params)
 
     def _get_span_type_for_module(self, instance):
         if isinstance(instance, dspy.Retrieve):

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -18,7 +18,7 @@ class MlflowCallback(BaseCallback):
     def __init__(self, prediction_context: Optional[Context] = None):
         self._client = mlflow.MlflowClient()
         self._call_id_to_span = {}
-        self._prediction_context = prediction_context
+        self._prediction_context = prediction_context or Context()
 
     def on_module_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         span_type = self._get_span_type_for_module(instance)

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -17,6 +17,9 @@ from mlflow.models import (
     ModelSignature,
     infer_pip_requirements,
 )
+from mlflow.models.dependencies_schemas import (
+    _get_dependencies_schemas,
+)
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.rag_signatures import SIGNATURE_FOR_LLM_INFERENCE_TASK
 from mlflow.models.resources import Resource, _ResourceBuilder
@@ -142,6 +145,13 @@ def save_model(
         saved_example = _save_example(mlflow_model, input_example, path)
     if metadata is not None:
         mlflow_model.metadata = metadata
+
+    with _get_dependencies_schemas() as dependencies_schemas:
+        schema = dependencies_schemas.to_dict()
+        if schema is not None:
+            if mlflow_model.metadata is None:
+                mlflow_model.metadata = {}
+            mlflow_model.metadata.update(schema)
 
     model_data_subpath = _MODEL_DATA_PATH
     # Construct new data folder in existing path.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/13783?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13783/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13783
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Similar to LangChain, we are making DSPy flavor able to take an arbitrary dependency schema at logging time. Differently, instead of using magic piece of code, we are explicitly parsing the saved dependency schema to the tracer's context at loading time. Notice that we only do it at loading time because this dependency schema for now is only relevant at serving time on Databricks platform.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
