### PR TITLE
Update ChatCompletionRequest and ChatCompletionResponse to use AnyType and allow more function types

### DIFF
--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -159,7 +159,7 @@ class ToolCall(_BaseDataclass):
     Args:
         function (:py:class:`FunctionToolCallArguments`): The arguments of the function tool call.
         id (str): The ID of the tool call. Defaults to a random UUID.
-        type (str): The type of the object.
+        type (str): The type of the object. Defaults to "function".
     """
 
     function: FunctionToolCallArguments

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -1,9 +1,9 @@
 import time
 import uuid
 from dataclasses import asdict, dataclass, field, fields
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
-from mlflow.types.schema import Array, ColSpec, DataType, Map, Object, Property, Schema
+from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
 
 # TODO: Switch to pydantic in a future version of MLflow.
 #       For now, to prevent adding pydantic as a core dependency,
@@ -159,12 +159,12 @@ class ToolCall(_BaseDataclass):
     Args:
         function (:py:class:`FunctionToolCallArguments`): The arguments of the function tool call.
         id (str): The ID of the tool call. Defaults to a random UUID.
-        type (str): The type of the object. Currently only "function" is supported.
+        type (str): The type of the object.
     """
 
     function: FunctionToolCallArguments
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    type: Literal["function"] = "function"
+    type: str = "function"
 
     def __post_init__(self):
         self._validate_field("id", str, True)
@@ -395,7 +395,7 @@ class ChatParams(_BaseDataclass):
         presence_penalty: (float): An optional param of positive or negative value,
             positive values penalize new tokens based on whether they appear in the text so far,
             increasing the model's likelihood to talk about new topics.
-        custom_inputs (Dict[str, str]): An optional param to provide arbitrary additional context
+        custom_inputs (Dict[str, Any]): An optional param to provide arbitrary additional context
             to the model. Both the keys and the values must be strings (i.e. nested dictionaries
             are not supported).
         tools (List[:py:class:`ToolDefinition`]): An optional list of tools that can be called by
@@ -413,7 +413,7 @@ class ChatParams(_BaseDataclass):
     frequency_penalty: Optional[float] = None
     presence_penalty: Optional[float] = None
 
-    custom_inputs: Optional[dict[str, str]] = None
+    custom_inputs: Optional[dict[str, Any]] = None
     tools: Optional[list[ToolDefinition]] = None
 
     def __post_init__(self):
@@ -439,14 +439,8 @@ class ChatParams(_BaseDataclass):
             for key, value in self.custom_inputs.items():
                 if not isinstance(key, str):
                     raise ValueError(
-                        "Expected `custom_inputs` to be of type `Dict[str, str]`, "
+                        "Expected `custom_inputs` to be of type `Dict[str, Any]`, "
                         f"received key of type `{type(key).__name__}` (key: {key})"
-                    )
-                if not isinstance(value, str):
-                    raise ValueError(
-                        "Expected `custom_inputs` to be of type `Dict[str, str]`, "
-                        f"received value of type `{type(value).__name__}` in "
-                        f"`custom_inputs['{key}']`)"
                     )
 
 
@@ -663,7 +657,7 @@ class ChatCompletionResponse(_BaseDataclass):
         object (str): The object type. Defaults to 'chat.completion'
         created (int): The time the response was created.
             **Optional**, defaults to the current time.
-        custom_outputs (Dict[str, str]): An field that can contain arbitrary additional context.
+        custom_outputs (Dict[str, Any]): An field that can contain arbitrary additional context.
             **Optional**, defaults to ``None``
     """
 
@@ -673,7 +667,7 @@ class ChatCompletionResponse(_BaseDataclass):
     model: Optional[str] = None
     object: str = "chat.completion"
     created: int = field(default_factory=lambda: int(time.time()))
-    custom_outputs: Optional[dict[str, str]] = None
+    custom_outputs: Optional[dict[str, Any]] = None
 
     def __post_init__(self):
         self._validate_field("id", str, False)
@@ -710,7 +704,7 @@ class ChatCompletionChunk(_BaseDataclass):
     model: Optional[str] = None
     object: str = "chat.completion.chunk"
     created: int = field(default_factory=lambda: int(time.time()))
-    custom_outputs: Optional[dict[str, str]] = None
+    custom_outputs: Optional[dict[str, Any]] = None
 
     def __post_init__(self):
         self._validate_field("id", str, False)
@@ -781,7 +775,7 @@ CHAT_MODEL_INPUT_SCHEMA = Schema(
             ),
             required=False,
         ),
-        ColSpec(name="custom_inputs", type=Map(DataType.string), required=False),
+        ColSpec(name="custom_inputs", type=Map(AnyType()), required=False),
     ]
 )
 
@@ -824,7 +818,7 @@ CHAT_MODEL_OUTPUT_SCHEMA = Schema(
             ),
             required=False,
         ),
-        ColSpec(name="custom_outputs", type=Map(DataType.string), required=False),
+        ColSpec(name="custom_outputs", type=Map(AnyType()), required=False),
     ]
 )
 

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -524,10 +524,7 @@ def test_chat_model_predict_stream(tmp_path):
 def test_chat_model_can_receive_and_return_metadata():
     messages = [{"role": "user", "content": "Hello!"}]
     params = {
-        "custom_inputs": {
-            "image_url": "example",
-            "detail": "high",
-        },
+        "custom_inputs": {"image_url": "example", "detail": "high", "other_dict": {"key": "value"}},
     }
     input_example = {
         "messages": messages,

--- a/tests/pyfunc/test_chat_model_validation.py
+++ b/tests/pyfunc/test_chat_model_validation.py
@@ -224,10 +224,6 @@ def test_chat_response_defaults():
     ("custom_inputs", "match"),
     [
         (1, r"Expected `custom_inputs` to be a dictionary, received `int`"),
-        (
-            {"nested": {"dict": "input"}},
-            r"received value of type `dict` in `custom_inputs\['nested'\]`",
-        ),
         ({1: "example"}, r"received key of type `int` \(key: 1\)"),
     ],
 )

--- a/tests/pyfunc/test_chat_model_validation.py
+++ b/tests/pyfunc/test_chat_model_validation.py
@@ -231,7 +231,7 @@ def test_chat_response_defaults():
         ({1: "example"}, r"received key of type `int` \(key: 1\)"),
     ],
 )
-def test_chat_request_custom_inputs_must_be_string_map(custom_inputs, match):
+def test_chat_request_custom_inputs_must_be_valid_map(custom_inputs, match):
     message = ChatMessage("user", "Hello")
     with pytest.raises(ValueError, match=match):
         ChatCompletionRequest(messages=[message], custom_inputs=custom_inputs)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/stevenchen-db/mlflow/pull/13857?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13857/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13857
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Update custom_inputs and custom_outputs in the ChatCompletionRequest and ChatCompletionResponse to use the newly introduced AnyType. In addition, this PR makes a small fix to the function type to allow specifying other types like "uc_function"

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
