### PR TITLE
[2/x] Support auto+manual tracing - LlamaIndex

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -33,10 +33,12 @@ from llama_index.core.schema import NodeWithScore
 from llama_index.core.tools import BaseTool
 from packaging.version import Version
 
+import mlflow
 from mlflow.entities import LiveSpan, SpanEvent, SpanType
 from mlflow.entities.document import Document
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
 from mlflow.tracking.client import MlflowClient
 
 _logger = logging.getLogger(__name__)
@@ -91,7 +93,7 @@ class _LlamaSpan(BaseSpan, extra="allow"):
         self._mlflow_span = mlflow_span
 
 
-def _end_span(span: LiveSpan, status=SpanStatusCode.OK, outputs=None):
+def _end_span(span: LiveSpan, status=SpanStatusCode.OK, outputs=None, token=None):
     """An utility function to end the span or trace."""
     if isinstance(outputs, (StreamingResponse, AsyncStreamingResponse, StreamingAgentChatResponse)):
         _logger.warning(
@@ -122,10 +124,14 @@ def _end_span(span: LiveSpan, status=SpanStatusCode.OK, outputs=None):
     else:
         MlflowClient().end_span(span.request_id, span.span_id, status=status, outputs=outputs)
 
+    if token:
+        detach_span_from_context(token)
+
 
 class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
     def __init__(self):
         super().__init__()
+        self._span_id_to_token = {}
         self._stream_resolver = StreamResolver()
         self._pending_spans: dict[str, _LlamaSpan] = {}
 
@@ -148,12 +154,13 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         with self.lock:
             parent = self.open_spans.get(parent_span_id) if parent_span_id else None
 
+        parent_span = parent._mlflow_span if parent else mlflow.get_current_active_span()
+
         try:
             input_args = bound_args.arguments
             attributes = self._get_instance_attributes(instance)
             span_type = self._get_span_type(instance) or SpanType.UNKNOWN
-            if parent:
-                parent_span = parent._mlflow_span
+            if parent_span:
                 # NB: Initiate the new client every time to handle tracking URI updates.
                 span = MlflowClient().start_span(
                     request_id=parent_span.request_id,
@@ -170,6 +177,9 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                     inputs=input_args,
                     attributes=attributes,
                 )
+
+            token = set_span_in_context(span)
+            self._span_id_to_token[span.span_id] = token
             return _LlamaSpan(id_=id_, parent_id=parent_span_id, mlflow_span=span)
         except BaseException as e:
             _logger.debug(f"Failed to create a new span: {e}", exc_info=True)
@@ -187,6 +197,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                 return
 
             span = llama_span._mlflow_span
+            token = self._span_id_to_token.pop(span.span_id, None)
 
             if self._stream_resolver.is_streaming_result(result):
                 # If the result is a generator, we keep the span in progress for streaming
@@ -194,11 +205,14 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                 is_pended = self._stream_resolver.register_stream_span(span, result)
                 if is_pended:
                     self._pending_spans[id_] = llama_span
+                    # We still need to detach the span from the context, otherwise it will
+                    # be considered as "active"
+                    detach_span_from_context(token)
                 else:
                     # If the span is not pended successfully, end it immediately
-                    _end_span(span=span, outputs=result)
+                    _end_span(span=span, outputs=result, token=token)
             else:
-                _end_span(span=span, outputs=result)
+                _end_span(span=span, outputs=result, token=token)
             return llama_span
         except BaseException as e:
             _logger.debug(f"Failed to end a span: {e}", exc_info=True)
@@ -213,6 +227,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         with self.lock:
             llama_span = self.open_spans.get(id_)
         span = llama_span._mlflow_span
+        token = self._span_id_to_token.pop(span.span_id, None)
 
         if LLAMA_INDEX_VERSION >= Version("0.10.59"):
             # LlamaIndex determines if a workflow is terminated or not by propagating an special
@@ -220,10 +235,10 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
             from llama_index.core.workflow.errors import WorkflowDone
 
             if err and isinstance(err, WorkflowDone):
-                return _end_span(span=span, status=SpanStatusCode.OK)
+                return _end_span(span=span, status=SpanStatusCode.OK, token=token)
 
         span.add_event(SpanEvent.from_exception(err))
-        _end_span(span=span, status="ERROR")
+        _end_span(span=span, status="ERROR", token=token)
         return llama_span
 
     def _get_span_type(self, instance: Any) -> SpanType:

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -118,14 +118,16 @@ def _end_span(span: LiveSpan, status=SpanStatusCode.OK, outputs=None, token=None
     if outputs is None:
         outputs = span.outputs
 
-    if span.parent_id is None:
-        # NB: Initiate the new client every time to handle tracking URI updates.
-        MlflowClient().end_trace(span.request_id, status=status, outputs=outputs)
-    else:
-        MlflowClient().end_span(span.request_id, span.span_id, status=status, outputs=outputs)
-
-    if token:
-        detach_span_from_context(token)
+    try:
+        if span.parent_id is None:
+            # NB: Initiate the new client every time to handle tracking URI updates.
+            MlflowClient().end_trace(span.request_id, status=status, outputs=outputs)
+        else:
+            MlflowClient().end_span(span.request_id, span.span_id, status=status, outputs=outputs)
+    finally:
+        # We should detach span even when end_span / end_trace API call fails
+        if token:
+            detach_span_from_context(token)
 
 
 class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13793?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13793/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13793
```

</p>
</details>

### What changes are proposed in this pull request?.

Adding similar manual tracing support for LlamaIndex auto-tracing. The mechanism is same as LangChain; attach the span to the context so fluent API / other tracing integration can detect it as a parent span.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with query/chat engine and workflow

![Untitled-2024-10-07-1602](https://github.com/user-attachments/assets/e87aadfd-43b6-47a8-b0a8-894aff736e57)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(*Note to release coordinator; please consolidate these PRs into a single release note*) Update LlamaIndex auto-tracing to work with manual tracing via fluent APIs and other tracing integrations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
