### PR TITLE
Bust browser cache when mlflow version changes

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerFrameRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerFrameRenderer.tsx
@@ -72,8 +72,8 @@ export const ModelTraceExplorerFrameRenderer = ({
       )}
       <iframe
         title="Model Trace Explorer"
-        // Include the version as a query parameter to bust the cache when the version changes:
-        // https://github.com/mlflow/mlflow/issues/13829
+        // Include the current mlflow version as a query parameter to bust the browser cache
+        // generated and prevent https://github.com/mlflow/mlflow/issues/13829.
         src={`static-files/lib/ml-model-trace-renderer/index.html?version=${Version}`}
         ref={iframeRef}
         css={{

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerFrameRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerFrameRenderer.tsx
@@ -6,6 +6,7 @@ import {
 } from '@databricks/web-shared/model-trace-explorer';
 import type { ModelTrace, ModelTraceChildToParentFrameMessageType } from '@databricks/web-shared/model-trace-explorer';
 import { TableSkeleton, TitleSkeleton } from '@databricks/design-system';
+import { Version } from '../../../common/constants';
 
 export const ModelTraceExplorerFrameRenderer = ({
   modelTrace,
@@ -71,7 +72,9 @@ export const ModelTraceExplorerFrameRenderer = ({
       )}
       <iframe
         title="Model Trace Explorer"
-        src="static-files/lib/ml-model-trace-renderer/index.html"
+        // Include the version as a query parameter to bust the cache when the version changes:
+        // https://github.com/mlflow/mlflow/issues/13829
+        src={`static-files/lib/ml-model-trace-renderer/index.html?version=${Version}`}
         ref={iframeRef}
         css={{
           border: 'none',


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13836?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13836/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13836
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix #13829. To avoid using the cached `mlflow/server/js/public/lib/ml-model-trace-renderer/index.html` when mlflow is upgraded to a newer/older version, include the version in the iframe source.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### First load (not cached):

<img width="821" alt="Screenshot 2024-11-20 at 11 21 58" src="https://github.com/user-attachments/assets/cd8400c6-bf73-45de-82b8-cb28bb6dc962">

### Second load (read from cache)

<img width="821" alt="Screenshot 2024-11-20 at 11 22 06" src="https://github.com/user-attachments/assets/fda52508-a571-436c-81b2-87335c2e41d8">

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
