### PR TITLE
Anytype: update infer signature for input example and doc

### DIFF
--- a/docs/source/llms/chat-model-intro/index.rst
+++ b/docs/source/llms/chat-model-intro/index.rst
@@ -580,8 +580,8 @@ Some of the biggest differences come up when it's time to log the model:
             input_example=(request, params),
         )
 
-With a custom :py:class:`~mlflow.pyfunc.PythonModel`, we need to manually define the input example, so that model signature can be inferred from it. This is a significant difference from the ChatModel API, which automatically configured the signature to conform to the standardized OpenAI-compatible input/output/parameter schemas.
-To learn more about auto inference of model signature based on an input example, see :ref:`GenAI model signature example <genai_model_signature_example>` section for details.
+With a custom :py:class:`~mlflow.pyfunc.PythonModel`, we need to manually define the input example so that a model signature can be inferred using the example. This is a significant difference from the ChatModel API, which automatically configures a signature that conforms to the standard OpenAI-compatible input/output/parameter schemas.
+To learn more about auto inference of model signature based on an input example, see the :ref:`GenAI model signature example <genai_model_signature_example>` section for details.
 
 There is also one notable difference in how we call the loaded model's ``predict`` method: parameters are passed as a dictionary via the ``params`` keyword argument, rather than in the dictionary containing the messages.
 

--- a/docs/source/llms/chat-model-intro/index.rst
+++ b/docs/source/llms/chat-model-intro/index.rst
@@ -562,8 +562,6 @@ Some of the biggest differences come up when it's time to log the model:
 
 .. code-block:: python
 
-    from mlflow.models import infer_signature
-
     code_path = "ollama_pyfunc_model.py"
 
     params = {
@@ -575,17 +573,15 @@ Some of the biggest differences come up when it's time to log the model:
     }
     request = {"messages": [{"role": "user", "content": "What is MLflow?"}]}
 
-    signature = infer_signature(model_input=request, params=params)
-
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(
             "ollama_pyfunc_model",
             python_model=code_path,
-            signature=signature,
             input_example=(request, params),
         )
 
-With a custom :py:class:`~mlflow.pyfunc.PythonModel`, we need to manually define the model signature and input example. This is a significant difference from the ChatModel API, which automatically configured the signature to conform to the standardized OpenAI-compatible input/output/parameter schemas.
+With a custom :py:class:`~mlflow.pyfunc.PythonModel`, we need to manually define the input example, so that model signature can be inferred from it. This is a significant difference from the ChatModel API, which automatically configured the signature to conform to the standardized OpenAI-compatible input/output/parameter schemas.
+To learn more about auto inference of model signature based on an input example, see :ref:`GenAI model signature example <genai_model_signature_example>` section for details.
 
 There is also one notable difference in how we call the loaded model's ``predict`` method: parameters are passed as a dictionary via the ``params`` keyword argument, rather than in the dictionary containing the messages.
 

--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -165,7 +165,7 @@ Column-based signature also support composite data types of these primitives.
     `mlflow.models.infer_signature` function infers a field as AnyType only if the field is always None (e.g. ``{"a": None} --> ['a': Any (optional)]``); if the field has other valid types, the field is inferred
     as optional instead (e.g. ``[{"a": None}, {"a": "abc"}] --> ['a': string (optional)]``).
     If one field explicitly accepts multiple valid types (e.g. ``[{"a": "string"}, {"a": 123}]``), `infer_signature` function would fail and you need to manually construct the signature using `ModelSignature` object
-    with `AnyType` type for the field.
+    with `AnyType` type for the field. (e.g. ``ModelSignature(Schema([ColSpec(AnyType(), "a", required=False)]))``)
 
 .. warning::
 
@@ -638,6 +638,8 @@ The same signature can be created explicitly as follows:
         inputs=input_schema, outputs=output_schema, params=params_schema
     )
 
+.. _genai_model_signature_example:
+
 Model signature examples for GenAI flavors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 GenAI flavors such as langchain, OpenAI, and transformers normally require an object (dictionary) based model signature.
@@ -808,10 +810,25 @@ If your model's output contains None values, these fields will be inferred as An
 
     print(infer_signature(data))
     # inputs:
-    # ['id': Any (optional), 'object': string (required), 'created': long (required), 'model': Any (optional),
-    # 'choices': Array({finish_reason: Any (optional), index: long (required),
-    # message: {content: string (required), role: string (required)} (required)}) (required),
-    # 'usage': {completion_tokens: Any (optional), prompt_tokens: Any (optional), total_tokens: Any (optional)} (required)]
+    # [
+    #     'id': Any (optional),
+    #     'object': string (required),
+    #     'created': long (required),
+    #     'model': Any (optional),
+    #     'choices': Array({
+    #         'finish_reason': Any (optional),
+    #         'index': long (required),
+    #         'message': {
+    #             'content': string (required),
+    #             'role': string (required)
+    #         } (required)
+    #     }) (required),
+    #     'usage': {
+    #         'completion_tokens': Any (optional),
+    #         'prompt_tokens': Any (optional),
+    #         'total_tokens': Any (optional)
+    #     } (required)
+    # ]
     # outputs:
     # None
     # params:

--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -158,11 +158,20 @@ Column-based signature also support composite data types of these primitives.
 - Array (list, numpy arrays)
 - Spark ML vector (it inherits ``Array[double]`` type)
 - Object (dictionary)
+- AnyType
+
+.. note::
+    AnyType is a special type that can be used to represent any data type, including None values. If this type is used, input data is not validated at all during schema enforcement process in pyfunc predict.
+    `mlflow.models.infer_signature` function infers a field as AnyType only if the field is always None (e.g. ``{"a": None} --> ['a': Any (optional)]``); if the field has other valid types, the field is inferred
+    as optional instead (e.g. ``[{"a": None}, {"a": "abc"}] --> ['a': string (optional)]``).
+    If one field explicitly accepts multiple valid types (e.g. ``[{"a": "string"}, {"a": 123}]``), `infer_signature` function would fail and you need to manually construct the signature using `ModelSignature` object
+    with `AnyType` type for the field.
 
 .. warning::
 
     * Support for Array and Object types was introduced in MLflow version **2.10.0**. These types will not be recognized in previous versions of MLflow.  If you are saving a model that uses these signature types, you should ensure that any other environment that attempts to load these models  has a version of MLflow installed that is at least 2.10.0.
     * Support for Spark ML vector type was introduced in MLflow version **2.15.0**, These type will not be recognized in previous versions of MLflow.
+    * Support for AnyType was introduced in MLflow version **2.19.0**. This type will not be recognized in previous versions of MLflow.
 
 Additional examples for composite data types can be seen by viewing the `signature examples notebook <notebooks/signature_examples.html>`_.
 
@@ -766,6 +775,48 @@ If your model has an optional input field, you can use below input_example as a 
     }
 
     print(infer_signature(input_example))
+
+If your model's output contains None values, these fields will be inferred as AnyType (since MLflow 2.19.0), for example:
+
+.. code-block:: python
+
+    from mlflow.models import infer_signature
+
+    data = [
+        {
+            "id": None,
+            "object": "chat.completion",
+            "created": 1731491873,
+            "model": None,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "MLflow",
+                    },
+                    "finish_reason": None,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": None,
+                "completion_tokens": None,
+                "total_tokens": None,
+            },
+        }
+    ]
+
+    print(infer_signature(data))
+    # inputs:
+    # ['id': Any (optional), 'object': string (required), 'created': long (required), 'model': Any (optional),
+    # 'choices': Array({finish_reason: Any (optional), index: long (required),
+    # message: {content: string (required), role: string (required)} (required)}) (required),
+    # 'usage': {completion_tokens: Any (optional), prompt_tokens: Any (optional), total_tokens: Any (optional)} (required)]
+    # outputs:
+    # None
+    # params:
+    # None
+
 
 3. Load the model back and make predictions:
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -21,7 +21,7 @@ OBJECT_TYPE = "object"
 MAP_TYPE = "map"
 ANY_TYPE = "any"
 SPARKML_VECTOR_TYPE = "sparkml_vector"
-ALOWWED_DTYPES = Union["Array", "DataType", "Map", "Object", "AnyType", str]
+ALLOWED_DTYPES = Union["Array", "DataType", "Map", "Object", "AnyType", str]
 EXPECTED_TYPE_MESSAGE = (
     "Expected mlflow.types.schema.Datatype, mlflow.types.schema.Array, "
     "mlflow.types.schema.Object, mlflow.types.schema.Map, mlflow.types.schema.AnyType "
@@ -154,28 +154,24 @@ class BaseType(ABC):
         """
         Determine if two objects are equal.
         """
-        raise NotImplementedError
 
     @abstractmethod
     def __repr__(self) -> str:
         """
         The string representation of the object.
         """
-        raise NotImplementedError
 
     @abstractmethod
     def to_dict(self) -> dict:
         """
         Dictionary representation of the object.
         """
-        raise NotImplementedError
 
     @abstractmethod
     def _merge(self, other: BaseType) -> BaseType:
         """
         Merge two objects and return the updated object if they're compatible.
         """
-        raise NotImplementedError
 
 
 class Property(BaseType):
@@ -186,7 +182,7 @@ class Property(BaseType):
     def __init__(
         self,
         name: str,
-        dtype: ALOWWED_DTYPES,
+        dtype: ALLOWED_DTYPES,
         required: bool = True,
     ) -> None:
         """
@@ -495,7 +491,7 @@ class Array(BaseType):
 
     def __init__(
         self,
-        dtype: ALOWWED_DTYPES,
+        dtype: ALLOWED_DTYPES,
     ) -> None:
         try:
             self._dtype = DataType[dtype] if isinstance(dtype, str) else dtype
@@ -613,7 +609,7 @@ class Map(BaseType):
     Specification used to represent a json-convertible map with string type keys.
     """
 
-    def __init__(self, value_type: ALOWWED_DTYPES):
+    def __init__(self, value_type: ALLOWED_DTYPES):
         try:
             self._value_type = DataType[value_type] if isinstance(value_type, str) else value_type
         except KeyError:
@@ -696,7 +692,7 @@ class Map(BaseType):
 
 
 @experimental
-class AnyType:
+class AnyType(BaseType):
     def __init__(self):
         """
         AnyType can store any json-serializable data including None values.
@@ -726,18 +722,18 @@ class AnyType:
     def to_dict(self):
         return {"type": ANY_TYPE}
 
-    def _merge(self, another_type: BaseType) -> BaseType:
-        if self == another_type:
+    def _merge(self, other: BaseType) -> BaseType:
+        if self == other:
             return deepcopy(self)
-        if isinstance(another_type, DataType):
-            return another_type
-        if not isinstance(another_type, BaseType):
+        if isinstance(other, DataType):
+            return other
+        if not isinstance(other, BaseType):
             raise MlflowException(
-                f"Can't merge AnyType with {type(another_type).__name__}, "
+                f"Can't merge AnyType with {type(other).__name__}, "
                 "it must be a BaseType or DataType"
             )
         # Merging AnyType with another type makes the other type optional
-        return another_type._merge(self)
+        return other._merge(self)
 
 
 class ColSpec:
@@ -747,7 +743,7 @@ class ColSpec:
 
     def __init__(
         self,
-        type: ALOWWED_DTYPES,
+        type: ALLOWED_DTYPES,
         name: Optional[str] = None,
         required: bool = True,
     ):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13846?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13846/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13846
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
If we fail to infer schema on model output, we now set it as AnyType since we don't validate the output anyways;
Add documentation for AnyType usage.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
