### PR TITLE
Validate `username` and `password` are not empty

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -770,6 +770,10 @@ def create_user():
         username = request.form["username"]
         password = request.form["password"]
 
+        if not username or not password:
+            message = "Username and password cannot be empty."
+            return make_response(message, 400)
+
         if store.has_user(username):
             flash(f"Username has already been taken: {username}")
             return alert(href=SIGNUP)
@@ -780,6 +784,10 @@ def create_user():
     elif content_type == "application/json":
         username = _get_request_param("username")
         password = _get_request_param("password")
+
+        if not username or not password:
+            message = "Username and password cannot be empty."
+            return make_response(message, 400)
 
         user = store.create_user(username, password)
         return jsonify({"user": user.to_json()})

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -748,11 +748,11 @@ def signup():
   </div>
   <label for="username">Username:</label>
   <br>
-  <input type="text" id="username" name="username">
+  <input type="text" id="username" name="username" minlength="4">
   <br>
   <label for="password">Password:</label>
   <br>
-  <input type="password" id="password" name="password">
+  <input type="password" id="password" name="password" minlength="4">
   <br>
   <br>
   <input type="submit" value="Sign up">

--- a/tests/server/auth/auth_test_utils.py
+++ b/tests/server/auth/auth_test_utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from mlflow.environment_variables import MLFLOW_TRACKING_PASSWORD, MLFLOW_TRACKING_USERNAME
 from mlflow.server.auth import auth_config
 
@@ -10,9 +12,9 @@ ADMIN_USERNAME = auth_config.admin_username
 ADMIN_PASSWORD = auth_config.admin_password
 
 
-def create_user(tracking_uri):
-    username = random_str()
-    password = random_str()
+def create_user(tracking_uri: str, username: Optional[str] = None, password: Optional[str] = None):
+    username = random_str() if username is None else username
+    password = random_str() if password is None else password
     response = _send_rest_tracking_post_request(
         tracking_uri,
         "/api/2.0/mlflow/users/create",

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -63,6 +63,19 @@ def test_authenticate(client, monkeypatch):
         client.search_experiments()
 
 
+@pytest.mark.parametrize(
+    ("username", "password"),
+    [
+        ("", "password"),
+        ("username", ""),
+        ("", ""),
+    ],
+)
+def test_validate_username_and_password(client, username, password):
+    with pytest.raises(requests.exceptions.HTTPError, match=r"BAD REQUEST"):
+        create_user(client.tracking_uri, username=username, password=password)
+
+
 def _mlflow_search_experiments_rest(base_uri, headers):
     response = requests.post(
         f"{base_uri}/api/2.0/mlflow/experiments/search",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13854?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13854/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13854
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Validate `username` and `password` are not empty for the signup request.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
