### PR TITLE
[3/x] Support auto+manual tracing - DSPy

### DIFF
--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -146,7 +146,6 @@ class MlflowCallback(BaseCallback):
 
         token = set_span_in_context(span)
         self._call_id_to_span[call_id] = SpanWithToken(span, token)
-        assert mlflow.get_current_active_span() == span
 
     def _end_span(
         self,

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -8,6 +8,8 @@ import mlflow
 from mlflow.entities import SpanStatusCode, SpanType
 from mlflow.entities.span_event import SpanEvent
 from mlflow.pyfunc.context import Context, maybe_set_prediction_context
+from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
+from mlflow.tracing.utils.token import SpanWithToken
 
 _logger = logging.getLogger(__name__)
 
@@ -19,6 +21,8 @@ class MlflowCallback(BaseCallback):
         self._client = mlflow.MlflowClient()
         self._call_id_to_span = {}
         self._prediction_context = prediction_context or Context()
+        # call_id: (LiveSpan, OTel token)
+        self._call_id_to_span: dict[str, SpanWithToken] = {}
 
     def on_module_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         span_type = self._get_span_type_for_module(instance)
@@ -111,15 +115,15 @@ class MlflowCallback(BaseCallback):
         attributes: dict[str, Any],
     ):
         # Get parent span in this order:
-        # 1. If there is an parent component in DSPy, use its span as parent span.
-        # 2. If there is an active span in MLflow, use it as parent span.
+        # 1. If there is an active span in MLflow, use it as parent span.
+        # 2. Use DSPy's active call ID to find the parent span as a fallback.
         # 3. Otherwise, start a new root span.
-        if parent_call_id := ACTIVE_CALL_ID.get():
-            parent_span = self._call_id_to_span.get(parent_call_id)
+        if active_span := mlflow.get_current_active_span():
+            parent_span = active_span
+        elif parent_call_id := ACTIVE_CALL_ID.get():
+            parent_span, _ = self._call_id_to_span.get(parent_call_id)
             if not parent_span:
                 _logger.warning("Failed to create a span. Parent span not found.")
-        elif active_span := mlflow.get_current_active_span():
-            parent_span = active_span
         else:
             parent_span = None
 
@@ -140,7 +144,9 @@ class MlflowCallback(BaseCallback):
             else:
                 span = self._client.start_trace(**common_params)
 
-        self._call_id_to_span[call_id] = span
+        token = set_span_in_context(span)
+        self._call_id_to_span[call_id] = SpanWithToken(span, token)
+        assert mlflow.get_current_active_span() == span
 
     def _end_span(
         self,
@@ -148,27 +154,30 @@ class MlflowCallback(BaseCallback):
         outputs: Optional[Any],
         exception: Optional[Exception] = None,
     ):
-        span = self._call_id_to_span.pop(call_id, None)
+        st = self._call_id_to_span.pop(call_id, None)
 
-        if not span:
+        if not st.span:
             _logger.warning(f"Failed to end a span. Span not found for call_id: {call_id}")
             return
 
         status = SpanStatusCode.OK if exception is None else SpanStatusCode.ERROR
 
         if exception:
-            span.add_event(SpanEvent.from_exception(exception))
+            st.span.add_event(SpanEvent.from_exception(exception))
 
         common_params = {
-            "request_id": span.request_id,
+            "request_id": st.span.request_id,
             "outputs": outputs,
             "status": status,
         }
 
-        if span.parent_id:
-            self._client.end_span(span_id=span.span_id, **common_params)
-        else:
-            self._client.end_trace(**common_params)
+        try:
+            if st.span.parent_id:
+                self._client.end_span(span_id=st.span.span_id, **common_params)
+            else:
+                self._client.end_trace(**common_params)
+        finally:
+            detach_span_from_context(st.token)
 
     def _get_span_type_for_module(self, instance):
         if isinstance(instance, dspy.Retrieve):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13795?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13795/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13795
```

</p>
</details>

### What changes are proposed in this pull request?.

Adding similar manual tracing support for DSPy auto-tracing. The mechanism is same as LangChain; attach the span to the context so fluent API / other tracing integration can detect it as a parent span.
### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with custom summarization module. Before this PR, MLflow generates 3 separate traces (one for DSPy, one for OpenAI, and one for custom trace via fluent API).

![trace dspy](https://github.com/user-attachments/assets/368dc4ac-6a1c-4335-ad2d-8c2452f2e815)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(*Note to release coordinator; please consolidate these PRs into a single release note*) Update DSPy auto-tracing to work with manual tracing via fluent APIs and other tracing integrations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
