### PR TITLE
Use in-memory figure object

### DIFF
--- a/examples/evaluation/evaluate_with_custom_metrics_comprehensive.py
+++ b/examples/evaluation/evaluate_with_custom_metrics_comprehensive.py
@@ -46,9 +46,9 @@ def custom_artifact(eval_df, builtin_metrics, _artifacts_dir):
     example_image = Figure()
     ax = example_image.subplots()
     ax.scatter(eval_df["prediction"], eval_df["target"])
-    ax.xlabel("Targets")
-    ax.ylabel("Predictions")
-    ax.title("Targets vs. Predictions")
+    ax.set_xlabel("Targets")
+    ax.set_ylabel("Predictions")
+    ax.set_title("Targets vs. Predictions")
     example_custom_class = ExampleClass(10)
 
     return {

--- a/examples/evaluation/evaluate_with_custom_metrics_comprehensive.py
+++ b/examples/evaluation/evaluate_with_custom_metrics_comprehensive.py
@@ -1,6 +1,6 @@
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlib.figure import Figure
 from sklearn.datasets import fetch_california_housing
 from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import train_test_split
@@ -43,11 +43,12 @@ def custom_artifact(eval_df, builtin_metrics, _artifacts_dir):
     example_dict = {"hello": "there", "test_list": [0.1, 0.3, 4]}
     example_dict.update(builtin_metrics)
     example_dict_2 = '{"a": 3, "b": [1, 2, 3]}'
-    example_image = plt.figure()
-    plt.scatter(eval_df["prediction"], eval_df["target"])
-    plt.xlabel("Targets")
-    plt.ylabel("Predictions")
-    plt.title("Targets vs. Predictions")
+    example_image = Figure()
+    ax = example_image.subplots()
+    ax.scatter(eval_df["prediction"], eval_df["target"])
+    ax.xlabel("Targets")
+    ax.ylabel("Predictions")
+    ax.title("Targets vs. Predictions")
     example_custom_class = ExampleClass(10)
 
     return {

--- a/mlflow/fastai/callback.py
+++ b/mlflow/fastai/callback.py
@@ -3,9 +3,9 @@ import os
 import tempfile
 from functools import partial
 
-import matplotlib.pyplot as plt
 import numpy as np
 from fastai.callback.core import Callback
+from matplotlib.figure import Figure
 
 import mlflow.tracking
 from mlflow.fastai import log_model
@@ -98,14 +98,14 @@ class __MlflowFastaiCallback(Callback, metaclass=ExceptionSafeClass):
                     mlflow.log_param(self.freeze_prefix + param + "_final", values[-1])
 
                     # Plot and save image of scheduling
-                    fig = plt.figure()
-                    plt.plot(values)
-                    plt.ylabel(param)
+                    fig = Figure()
+                    ax = fig.subplots()
+                    ax.plot(values)
+                    ax.set_ylabel(param)
 
                     with tempfile.TemporaryDirectory() as tempdir:
                         scheds_file = os.path.join(tempdir, self.freeze_prefix + param + ".png")
-                        plt.savefig(scheds_file)
-                        plt.close(fig)
+                        fig.savefig(scheds_file)
                         mlflow.log_artifact(local_path=scheds_file)
                 break
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib.figure import Figure
 from PIL import Image, ImageChops
 from pyspark.ml.linalg import Vectors
 from pyspark.sql import SparkSession
@@ -1521,10 +1521,10 @@ def test_custom_metric_logs_artifacts_from_paths(
 
         # images
         for ext in img_formats:
-            fig = plt.figure(figsize=(fig_x, fig_y), dpi=fig_dpi)
-            plt.plot([1, 2, 3])
+            fig = Figure(figsize=(fig_x, fig_y), dpi=fig_dpi)
+            ax = fig.add_subplot()
+            ax.plot([1, 2, 3])
             fig.savefig(path_join(tmp_path, f"test.{ext}"), format=ext)
-            plt.clf()
             example_artifacts[f"test_{ext}_artifact"] = path_join(tmp_path, f"test.{ext}")
 
         # json
@@ -1566,10 +1566,10 @@ def test_custom_metric_logs_artifacts_from_paths(
             assert f"test_{img_ext}_artifact.{img_ext}" in artifacts
             assert isinstance(result.artifacts[f"test_{img_ext}_artifact"], ImageEvaluationArtifact)
 
-            fig = plt.figure(figsize=(fig_x, fig_y), dpi=fig_dpi)
-            plt.plot([1, 2, 3])
+            fig = Figure(figsize=(fig_x, fig_y), dpi=fig_dpi)
+            ax = fig.add_subplot()
+            ax.plot([1, 2, 3])
             fig.savefig(path_join(tmp_dir, f"test.{img_ext}"), format=img_ext)
-            plt.clf()
 
             saved_img = Image.open(path_join(tmp_dir, f"test.{img_ext}"))
             result_img = result.artifacts[f"test_{img_ext}_artifact"].content
@@ -1624,8 +1624,9 @@ class _ExampleToBePickledObject:
 def test_custom_metric_logs_artifacts_from_objects(
     binary_logistic_regressor_model_uri, breast_cancer_dataset
 ):
-    fig = plt.figure()
-    plt.plot([1, 2, 3])
+    fig = Figure()
+    ax = fig.subplots()
+    ax.plot([1, 2, 3])
     buf = io.BytesIO()
     fig.savefig(buf)
     buf.seek(0)

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1522,7 +1522,7 @@ def test_custom_metric_logs_artifacts_from_paths(
         # images
         for ext in img_formats:
             fig = Figure(figsize=(fig_x, fig_y), dpi=fig_dpi)
-            ax = fig.add_subplot()
+            ax = fig.subplots()
             ax.plot([1, 2, 3])
             fig.savefig(path_join(tmp_path, f"test.{ext}"), format=ext)
             example_artifacts[f"test_{ext}_artifact"] = path_join(tmp_path, f"test.{ext}")
@@ -1567,7 +1567,7 @@ def test_custom_metric_logs_artifacts_from_paths(
             assert isinstance(result.artifacts[f"test_{img_ext}_artifact"], ImageEvaluationArtifact)
 
             fig = Figure(figsize=(fig_x, fig_y), dpi=fig_dpi)
-            ax = fig.add_subplot()
+            ax = fig.subplots()
             ax.plot([1, 2, 3])
             fig.savefig(path_join(tmp_dir, f"test.{img_ext}"), format=img_ext)
 

--- a/tests/models/test_artifacts.py
+++ b/tests/models/test_artifacts.py
@@ -1,10 +1,10 @@
 import json
 import pathlib
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib.figure import Figure
 
 from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation.artifacts import (
@@ -38,9 +38,9 @@ class __DummyClass:
 @pytest.mark.parametrize(
     ("is_file", "artifact", "artifact_type", "ext"),
     [
-        (True, lambda path: plt.figure().savefig(path), ImageEvaluationArtifact, "png"),
-        (True, lambda path: plt.figure().savefig(path), ImageEvaluationArtifact, "jpg"),
-        (True, lambda path: plt.figure().savefig(path), ImageEvaluationArtifact, "jpeg"),
+        (True, lambda path: Figure().savefig(path), ImageEvaluationArtifact, "png"),
+        (True, lambda path: Figure().savefig(path), ImageEvaluationArtifact, "jpg"),
+        (True, lambda path: Figure().savefig(path), ImageEvaluationArtifact, "jpeg"),
         (True, __generate_dummy_json_file, JsonEvaluationArtifact, "json"),
         (True, lambda path: pathlib.Path(path).write_text("test"), TextEvaluationArtifact, "txt"),
         (
@@ -63,7 +63,7 @@ class __DummyClass:
         ),
         (False, pd.DataFrame({"test": [1, 2, 3]}), CsvEvaluationArtifact, "csv"),
         (False, np.array([1, 2, 3]), NumpyEvaluationArtifact, "npy"),
-        (False, plt.figure(), ImageEvaluationArtifact, "png"),
+        (False, Figure(), ImageEvaluationArtifact, "png"),
         (False, {"a": 1, "b": "e", "c": 1.2, "d": [1, 2]}, JsonEvaluationArtifact, "json"),
         (False, [1, 2, 3, "test"], JsonEvaluationArtifact, "json"),
         (False, '{"a": 1, "b": [1.2, 3]}', JsonEvaluationArtifact, "json"),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13823?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13823/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13823
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`matplotlib.pyplot.figure` generates an interactive plot window as shown below. We can use `matplotlib.figure.Figure` instead.

Uploading Screen Recording 2024-11-19 at 17.07.46.mov…

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
