### PR TITLE
Use a reusable workflow for cross-version tests

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -127,21 +127,21 @@ jobs:
             python dev/set_matrix.py
           fi
 
-  g1:
+  group1:
     needs: set-matrix
     if: ${{ needs.set-matrix.outputs.is_matrix1_empty == 'false' }}
     uses: ./.github/workflows/run-cross-version-tests.yml
     with:
       matrix: ${{ toJson(fromJson(needs.set-matrix.outputs.matrix1)) }}
 
-  g2:
+  group2:
     needs: set-matrix
     if: ${{ needs.set-matrix.outputs.is_matrix2_empty == 'false' }}
     uses: ./.github/workflows/run-cross-version-tests.yml
     with:
       matrix: ${{ toJson(fromJson(needs.set-matrix.outputs.matrix2)) }}
 
-  g3:
+  group3:
     needs: set-matrix
     if: ${{ needs.set-matrix.outputs.is_matrix3_empty == 'false' }}
     uses: ./.github/workflows/run-cross-version-tests.yml

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -64,8 +64,10 @@ jobs:
     outputs:
       matrix1: ${{ steps.set-matrix.outputs.matrix1 }}
       matrix2: ${{ steps.set-matrix.outputs.matrix2 }}
+      matrix3: ${{ steps.set-matrix.outputs.matrix2 }}
       is_matrix1_empty: ${{ steps.set-matrix.outputs.is_matrix1_empty }}
       is_matrix2_empty: ${{ steps.set-matrix.outputs.is_matrix2_empty }}
+      is_matrix3_empty: ${{ steps.set-matrix.outputs.is_matrix3_empty }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -125,94 +127,23 @@ jobs:
             python dev/set_matrix.py
           fi
 
-  test1:
+  g1:
     needs: set-matrix
-    if: ${{ needs.set-matrix.outputs.is_matrix1_empty == 'false' }}
-    runs-on: ${{ matrix.runs_on }}
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix1) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
-          ref: ${{ github.event.inputs.ref }}
-      - uses: ./.github/actions/free-disk-space
-        if: matrix.free_disk_space
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: ${{ matrix.python }}
-      - uses: ./.github/actions/setup-pyenv
-      - uses: ./.github/actions/setup-java
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Install mlflow & test dependencies
-        run: |
-          pip install wheel
-          pip install .[extras]
-          pip install -r requirements/test-requirements.txt
-      - name: Install ${{ matrix.package }} ${{ matrix.version }}
-        run: |
-          ${{ matrix.install }}
-      - uses: ./.github/actions/show-versions
-      - uses: ./.github/actions/pipdeptree
-      - name: Pre-test
-        if: matrix.pre_test
-        run: |
-          ${{ matrix.pre_test }}
-      - name: Run tests
-        env:
-          MLFLOW_CONDA_HOME: /usr/share/miniconda
-          SPARK_LOCAL_IP: localhost
-          JOHNSNOWLABS_LICENSE_JSON: ${{ secrets.JOHNSNOWLABS_LICENSE_JSON }}
-          HF_HUB_ENABLE_HF_TRANSFER: 1
-        run: |
-          ${{ matrix.run }}
+    uses: ./.github/workflows/run-cross-version-tests.yml
+    with:
+      matrix: ${{ toJson(fromJson(needs.set-matrix.outputs.matrix1)) }}
+      empty: ${{ needs.set-matrix.outputs.is_matrix1_empty }}
 
-  test2:
+  g2:
     needs: set-matrix
-    if: ${{ needs.set-matrix.outputs.is_matrix2_empty == 'false' }}
-    runs-on: ${{ matrix.runs_on }}
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix2) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
-          ref: ${{ github.event.inputs.ref }}
-      - uses: ./.github/actions/free-disk-space
-        if: matrix.free_disk_space
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: ${{ matrix.python }}
-      - uses: ./.github/actions/setup-pyenv
-      - uses: ./.github/actions/setup-java
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Install mlflow & test dependencies
-        run: |
-          pip install wheel
-          pip install .[extras]
-          pip install -r requirements/test-requirements.txt
-      - name: Install ${{ matrix.package }} ${{ matrix.version }}
-        run: |
-          ${{ matrix.install }}
-      - uses: ./.github/actions/show-versions
-      - uses: ./.github/actions/pipdeptree
-      - name: Pre-test
-        if: matrix.pre_test
-        run: |
-          ${{ matrix.pre_test }}
-      - name: Run tests
-        env:
-          MLFLOW_CONDA_HOME: /usr/share/miniconda
-          SPARK_LOCAL_IP: localhost
-          JOHNSNOWLABS_LICENSE_JSON: ${{ secrets.JOHNSNOWLABS_LICENSE_JSON }}
-          HF_HUB_ENABLE_HF_TRANSFER: 1
-        run: |
-          ${{ matrix.run }}
+    uses: ./.github/workflows/run-cross-version-tests.yml
+    with:
+      matrix: ${{ toJson(fromJson(needs.set-matrix.outputs.matrix2)) }}
+      empty: ${{ needs.set-matrix.outputs.is_matrix2_empty }}
+
+  g3:
+    needs: set-matrix
+    uses: ./.github/workflows/run-cross-version-tests.yml
+    with:
+      matrix: ${{ toJson(fromJson(needs.set-matrix.outputs.matrix3)) }}
+      empty: ${{ needs.set-matrix.outputs.is_matrix3_empty }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -129,21 +129,21 @@ jobs:
 
   g1:
     needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.is_matrix1_empty == 'false' }}
     uses: ./.github/workflows/run-cross-version-tests.yml
     with:
       matrix: ${{ toJson(fromJson(needs.set-matrix.outputs.matrix1)) }}
-      empty: ${{ needs.set-matrix.outputs.is_matrix1_empty }}
 
   g2:
     needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.is_matrix2_empty == 'false' }}
     uses: ./.github/workflows/run-cross-version-tests.yml
     with:
       matrix: ${{ toJson(fromJson(needs.set-matrix.outputs.matrix2)) }}
-      empty: ${{ needs.set-matrix.outputs.is_matrix2_empty }}
 
   g3:
     needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.is_matrix3_empty == 'false' }}
     uses: ./.github/workflows/run-cross-version-tests.yml
     with:
       matrix: ${{ toJson(fromJson(needs.set-matrix.outputs.matrix3)) }}
-      empty: ${{ needs.set-matrix.outputs.is_matrix3_empty }}

--- a/.github/workflows/run-cross-version-tests.yml
+++ b/.github/workflows/run-cross-version-tests.yml
@@ -1,0 +1,72 @@
+name: Run cross version tests
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        required: true
+        type: string
+      empty:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -exo pipefail {0}
+
+env:
+  MLFLOW_HOME: /home/runner/work/mlflow/mlflow
+  PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+
+jobs:
+  run:
+    if: ${{ inputs.empty == 'false' }}
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(inputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+      - uses: ./.github/actions/free-disk-space
+        if: matrix.free_disk_space
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Install mlflow & test dependencies
+        run: |
+          pip install wheel
+          pip install .[extras]
+          pip install -r requirements/test-requirements.txt
+      - name: Install ${{ matrix.package }} ${{ matrix.version }}
+        run: |
+          ${{ matrix.install }}
+      - uses: ./.github/actions/show-versions
+      - uses: ./.github/actions/pipdeptree
+      - name: Pre-test
+        if: matrix.pre_test
+        run: |
+          ${{ matrix.pre_test }}
+      - name: Run tests
+        env:
+          MLFLOW_CONDA_HOME: /usr/share/miniconda
+          SPARK_LOCAL_IP: localhost
+          JOHNSNOWLABS_LICENSE_JSON: ${{ secrets.JOHNSNOWLABS_LICENSE_JSON }}
+          HF_HUB_ENABLE_HF_TRANSFER: 1
+        run: |
+          ${{ matrix.run }}

--- a/.github/workflows/run-cross-version-tests.yml
+++ b/.github/workflows/run-cross-version-tests.yml
@@ -6,9 +6,6 @@ on:
       matrix:
         required: true
         type: string
-      empty:
-        required: true
-        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/run-cross-version-tests.yml
+++ b/.github/workflows/run-cross-version-tests.yml
@@ -24,7 +24,6 @@ env:
 
 jobs:
   run:
-    if: ${{ inputs.empty == 'false' }}
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 120
     strategy:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -718,31 +718,11 @@ def split(matrix, n):
         yield chunk
 
 
-def validate_action_config(num_jobs: int):
-    with open(".github/workflows/cross-version-tests.yml") as f:
-        s = f.read()
-    s = re.sub(
-        r"needs\.set-matrix\.outputs\.matrix\d",
-        "needs.set-matrix.outputs.matrix",
-        s,
-    )
-    s = re.sub(
-        r"needs\.set-matrix\.outputs\.is_matrix\d_empty",
-        "needs.set-matrix.outputs.is_matrix_empty",
-        s,
-    )
-    jobs = yaml.safe_load(s)["jobs"]
-    jobs = [v for name, v in jobs.items() if name.startswith("test")]
-    assert len(jobs) == num_jobs, f"Expected {num_jobs} jobs, but got {len(jobs)}"
-    assert all(jobs[0] == j for j in jobs[1:]), "All jobs must have the same configuration"
-
-
 def main(args):
     # https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
     # > A job matrix can generate a maximum of 256 jobs per workflow run.
     MAX_ITEMS = 256
-    NUM_JOBS = 2
-    validate_action_config(NUM_JOBS)
+    NUM_JOBS = 3
 
     print(divider("Parameters"))
     print(json.dumps(args, indent=2))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13898?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13898/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13898
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use a reusable workflow to DRY the cross-version tests config.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
