### PR TITLE
Support colored log and highlight the lack of signature

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -788,9 +788,11 @@ class Model:
             # fallback when not provided by user, which is set during flavor's save_model() call.
             if mlflow_model.signature is None:
                 if serving_input is None:
-                    _logger.warning(_LOG_MODEL_MISSING_INPUT_EXAMPLE_WARNING)
+                    _logger.warning(
+                        _LOG_MODEL_MISSING_INPUT_EXAMPLE_WARNING, extra={"color": "red"}
+                    )
                 elif tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks":
-                    _logger.warning(_LOG_MODEL_MISSING_SIGNATURE_WARNING)
+                    _logger.warning(_LOG_MODEL_MISSING_SIGNATURE_WARNING, extra={"color": "red"})
 
             env_vars = None
             # validate input example works for serving when logging the model

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -90,7 +90,6 @@ class MlflowFormatter(logging.Formatter):
         if color := getattr(record, "color", None):
             if color in self.COLORS and sys.platform != "win32":
                 color_code = self._escape(self.COLORS[color])
-                record.msg = f"{color_code}{record.msg}{self.RESET}"
                 return f"{color_code}{super().format(record)}{self.RESET}"
         return super().format(record)
 

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -58,13 +58,50 @@ def enable_logging():
     MLFLOW_LOGGING_STREAM.enabled = True
 
 
+class MlflowFormatter(logging.Formatter):
+    """Custom Formatter Class to support colored log"""
+
+    # Copied from color log package https://github.com/borntyping/python-colorlog/blob/main/colorlog/escape_codes.py
+    COLORS = {
+        "black": 30,
+        "red": 31,
+        "green": 32,
+        "yellow": 33,
+        "blue": 34,
+        "purple": 35,
+        "cyan": 36,
+        "white": 37,
+        "light_black": 90,
+        "light_red": 91,
+        "light_green": 92,
+        "light_yellow": 93,
+        "light_blue": 94,
+        "light_purple": 95,
+        "light_cyan": 96,
+        "light_white": 97,
+    }
+    RESET = "\033[0m"
+
+    def format(self, record):
+        if color := getattr(record, "color", None):
+            if color in self.COLORS:
+                color_code = self._escape(self.COLORS[color])
+                record.msg = f"{color_code}{record.msg}{self.RESET}"
+        return super().format(record)
+
+    def _escape(self, code: int) -> str:
+        return f"\033[{code}m"
+
+
 def _configure_mlflow_loggers(root_module_name):
+    # logging.setLoggerClass(MlflowLogger)
     logging.config.dictConfig(
         {
             "version": 1,
             "disable_existing_loggers": False,
             "formatters": {
                 "mlflow_formatter": {
+                    "()": MlflowFormatter,
                     "format": LOGGING_LINE_FORMAT,
                     "datefmt": LOGGING_DATETIME_FORMAT,
                 },

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -62,10 +62,10 @@ class MlflowFormatter(logging.Formatter):
     """
     Custom Formatter Class to support colored log
     ANSI characters might not work natively on older Windows, so disabling the feature for win32.
-    See https://github.com/borntyping/python-colorlog/blob/main/colorlog/escape_codes.py#L16C8-L16C31
+    See https://github.com/borntyping/python-colorlog/blob/dfa10f59186d3d716aec4165ee79e58f2265c0eb/colorlog/escape_codes.py#L16C8-L16C31
     """
 
-    # Copied from color log package https://github.com/borntyping/python-colorlog/blob/main/colorlog/escape_codes.py
+    # Copied from color log package https://github.com/borntyping/python-colorlog/blob/dfa10f59186d3d716aec4165ee79e58f2265c0eb/colorlog/escape_codes.py#L33-L50
     COLORS = {
         "black": 30,
         "red": 31,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/13848?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13848/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13848
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Within the warnings of mlflow, we sometimes want to highlight some of them to make them obvious.
1. Create a custom logging formatter that includes ANSI escape characters if color kwarg is passed
2. Highlight the warnings for the lack of model signature when logging

### Design Choice
There are mainly two options for the implementation
1. Use both Custom Logger and Custom Formatter and change the interface of logger
2. Use Custom Formatter only and keep the interface of logger

In option #1,  we define our own Logger class that inherits `logging.Logger` and set the class as default Logger. The benefit is we can pass the color str as a top argument like the sample below.

```python
class CustomLogger(logging.Logger):
   def warning(self, msg, *args, **kwargs):
        if color := kwargs.pop('color', None):
           extra = kwargs.get('extra', {})
           extra['color'] = color
           kwargs['extra'] = extra
       self.log(logging.WARNING, msg, *args, **kwargs)
logging.setLoggerClass(CustomLogger)
logger = logging.getLogger(__name__)
logger.warning("warning", color="red")
```

The downside is that logging.setLoggerClass will change the default Logger Class globally and there is a risk that the logger class is overwritten when logger instance is instantiated in the downstream logic, which causes exceptions due to the interface mismatch. Therefore, I decided to go with option #2, then the way to configure colors is like the code below:
```python
logger = logging.getLogger(__name__)
logger.warning("warning", extra={"color": "red"})
```

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="1004" alt="image" src="https://github.com/user-attachments/assets/6b74fa87-520d-4cd0-a4bb-fa0f82b06fe2">

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
