### PR TITLE
Fix mlflow.evaluate() to allow passing in a spark connect dataframe 

### DIFF
--- a/mlflow/data/evaluation_dataset.py
+++ b/mlflow/data/evaluation_dataset.py
@@ -180,9 +180,9 @@ def convert_data_to_mlflow_dataset(data, targets=None, predictions=None):
     """Convert input data to mlflow dataset."""
     supported_dataframe_types = [pd.DataFrame]
     if "pyspark" in sys.modules:
-        from pyspark.sql import DataFrame as SparkDataFrame
+        from mlflow.utils.spark_utils import get_spark_dataframe_type
 
-        supported_dataframe_types.append(SparkDataFrame)
+        spark_df_type = get_spark_dataframe_type()
 
     if predictions is not None:
         _validate_dataset_type_supports_predictions(
@@ -201,7 +201,7 @@ def convert_data_to_mlflow_dataset(data, targets=None, predictions=None):
         return mlflow.data.from_numpy(data, targets=targets)
     elif isinstance(data, pd.DataFrame):
         return mlflow.data.from_pandas(df=data, targets=targets, predictions=predictions)
-    elif "pyspark" in sys.modules and isinstance(data, SparkDataFrame):
+    elif "pyspark" in sys.modules and isinstance(data, spark_df_type):
         return mlflow.data.from_spark(df=data, targets=targets, predictions=predictions)
     else:
         # Cannot convert to mlflow dataset, return original data.
@@ -277,15 +277,10 @@ class EvaluationDataset:
             # add checking `'pyspark' in sys.modules` to avoid importing pyspark when user
             # run code not related to pyspark.
             if "pyspark" in sys.modules:
-                from mlflow.utils.spark_utils import is_spark_connect_mode
-
-                if is_spark_connect_mode():
-                    from pyspark.sql.connect.dataframe import DataFrame as SparkDataFrame
-                else:
-                    from pyspark.sql import DataFrame as SparkDataFrame
-
-                self._supported_dataframe_types = (pd.DataFrame, SparkDataFrame)
-                self._spark_df_type = SparkDataFrame
+                from mlflow.utils.spark_utils import get_spark_dataframe_type
+                spark_df_type = get_spark_dataframe_type()
+                self._supported_dataframe_types = (pd.DataFrame, spark_df_type)
+                self._spark_df_type = spark_df_type
         except ImportError:
             pass
 

--- a/mlflow/data/evaluation_dataset.py
+++ b/mlflow/data/evaluation_dataset.py
@@ -278,6 +278,7 @@ class EvaluationDataset:
             # run code not related to pyspark.
             if "pyspark" in sys.modules:
                 from mlflow.utils.spark_utils import is_spark_connect_mode
+
                 if is_spark_connect_mode():
                     from pyspark.sql.connect.dataframe import DataFrame as SparkDataFrame
                 else:

--- a/mlflow/data/evaluation_dataset.py
+++ b/mlflow/data/evaluation_dataset.py
@@ -278,6 +278,7 @@ class EvaluationDataset:
             # run code not related to pyspark.
             if "pyspark" in sys.modules:
                 from mlflow.utils.spark_utils import get_spark_dataframe_type
+
                 spark_df_type = get_spark_dataframe_type()
                 self._supported_dataframe_types = (pd.DataFrame, spark_df_type)
                 self._spark_df_type = spark_df_type

--- a/mlflow/data/evaluation_dataset.py
+++ b/mlflow/data/evaluation_dataset.py
@@ -277,7 +277,11 @@ class EvaluationDataset:
             # add checking `'pyspark' in sys.modules` to avoid importing pyspark when user
             # run code not related to pyspark.
             if "pyspark" in sys.modules:
-                from pyspark.sql import DataFrame as SparkDataFrame
+                from mlflow.utils.spark_utils import is_spark_connect_mode
+                if is_spark_connect_mode():
+                    from pyspark.sql.connect.dataframe import DataFrame as SparkDataFrame
+                else:
+                    from pyspark.sql import DataFrame as SparkDataFrame
 
                 self._supported_dataframe_types = (pd.DataFrame, SparkDataFrame)
                 self._spark_df_type = SparkDataFrame

--- a/mlflow/data/evaluation_dataset.py
+++ b/mlflow/data/evaluation_dataset.py
@@ -183,6 +183,7 @@ def convert_data_to_mlflow_dataset(data, targets=None, predictions=None):
         from mlflow.utils.spark_utils import get_spark_dataframe_type
 
         spark_df_type = get_spark_dataframe_type()
+        supported_dataframe_types.append(spark_df_type)
 
     if predictions is not None:
         _validate_dataset_type_supports_predictions(

--- a/mlflow/utils/spark_utils.py
+++ b/mlflow/utils/spark_utils.py
@@ -4,3 +4,12 @@ def is_spark_connect_mode():
     except ImportError:
         return False
     return is_remote()
+
+
+def get_spark_dataframe_type():
+    if is_spark_connect_mode():
+        from pyspark.sql.connect.dataframe import DataFrame as SparkDataFrame
+    else:
+        from pyspark.sql import DataFrame as SparkDataFrame
+
+    return SparkDataFrame


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/13889?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13889/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13889
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix mlflow.evaluate() to allow passing in a spark connect dataframe 

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
