### PR TITLE
Raise an explicit error when 'databricks-agents' is missing

### DIFF
--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1225,6 +1225,16 @@ def test_resolve_evaluators_and_configs():
         resolve_evaluators_and_configs(["default", "dummy_evaluator"], {"abc": {"a": 3}})
 
 
+def test_resolve_evaluators_raise_for_missing_databricks_agent_dependency():
+    with pytest.raises(
+        MlflowException,
+        match="Databricks Agents SDK must be installed to use the `databricks-agent` model type.",
+    ):
+        resolve_evaluators_and_configs(
+            evaluators=None, evaluator_config=None, model_type="databricks-agent"
+        )
+
+
 def test_evaluate_env_manager_params(multiclass_logistic_regressor_model_uri, iris_dataset):
     model = mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13859?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13859/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13859
```

</p>
</details>

### What changes are proposed in this pull request?

Databricks users can run Mosaic AI Agent Evaluation by simply running the `mlflow.evaluate()` API with `model_type="databricks-agent"` parameter. It requires the `databrciks-agents` Python package to be installed, however, current error message when the package is not installed is not very helpful.

![Screenshot 2024-11-25 at 14 46 11](https://github.com/user-attachments/assets/6d89aa2f-46d3-462d-a239-19e08404aff7)

```
The model could not be evaluated by any of the registered evaluators, please verify that the model type and other configs are set correctly.
```

This PR adds an explicit check for the package existence when the model type is specified and raise an exception with more straight message.

**Note**: Ideally this kind of Databricks-only logic should reside in the custom evaluator implementation in their code base. However, since the entire evaluator itself is within the `databricks-agents` package, we need to catch it within MLflow side.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Running evaluation without `databricks-agents` installed:

![Screenshot 2024-11-25 at 14 41 57](https://github.com/user-attachments/assets/c093f02e-57dd-4b94-8120-3143caa87162)

After running `%pip install databricks-agents`

![Screenshot 2024-11-25 at 14 43 27](https://github.com/user-attachments/assets/c664e332-dacd-4fc0-8437-f5ce0ca22dfd)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
