### PR TITLE
Fix langchain agent executor tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -725,7 +725,7 @@ langchain:
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
       if [[ $PYDANTIC_VERSION == 1.* ]]; then
-        pip install 'pydantic>2' 'fastapi>=0.100.0'
+        pip install 'pydantic>=2' 'fastapi>=0.100.0'
         echo "Testing langchain model export with pydantic v2"
         pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py --ignore tests/langchain/test_langchain_evaluation.py
       fi
@@ -758,7 +758,7 @@ langchain:
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
       if [[ $PYDANTIC_VERSION == 1.* ]]; then
-        pip install 'pydantic>2' 'fastapi>=0.100.0'
+        pip install 'pydantic>=2' 'fastapi>=0.100.0'
         echo "Testing langchain autolog with pydantic v2"
         pytest tests/langchain/test_langchain_autolog.py
       fi

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -706,7 +706,6 @@ langchain:
           "uvicorn",
           # Required for testing Databricks dependency extraction
           "databricks-vectorsearch",
-          "pydantic<2.10",
         ]
       # langchain-openai 0.1.22 is imcomptible with earlier langchain-core due to
       # https://github.com/langchain-ai/langchain/commit/b83f1eb0d56dbf99605a1fce93953ee09d77aabf
@@ -726,7 +725,7 @@ langchain:
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
       if [[ $PYDANTIC_VERSION == 1.* ]]; then
-        pip install 'pydantic>=2,<2.10' 'fastapi>=0.100.0'
+        pip install 'pydantic>2' 'fastapi>=0.100.0'
         echo "Testing langchain model export with pydantic v2"
         pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py --ignore tests/langchain/test_langchain_evaluation.py
       fi

--- a/tests/langchain/sample_code/openai_agent.py
+++ b/tests/langchain/sample_code/openai_agent.py
@@ -63,7 +63,7 @@ def create_openai_agent():
         agent=agent,
         tools=tools,
         # Use env var to switch model configuration during testing
-        return_intermediate_steps=os.environ.get("RETURN_INTERMEDIATE_STEPS", False),
+        return_intermediate_steps=os.environ.get("RETURN_INTERMEDIATE_STEPS", "false") == "true",
     )
 
 

--- a/tests/langchain/sample_code/openai_agent.py
+++ b/tests/langchain/sample_code/openai_agent.py
@@ -59,11 +59,12 @@ def create_openai_agent():
         ]
     )
     agent = create_openai_tools_agent(llm, tools, prompt)
+    return_immediate = os.environ.get("RETURN_INTERMEDIATE_STEPS", "false").lower() == "true"
     return AgentExecutor(
         agent=agent,
         tools=tools,
         # Use env var to switch model configuration during testing
-        return_intermediate_steps=os.environ.get("RETURN_INTERMEDIATE_STEPS", "false") == "true",
+        return_intermediate_steps=return_immediate,
     )
 
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -7,7 +7,6 @@ from typing import Any, Optional
 from unittest import mock
 
 import langchain
-import openai
 import pytest
 from langchain.chains.llm import LLMChain
 from langchain_core.callbacks.base import (
@@ -91,34 +90,6 @@ def create_openai_runnable():
         template="What is {product}?",
     )
     return prompt | ChatOpenAI(temperature=0.9) | StrOutputParser()
-
-
-def create_openai_llmagent():
-    from langchain.agents import AgentType, initialize_agent, load_tools
-
-    with mock.patch("openai.OpenAI") as mock_openai:
-        mock_openai.return_value.completions.create.return_value = {
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "choices": [
-                {
-                    "index": 0,
-                    "finish_reason": "stop",
-                    "text": f"Final Answer: {TEST_CONTENT}",
-                }
-            ],
-            "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
-        }
-        llm = OpenAI(temperature=0)
-    tools = load_tools(["serpapi", "llm-math"], llm=llm)
-    return initialize_agent(
-        tools,
-        llm,
-        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
-        verbose=True,
-        return_intermediate_steps=False,
-    )
 
 
 def create_retriever(tmp_path):
@@ -418,18 +389,26 @@ def test_loaded_llmchain_within_model_evaluation(mock_get_display, tmp_path, asy
 @pytest.mark.skipif(not _LC_COMMUNITY_INSTALLED, reason="This test requires langchain_community")
 def test_agent_autolog(async_logging_enabled):
     mlflow.langchain.autolog(log_models=True)
-    model = create_openai_llmagent()
+
+    # Load the agent definition (with OpenAI mock) from the sample script
+    from tests.langchain.sample_code.openai_agent import create_openai_agent
+
+    model = create_openai_agent()
+    input = {"input": "The result of 2 * 3 is 6."}
+    expected_output = {"output": "The result of 2 * 3 is 6."}
+
     with mock.patch("mlflow.langchain.log_model") as log_model_mock:
         # ensure __call__ is patched
-        assert model("Hi", return_only_outputs=True) == {"output": TEST_CONTENT}
-        assert model("Hi", return_only_outputs=True) == {"output": TEST_CONTENT}
+        assert model(input, return_only_outputs=True) == expected_output
+        assert model(input, return_only_outputs=True) == expected_output
         log_model_mock.assert_called_once()
 
-    model = create_openai_llmagent()
+    model = create_openai_agent()
+
     with mock.patch("mlflow.langchain.log_model") as log_model_mock:
         # ensure invoke is patched
-        assert model.invoke("Hi", return_only_outputs=True) == {"output": TEST_CONTENT}
-        assert model.invoke("Hi", return_only_outputs=True) == {"output": TEST_CONTENT}
+        assert model.invoke(input, return_only_outputs=True) == expected_output
+        assert model.invoke(input, return_only_outputs=True) == expected_output
         log_model_mock.assert_called_once()
 
     if async_logging_enabled:
@@ -439,41 +418,9 @@ def test_agent_autolog(async_logging_enabled):
     assert len(traces) == 4
     for trace in traces:
         spans = [(s.name, s.span_type) for s in trace.data.spans]
-        assert spans == [
-            ("AgentExecutor", "CHAIN"),
-            ("LLMChain", "CHAIN"),
-            ("OpenAI", "LLM"),
-        ]
-        assert trace.data.spans[0].inputs == {"input": "Hi"}
-        assert trace.data.spans[0].outputs == {"output": TEST_CONTENT}
-
-
-# TODO: Fix the AgentExecutor saving issue and remove the skip
-@pytest.mark.skipif(
-    Version(openai.__version__) >= Version("1.0"),
-    reason="OpenAI Client since 1.0 contains thread lock object that cannot be pickled.",
-)
-def test_loaded_agent_autolog():
-    mlflow.langchain.autolog(log_models=True, log_input_examples=True)
-    model, input, mock_response = create_openai_llmagent()
-    with mlflow.start_run() as run:
-        assert model(input, return_only_outputs=True) == {"output": TEST_CONTENT}
-    with mock.patch("mlflow.langchain.log_model") as log_model_mock:
-        loaded_model = mlflow.langchain.load_model(f"runs:/{run.info.run_id}/model")
-        assert loaded_model(input, return_only_outputs=True) == {"output": TEST_CONTENT}
-        log_model_mock.assert_not_called()
-
-        mlflow_model = get_mlflow_model(run.info.artifact_uri)
-        model_path = os.path.join(run.info.artifact_uri, MODEL_DIR)
-        input_example = _read_example(mlflow_model, model_path)
-        assert input_example == input
-
-        pyfunc_model = mlflow.pyfunc.load_model(f"runs:/{run.info.run_id}/model")
-        assert pyfunc_model.predict(input) == [TEST_CONTENT]
-        log_model_mock.assert_not_called()
-
-        signature = mlflow_model.signature
-        assert signature == infer_signature(input, [TEST_CONTENT])
+        assert len(spans) == 16
+        assert trace.data.spans[0].inputs == input
+        assert trace.data.spans[0].outputs == expected_output
 
 
 def test_runnable_sequence_autolog(async_logging_enabled):

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -387,6 +387,10 @@ def test_loaded_llmchain_within_model_evaluation(mock_get_display, tmp_path, asy
 
 
 @pytest.mark.skipif(not _LC_COMMUNITY_INSTALLED, reason="This test requires langchain_community")
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="ToolCall message is not available in older versions",
+)
 def test_agent_autolog(async_logging_enabled):
     mlflow.langchain.autolog(log_models=True)
 

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -3,12 +3,10 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional
-from unittest import mock
 from unittest.mock import MagicMock
 
 import langchain
 import pytest
-from langchain.agents import AgentType, initialize_agent, load_tools
 from langchain.chains.llm import LLMChain
 from langchain.prompts import PromptTemplate
 from langchain.prompts.chat import SystemMessagePromptTemplate
@@ -61,36 +59,6 @@ def create_retriever():
     embeddings = FakeEmbeddings(size=5)
     db = FAISS.from_documents(docs, embeddings)
     return db.as_retriever()
-
-
-def create_openai_llmagent():
-    # First, let's load the language model we're going to use to control the agent.
-    with mock.patch("openai.OpenAI") as mock_openai:
-        mock_openai.return_value.completions.create.return_value = {
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "choices": [
-                {
-                    "index": 0,
-                    "finish_reason": "stop",
-                    "text": "Final Answer: test",
-                }
-            ],
-            "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
-        }
-        llm = OpenAI(temperature=0)
-
-    # Next, let's load some tools to use.
-    tools = load_tools(["llm-math"], llm=llm)
-
-    # Finally, let's initialize an agent with the tools.
-    return initialize_agent(
-        tools,
-        llm,
-        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
-        verbose=True,
-    )
 
 
 def _validate_trace_json_serialization(trace):
@@ -414,18 +382,24 @@ def test_e2e_rag_model_tracing_in_serving(mock_databricks_serving_with_tracing_e
 
 
 def test_agent_success(mock_databricks_serving_with_tracing_env):
-    agent = create_openai_llmagent()
-    langchain_input = {"input": "What is 123 raised to the .023 power?"}
-    expected_output = {"output": "test"}
+    # Load the agent definition (with OpenAI mock) from the sample script
+    from tests.langchain.sample_code.openai_agent import create_openai_agent
+
+    agent = create_openai_agent()
+
+    langchain_input = {"input": "what is the value of magic_function(3)?"}
+    expected_output = {"output": "The result of 2 * 3 is 6."}
     request_id = "test_request_id"
     response, trace_dict = _predict_with_callbacks(agent, request_id, langchain_input)
 
     assert response == expected_output
-    trace = Trace.from_dict(trace_dict)
-    spans = trace.data.spans
-    assert len(spans) == 3
 
-    # AgentExecutor
+    trace = Trace.from_dict(trace_dict)
+    assert trace.info.status == "OK"
+
+    spans = trace.data.spans
+    assert len(spans) == 16
+
     root_span = spans[0]
     assert root_span.name == "AgentExecutor"
     assert root_span.span_type == "CHAIN"
@@ -436,20 +410,6 @@ def test_agent_success(mock_databricks_serving_with_tracing_env):
         root_span.end_time_ns // 1_000_000
         - (trace.info.timestamp_ms + trace.info.execution_time_ms)
     ) <= 1
-    root_span_id = root_span.span_id
-
-    # LLMChain of the agent
-    llm_chain_span = spans[1]
-    assert llm_chain_span.parent_id == root_span_id
-    assert llm_chain_span.span_type == "CHAIN"
-    assert llm_chain_span.inputs["input"] == langchain_input["input"]
-    assert llm_chain_span.outputs == {"text": "Final Answer: test"}
-
-    # LLM of the LLMChain
-    llm_span = spans[2]
-    assert llm_span.parent_id == llm_chain_span.span_id
-    assert llm_span.span_type == "LLM"
-    assert llm_span.outputs["generations"][0][0]["text"] == "Final Answer: test"
 
     _validate_trace_json_serialization(trace)
 

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -381,6 +381,10 @@ def test_e2e_rag_model_tracing_in_serving(mock_databricks_serving_with_tracing_e
     _validate_trace_json_serialization(trace)
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="ToolCall message is not available in older versions",
+)
 def test_agent_success(mock_databricks_serving_with_tracing_env):
     # Load the agent definition (with OpenAI mock) from the sample script
     from tests.langchain.sample_code.openai_agent import create_openai_agent


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13850?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13850/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13850
```

</p>
</details>

### What changes are proposed in this pull request?

Agent with the `llm-math` tool does not work with Pydantic 2.10.0. Indeed, the underlying class `LLMMathChain` was deprecated ([ref](https://api.python.langchain.com/en/latest/chains/langchain.chains.llm_math.base.LLMMathChain.html)) so the issue will not likely to be fixed soon. This PR changes the test model to use the custom tool rather than `llm-math`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
