### PR TITLE
[1/x] Support auto+manual tracing - LangChain

### DIFF
--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from typing import Union
 
 from langchain_core.callbacks.base import BaseCallbackHandler, BaseCallbackManager
+from langchain_core.runnables import RunnableSequence
 from packaging.version import Version
 
 import mlflow
@@ -85,9 +86,26 @@ def patched_inference(func_name, original, self, *args, **kwargs):
             return original(self, *args, **kwargs)
 
     config = AutoLoggingConfig.init(mlflow.langchain.FLAVOR_NAME)
+    should_trace = not IS_PATCHING_DISABLED_FOR_TRACING.get() and config.log_traces
 
-    if not IS_PATCHING_DISABLED_FOR_TRACING.get() and config.log_traces:
-        args, kwargs = _get_args_with_mlflow_tracer(func_name, args, kwargs)
+    if should_trace:
+        tracer = MlflowLangchainTracer(
+            # NB: RunnableSequence's batch() and abatch() methods are implemented in a peculiar way
+            # that iterate on steps->items sequentially within the same thread. For example, if a
+            # sequence has 2 steps and the batch size is 3, the execution flow will be:
+            #  - Step 1 for item 1
+            #  - Step 1 for item 2
+            #  - Step 1 for item 3
+            #  - Step 2 for item 1
+            #  - Step 2 for item 2
+            #  - Step 2 for item 3
+            # Due to this behavior, we cannot attach the span to the context for this particular
+            # API, otherwise spans for different inputs will be mixed up.
+            set_span_in_context=not (
+                isinstance(self, RunnableSequence) and func_name in ["batch", "abatch"]
+            )
+        )
+        args, kwargs = _get_args_with_mlflow_tracer(tracer, func_name, args, kwargs)
 
     # Traces does not require an MLflow run, only the other optional artifacts require it.
     if not IS_PATCHING_DISABLED_FOR_ARTIFACTS and config.should_log_optional_artifacts():
@@ -96,15 +114,21 @@ def patched_inference(func_name, original, self, *args, **kwargs):
             _log_optional_artifacts(config, run_id, result, self, func_name, *args, **kwargs)
     else:
         result = _invoke(self, *args, **kwargs)
+
+    if should_trace:
+        # Make sure all spans are flushed before finishing the inference. LangChain's on_xyz_end
+        # callbacks are not guaranteed to be invoked always, which results in leaking the active
+        # span context to the next inference call. Flushing the tracer ensures that all spans are
+        # finished and detached from the context.
+        tracer.flush()
+
     return result
 
 
-def _get_args_with_mlflow_tracer(func_name, args, kwargs):
+def _get_args_with_mlflow_tracer(mlflow_tracer, func_name, args, kwargs):
     """
     Get the patched arguments with MLflow tracer injected.
     """
-    mlflow_tracer = MlflowLangchainTracer()
-
     if func_name in ["invoke", "batch", "stream", "ainvoke", "abatch", "astream"]:
         # `config` is the second positional argument of runnable APIs such as
         # invoke, batch, stream, ainvoke, abatch, and astream

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -119,8 +119,8 @@ def patched_inference(func_name, original, self, *args, **kwargs):
         if should_trace:
             # Make sure all spans are flushed before finishing the inference. LangChain's on_xyz_end
             # callbacks are not guaranteed to be invoked always, which results in leaking the active
-            # span context to the next inference call. Flushing the tracer ensures that all spans are
-            # finished and detached from the context.
+            # span context to the next inference call. Flushing the tracer ensures that all spans
+            # are finished and detached from the context.
             tracer.flush()
 
     return result

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -91,7 +91,7 @@ def patched_inference(func_name, original, self, *args, **kwargs):
     if should_trace:
         tracer = MlflowLangchainTracer(
             # NB: RunnableSequence's batch() and abatch() methods are implemented in a peculiar way
-            # that iterate on steps->items sequentially within the same thread. For example, if a
+            # that iterates on steps->items sequentially within the same thread. For example, if a
             # sequence has 2 steps and the batch size is 3, the execution flow will be:
             #  - Step 1 for item 1
             #  - Step 1 for item 2

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -104,7 +104,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
                 )
 
             # Attach the span to the current context to mark it "active"
-            token = set_span_in_context(span._span) if self._set_span_in_context else None
+            token = set_span_in_context(span) if self._set_span_in_context else None
             self._run_span_mapping[str(run_id)] = (span, token)
         return span
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -12,6 +12,7 @@ import json
 import logging
 from typing import Optional
 
+from opentelemetry import context as context_api
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 
@@ -84,6 +85,28 @@ def start_detached_span(
     if experiment_id:
         attributes[SpanAttributeKey.EXPERIMENT_ID] = json.dumps(experiment_id)
     return tracer.start_span(name, context=context, attributes=attributes, start_time=start_time_ns)
+
+
+def set_span_in_context(span: trace.Span):
+    """
+    Set the given OpenTelemetry span as the active span in the current context.
+
+    Args:
+        span: The OpenTelemetry span to be set as the active span.
+    """
+    context = trace.set_span_in_context(span)
+    token = context_api.attach(context)
+    return token  # noqa: RET504
+
+
+def detach_span_from_context(token):
+    """
+    Remove the active span from the current context.
+
+    Args:
+        token: The token returned by `_set_span_to_active` function.
+    """
+    context_api.detach(token)
 
 
 def _get_tracer(module_name: str):

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -10,7 +10,7 @@ use OpenTelemetry e.g. PromptFlow, Snowpark.
 import functools
 import json
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
@@ -25,6 +25,9 @@ from mlflow.utils.databricks_utils import (
     is_in_databricks_model_serving_environment,
     is_mlflow_tracing_enabled_in_model_serving,
 )
+
+if TYPE_CHECKING:
+    from mlflow.entities import Span
 
 # Global tracer provider instance. We manage the tracer provider by ourselves instead of using
 # the global tracer provider provided by OpenTelemetry.
@@ -87,14 +90,14 @@ def start_detached_span(
     return tracer.start_span(name, context=context, attributes=attributes, start_time=start_time_ns)
 
 
-def set_span_in_context(span: trace.Span):
+def set_span_in_context(span: "Span"):
     """
     Set the given OpenTelemetry span as the active span in the current context.
 
     Args:
-        span: The OpenTelemetry span to be set as the active span.
+        span: An MLflow span object to set as the active span.
     """
-    context = trace.set_span_in_context(span)
+    context = trace.set_span_in_context(span._span)
     token = context_api.attach(context)
     return token  # noqa: RET504
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -7,6 +7,7 @@ tracer provider and ensure that it won't interfere with the other external libra
 use OpenTelemetry e.g. PromptFlow, Snowpark.
 """
 
+import contextvars
 import functools
 import json
 import logging
@@ -90,19 +91,22 @@ def start_detached_span(
     return tracer.start_span(name, context=context, attributes=attributes, start_time=start_time_ns)
 
 
-def set_span_in_context(span: "Span"):
+def set_span_in_context(span: "Span") -> contextvars.Token:
     """
     Set the given OpenTelemetry span as the active span in the current context.
 
     Args:
         span: An MLflow span object to set as the active span.
+
+    Returns:
+        A token object that will be required when detaching the span from the context.
     """
     context = trace.set_span_in_context(span._span)
     token = context_api.attach(context)
     return token  # noqa: RET504
 
 
-def detach_span_from_context(token):
+def detach_span_from_context(token: contextvars.Token):
     """
     Remove the active span from the current context.
 

--- a/mlflow/tracing/utils/token.py
+++ b/mlflow/tracing/utils/token.py
@@ -1,0 +1,20 @@
+import contextvars
+from dataclasses import dataclass
+from typing import Optional
+
+from mlflow.entities import LiveSpan
+
+
+@dataclass
+class SpanWithToken:
+    """
+    A utility container to hold an MLflow span and its corresponding OpenTelemetry token.
+
+    The token is a special object that is generated when setting a span as active within
+    the Open Telemetry span context. This token is required when inactivate the span i.e.
+    detaching the span from the context. This will only be used when MlflowLangchainTracer
+    is configured to set the span as active span by setting `set_span_in_context=True`.
+    """
+
+    span: LiveSpan
+    token: Optional[contextvars.Token] = None

--- a/mlflow/tracing/utils/token.py
+++ b/mlflow/tracing/utils/token.py
@@ -12,8 +12,7 @@ class SpanWithToken:
 
     The token is a special object that is generated when setting a span as active within
     the Open Telemetry span context. This token is required when inactivate the span i.e.
-    detaching the span from the context. This will only be used when MlflowLangchainTracer
-    is configured to set the span as active span by setting `set_span_in_context=True`.
+    detaching the span from the context.
     """
 
     span: LiveSpan

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,15 @@ def reset_tracing():
     IPythonTraceDisplayHandler._instance = None
 
 
+@pytest.fixture(autouse=True)
+def validate_trace_finish():
+    yield
+
+    # Validate all spans are finished by the end of the each test.
+    # Leaked span is critical problem and also hard to find without an explicit check.
+    assert mlflow.get_current_active_span() is None
+
+
 @pytest.fixture(autouse=True, scope="session")
 def enable_test_mode_by_default_for_autologging_integrations():
     """

--- a/tests/langchain/sample_code/langgraph_with_custom_span.py
+++ b/tests/langchain/sample_code/langgraph_with_custom_span.py
@@ -1,0 +1,61 @@
+from typing import Literal
+
+from langchain.prompts import PromptTemplate
+from langchain.schema.output_parser import StrOutputParser
+from langchain_core.messages import AIMessage, ToolCall
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+import mlflow
+from mlflow.entities.span import SpanType
+
+
+class FakeOpenAI(ChatOpenAI, extra="allow"):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._responses = iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[ToolCall(name="get_weather", args={"city": "sf"}, id="123")],
+                ),
+                AIMessage(content="The weather in San Francisco is always sunny!"),
+            ]
+        )
+
+    def _generate(self, *args, **kwargs):
+        return ChatResult(generations=[ChatGeneration(message=next(self._responses))])
+
+
+def get_inner_runnable():
+    llm = ChatOpenAI()
+    prompt = PromptTemplate.from_template("what is the weather in {city}?")
+    return prompt | llm | StrOutputParser()
+
+
+@tool
+def get_weather(city: Literal["nyc", "sf"]):
+    """Use this to get weather information."""
+    with mlflow.start_span(name="get_weather_inner", span_type=SpanType.CHAIN) as span:
+        span.set_inputs(city)
+
+        # Call another LangChain module
+        inner_runnable = get_inner_runnable()
+        inner_runnable.invoke({"city": city})
+
+        if city == "nyc":
+            output = "It might be cloudy in nyc"
+        elif city == "sf":
+            output = "It's always sunny in sf"
+        span.set_outputs(output)
+    return output
+
+
+llm = FakeOpenAI()
+tools = [get_weather]
+graph = create_react_agent(llm, tools)
+
+mlflow.models.set_model(graph)

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -198,9 +198,6 @@ def test_llm_internal_exception():
     finally:
         callback.flush()
 
-    # Active span should not leak after flush
-    assert mlflow.get_current_active_span() is None
-
 
 def test_retriever_success():
     callback = MlflowLangchainTracer()
@@ -290,9 +287,6 @@ def test_retriever_internal_exception():
             )
     finally:
         callback.flush()
-
-    # Active span should not leak after flush
-    assert mlflow.get_current_active_span() is None
 
 
 def test_multiple_components():

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -20,6 +20,7 @@ from langchain_community.vectorstores import FAISS
 from langchain_core.documents import Document
 from langchain_core.output_parsers.string import StrOutputParser
 from langchain_core.outputs import LLMResult
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import tool
 from packaging.version import Version
 
@@ -188,12 +189,17 @@ def test_llm_internal_exception():
         run_id=run_id,
         name="test_llm",
     )
-    callback._run_span_mapping = {}
-    with pytest.raises(
-        Exception,
-        match=f"Span for run_id {run_id} not found.",
-    ):
-        callback.on_llm_end(LLMResult(generations=[[{"text": "generated text"}]]), run_id=run_id)
+    try:
+        with pytest.raises(
+            Exception,
+            match="Span for run_id dummy not found.",
+        ):
+            callback.on_llm_end(LLMResult(generations=[[{"text": "generated"}]]), run_id="dummy")
+    finally:
+        callback.flush()
+
+    # Active span should not leak after flush
+    assert mlflow.get_current_active_span() is None
 
 
 def test_retriever_success():
@@ -267,20 +273,26 @@ def test_retriever_internal_exception():
         run_id=run_id,
         name="test_retriever",
     )
-    callback._run_span_mapping = {}
-    with pytest.raises(
-        Exception,
-        match=f"Span for run_id {run_id} not found.",
-    ):
-        callback.on_retriever_end(
-            [
-                Document(
-                    page_content="document content 1",
-                    metadata={"chunk_id": "1", "doc_uri": "uri1"},
-                )
-            ],
-            run_id=run_id,
-        )
+
+    try:
+        with pytest.raises(
+            Exception,
+            match="Span for run_id dummy not found.",
+        ):
+            callback.on_retriever_end(
+                [
+                    Document(
+                        page_content="document content 1",
+                        metadata={"chunk_id": "1", "doc_uri": "uri1"},
+                    )
+                ],
+                run_id="dummy",
+            )
+    finally:
+        callback.flush()
+
+    # Active span should not leak after flush
+    assert mlflow.get_current_active_span() is None
 
 
 def test_multiple_components():
@@ -590,35 +602,49 @@ def test_tracer_noop_when_tracing_disabled(monkeypatch):
     Version(langchain.__version__) < Version("0.1.0"),
     reason="ChatPromptTemplate expecting dict input",
 )
-def test_tracer_nested_trace():
-    # Validate if the callback works properly if it is used in a context
-    # of an active span created by MLflow fluent API.
+def test_tracer_with_manual_traces():
+    # Validate if the callback works properly when outer and inner spans
+    # are created by fluent APIs.
     llm = OpenAI(temperature=0.9)
     prompt = PromptTemplate(
-        input_variables=["product"],
-        template="What is {product}?",
+        input_variables=["color"],
+        template="What is the complementary color of {color}?",
     )
-    chain = prompt | llm | StrOutputParser()
+
+    # Inner spans are created within RunnableLambda
+    def foo(s: str):
+        with mlflow.start_span(name="foo_inner") as span:
+            span.set_inputs(s)
+            s = s.replace("red", "blue")
+            s = bar(s)
+            span.set_outputs(s)
+        return s
+
+    @mlflow.trace
+    def bar(s):
+        return s.replace("blue", "green")
+
+    chain = RunnableLambda(foo) | prompt | llm | StrOutputParser()
 
     @mlflow.trace(name="parent", span_type="SPECIAL")
     def run(message):
         return chain.invoke(message, config={"callbacks": [MlflowLangchainTracer()]})
 
-    response = run("MLflow")
-    expected_response = TEST_CONTENT
+    response = run("red")
+    expected_response = "What is the complementary color of green?"
     assert response == expected_response
 
     trace = mlflow.get_last_active_trace()
     assert trace is not None
     spans = trace.data.spans
     assert spans[0].name == "parent"
-    assert spans[0].span_type == "SPECIAL"
-    assert spans[0].inputs == {"message": "MLflow"}
-    assert spans[0].outputs == TEST_CONTENT
-    assert spans[0].status == SpanStatus(SpanStatusCode.OK)
     assert spans[1].name == "RunnableSequence"
-    assert spans[1].span_type == "CHAIN"
-    assert spans[1].inputs == "MLflow"
-    assert spans[1].outputs == TEST_CONTENT
-    assert spans[1].status == SpanStatus(SpanStatusCode.OK)
     assert spans[1].parent_id == spans[0].span_id
+    assert spans[2].name == "foo"
+    assert spans[2].parent_id == spans[1].span_id
+    assert spans[3].name == "foo_inner"
+    assert spans[3].parent_id == spans[2].span_id
+    assert spans[4].name == "bar"
+    assert spans[4].parent_id == spans[3].span_id
+    assert spans[5].name == "PromptTemplate"
+    assert spans[5].parent_id == spans[1].span_id

--- a/tests/langchain/test_langgraph.py
+++ b/tests/langchain/test_langgraph.py
@@ -142,6 +142,10 @@ def test_langgraph_tracing_diy_graph():
     assert len(chat_spans) == 3
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="Agent behavior is not stable across minor versions",
+)
 def test_langgraph_tracing_with_custom_span():
     mlflow.langchain.autolog()
 

--- a/tests/langchain/test_langgraph.py
+++ b/tests/langchain/test_langgraph.py
@@ -140,3 +140,52 @@ def test_langgraph_tracing_diy_graph():
 
     chat_spans = [span for span in traces[0].data.spans if span.name.startswith("ChatOpenAI")]
     assert len(chat_spans) == 3
+
+
+def test_langgraph_tracing_with_custom_span():
+    mlflow.langchain.autolog()
+
+    input_example = {"messages": [{"role": "user", "content": "what is the weather in sf?"}]}
+
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            "tests/langchain/sample_code/langgraph_with_custom_span.py",
+            "langgraph",
+            input_example=input_example,
+        )
+
+    loaded_graph = mlflow.langchain.load_model(model_info.model_uri)
+
+    # No trace should be created for the first call
+    assert mlflow.get_last_active_trace() is None
+
+    loaded_graph.invoke(input_example)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert traces[0].data.spans[0].name == "LangGraph"
+    assert traces[0].data.spans[0].inputs == input_example
+
+    spans = traces[0].data.spans
+
+    # Validate chat model spans
+    chat_spans = [s for s in spans if s.span_type == SpanType.CHAT_MODEL]
+    assert len(chat_spans) == 3
+
+    # Validate tool span
+    tool_span = next(s for s in spans if s.span_type == SpanType.TOOL)
+    assert tool_span.name == "get_weather"
+    assert tool_span.inputs == {"city": "sf"}
+    assert tool_span.outputs["content"] == "It's always sunny in sf"
+    assert tool_span.outputs["status"] == "success"
+    assert tool_span.status.status_code == SpanStatusCode.OK
+
+    # Validate inner span
+    inner_span = next(s for s in spans if s.name == "get_weather_inner")
+    assert inner_span.parent_id == tool_span.span_id
+    assert inner_span.inputs == "sf"
+    assert inner_span.outputs == "It's always sunny in sf"
+
+    inner_runnable_span = next(s for s in spans if s.parent_id == inner_span.span_id)
+    assert inner_runnable_span.name == "RunnableSequence_2"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13790?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13790/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13790
```

</p>
</details>

### Problem
Currently, mixing auto-tracing and manual tracing does not work for LangChain. For example, 
```
def foo(s: str):
    with mlflow.start_span(name="foo_inner", span_type=SpanType.TOOL) as span:
        span.set_inputs(s)
        s = s.replace("red", "blue")
        span.set_outputs(s)
    return s

chain = RunnableLambda(foo) | prompt | llm | StrOutputParser()
response = chain.invoke("red")
```

In this case, ideally the `"foo_inner"` span should be created within the LangChain Trace, under the RunnableLambda span. However, currently this is not the case and MLflow will create it as a separate trace. This is because LangChainTracer uses client API for generating spans, which is independent from the fluent API. Spans created from the client API is not set as an "active" span in the OpenTelemetry's context, as a result, fluent API won't find it as a parent span.

Also, LangChain trace is also isolated from other auto-tracing integration, in this case, OpenAI auto-tracing. As a results, this will creates three separate traces (1) foo_inner (2) OpenAI trace (3) LangChain trace. This is pretty confusing.


![trace](https://github.com/user-attachments/assets/8db6acba-00a6-40c0-9b8c-ed23488977b4)


### Solution

The initial reason we took this design is thread-safety. I thought the "active" span management in OpenTelemetry is not thread-safe. However, it actually **is** thread-safe, because context is managed via `ContextVar`, which is isolated between threads.

Therefore, this PR changes reverts design choice. We still needs to use client API because fluent API (context manager and decorator) is not suitable for callback. However, we explicitly attach the span created by the client API to OpenTelemetry context, so it will be set as "active".

By doing so, the above example will generate a single unified trace.

![Screenshot 2024-11-14 at 19 04 17](https://github.com/user-attachments/assets/d99eabfe-216e-4518-84e8-f400519c8452)

**Note**: I will apply the same solution to other libraries like LlamaIndex, DSPy, in follow-up PRs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with both LECL and LangGraph. The following screenshot is for LangGraph, where `custom_inner_span` is created with fluent API, that is a parent span of another runnable sequence.

![Screenshot 2024-11-14 at 19 05 55](https://github.com/user-attachments/assets/552d6b6a-a8e0-42b5-8f19-11e68a75345f)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

I will file a doc update PR after updating other libraries callbacks. We can add some examples of mixing fluent APIs and auto-tracing, as well as some unsupported edge cases (e.g. RunnableSequence's `batch` API). 

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Update LangChain auto-tracing to work with manual tracing via fluent APIs and other tracing integrations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
