### PR TITLE
Log more git info as run tags

### DIFF
--- a/mlflow/tracking/context/git_context.py
+++ b/mlflow/tracking/context/git_context.py
@@ -1,32 +1,22 @@
-import logging
+import functools
+from typing import Optional
 
 from mlflow.tracking.context.abstract_context import RunContextProvider
 from mlflow.tracking.context.default_context import _get_main_file
-from mlflow.utils.git_utils import get_git_commit
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
-
-_logger = logging.getLogger(__name__)
-
-
-def _get_source_version():
-    main_file = _get_main_file()
-    if main_file is not None:
-        return get_git_commit(main_file)
-    return None
+from mlflow.utils.git_utils import GitInfo
 
 
 class GitRunContext(RunContextProvider):
-    def __init__(self):
-        self._cache = {}
-
-    @property
-    def _source_version(self):
-        if "source_version" not in self._cache:
-            self._cache["source_version"] = _get_source_version()
-        return self._cache["source_version"]
+    @functools.cached_property
+    def _git_info(self) -> Optional[GitInfo]:
+        if main_file := _get_main_file():
+            return GitInfo.load(main_file)
+        return None
 
     def in_context(self):
-        return self._source_version is not None
+        return self._git_info is not None
 
-    def tags(self):
-        return {MLFLOW_GIT_COMMIT: self._source_version}
+    def tags(self) -> dict[str, str]:
+        if self._git_info:
+            return self._git_info.to_mlflow_tags()
+        return {}

--- a/mlflow/tracking/context/git_context.py
+++ b/mlflow/tracking/context/git_context.py
@@ -10,7 +10,7 @@ class GitRunContext(RunContextProvider):
     @functools.cached_property
     def _git_info(self) -> Optional[GitInfo]:
         if main_file := _get_main_file():
-            return GitInfo.load(main_file)
+            return GitInfo.from_path(main_file)
         return None
 
     def in_context(self):

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -26,7 +26,7 @@ class GitInfo:
         return tags
 
     @classmethod
-    def load(cls, path: str) -> Optional["GitInfo"]:
+    def from_path(cls, path: str) -> Optional["GitInfo"]:
         try:
             from git import Repo
         except ImportError as e:
@@ -54,12 +54,13 @@ class GitInfo:
             return None
 
 
+# TODO: Remove the following functions in favor of the GitInfo class.
 def get_git_repo_url(path: str) -> Optional[str]:
     """
     Obtains the url of the git repository associated with the specified path,
     returning ``None`` if the path does not correspond to a git repository.
     """
-    return info.url if (info := GitInfo.load(path)) else None
+    return info.url if (info := GitInfo.from_path(path)) else None
 
 
 def get_git_commit(path: str) -> Optional[str]:
@@ -68,7 +69,7 @@ def get_git_commit(path: str) -> Optional[str]:
     with the specified path, returning ``None`` if the path does not correspond to a git
     repository.
     """
-    return info.commit if (info := GitInfo.load(path)) else None
+    return info.commit if (info := GitInfo.from_path(path)) else None
 
 
 def get_git_branch(path: str) -> Optional[str]:
@@ -76,4 +77,4 @@ def get_git_branch(path: str) -> Optional[str]:
     Obtains the name of the current branch of the git repository associated with the specified
     path, returning ``None`` if the path does not correspond to a git repository.
     """
-    return info.branch if (info := GitInfo.load(path)) else None
+    return info.branch if (info := GitInfo.from_path(path)) else None

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -1,8 +1,57 @@
 import logging
-import os
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
+from mlflow.utils import mlflow_tags
+
 _logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GitInfo:
+    commit: str
+    branch: str
+    url: Optional[str] = None
+
+    def to_mlflow_tags(self) -> dict[str, str]:
+        tags = {
+            mlflow_tags.MLFLOW_GIT_COMMIT: self.commit,
+            mlflow_tags.LEGACY_MLFLOW_GIT_BRANCH_NAME: self.branch,
+            mlflow_tags.MLFLOW_GIT_BRANCH: self.branch,
+        }
+        if self.url:
+            tags[mlflow_tags.MLFLOW_GIT_REPO_URL] = self.url
+            tags[mlflow_tags.LEGACY_MLFLOW_GIT_REPO_URL] = self.url
+        return tags
+
+    @classmethod
+    def load(cls, path: str) -> Optional["GitInfo"]:
+        try:
+            from git import Repo
+        except ImportError as e:
+            _logger.warning(
+                "Failed to import Git (the Git executable is probably not on your PATH),"
+                " so Git SHA is not available. Error: %s",
+                e,
+            )
+            return None
+
+        try:
+            path = Path(path)
+            if path.is_file():
+                path = path.parent
+            repo = Repo(path, search_parent_directories=True)
+            if str(path) in repo.ignored(path):
+                return None
+
+            return cls(
+                commit=repo.head.commit.hexsha,
+                branch=repo.active_branch.name,
+                url=next((r.url for r in repo.remotes), None),
+            )
+        except Exception:
+            return None
 
 
 def get_git_repo_url(path: str) -> Optional[str]:
@@ -10,21 +59,7 @@ def get_git_repo_url(path: str) -> Optional[str]:
     Obtains the url of the git repository associated with the specified path,
     returning ``None`` if the path does not correspond to a git repository.
     """
-    try:
-        from git import Repo
-    except ImportError as e:
-        _logger.warning(
-            "Failed to import Git (the Git executable is probably not on your PATH),"
-            " so Git SHA is not available. Error: %s",
-            e,
-        )
-        return None
-
-    try:
-        repo = Repo(path, search_parent_directories=True)
-        return next((remote.url for remote in repo.remotes), None)
-    except Exception:
-        return None
+    return info.url if (info := GitInfo.load(path)) else None
 
 
 def get_git_commit(path: str) -> Optional[str]:
@@ -33,24 +68,7 @@ def get_git_commit(path: str) -> Optional[str]:
     with the specified path, returning ``None`` if the path does not correspond to a git
     repository.
     """
-    try:
-        from git import Repo
-    except ImportError as e:
-        _logger.warning(
-            "Failed to import Git (the Git executable is probably not on your PATH),"
-            " so Git SHA is not available. Error: %s",
-            e,
-        )
-        return None
-    try:
-        if os.path.isfile(path):
-            path = os.path.dirname(os.path.abspath(path))
-        repo = Repo(path, search_parent_directories=True)
-        if path in repo.ignored(path):
-            return None
-        return repo.head.commit.hexsha
-    except Exception:
-        return None
+    return info.commit if (info := GitInfo.load(path)) else None
 
 
 def get_git_branch(path: str) -> Optional[str]:
@@ -58,20 +76,4 @@ def get_git_branch(path: str) -> Optional[str]:
     Obtains the name of the current branch of the git repository associated with the specified
     path, returning ``None`` if the path does not correspond to a git repository.
     """
-    try:
-        from git import Repo
-    except ImportError as e:
-        _logger.warning(
-            "Failed to import Git (the Git executable is probably not on your PATH),"
-            " so Git SHA is not available. Error: %s",
-            e,
-        )
-        return None
-
-    try:
-        if os.path.isfile(path):
-            path = os.path.dirname(path)
-        repo = Repo(path, search_parent_directories=True)
-        return repo.active_branch.name
-    except Exception:
-        return None
+    return info.branch if (info := GitInfo.load(path)) else None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13904?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13904/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13904
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

A fix for that LinkedIn post. Logs a few more GitHub tags.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
