### PR TITLE
Set dspy settings at `predict` call

### DIFF
--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -37,12 +37,8 @@ def _set_tracer_context(model_path, callbacks):
 def _load_model(model_uri, dst_path=None):
     import dspy
 
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path
-    )
-    flavor_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name="dspy"
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name="dspy")
 
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     model_path = flavor_conf.get("model_path", _DEFAULT_MODEL_PATH)

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
@@ -9,6 +10,8 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
 )
 from mlflow.pyfunc import PythonModel
+
+_logger = logging.getLogger(__name__)
 
 
 class DspyModelWrapper(PythonModel):
@@ -32,8 +35,11 @@ class DspyModelWrapper(PythonModel):
         self.model_config = model_config or {}
 
     def predict(self, inputs: Any, params: Optional[dict[str, Any]] = None):
+        import dspy
         import numpy as np
         import pandas as pd
+
+        dspy.settings.configure(**self.dspy_settings)
 
         supported_input_types = (np.ndarray, pd.DataFrame, str, dict)
         if not isinstance(inputs, supported_input_types):
@@ -68,6 +74,8 @@ class DspyChatModelWrapper(DspyModelWrapper):
     def predict(self, inputs: Any, params: Optional[dict[str, Any]] = None):
         import dspy
         import pandas as pd
+
+        dspy.settings.configure(**self.dspy_settings)
 
         if isinstance(inputs, dict):
             converted_inputs = inputs["messages"]
@@ -104,7 +112,10 @@ class DspyChatModelWrapper(DspyModelWrapper):
             choices.append(
                 {
                     "index": 0,
-                    "message": {"role": "assistant", "content": json.dumps(outputs.toDict())},
+                    "message": {
+                        "role": "assistant",
+                        "content": json.dumps(outputs.toDict()),
+                    },
                     "finish_reason": "stop",
                 }
             )
@@ -123,7 +134,10 @@ class DspyChatModelWrapper(DspyModelWrapper):
                     choices.append(
                         {
                             "index": 0,
-                            "message": {"role": role, "content": json.dumps(outputs.toDict())},
+                            "message": {
+                                "role": role,
+                                "content": json.dumps(outputs.toDict()),
+                            },
                             "finish_reason": "stop",
                         }
                     )

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -75,6 +75,8 @@ class DspyChatModelWrapper(DspyModelWrapper):
         import dspy
         import pandas as pd
 
+        # `dspy.settings` cannot be shared across threads, so we are setting it at every predict
+        # call.
         dspy.settings.configure(**self.dspy_settings)
 
         if isinstance(inputs, dict):

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -662,7 +662,7 @@ dspy:
     install_dev: |
       pip install git+https://github.com/stanfordnlp/dspy.git
   models:
-    minimum: "2.5.6"
+    minimum: "2.5.17"
     maximum: "2.5.31"
     requirements:
       ">= 0.0.0": ["openai"]

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -268,7 +268,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "dspy"
         },
         "models": {
-            "minimum": "2.5.6",
+            "minimum": "2.5.17",
             "maximum": "2.5.31"
         },
         "autologging": {

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -9,7 +9,6 @@ from dspy.utils.dummies import DSPDummyLM, dummy_rm
 import mlflow
 from mlflow.models import Model, ModelSignature
 from mlflow.types.schema import ColSpec, Schema
-
 from tests.helper_functions import (
     _assert_pip_requirements,
     _compare_logged_code_paths,
@@ -55,7 +54,12 @@ def test_basic_save():
 
 
 def test_save_compiled_model():
-    train_data = ["What is 2 + 2?", "What is 3 + 3?", "What is 4 + 4?", "What is 5 + 5?"]
+    train_data = [
+        "What is 2 + 2?",
+        "What is 3 + 3?",
+        "What is 4 + 4?",
+        "What is 5 + 5?",
+    ]
     train_label = ["4", "6", "8", "10"]
     trainset = [
         dspy.Example(question=q, answer=a).with_inputs("question")
@@ -84,7 +88,10 @@ def test_save_compiled_model():
     loaded_model = mlflow.dspy.load_model(model_url)
 
     assert isinstance(loaded_model, CoT)
-    assert loaded_model.prog.predictors()[0].demos == optimized_cot.prog.predictors()[0].demos
+    assert (
+        loaded_model.prog.predictors()[0].demos
+        == optimized_cot.prog.predictors()[0].demos
+    )
 
 
 def test_dspy_save_preserves_object_state():
@@ -107,7 +114,7 @@ def test_dspy_save_preserves_object_state():
             prediction = self.generate_answer(context=context, question=question)
             return dspy.Prediction(context=context, answer=prediction.answer)
 
-    def dummy_metric(program):
+    def dummy_metric(*args, **kwargs):
         return 1.0
 
     random_answers = ["4", "6", "8", "10"]
@@ -115,7 +122,12 @@ def test_dspy_save_preserves_object_state():
     rm = dummy_rm(passages=["dummy1", "dummy2", "dummy3"])
     dspy.settings.configure(lm=lm, rm=rm)
 
-    train_data = ["What is 2 + 2?", "What is 3 + 3?", "What is 4 + 4?", "What is 5 + 5?"]
+    train_data = [
+        "What is 2 + 2?",
+        "What is 3 + 3?",
+        "What is 4 + 4?",
+        "What is 5 + 5?",
+    ]
     train_label = ["4", "6", "8", "10"]
     trainset = [
         dspy.Example(question=q, answer=a).with_inputs("question")
@@ -192,10 +204,15 @@ def test_load_logged_model_in_native_dspy():
     loaded_dspy_model = mlflow.dspy.load_model(model_url)
 
     assert isinstance(loaded_dspy_model, CoT)
-    assert loaded_dspy_model.prog.predictors()[0].demos == dspy_model.prog.predictors()[0].demos
+    assert (
+        loaded_dspy_model.prog.predictors()[0].demos
+        == dspy_model.prog.predictors()[0].demos
+    )
 
 
 def test_serving_logged_model():
+    mlflow.dspy.autolog()
+
     # Need to redefine a CoT in the test case for cloudpickle to find the class.
     class CoT(dspy.Module):
         def __init__(self):
@@ -347,7 +364,9 @@ def test_additional_pip_requirements():
     artifact_path = "model"
     dspy_model = CoT()
     with mlflow.start_run():
-        mlflow.dspy.log_model(dspy_model, artifact_path, extra_pip_requirements=["dummy"])
+        mlflow.dspy.log_model(
+            dspy_model, artifact_path, extra_pip_requirements=["dummy"]
+        )
 
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, "dummy"]
@@ -366,5 +385,8 @@ def test_infer_signature_from_input_examples():
         loaded_model = Model.load(model_uri)
         assert loaded_model.signature.inputs == Schema([ColSpec("string")])
         assert loaded_model.signature.outputs == Schema(
-            [ColSpec(name="rationale", type="string"), ColSpec(name="answer", type="string")]
+            [
+                ColSpec(name="rationale", type="string"),
+                ColSpec(name="answer", type="string"),
+            ]
         )

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -9,6 +9,7 @@ from dspy.utils.dummies import DSPDummyLM, dummy_rm
 import mlflow
 from mlflow.models import Model, ModelSignature
 from mlflow.types.schema import ColSpec, Schema
+
 from tests.helper_functions import (
     _assert_pip_requirements,
     _compare_logged_code_paths,
@@ -88,10 +89,7 @@ def test_save_compiled_model():
     loaded_model = mlflow.dspy.load_model(model_url)
 
     assert isinstance(loaded_model, CoT)
-    assert (
-        loaded_model.prog.predictors()[0].demos
-        == optimized_cot.prog.predictors()[0].demos
-    )
+    assert loaded_model.prog.predictors()[0].demos == optimized_cot.prog.predictors()[0].demos
 
 
 def test_dspy_save_preserves_object_state():
@@ -204,15 +202,10 @@ def test_load_logged_model_in_native_dspy():
     loaded_dspy_model = mlflow.dspy.load_model(model_url)
 
     assert isinstance(loaded_dspy_model, CoT)
-    assert (
-        loaded_dspy_model.prog.predictors()[0].demos
-        == dspy_model.prog.predictors()[0].demos
-    )
+    assert loaded_dspy_model.prog.predictors()[0].demos == dspy_model.prog.predictors()[0].demos
 
 
 def test_serving_logged_model():
-    mlflow.dspy.autolog()
-
     # Need to redefine a CoT in the test case for cloudpickle to find the class.
     class CoT(dspy.Module):
         def __init__(self):
@@ -364,9 +357,7 @@ def test_additional_pip_requirements():
     artifact_path = "model"
     dspy_model = CoT()
     with mlflow.start_run():
-        mlflow.dspy.log_model(
-            dspy_model, artifact_path, extra_pip_requirements=["dummy"]
-        )
+        mlflow.dspy.log_model(dspy_model, artifact_path, extra_pip_requirements=["dummy"])
 
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, "dummy"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/13895?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13895/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13895
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Set dspy settings at `predict` call because DSPy recently introduces a more strict control over multithreading, which prevents the child thread to access the `dspy.settings` instance. This is fine if the `dspy.settings` is set at the main thread, however it is causing a problem in cloud platform's model serving, where `dspy.settings` is set in a child thread, and `predict` spawns new children threads. This PR keeps `dspy.settings` attached to the wrapper class, and explicitly configure the settings at every `predict()` call. Because it's all static information setup, the time cost increase is negligible. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
