### PR TITLE
Update Transformer's chatbot tutorial not to conflict with ChatModel tutorials

### DIFF
--- a/docs/source/llms/transformers/tutorials/conversational/pyfunc-chat-model.ipynb
+++ b/docs/source/llms/transformers/tutorials/conversational/pyfunc-chat-model.ipynb
@@ -4,19 +4,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Building and Serving an OpenAI-compatible Chatbot\n",
+    "## Deploying a Transformer model as an OpenAI-compatible Chatbot\n",
     "\n",
-    "Welcome to our tutorial on using Transformers and MLflow to create an OpenAI-compatible chat model. In MLflow 2.11 and up, the [ChatModel](https://mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.ChatModel) class has been added, allowing for convenient creation of served models that conform to the OpenAI API spec. This enables you to seamlessly swap out your chat app's backing LLM, or to easily evaluate different models without having to edit your client-side code.\n",
+    "Welcome to our tutorial on using Transformers and MLflow to create an OpenAI-compatible chat model. In MLflow 2.11 and up, MLflow's Transformers flavors support special task type `llm/v1/chat`, which turns thousands of [text-generation](https://huggingface.co/models?pipeline_tag=text-generation) model on Hugging Face into conversational chat bots interoperable with OpenAI models. This enables you to seamlessly swap out your chat app’s backing LLM, or to easily evaluate different models without having to edit your client-side code.\n",
     "\n",
     "If you haven't already seen it, you may find it helpful to go through our [introductory notebook on chat and Transformers](https://mlflow.org/docs/latest/llms/transformers/tutorials/conversational/conversational-model.html) before proceeding with this one, as this notebook is slightly higher-level and does not delve too deeply into the inner workings of Transformers or MLflow Tracking.\n",
+    "\n",
+    "\n",
+    "**Note**: This page covers how to deploy a **Transformers** models as a chatbot. If you are using different framework or custom python model, use [ChatModel](https://mlflow.org/docs/latest/llms/chat-model-intro/index.html) instead to build an OpenAI-compatible chat bot.\n",
     "\n",
     "### Learning objectives\n",
     "\n",
     "In this tutorial, you will:\n",
     "\n",
     "- Create an OpenAI-compatible chat model using TinyLLama-1.1B-Chat\n",
-    "- Serve the model with MLflow Model Serving\n",
-    "- Learn how to use MLflow's `pyfunc` API to add arbitrary customization to your model"
+    "- Log the model to MLflow and loaded it back for local inference.\n",
+    "- Serve the model with MLflow Model Serving"
    ]
   },
   {
@@ -441,236 +444,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Customizing the model\n",
-    "\n",
-    "As always, custom functionality can be achieved with MLflow's `pyfunc` API. In the cell below, we create a custom Chat-flavored `pyfunc` model by subclassing `mlflow.pyfunc.ChatModel`. \n",
-    "\n",
-    "In this example, we'll use our previously-saved TinyLlama pipeline as the backing model by loading it with `mlflow.transformers.load_model()`, and then build our own customizations on top of it. However, `ChatModel` is agnostic to how you generate the outputs. You could use another transformer, Langchain, native OpenAI integrations, or even no LLM at all! As long the result of `predict` is of type `mlflow.types.llm.ChatResponse`, you'll be able to take advantage of the automatic signature generation and input/output parsing.\n",
-    "\n",
-    "The possibilities for customization are endless here, but as a quick example, the code below simply edits the ID of the response, rather than having it be a random UUID. Of course, you could also insert any side-effects you wanted here, such as asynchronously logging some metadata for analytics."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import random\n",
-    "\n",
-    "import mlflow\n",
-    "from mlflow.types.llm import ChatResponse\n",
-    "\n",
-    "\n",
-    "class MyChatModel(mlflow.pyfunc.ChatModel):\n",
-    "    def load_context(self, context):\n",
-    "        # load our previously-saved Transformers pipeline from context.artifacts\n",
-    "        self.pipeline = mlflow.transformers.load_model(context.artifacts[\"chat_model_path\"])\n",
-    "\n",
-    "    def predict(self, context, messages, params):\n",
-    "        tokenizer = self.pipeline.tokenizer\n",
-    "        prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)\n",
-    "\n",
-    "        # perform inference using the loaded pipeline\n",
-    "        output = self.pipeline(prompt, return_full_text=False, generation_kwargs=params.to_dict())\n",
-    "        text = output[0][\"generated_text\"]\n",
-    "        id = f\"some_meaningful_id_{random.randint(0, 100)}\"\n",
-    "\n",
-    "        # construct token usage information\n",
-    "        prompt_tokens = len(tokenizer.encode(prompt))\n",
-    "        completion_tokens = len(tokenizer.encode(text))\n",
-    "        usage = {\n",
-    "            \"prompt_tokens\": prompt_tokens,\n",
-    "            \"completion_tokens\": completion_tokens,\n",
-    "            \"total_tokens\": prompt_tokens + completion_tokens,\n",
-    "        }\n",
-    "\n",
-    "        # here, we can do any post-processing or side-effects required.\n",
-    "        # for example, we could log the generated text to a database for\n",
-    "        # analytics, or check the output for any banned words or phrases\n",
-    "        # and return a different response if any are found.\n",
-    "\n",
-    "        # in this example, we just return the generated text as the response\n",
-    "\n",
-    "        response = {\n",
-    "            \"id\": id,\n",
-    "            \"model\": \"MyChatModel\",\n",
-    "            \"choices\": [\n",
-    "                {\n",
-    "                    \"index\": 0,\n",
-    "                    \"message\": {\"role\": \"assistant\", \"content\": text},\n",
-    "                    \"finish_reason\": \"stop\",\n",
-    "                }\n",
-    "            ],\n",
-    "            \"usage\": usage,\n",
-    "        }\n",
-    "\n",
-    "        return ChatResponse(**response)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Similar to what happens above, upon saving an instance of `MyChatModel`, MLflow will automatically recognize the `mlflow.pyfunc.ChatModel` subclass, and set chat signatures and handle input and output parsing automatically. Note that enforcement is performed on the output--MLflow will run inference on an example input, and assert that the output is of type `ChatResponse`.\n",
-    "\n",
-    "Full documentation for the `ChatResponse` type can be found in the [API reference](https://mlflow.org/docs/latest/python_api/mlflow.types.html#mlflow.types.llm.ChatResponse)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024/02/26 21:12:47 INFO mlflow.pyfunc: Predicting on input example to validate output\n",
-      "/var/folders/qd/9rwd0_gd0qs65g4sdqlm51hr0000gp/T/ipykernel_55429/2958668123.py:10: FutureWarning: The 'transformers' MLflow Models integration is known to be compatible with the following package version ranges: ``4.25.1`` -  ``4.37.1``. MLflow Models integrations with transformers may not succeed when used with package versions outside of this range.\n",
-      "  self.pipeline = mlflow.transformers.load_model(context.artifacts[\"chat_model_path\"])\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cd12a6afe29847bcb79bdb01fc4892bd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Loading checkpoint shards:   0%|          | 0/5 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024/02/26 21:12:47 WARNING mlflow.transformers: Could not specify device parameter for this pipeline type\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8986e18350c44293944a8dc63d5e8324",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Loading checkpoint shards:   0%|          | 0/5 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ab96f52af76949b790de16a3567619f3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading artifacts:   0%|          | 0/19 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024/02/26 21:13:19 INFO mlflow.store.artifact.artifact_repo: The progress bar can be disabled by setting the environment variable MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR to false\n"
-     ]
-    }
-   ],
-   "source": [
-    "mlflow.pyfunc.save_model(\n",
-    "    path=\"my-model\",\n",
-    "    python_model=MyChatModel(),\n",
-    "    # provide the path to the pipeline we saved earlier\n",
-    "    artifacts={\"chat_model_path\": \"tinyllama-chat\"},\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As before, we can now serve the model by running the following in a terminal shell:\n",
-    "\n",
-    "```\n",
-    "$ mlflow models serve -m my-model\n",
-    "```\n",
-    "\n",
-    "And we should now be able to query it via HTTP request:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
-      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100   666  100   577  100    89     23      3  0:00:29  0:00:24  0:00:05   141\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "  \"id\": \"some_meaningful_id_33\",\n",
-      "  \"model\": \"MyChatModel\",\n",
-      "  \"choices\": [\n",
-      "    {\n",
-      "      \"index\": 0,\n",
-      "      \"message\": {\n",
-      "        \"role\": \"assistant\",\n",
-      "        \"content\": \"Here's a simple hello world program in Python:\\n\\n```python\\nprint(\\\"Hello, world!\\\")\\n```\\n\\nThis program prints the string \\\"Hello, world!\\\" to the console. You can run this program by typing it into the Python interpreter or by running the command `python hello_world.py` in your terminal.\"\n",
-      "      },\n",
-      "      \"finish_reason\": \"stop\"\n",
-      "    }\n",
-      "  ],\n",
-      "  \"usage\": {\n",
-      "    \"prompt_tokens\": 25,\n",
-      "    \"completion_tokens\": 71,\n",
-      "    \"total_tokens\": 96\n",
-      "  },\n",
-      "  \"object\": \"chat.completion\",\n",
-      "  \"created\": 1708949708\n",
-      "}\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%sh\n",
-    "curl http://127.0.0.1:5000/invocations \\\n",
-    "    -H 'Content-Type: application/json' \\\n",
-    "    -d '{ \"messages\": [{\"role\": \"user\", \"content\": \"Write me a hello world program in python\"}] }' \\\n",
-    "    | jq"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Conclusion\n",
     "\n",
-    "In this tutorial, you learned how to create an OpenAI-compatible chat model by specifying \"llm/v1/chat\" as the task when saving Transformers pipelines. You also learned how to leverage Custom Pyfunc to add customizations that fit your specific use-case.\n",
+    "In this tutorial, you learned how to create an OpenAI-compatible chat model by specifying \"llm/v1/chat\" as the task when saving Transformers pipelines.\n",
     "\n",
     "### What's next?\n",
     "\n",
-    "- [In-depth Pyfunc Walkthrough](https://mlflow.org/docs/latest/traditional-ml/creating-custom-pyfunc/index.html). We briefly touched on custom `pyfunc` in this tutorial, but if you're looking for more detail on the anatomy of a `pyfunc` model, the linked page provides an in-depth overview of all the components.\n",
+    "- [Learn about custom ChatModel](hhttps://mlflow.org/docs/latest/llms/chat-model-intro/index.html). If you're looking for futrher customization or models outside Transformers, the linked page provides a hand-on guidance for how to build a chat bot with MLflow's ``ChatModel`` class.\n",
     "- [More on MLflow AI Gateway](https://mlflow.org/docs/latest/deployment/index.html). In this tutorial, we saw how to deploy a model using a local server, but MLflow provides many other ways to deploy your models to production. Check out this page to learn more about the different options.\n",
     "- [More on MLflow's Transformers Integration](https://mlflow.org/docs/latest/llms/transformers/index.html). This page provides a comprehensive overview on MLflow's Transformers integrations, along with lots of hands-on guides and notebooks. Learn how to fine-tune models, use prompt templates, and more!\n",
     "- [Other LLM Integrations](https://mlflow.org/docs/latest/llms/index.html). Aside from Transformers, MLflow has integrations with many other popular LLM libraries, such as Langchain and OpenAI."

--- a/docs/source/llms/transformers/tutorials/conversational/pyfunc-chat-model.ipynb
+++ b/docs/source/llms/transformers/tutorials/conversational/pyfunc-chat-model.ipynb
@@ -6,19 +6,19 @@
    "source": [
     "## Deploying a Transformer model as an OpenAI-compatible Chatbot\n",
     "\n",
-    "Welcome to our tutorial on using Transformers and MLflow to create an OpenAI-compatible chat model. In MLflow 2.11 and up, MLflow's Transformers flavors support special task type `llm/v1/chat`, which turns thousands of [text-generation](https://huggingface.co/models?pipeline_tag=text-generation) model on Hugging Face into conversational chat bots interoperable with OpenAI models. This enables you to seamlessly swap out your chat app’s backing LLM, or to easily evaluate different models without having to edit your client-side code.\n",
+    "Welcome to our tutorial on using Transformers and MLflow to create an OpenAI-compatible chat model. In MLflow 2.11 and up, MLflow's Transformers flavors support special task type `llm/v1/chat`, which turns thousands of [text-generation](https://huggingface.co/models?pipeline_tag=text-generation) models on Hugging Face into conversational chat bots that are interoperable with OpenAI models. This enables you to seamlessly swap out your chat app’s backing LLM or to easily evaluate different models without having to edit your client-side code.\n",
     "\n",
     "If you haven't already seen it, you may find it helpful to go through our [introductory notebook on chat and Transformers](https://mlflow.org/docs/latest/llms/transformers/tutorials/conversational/conversational-model.html) before proceeding with this one, as this notebook is slightly higher-level and does not delve too deeply into the inner workings of Transformers or MLflow Tracking.\n",
     "\n",
     "\n",
-    "**Note**: This page covers how to deploy a **Transformers** models as a chatbot. If you are using different framework or custom python model, use [ChatModel](https://mlflow.org/docs/latest/llms/chat-model-intro/index.html) instead to build an OpenAI-compatible chat bot.\n",
+    "**Note**: This page covers how to deploy a **Transformers** models as a chatbot. If you are using a different framework or a custom python model, use [ChatModel](https://mlflow.org/docs/latest/llms/chat-model-intro/index.html) instead to build an OpenAI-compatible chat bot.\n",
     "\n",
     "### Learning objectives\n",
     "\n",
     "In this tutorial, you will:\n",
     "\n",
     "- Create an OpenAI-compatible chat model using TinyLLama-1.1B-Chat\n",
-    "- Log the model to MLflow and loaded it back for local inference.\n",
+    "- Log the model to MLflow and load it back for local inference.\n",
     "- Serve the model with MLflow Model Serving"
    ]
   },


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13787?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13787/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13787
```

</p>
</details>

### What changes are proposed in this pull request?

[This tutorial page](https://mlflow.org/docs/latest/llms/transformers/tutorials/conversational/pyfunc-chat-model.html) shows up at the top rank when searching for "MLflow chat model" on Google. This is a bit old page and also primary talks about Transformers `llm/v1/chat` feature before `ChatModel`, so not an ideal place for users to visit for the guidance about `ChatModel`.

This PR changes the page and title to focus on Transformers only so it won't surpass the newer ChatModel tutorials on web search.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
