### PR TITLE
Fix `mlflow.end_run` inside a MLflow run context manager

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -220,7 +220,7 @@ class ActiveRun(Run):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         active_run_stack = _active_run_stack.get()
-        if self in active_run_stack:  # Am I still active?
+        if self in active_run_stack:  # Is this run still active?
             status = RunStatus.FINISHED if exc_type is None else RunStatus.FAILED
             end_run(RunStatus.to_string(status))
         return exc_type is None

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -220,7 +220,7 @@ class ActiveRun(Run):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         active_run_stack = _active_run_stack.get()
-        if len(active_run_stack) > 0 and active_run_stack[-1] is self:
+        if self in active_run_stack:  # Am I still active?
             status = RunStatus.FINISHED if exc_type is None else RunStatus.FAILED
             end_run(RunStatus.to_string(status))
         return exc_type is None

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -219,8 +219,10 @@ class ActiveRun(Run):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        status = RunStatus.FINISHED if exc_type is None else RunStatus.FAILED
-        end_run(RunStatus.to_string(status))
+        active_run_stack = _active_run_stack.get()
+        if len(active_run_stack) > 0 and active_run_stack[-1] is self:
+            status = RunStatus.FINISHED if exc_type is None else RunStatus.FAILED
+            end_run(RunStatus.to_string(status))
         return exc_type is None
 
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1661,22 +1661,19 @@ def test_subprocess_inherit_registry_uri(tmp_path):
     assert sqlite_uri in stdout
 
 
-def test_end_run_inside_context_manager():
+def test_end_run_inside_start_run_context_manager():
     client = MlflowClient()
 
     with mlflow.start_run() as parent_run:
         with mlflow.start_run(nested=True) as child_run:
             mlflow.end_run("FAILED")
-            assert (
-                client.get_run(child_run.info.run_id).info.status
-                == RunStatus.to_string(RunStatus.FAILED)
+            assert client.get_run(child_run.info.run_id).info.status == RunStatus.to_string(
+                RunStatus.FAILED
             )
 
-        assert (
-            client.get_run(parent_run.info.run_id).info.status
-            == RunStatus.to_string(RunStatus.RUNNING)
+        assert client.get_run(parent_run.info.run_id).info.status == RunStatus.to_string(
+            RunStatus.RUNNING
         )
-    assert (
-        client.get_run(parent_run.info.run_id).info.status
-        == RunStatus.to_string(RunStatus.FINISHED)
+    assert client.get_run(parent_run.info.run_id).info.status == RunStatus.to_string(
+        RunStatus.FINISHED
     )

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1661,10 +1661,7 @@ def test_subprocess_inherit_registry_uri(tmp_path):
     assert sqlite_uri in stdout
 
 
-def test_end_run_inside_context_manager(tmp_path):
-    sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
-    mlflow.set_registry_uri(sqlite_uri)
-
+def test_end_run_inside_context_manager():
     client = MlflowClient()
 
     with mlflow.start_run() as parent_run:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/13888?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13888/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13888
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> closes #13874

### What changes are proposed in this pull request?

Fixes  #13874

Testing:
```
import mlflow

mlflow.set_experiment("nested_run_debugging")
with mlflow.start_run():
    for i in range(10):
        with mlflow.start_run(nested=True):
            mlflow.log_param("index", i)
            if i == 3:
                mlflow.end_run("FAILED")
```

Before:
![image](https://github.com/user-attachments/assets/075058a0-59d9-4b4f-b7f1-5e3475902cb3)

After:
<img width="481" alt="image" src="https://github.com/user-attachments/assets/ba8e94ac-7edf-4680-8b6d-c091b42412cd">


### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
