### PR TITLE
Migrate OpenAI LLM judge implementation to use gateway provider

### DIFF
--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -337,7 +337,7 @@ class OpenAIProvider(BaseProvider):
             headers=self.headers,
             base_url=self.base_url,
             path="chat/completions",
-            payload=OpenAIAdapter.chat_to_model(payload, self.config),
+            payload=self.adapter_class.chat_to_model(payload, self.config),
         )
 
         async for chunk in handle_incomplete_chunks(stream):
@@ -362,7 +362,7 @@ class OpenAIProvider(BaseProvider):
             headers=self.headers,
             base_url=self.base_url,
             path="chat/completions",
-            payload=OpenAIAdapter.chat_to_model(payload, self.config),
+            payload=self.adapter_class.chat_to_model(payload, self.config),
         )
 
     async def _chat_uc_function(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
@@ -405,7 +405,7 @@ class OpenAIProvider(BaseProvider):
                 headers=self.headers,
                 base_url=self.base_url,
                 path="chat/completions",
-                payload=OpenAIAdapter.chat_to_model(
+                payload=self.adapter_class.chat_to_model(
                     {
                         **payload,
                         "messages": messages,
@@ -442,7 +442,7 @@ class OpenAIProvider(BaseProvider):
                     headers=self.headers,
                     base_url=self.base_url,
                     path="chat/completions",
-                    payload=OpenAIAdapter.chat_to_model(
+                    payload=self.adapter_class.chat_to_model(
                         {
                             **payload,
                             "messages": messages,
@@ -533,7 +533,7 @@ class OpenAIProvider(BaseProvider):
                 headers=self.headers,
                 base_url=self.base_url,
                 path="chat/completions",
-                payload=OpenAIAdapter.chat_to_model(payload, self.config),
+                payload=self.adapter_class.chat_to_model(payload, self.config),
             )
             token_usage_accumulator.update(resp.get("usage", {}))
 

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -1,12 +1,13 @@
 import json
 import os
 from typing import TYPE_CHECKING, AsyncIterable
+from urllib.parse import urlparse, urlunparse
 
 from mlflow.environment_variables import MLFLOW_ENABLE_UC_FUNCTIONS
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import OpenAIAPIType, OpenAIConfig, RouteConfig
 from mlflow.gateway.exceptions import AIGatewayException
-from mlflow.gateway.providers.base import BaseProvider
+from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat, completions, embeddings
 from mlflow.gateway.uc_function_utils import (
@@ -38,6 +39,212 @@ def _get_workspace_client():
         )
 
 
+class OpenAIAdapter(ProviderAdapter):
+    @classmethod
+    def chat_to_model(cls, payload, config):
+        return cls._add_model_to_payload_if_necessary(payload, config)
+
+    @classmethod
+    def completion_to_model(cls, payload, config):
+        payload["messages"] = [{"role": "user", "content": payload.pop("prompt")}]
+        return cls._add_model_to_payload_if_necessary(payload, config)
+
+    @classmethod
+    def embeddings_to_model(cls, payload, config):
+        return cls._add_model_to_payload_if_necessary(payload, config)
+
+    @classmethod
+    def _add_model_to_payload_if_necessary(cls, payload, config):
+        # NB: For Azure OpenAI, the deployment name (which is included in the URL) specifies
+        # the model; it is not specified in the payload. For OpenAI outside of Azure, the
+        # model is always specified in the payload
+        if config.model.config.openai_api_type not in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD):
+            return {"model": config.model.name, **payload}
+        else:
+            return payload
+
+    @classmethod
+    def model_to_chat(cls, resp, config):
+        # Response example (https://platform.openai.com/docs/api-reference/chat/create)
+        # ```
+        # {
+        #    "id":"chatcmpl-abc123",
+        #    "object":"chat.completion",
+        #    "created":1677858242,
+        #    "model":"gpt-4o-mini",
+        #    "usage":{
+        #       "prompt_tokens":13,
+        #       "completion_tokens":7,
+        #       "total_tokens":20
+        #    },
+        #    "choices":[
+        #       {
+        #          "message":{
+        #             "role":"assistant",
+        #             "content":"\n\nThis is a test!"
+        #          },
+        #          "finish_reason":"stop",
+        #          "index":0
+        #       }
+        #    ]
+        # }
+        # ```
+        return chat.ResponsePayload(
+            id=resp["id"],
+            object=resp["object"],
+            created=resp["created"],
+            model=resp["model"],
+            choices=[
+                chat.Choice(
+                    index=idx,
+                    message=chat.ResponseMessage(
+                        role=c["message"]["role"],
+                        content=c["message"].get("content"),
+                        tool_calls=(
+                            (calls := c["message"].get("tool_calls"))
+                            and [chat.ToolCall(**c) for c in calls]
+                        ),
+                    ),
+                    finish_reason=c.get("finish_reason"),
+                )
+                for idx, c in enumerate(resp["choices"])
+            ],
+            usage=chat.ChatUsage(
+                prompt_tokens=resp["usage"]["prompt_tokens"],
+                completion_tokens=resp["usage"]["completion_tokens"],
+                total_tokens=resp["usage"]["total_tokens"],
+            ),
+        )
+
+    @classmethod
+    def model_to_chat_streaming(cls, resp, config):
+        return chat.StreamResponsePayload(
+            id=resp["id"],
+            object=resp["object"],
+            created=resp["created"],
+            model=resp["model"],
+            choices=[
+                chat.StreamChoice(
+                    index=c["index"],
+                    finish_reason=c["finish_reason"],
+                    delta=chat.StreamDelta(
+                        role=c["delta"].get("role"), content=c["delta"].get("content")
+                    ),
+                )
+                for c in resp["choices"]
+            ],
+        )
+
+    @classmethod
+    def model_to_completions(self, resp, config):
+        # Response example (https://platform.openai.com/docs/api-reference/completions/create)
+        # ```
+        # {
+        #   "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+        #   "object": "text_completion",
+        #   "created": 1589478378,
+        #   "model": "text-davinci-003",
+        #   "choices": [
+        #     {
+        #       "text": "\n\nThis is indeed a test",
+        #       "index": 0,
+        #       "logprobs": null,
+        #       "finish_reason": "length"
+        #     }
+        #   ],
+        #   "usage": {
+        #     "prompt_tokens": 5,
+        #     "completion_tokens": 7,
+        #     "total_tokens": 12
+        #   }
+        # }
+        # ```
+        return completions.ResponsePayload(
+            id=resp["id"],
+            # The chat models response from OpenAI is of object type "chat.completion". Since
+            # we're using the completions response format here, we hardcode the "text_completion"
+            # object type in the response instead
+            object="text_completion",
+            created=resp["created"],
+            model=resp["model"],
+            choices=[
+                completions.Choice(
+                    index=idx,
+                    text=c["message"]["content"],
+                    finish_reason=c["finish_reason"],
+                )
+                for idx, c in enumerate(resp["choices"])
+            ],
+            usage=completions.CompletionsUsage(
+                prompt_tokens=resp["usage"]["prompt_tokens"],
+                completion_tokens=resp["usage"]["completion_tokens"],
+                total_tokens=resp["usage"]["total_tokens"],
+            ),
+        )
+
+    @classmethod
+    def model_to_completions_streaming(cls, resp, config):
+        return completions.StreamResponsePayload(
+            id=resp["id"],
+            # The chat models response from OpenAI is of object type "chat.completion.chunk".
+            # Since we're using the completions response format here, we hardcode the
+            # "text_completion_chunk" object type in the response instead
+            object="text_completion_chunk",
+            created=resp["created"],
+            model=resp["model"],
+            choices=[
+                completions.StreamChoice(
+                    index=c["index"],
+                    finish_reason=c["finish_reason"],
+                    delta=completions.StreamDelta(
+                        content=c["delta"].get("content"),
+                    ),
+                )
+                for c in resp["choices"]
+            ],
+        )
+
+    @classmethod
+    def model_to_embeddings(cls, resp, config):
+        # Response example (https://platform.openai.com/docs/api-reference/embeddings/create):
+        # ```
+        # {
+        #   "object": "list",
+        #   "data": [
+        #     {
+        #       "object": "embedding",
+        #       "embedding": [
+        #         0.0023064255,
+        #         -0.009327292,
+        #         .... (1536 floats total for ada-002)
+        #         -0.0028842222,
+        #       ],
+        #       "index": 0
+        #     }
+        #   ],
+        #   "model": "text-embedding-ada-002",
+        #   "usage": {
+        #     "prompt_tokens": 8,
+        #     "total_tokens": 8
+        #   }
+        # }
+        # ```
+        return embeddings.ResponsePayload(
+            data=[
+                embeddings.EmbeddingObject(
+                    embedding=d["embedding"],
+                    index=idx,
+                )
+                for idx, d in enumerate(resp["data"])
+            ],
+            model=resp["model"],
+            usage=embeddings.EmbeddingsUsage(
+                prompt_tokens=resp["usage"]["prompt_tokens"],
+                total_tokens=resp["usage"]["total_tokens"],
+            ),
+        )
+
+
 class OpenAIProvider(BaseProvider):
     NAME = "OpenAI"
     CONFIG_TYPE = OpenAIConfig
@@ -52,7 +259,7 @@ class OpenAIProvider(BaseProvider):
         self.openai_config: OpenAIConfig = config.model.config
 
     @property
-    def _request_base_url(self):
+    def base_url(self):
         api_type = self.openai_config.openai_api_type
         if api_type == OpenAIAPIType.OPENAI:
             base_url = self.openai_config.openai_api_base or "https://api.openai.com/v1"
@@ -77,7 +284,7 @@ class OpenAIProvider(BaseProvider):
             )
 
     @property
-    def _request_headers(self):
+    def headers(self):
         api_type = self.openai_config.openai_api_type
         if api_type == OpenAIAPIType.OPENAI:
             headers = {
@@ -99,14 +306,24 @@ class OpenAIProvider(BaseProvider):
                 f"Invalid OpenAI API type '{self.openai_config.openai_api_type}'"
             )
 
-    def _add_model_to_payload_if_necessary(self, payload):
-        # NB: For Azure OpenAI, the deployment name (which is included in the URL) specifies
-        # the model; it is not specified in the payload. For OpenAI outside of Azure, the
-        # model is always specified in the payload
-        if self.openai_config.openai_api_type not in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD):
-            return {"model": self.config.model.name, **payload}
+    @property
+    def adapter_class(self):
+        return OpenAIAdapter
+
+    def get_endpoint_url(self, route_type: str) -> str:
+        if route_type == "llm/v1/chat":
+            route_path = "chat/completions"
+        elif route_type == "llm/v1/completions":
+            route_path = "completions"
+        elif route_type == "llm/v1/embeddings":
+            route_path = "embeddings"
         else:
-            return payload
+            raise ValueError(f"Invalid route type {route_type}")
+
+        # Append the route path to the base URL. Note that we cannot simply append the route path
+        # at the end of the base URL because it has query parameters for the Azure OpenAI case.
+        parsed_base_url = urlparse(self.base_url)
+        return urlunparse(parsed_base_url._replace(path=f"{parsed_base_url.path}/{route_path}"))
 
     async def chat_stream(
         self, payload: chat.RequestPayload
@@ -117,10 +334,10 @@ class OpenAIProvider(BaseProvider):
         self.check_for_model_field(payload)
 
         stream = send_stream_request(
-            headers=self._request_headers,
-            base_url=self._request_base_url,
+            headers=self.headers,
+            base_url=self.base_url,
             path="chat/completions",
-            payload=self._add_model_to_payload_if_necessary(payload),
+            payload=OpenAIAdapter.chat_to_model(payload, self.config),
         )
 
         async for chunk in handle_incomplete_chunks(stream):
@@ -133,22 +350,7 @@ class OpenAIProvider(BaseProvider):
                 return
 
             resp = json.loads(data)
-            yield chat.StreamResponsePayload(
-                id=resp["id"],
-                object=resp["object"],
-                created=resp["created"],
-                model=resp["model"],
-                choices=[
-                    chat.StreamChoice(
-                        index=c["index"],
-                        finish_reason=c["finish_reason"],
-                        delta=chat.StreamDelta(
-                            role=c["delta"].get("role"), content=c["delta"].get("content")
-                        ),
-                    )
-                    for c in resp["choices"]
-                ],
-            )
+            yield OpenAIAdapter.model_to_chat_streaming(resp, self.config)
 
     async def _chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         from fastapi.encoders import jsonable_encoder
@@ -157,10 +359,10 @@ class OpenAIProvider(BaseProvider):
         self.check_for_model_field(payload)
 
         return await send_request(
-            headers=self._request_headers,
-            base_url=self._request_base_url,
+            headers=self.headers,
+            base_url=self.base_url,
             path="chat/completions",
-            payload=self._add_model_to_payload_if_necessary(payload),
+            payload=OpenAIAdapter.chat_to_model(payload, self.config),
         )
 
     async def _chat_uc_function(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
@@ -200,14 +402,15 @@ class OpenAIProvider(BaseProvider):
                 *user_tool_messages,
             ]
             resp = await send_request(
-                headers=self._request_headers,
-                base_url=self._request_base_url,
+                headers=self.headers,
+                base_url=self.base_url,
                 path="chat/completions",
-                payload=self._add_model_to_payload_if_necessary(
+                payload=OpenAIAdapter.chat_to_model(
                     {
                         **payload,
                         "messages": messages,
-                    }
+                    },
+                    self.config,
                 ),
             )
             token_usage_accumulator.update(resp.get("usage", {}))
@@ -236,14 +439,15 @@ class OpenAIProvider(BaseProvider):
             resp = None
             for _ in range(20):  # loop until we get a response without tool_calls
                 resp = await send_request(
-                    headers=self._request_headers,
-                    base_url=self._request_base_url,
+                    headers=self.headers,
+                    base_url=self.base_url,
                     path="chat/completions",
-                    payload=self._add_model_to_payload_if_necessary(
+                    payload=OpenAIAdapter.chat_to_model(
                         {
                             **payload,
                             "messages": messages,
-                        }
+                        },
+                        self.config,
                     ),
                 )
                 token_usage_accumulator.update(resp.get("usage", {}))
@@ -326,10 +530,10 @@ class OpenAIProvider(BaseProvider):
         else:
             # No UC functions to execute
             resp = await send_request(
-                headers=self._request_headers,
-                base_url=self._request_base_url,
+                headers=self.headers,
+                base_url=self.base_url,
                 path="chat/completions",
-                payload=self._add_model_to_payload_if_necessary(payload),
+                payload=OpenAIAdapter.chat_to_model(payload, self.config),
             )
             token_usage_accumulator.update(resp.get("usage", {}))
 
@@ -344,84 +548,7 @@ class OpenAIProvider(BaseProvider):
         else:
             resp = await self._chat(payload)
 
-        # Response example (https://platform.openai.com/docs/api-reference/chat/create)
-        # ```
-        # {
-        #    "id":"chatcmpl-abc123",
-        #    "object":"chat.completion",
-        #    "created":1677858242,
-        #    "model":"gpt-4o-mini",
-        #    "usage":{
-        #       "prompt_tokens":13,
-        #       "completion_tokens":7,
-        #       "total_tokens":20
-        #    },
-        #    "choices":[
-        #       {
-        #          "message":{
-        #             "role":"assistant",
-        #             "content":"\n\nThis is a test!"
-        #          },
-        #          "finish_reason":"stop",
-        #          "index":0
-        #       }
-        #    ]
-        # }
-        # ```
-        return chat.ResponsePayload(
-            id=resp["id"],
-            object=resp["object"],
-            created=resp["created"],
-            model=resp["model"],
-            choices=[
-                chat.Choice(
-                    index=idx,
-                    message=chat.ResponseMessage(
-                        role=c["message"]["role"],
-                        content=c["message"].get("content"),
-                        tool_calls=(
-                            (calls := c["message"].get("tool_calls"))
-                            and [chat.ToolCall(**c) for c in calls]
-                        ),
-                    ),
-                    finish_reason=c.get("finish_reason"),
-                )
-                for idx, c in enumerate(resp["choices"])
-            ],
-            usage=chat.ChatUsage(
-                prompt_tokens=resp["usage"]["prompt_tokens"],
-                completion_tokens=resp["usage"]["completion_tokens"],
-                total_tokens=resp["usage"]["total_tokens"],
-            ),
-        )
-
-    def _prepare_completion_request_payload(self, payload):
-        payload["messages"] = [{"role": "user", "content": payload.pop("prompt")}]
-        return payload
-
-    def _prepare_completion_response_payload(self, resp):
-        return completions.ResponsePayload(
-            id=resp["id"],
-            # The chat models response from OpenAI is of object type "chat.completion". Since
-            # we're using the completions response format here, we hardcode the "text_completion"
-            # object type in the response instead
-            object="text_completion",
-            created=resp["created"],
-            model=resp["model"],
-            choices=[
-                completions.Choice(
-                    index=idx,
-                    text=c["message"]["content"],
-                    finish_reason=c["finish_reason"],
-                )
-                for idx, c in enumerate(resp["choices"])
-            ],
-            usage=completions.CompletionsUsage(
-                prompt_tokens=resp["usage"]["prompt_tokens"],
-                completion_tokens=resp["usage"]["completion_tokens"],
-                total_tokens=resp["usage"]["total_tokens"],
-            ),
-        )
+        return OpenAIAdapter.model_to_chat(resp, self.config)
 
     async def completions_stream(
         self, payload: completions.RequestPayload
@@ -430,13 +557,11 @@ class OpenAIProvider(BaseProvider):
 
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
-        payload = self._prepare_completion_request_payload(payload)
-
         stream = send_stream_request(
-            headers=self._request_headers,
-            base_url=self._request_base_url,
+            headers=self.headers,
+            base_url=self.base_url,
             path="chat/completions",
-            payload=self._add_model_to_payload_if_necessary(payload),
+            payload=OpenAIAdapter.completion_to_model(payload, self.config),
         )
 
         async for chunk in handle_incomplete_chunks(stream):
@@ -449,62 +574,20 @@ class OpenAIProvider(BaseProvider):
                 return
 
             resp = json.loads(data)
-            yield completions.StreamResponsePayload(
-                id=resp["id"],
-                # The chat models response from OpenAI is of object type "chat.completion.chunk".
-                # Since we're using the completions response format here, we hardcode the
-                # "text_completion_chunk" object type in the response instead
-                object="text_completion_chunk",
-                created=resp["created"],
-                model=resp["model"],
-                choices=[
-                    completions.StreamChoice(
-                        index=c["index"],
-                        finish_reason=c["finish_reason"],
-                        delta=completions.StreamDelta(
-                            content=c["delta"].get("content"),
-                        ),
-                    )
-                    for c in resp["choices"]
-                ],
-            )
+            yield OpenAIAdapter.model_to_completions_streaming(resp, self.config)
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
         from fastapi.encoders import jsonable_encoder
 
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
-        payload = self._prepare_completion_request_payload(payload)
-
         resp = await send_request(
-            headers=self._request_headers,
-            base_url=self._request_base_url,
+            headers=self.headers,
+            base_url=self.base_url,
             path="chat/completions",
-            payload=self._add_model_to_payload_if_necessary(payload),
+            payload=OpenAIAdapter.completion_to_model(payload, self.config),
         )
-        # Response example (https://platform.openai.com/docs/api-reference/completions/create)
-        # ```
-        # {
-        #   "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
-        #   "object": "text_completion",
-        #   "created": 1589478378,
-        #   "model": "text-davinci-003",
-        #   "choices": [
-        #     {
-        #       "text": "\n\nThis is indeed a test",
-        #       "index": 0,
-        #       "logprobs": null,
-        #       "finish_reason": "length"
-        #     }
-        #   ],
-        #   "usage": {
-        #     "prompt_tokens": 5,
-        #     "completion_tokens": 7,
-        #     "total_tokens": 12
-        #   }
-        # }
-        # ```
-        return self._prepare_completion_response_payload(resp)
+        return OpenAIAdapter.model_to_completions(resp, self.config)
 
     async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
         from fastapi.encoders import jsonable_encoder
@@ -512,45 +595,9 @@ class OpenAIProvider(BaseProvider):
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         resp = await send_request(
-            headers=self._request_headers,
-            base_url=self._request_base_url,
+            headers=self.headers,
+            base_url=self.base_url,
             path="embeddings",
-            payload=self._add_model_to_payload_if_necessary(payload),
+            payload=OpenAIAdapter.embeddings_to_model(payload, self.config),
         )
-        # Response example (https://platform.openai.com/docs/api-reference/embeddings/create):
-        # ```
-        # {
-        #   "object": "list",
-        #   "data": [
-        #     {
-        #       "object": "embedding",
-        #       "embedding": [
-        #         0.0023064255,
-        #         -0.009327292,
-        #         .... (1536 floats total for ada-002)
-        #         -0.0028842222,
-        #       ],
-        #       "index": 0
-        #     }
-        #   ],
-        #   "model": "text-embedding-ada-002",
-        #   "usage": {
-        #     "prompt_tokens": 8,
-        #     "total_tokens": 8
-        #   }
-        # }
-        # ```
-        return embeddings.ResponsePayload(
-            data=[
-                embeddings.EmbeddingObject(
-                    embedding=d["embedding"],
-                    index=idx,
-                )
-                for idx, d in enumerate(resp["data"])
-            ],
-            model=resp["model"],
-            usage=embeddings.EmbeddingsUsage(
-                prompt_tokens=resp["usage"]["prompt_tokens"],
-                total_tokens=resp["usage"]["total_tokens"],
-            ),
-        )
+        return OpenAIAdapter.model_to_embeddings(resp, self.config)

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -10,8 +10,6 @@ import warnings
 from typing import Any, AsyncGenerator, Optional
 from urllib.parse import urlparse
 
-from starlette.responses import StreamingResponse
-
 from mlflow.environment_variables import MLFLOW_GATEWAY_URI
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES
@@ -302,6 +300,8 @@ async def handle_incomplete_chunks(
 
 
 async def make_streaming_response(resp):
+    from starlette.responses import StreamingResponse
+
     if isinstance(resp, AsyncGenerator):
         return StreamingResponse(
             (to_sse_chunk(d.json()) async for d in resp),

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -184,6 +184,7 @@ def _get_api_config() -> _OpenAIApiConfig:
         _OpenAIEnvVar.OPENAI_BASE_URL.value
     )
     deployment_id = os.getenv(_OpenAIEnvVar.OPENAI_DEPLOYMENT_NAME.value, None)
+    organization = os.getenv(_OpenAIEnvVar.OPENAI_ORGANIZATION.value, None)
     if api_type in ("azure", "azure_ad", "azuread"):
         batch_size = 16
         max_tokens_per_minute = 60_000
@@ -201,6 +202,7 @@ def _get_api_config() -> _OpenAIApiConfig:
         api_base=api_base,
         api_version=api_version,
         deployment_id=deployment_id,
+        organization=organization,
     )
 
 

--- a/mlflow/utils/openai_utils.py
+++ b/mlflow/utils/openai_utils.py
@@ -131,7 +131,7 @@ class _OpenAIApiConfig(NamedTuple):
     api_version: Optional[str]
     api_base: str
     deployment_id: Optional[str]
-    organization: Optional[str]
+    organization: Optional[str] = None
     max_retries: int = 5
     timeout: float = 60.0
 

--- a/mlflow/utils/openai_utils.py
+++ b/mlflow/utils/openai_utils.py
@@ -131,6 +131,7 @@ class _OpenAIApiConfig(NamedTuple):
     api_version: Optional[str]
     api_base: str
     deployment_id: Optional[str]
+    organization: Optional[str]
     max_retries: int = 5
     timeout: float = 60.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,7 @@ exclude = [
 ]
 
 [tool.clint.forbidden-top-level-imports]
-"mlflow/gateway/providers/*" = ["fastapi"]
+"mlflow/gateway/providers/*" = ["fastapi", "starlette"]
 
 # typos
 [tool.typos.default.extend-words]

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -90,7 +90,9 @@ def test_score_model_on_payload_throws_for_invalid():
 
 
 def test_score_model_openai_without_key():
-    with pytest.raises(MlflowException, match="OPENAI_API_KEY environment variable not set"):
+    with pytest.raises(
+        MlflowException, match="OpenAI API key must be set in the ``OPENAI_API_KEY``"
+    ):
         score_model_on_payload("openai:/gpt-4o-mini", "")
 
 
@@ -119,22 +121,27 @@ _OAI_RESPONSE = {
 
 
 def test_score_model_openai(set_envs):
-    with mock.patch("openai.OpenAI") as mock_client:
-        mock_client().chat.completions.create().model_dump.return_value = _OAI_RESPONSE
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_post:
         resp = score_model_on_payload("openai:/gpt-4o-mini", "my prompt", {"temperature": 0.1})
 
         assert resp == "\n\nThis is a test!"
-        mock_client().chat.completions.create.assert_called_with(
-            messages=[{"role": "user", "content": "my prompt"}],
-            model="gpt-4o-mini",
-            extra_headers={},
-            temperature=0.1,
+        mock_post.assert_called_once_with(
+            endpoint="https://api.openai.com/v1/chat/completions",
+            headers={"Authorization": "Bearer test"},
+            payload={
+                "messages": [{"role": "user", "content": "my prompt"}],
+                "model": "gpt-4o-mini",
+                "temperature": 0.1,
+            },
         )
 
 
 def test_score_model_openai_with_custom_header_and_proxy_url(set_envs):
-    with mock.patch("openai.OpenAI") as mock_client:
-        mock_client().chat.completions.create().model_dump.return_value = _OAI_RESPONSE
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_post:
         resp = score_model_on_payload(
             model_uri="openai:/gpt-4o-mini",
             payload="my prompt",
@@ -144,33 +151,40 @@ def test_score_model_openai_with_custom_header_and_proxy_url(set_envs):
         )
 
         assert resp == "\n\nThis is a test!"
-        mock_client().chat.completions.create.assert_called_with(
-            messages=[{"role": "user", "content": "my prompt"}],
-            model="gpt-4o-mini",
-            extra_headers={"foo": "bar"},
-            temperature=0.1,
+        mock_post.assert_called_once_with(
+            endpoint="https://my-proxy.com/chat",
+            headers={"Authorization": "Bearer test", "foo": "bar"},
+            payload={
+                "messages": [{"role": "user", "content": "my prompt"}],
+                "model": "gpt-4o-mini",
+                "temperature": 0.1,
+            },
         )
 
 
 def test_openai_other_error(set_envs):
-    with mock.patch("openai.OpenAI") as mock_client:
-        mock_client().chat.completions.create.side_effect = (Exception("foo"),)
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request",
+        side_effect=Exception("foo"),
+    ):
         with pytest.raises(Exception, match="foo"):
             score_model_on_payload("openai:/gpt-4o-mini", "my prompt", {"temperature": 0.1})
-        mock_client().chat.completions.create.assert_called_once()
 
 
 def test_score_model_azure_openai(set_azure_envs):
-    with mock.patch("openai.AzureOpenAI") as mock_client:
-        mock_client().chat.completions.create().model_dump.return_value = _OAI_RESPONSE
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_post:
         resp = score_model_on_payload("openai:/gpt-4o-mini", "my prompt", {"temperature": 0.1})
 
         assert resp == "\n\nThis is a test!"
-        mock_client().chat.completions.create.assert_called_with(
-            messages=[{"role": "user", "content": "my prompt"}],
-            model="gpt-4o-mini",
-            extra_headers={},
-            temperature=0.1,
+        mock_post.assert_called_once_with(
+            endpoint="https://openai-for.openai.azure.com/openai/deployments/test-openai/chat/completions?api-version=2023-05-15",
+            headers={"api-key": "test"},
+            payload={
+                "messages": [{"role": "user", "content": "my prompt"}],
+                "temperature": 0.1,
+            },
         )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13862?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13862/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13862
```

</p>
</details>

### What changes are proposed in this pull request?

In https://github.com/mlflow/mlflow/pull/13717, we added support for using non-OpenAI LLM providers as a "judge" model for LLM-as-a-Judge metrics, such as `anthoropic`. At this moment, the judge calling logic is different between OpenAI and non-OpenAI judges.

1. For OpenAI judges (e.g., `openai:/gpt-4o-mini`), we use OpenAI SDK to invoke their endpoints.
2. For non-OpenAI judges (e.g., `anthropic:/claude-3-5-sonnet-20241022`), we makes use of the adapter logic built for MLflow Gateway, which translate different request/response payload format into the OpenAI's standard format.

However, this decreases the code maintainability and cause unexpected behavior difference. Therefore, this PR migrates OpenAI judge implementation to use the adapter logic as well. This change is also required to support `proxy_endpoint` parameter.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested with (1) OpenAI (2) AzureOpenAI (3) Proxy endpoint

(1) OpenAI:
```
import os

with mlflow.start_run(run_name="eval-azure-openai"):
    results = mlflow.evaluate(
        data=eval_data,
        predictions="outputs",
        targets="ground_truth",
        extra_metrics=[answer_similarity(model="openai:/gpt-4o-mini")]
    )
    display(results.tables["eval_results_table"])
```

![Screenshot 2024-11-25 at 16 38 51](https://github.com/user-attachments/assets/d1200c1c-9176-4c73-ae92-43159537b7f5)


(2) Azure OpenAI:
```
import os

os.environ["OPENAI_API_KEY"] = "<my-aoai-key>"
os.environ["OPENAI_API_BASE"] = "<my-aoai-endpoint>"
os.environ["OPENAI_API_TYPE"] = "azure"
os.environ["OPENAI_API_VERSION"] = "2024-08-01-preview"
os.environ["OPENAI_DEPLOYMENT_NAME"] = "gpt-4o-mini"

with mlflow.start_run(run_name="eval-azure-openai"):
    results = mlflow.evaluate(
        data=eval_data,
        predictions="outputs",
        targets="ground_truth",
        extra_metrics=[answer_similarity(model="openai:/gpt-4o-mini")]
    )
    display(results.tables["eval_results_table"])
```

![Screenshot 2024-11-25 at 16 39 03](https://github.com/user-attachments/assets/051ff6ee-83c7-4204-8435-722180c9289f)


(3) Proxy endpoint:
(A [Databricks FMAPI](https://docs.databricks.com/en/machine-learning/foundation-models/index.html) endpoint has OpenAI compatible format but in a different URL path structure than OpenAI, therefore this is a good test case to test the `proxy_url` parameter).
```
similarity = answer_similarity(
      model="openai:/llama-3-1-70b-instruct",
      proxy_url="https://<test-workspace>/serving-endpoints/databricks-meta-llama-3-1-70b-instruct/invocations",
      extra_headers={"Authorization": f"Bearer {<MY_DB_TOKEN>}"}
)

with mlflow.start_run(run_name="eval_openai_proxy"):
    results = mlflow.evaluate(
        data=eval_data,
        predictions="outputs",
        targets="ground_truth",
        extra_metrics=[

        ]
    )
    display(results.tables["eval_results_table"])
```

![Screenshot 2024-11-25 at 16 39 20](https://github.com/user-attachments/assets/98c08f0a-5740-4d08-bd38-89231dce9f38)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
