### PR TITLE
Add API for disabling trace display

### DIFF
--- a/mlflow/tracing/__init__.py
+++ b/mlflow/tracing/__init__.py
@@ -1,12 +1,4 @@
-from mlflow.tracing.display import IPythonTraceDisplayHandler
+from mlflow.tracing.display import disable_notebook_display, enable_notebook_display
 from mlflow.tracing.provider import disable, enable
 
 __all__ = ["disable", "enable", "disable_notebook_display", "enable_notebook_display"]
-
-
-def disable_notebook_display():
-    IPythonTraceDisplayHandler.disable()
-
-
-def enable_notebook_display():
-    IPythonTraceDisplayHandler.enable()

--- a/mlflow/tracing/__init__.py
+++ b/mlflow/tracing/__init__.py
@@ -1,3 +1,12 @@
+from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.provider import disable, enable
 
-__all__ = ["disable", "enable"]
+__all__ = ["disable", "enable", "disable_notebook_display", "enable_notebook_display"]
+
+
+def disable_notebook_display():
+    get_display_handler().disable()
+
+
+def enable_notebook_display():
+    get_display_handler().enable()

--- a/mlflow/tracing/__init__.py
+++ b/mlflow/tracing/__init__.py
@@ -1,12 +1,12 @@
-from mlflow.tracing.display import get_display_handler
+from mlflow.tracing.display import IPythonTraceDisplayHandler
 from mlflow.tracing.provider import disable, enable
 
 __all__ = ["disable", "enable", "disable_notebook_display", "enable_notebook_display"]
 
 
 def disable_notebook_display():
-    get_display_handler().disable()
+    IPythonTraceDisplayHandler.disable()
 
 
 def enable_notebook_display():
-    get_display_handler().enable()
+    IPythonTraceDisplayHandler.enable()

--- a/mlflow/tracing/display/__init__.py
+++ b/mlflow/tracing/display/__init__.py
@@ -5,3 +5,27 @@ __all__ = ["IPythonTraceDisplayHandler", "get_display_handler"]
 
 def get_display_handler() -> IPythonTraceDisplayHandler:
     return IPythonTraceDisplayHandler.get_instance()
+
+
+def disable_notebook_display():
+    """
+    Disables displaying the MLflow Trace UI in notebook output cells.
+    Call :py:func:`mlflow.tracing.enable_notebook_display()` to re-enable display.
+    """
+    IPythonTraceDisplayHandler.disable()
+
+
+def enable_notebook_display():
+    """
+    Enables the MLflow Trace UI in notebook output cells. The display is on
+    by default, and the Trace UI will show up when any of the following operations
+    are executed:
+
+    * On trace completion (i.e. whenever a trace is exported)
+    * When calling the :py:func:`mlflow.search_traces` fluent API
+    * When calling the :py:meth:`mlflow.client.MlflowClient.get_trace`
+      or :py:meth:`mlflow.client.MlflowClient.search_traces` client APIs
+
+    To disable, please call :py:func:`mlflow.tracing.disable_notebook_display()`.
+    """
+    IPythonTraceDisplayHandler.enable()

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -1,14 +1,17 @@
 import json
 import logging
+from typing import TYPE_CHECKING
 
-from mlflow.entities import Trace
 from mlflow.environment_variables import MLFLOW_MAX_TRACES_TO_DISPLAY_IN_NOTEBOOK
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 
 _logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from mlflow.entities import Trace
 
-def _serialize_trace_list(traces: list[Trace]):
+
+def _serialize_trace_list(traces: list["Trace"]):
     return json.dumps(
         # we can't just call trace.to_json() because this
         # will cause the trace to be serialized twice (once
@@ -37,7 +40,6 @@ class IPythonTraceDisplayHandler:
         cls._disabled = False
         if cls._instance is None:
             cls._instance = IPythonTraceDisplayHandler()
-
 
     def __init__(self):
         # This only works in Databricks notebooks
@@ -95,7 +97,7 @@ class IPythonTraceDisplayHandler:
             # the core functionality if the display fails.
             _logger.debug("Failed to display traces", exc_info=True)
 
-    def get_mimebundle(self, traces: list[Trace]):
+    def get_mimebundle(self, traces: list["Trace"]):
         if len(traces) == 1:
             return traces[0]._repr_mimebundle_()
         else:
@@ -104,7 +106,7 @@ class IPythonTraceDisplayHandler:
                 "text/plain": repr(traces),
             }
 
-    def display_traces(self, traces: list[Trace]):
+    def display_traces(self, traces: list["Trace"]):
         # This only works in Databricks notebooks
         if not is_in_databricks_runtime() or self._disabled:
             return


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/13883?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/13883/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13883
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The approach here is simple, just adding a class variable that causes early return if set to true.

Note that we don't deregister the post-run hook, we just make it do nothing. This is for convenience, so we don't have to re-register it upon enabling. Since the trace display update function also returns early, there should not be any significant performance impact.

I will update the docs for this feature once it's available in OSS (should be some time this sprint).


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested manually in a notebook, defining a traced function `foo()` and disabling display before the cell finishes rendering.

<img width="856" alt="Screenshot 2024-11-27 at 3 45 12 PM" src="https://github.com/user-attachments/assets/7cb1b21a-bcc0-4d1c-a3e0-175ceb0616c0">


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
