### PR TITLE
Support setting retriever schema for DSPy model within constructor

### DIFF
--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -17,6 +17,7 @@ from mlflow.models import (
     ModelSignature,
     infer_pip_requirements,
 )
+from mlflow.models.dependencies_schemas import _get_dependencies_schemas
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.rag_signatures import SIGNATURE_FOR_LLM_INFERENCE_TASK
 from mlflow.models.resources import Resource, _ResourceBuilder
@@ -142,6 +143,13 @@ def save_model(
         saved_example = _save_example(mlflow_model, input_example, path)
     if metadata is not None:
         mlflow_model.metadata = metadata
+
+    with _get_dependencies_schemas() as dependencies_schemas:
+        schema = dependencies_schemas.to_dict()
+        if schema is not None:
+            if mlflow_model.metadata is None:
+                mlflow_model.metadata = {}
+            mlflow_model.metadata.update(schema)
 
     model_data_subpath = _MODEL_DATA_PATH
     # Construct new data folder in existing path.

--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -1,11 +1,15 @@
+import json
 import logging
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from mlflow.utils.annotations import experimental
+
+if TYPE_CHECKING:
+    from mlflow.models.model import Model
 
 _logger = logging.getLogger(__name__)
 
@@ -138,6 +142,24 @@ def _get_dependencies_schemas():
         yield dependencies_schemas
     finally:
         _clear_dependencies_schemas()
+
+
+def _get_dependencies_schema_from_model(model: "Model") -> Optional[dict]:
+    """
+    Get the dependencies schema from the logged model metadata.
+
+    `dependencies_schemas` is a dictionary that defines the dependencies schemas, such as
+    the retriever schemas. This code is now only useful for Databricks integration.
+    """
+    if model.metadata and "dependencies_schemas" in model.metadata:
+        dependencies_schemas = model.metadata["dependencies_schemas"]
+        return {
+            "dependencies_schemas": {
+                dependency: json.dumps(schema)
+                for dependency, schema in dependencies_schemas.items()
+            }
+        }
+    return None
 
 
 @dataclass

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -807,7 +807,8 @@ class PyFuncModel:
         self, data: PyFuncLLMSingleInput, params: Optional[dict[str, Any]] = None
     ) -> Iterator[PyFuncLLMOutputChunk]:
         with self._try_get_or_generate_prediction_context() as context:
-            self._update_dependencies_schemas_in_prediction_context(context)
+            if schema := _get_dependencies_schema_from_model(self._model_meta):
+                context.update(**schema)
             return self._predict_stream(data, params)
 
     def _predict_stream(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -401,7 +401,6 @@ import functools
 import hashlib
 import importlib
 import inspect
-import json
 import logging
 import os
 import shutil
@@ -437,6 +436,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature
 from mlflow.models.dependencies_schemas import (
     _clear_dependencies_schemas,
+    _get_dependencies_schema_from_model,
     _get_dependencies_schemas,
 )
 from mlflow.models.flavor_backend_registry import get_flavor_backend
@@ -747,16 +747,6 @@ class PyFuncModel:
         """
         return self.__model_impl
 
-    def _update_dependencies_schemas_in_prediction_context(self, context: Context):
-        if self._model_meta and self._model_meta.metadata:
-            dependencies_schemas = self._model_meta.metadata.get("dependencies_schemas", {})
-            context.update(
-                dependencies_schemas={
-                    dependency: json.dumps(schema)
-                    for dependency, schema in dependencies_schemas.items()
-                }
-            )
-
     @contextmanager
     def _try_get_or_generate_prediction_context(self):
         # set context for prediction if it's not set
@@ -768,7 +758,8 @@ class PyFuncModel:
 
     def predict(self, data: PyFuncInput, params: Optional[dict[str, Any]] = None) -> PyFuncOutput:
         with self._try_get_or_generate_prediction_context() as context:
-            self._update_dependencies_schemas_in_prediction_context(context)
+            if schema := _get_dependencies_schema_from_model(self._model_meta):
+                context.update(**schema)
             return self._predict(data, params)
 
     def _predict(self, data: PyFuncInput, params: Optional[dict[str, Any]] = None) -> PyFuncOutput:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13800?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13800/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13800
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Setting dependency (retriever) schema is necessary for Databricks Agent Platform to render source documentation properly in their Review App. The schema is set by users by calling `mlflow.models.set_retriever_schema` and it will be eventually propagated to the trace tag. This PR adds retriever schema handling similar to what we did to LangChain and Pyfunc, with some clean up for duplicated logic.

One challenge was `set_retriever_schema` is designed exclusively for models-from-code logging. This method needs to be called before the model logging. For models-from-code logging, users will put this call within their model script, which will be executed by MLflow when logging the model. However, DSPy flavor does not support models-from-code.

Aw a workaround, we decided to recommend users to put `set_retriever_schema` in the constructor of their DSPy module. Also particularly, DatabricksRM will run this automatically in the constructor so users don't need to do that manually ([ref](https://github.com/stanfordnlp/dspy/compare/main...chenmoneygithub:dspy:fix-databricksrm)).

```
import mlflow

class MyModule(dspy.Module):
    def __init__(self, ...):
        mlflow.models.set_retriever_schema(
            primary_key="id",
            text_column="text",
            doc_uri="source"
       )    
```

Since users need to instantiate their module to pass it to `mlflow.dspy.log_model`, `set_retriever_schema` in the constructor is guaranteed to be called.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Source doc is shown in the Review App, meaning that the retriever schema is handled properly.
 
![Screenshot 2024-11-16 at 1 43 23](https://github.com/user-attachments/assets/bc093068-0216-4973-8d1b-f00bfc122946)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support setting retriever schema for DSPy flavor to make it work with Databricks Agent Platform.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
