### PR TITLE
Allow changing max_workers for built-in LLM-as-a-Judge metrics

### DIFF
--- a/mlflow/metrics/genai/metric_definitions.py
+++ b/mlflow/metrics/genai/metric_definitions.py
@@ -19,6 +19,7 @@ def answer_similarity(
     parameters: Optional[dict[str, Any]] = None,
     extra_headers: Optional[dict[str, str]] = None,
     proxy_url: Optional[str] = None,
+    max_workers: int = 10,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the answer similarity of an LLM
@@ -53,6 +54,8 @@ def answer_similarity(
             judge model is served via a proxy endpoint, not directly via LLM provider services.
             If not specified, the default URL for the LLM provider will be used
             (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
+        max_workers: (Optional) The maximum number of workers to use for judge scoring.
+            Defaults to 10 workers.
 
     Returns:
         A metric object
@@ -94,6 +97,7 @@ def answer_similarity(
         metric_metadata=metric_metadata,
         extra_headers=extra_headers,
         proxy_url=proxy_url,
+        max_workers=max_workers,
     )
 
 
@@ -106,6 +110,7 @@ def answer_correctness(
     parameters: Optional[dict[str, Any]] = None,
     extra_headers: Optional[dict[str, str]] = None,
     proxy_url: Optional[str] = None,
+    max_workers: int = 10,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the answer correctness of an LLM
@@ -142,6 +147,8 @@ def answer_correctness(
             judge model is served via a proxy endpoint, not directly via LLM provider services.
             If not specified, the default URL for the LLM provider will be used
             (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
+        max_workers: (Optional) The maximum number of workers to use for judge scoring.
+            Defaults to 10 workers.
 
     Returns:
         A metric object
@@ -182,6 +189,7 @@ def answer_correctness(
         metric_metadata=metric_metadata,
         extra_headers=extra_headers,
         proxy_url=proxy_url,
+        max_workers=max_workers,
     )
 
 
@@ -194,6 +202,7 @@ def faithfulness(
     parameters: Optional[dict[str, Any]] = None,
     extra_headers: Optional[dict[str, str]] = None,
     proxy_url: Optional[str] = None,
+    max_workers: int = 10,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the faithfullness of an LLM using the
@@ -228,6 +237,8 @@ def faithfulness(
             judge model is served via a proxy endpoint, not directly via LLM provider services.
             If not specified, the default URL for the LLM provider will be used
             (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
+        max_workers: (Optional) The maximum number of workers to use for judge scoring.
+            Defaults to 10 workers.
 
     Returns:
         A metric object
@@ -267,6 +278,7 @@ def faithfulness(
         metric_metadata=metric_metadata,
         extra_headers=extra_headers,
         proxy_url=proxy_url,
+        max_workers=max_workers,
     )
 
 
@@ -279,6 +291,7 @@ def answer_relevance(
     parameters: Optional[dict[str, Any]] = None,
     extra_headers: Optional[dict[str, str]] = None,
     proxy_url: Optional[str] = None,
+    max_workers: int = 10,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the answer relevance of an LLM
@@ -309,6 +322,8 @@ def answer_relevance(
             judge model is served via a proxy endpoint, not directly via LLM provider services.
             If not specified, the default URL for the LLM provider will be used
             (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
+        max_workers: (Optional) The maximum number of workers to use for judge scoring.
+            Defaults to 10 workers.
 
     Returns:
         A metric object
@@ -346,6 +361,7 @@ def answer_relevance(
         metric_metadata=metric_metadata,
         extra_headers=extra_headers,
         proxy_url=proxy_url,
+        max_workers=max_workers,
     )
 
 
@@ -357,6 +373,7 @@ def relevance(
     parameters: Optional[dict[str, Any]] = None,
     extra_headers: Optional[dict[str, str]] = None,
     proxy_url: Optional[str] = None,
+    max_workers: int = 10,
 ) -> EvaluationMetric:
     """
     This function will create a genai metric used to evaluate the evaluate the relevance of an
@@ -392,6 +409,8 @@ def relevance(
             judge model is served via a proxy endpoint, not directly via LLM provider services.
             If not specified, the default URL for the LLM provider will be used
             (e.g., https://api.openai.com/v1/chat/completions for OpenAI chat models).
+        max_workers: (Optional) The maximum number of workers to use for judge scoring.
+            Defaults to 10 workers.
 
     Returns:
         A metric object
@@ -432,4 +451,5 @@ def relevance(
         metric_metadata=metric_metadata,
         extra_headers=extra_headers,
         proxy_url=proxy_url,
+        max_workers=max_workers,
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13858?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13858/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13858
```

</p>
</details>

### What changes are proposed in this pull request?

Allow specifying `max_workers` parameter for built-in LLM-as-a-Judge metrics such as `answer_correctness()`, so that users can control the max parallelization to their judge endpoint. Currently, while the parameter exists in the`mlflow.metric.genai.make_genai_metric()` function that is used within these built-in metrics definition, the parameter is not exposed for metrics functions, hence users cannot control it and face rate limiting errors.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Allow changing `max_workers` setting for built-in LLM-as-a-Judge metrics.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
