### PR TITLE
Add log_trace option to mlflow.autolog

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -187,7 +187,7 @@ jobs:
           source .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
           # transformers doesn't support Keras 3 yet. tf-keras needs to be installed as a workaround.
-          pip install tf-keras
+          pip install tf-keras uvicorn
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -188,6 +188,8 @@ jobs:
           source ./dev/install-common-deps.sh --ml
           # transformers doesn't support Keras 3 yet. tf-keras needs to be installed as a workaround.
           pip install tf-keras uvicorn
+          # Required by mlflow.litellm. Temporarily update the version here due to version conflict with dspy.
+          pip install "litellm>=1.52.9"
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Run tests

--- a/mlflow/autogen/__init__.py
+++ b/mlflow/autogen/__init__.py
@@ -29,7 +29,7 @@ def autolog(
     # caveat is that the wrapped function is NOT executed when disable=True is passed. This prevents
     # us from running cleaning up logging when autologging is turned off. To workaround this, we
     # annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
-    # TODO: since this implementation is inconsistent, explore an universal way to solve the issue.
+    # TODO: since this implementation is inconsistent, explore a universal way to solve the issue.
     if log_traces and not disable:
         runtime_logging.start(logger=MlflowAutogenLogger())
     else:

--- a/mlflow/autogen/__init__.py
+++ b/mlflow/autogen/__init__.py
@@ -29,12 +29,17 @@ def autolog(
     # caveat is that the wrapped function is NOT executed when disable=True is passed. This prevents
     # us from running cleaning up logging when autologging is turned off. To workaround this, we
     # annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
+    # TODO: since this implementation is inconsistent, explore an universal way to solve the issue.
     if log_traces and not disable:
         runtime_logging.start(logger=MlflowAutogenLogger())
     else:
         runtime_logging.stop()
 
     _autolog(log_traces=log_traces, disable=disable, silent=silent)
+
+
+# This is required by mlflow.autolog()
+autolog.integration_name = FLAVOR_NAME
 
 
 @autologging_integration(FLAVOR_NAME)

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -27,6 +27,7 @@ def autolog(
     # us from running cleaning up logging when autologging is turned off. To workaround this, we
     # annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
     # This needs to be called before doing any safe-patching (otherwise safe-patch will be no-op).
+    # TODO: since this implementation is inconsistent, explore an universal way to solve the issue.
     _autolog(log_traces=log_traces, disable=disable, silent=silent)
 
     import dspy
@@ -74,6 +75,10 @@ def autolog(
             call_patch,
             trace_disabled_fn,
         )
+
+
+# This is required by mlflow.autolog()
+autolog.integration_name = FLAVOR_NAME
 
 
 @autologging_integration(FLAVOR_NAME)

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -27,7 +27,7 @@ def autolog(
     # us from running cleaning up logging when autologging is turned off. To workaround this, we
     # annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
     # This needs to be called before doing any safe-patching (otherwise safe-patch will be no-op).
-    # TODO: since this implementation is inconsistent, explore an universal way to solve the issue.
+    # TODO: since this implementation is inconsistent, explore a universal way to solve the issue.
     _autolog(log_traces=log_traces, disable=disable, silent=silent)
 
     import dspy

--- a/mlflow/litellm/__init__.py
+++ b/mlflow/litellm/__init__.py
@@ -35,7 +35,7 @@ def autolog(
     # the wrapped function is NOT executed when disable=True is passed. As a workaround,
     # we annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
     # This needs to be called before doing any safe-patching (otherwise safe-patch will be no-op).
-    # TODO: since this implementation is inconsistent, explore an universal way to solve the issue.
+    # TODO: since this implementation is inconsistent, explore a universal way to solve the issue.
     _autolog(log_traces=log_traces, disable=disable, silent=silent)
 
     if log_traces and not disable:

--- a/mlflow/litellm/__init__.py
+++ b/mlflow/litellm/__init__.py
@@ -31,7 +31,11 @@ def autolog(
     """
     import litellm
 
+    # NB: The @autologging_integration annotation is used for adding shared logic. However,
+    # the wrapped function is NOT executed when disable=True is passed. As a workaround,
+    # we annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
     # This needs to be called before doing any safe-patching (otherwise safe-patch will be no-op).
+    # TODO: since this implementation is inconsistent, explore an universal way to solve the issue.
     _autolog(log_traces=log_traces, disable=disable, silent=silent)
 
     if log_traces and not disable:
@@ -70,6 +74,10 @@ def autolog(
         # Callback also needs to be removed from 'callbacks' as litellm adds
         # success/failure callbacks to there as well.
         litellm.callbacks = _remove_mlflow_callbacks(litellm.callbacks)
+
+
+# This is required by mlflow.autolog()
+autolog.integration_name = FLAVOR_NAME
 
 
 # NB: The @autologging_integration annotation must be applied here, and the callback injection

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -574,7 +574,7 @@ def autolog(
     # caveat is that the wrapped function is NOT executed when disable=True is passed. This prevents
     # us from running cleaning up logging when autologging is turned off. To workaround this, we
     # annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
-    # TODO: since this implementation is inconsistent, explore an universal way to solve the issue.
+    # TODO: since this implementation is inconsistent, explore a universal way to solve the issue.
     if log_traces and not disable:
         set_llama_index_tracer()
     else:

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -574,12 +574,17 @@ def autolog(
     # caveat is that the wrapped function is NOT executed when disable=True is passed. This prevents
     # us from running cleaning up logging when autologging is turned off. To workaround this, we
     # annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
+    # TODO: since this implementation is inconsistent, explore an universal way to solve the issue.
     if log_traces and not disable:
         set_llama_index_tracer()
     else:
         remove_llama_index_tracer()
 
     _autolog(log_traces=log_traces, disable=disable, silent=silent)
+
+
+# This is required by mlflow.autolog()
+autolog.integration_name = FLAVOR_NAME
 
 
 @autologging_integration(FLAVOR_NAME)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2389,8 +2389,8 @@ def autolog(
         "dspy": "mlflow.dspy",
     }
 
-    # Currently genai libraries are not auto-logged when disable=False on Databricks.
-    # Remove this logic once a feature flag is implemented in Databricks Runtime init logic.
+    # Currently, GenAI libraries are not auto-logged when disable=False on Databricks.
+    # TODO: Remove this logic once a feature flag is implemented in Databricks Runtime init logic.
     if is_in_databricks_runtime() and (not disable):
         target_library_and_module = LIBRARY_TO_AUTOLOG_MODULE
     else:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2473,7 +2473,7 @@ def autolog(
         setup_autologging(pyspark_module)
         setup_autologging(pyspark_ml_module)
     else:
-        if "spark" in target_library_and_module:
+        if "pyspark" in target_library_and_module:
             register_post_import_hook(setup_autologging, "pyspark", overwrite=True)
         if "pyspark.ml" in target_library_and_module:
             register_post_import_hook(setup_autologging, "pyspark.ml", overwrite=True)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2389,7 +2389,9 @@ def autolog(
         "dspy": "mlflow.dspy",
     }
 
-    # Currently, GenAI libraries are not auto-logged when disable=False on Databricks.
+    # Currently, GenAI libraries are not enabled by `mlflow.autolog` in Databricks,
+    # particularly when disable=False. This is because the function is automatically invoked
+    # by system and we don't want to take the risk of enabling GenAI libraries all at once.
     # TODO: Remove this logic once a feature flag is implemented in Databricks Runtime init logic.
     if is_in_databricks_runtime() and (not disable):
         target_library_and_module = LIBRARY_TO_AUTOLOG_MODULE
@@ -2460,8 +2462,8 @@ def autolog(
     # for each autolog library (except pyspark), register a post-import hook.
     # this way, we do not send any errors to the user until we know they are using the library.
     # the post-import hook also retroactively activates for previously-imported libraries.
-    for module in list(set(target_library_and_module.keys()) - {"pyspark", "pyspark.ml"}):
-        register_post_import_hook(setup_autologging, module, overwrite=True)
+    for library in list(set(target_library_and_module) - {"pyspark", "pyspark.ml"}):
+        register_post_import_hook(setup_autologging, library, overwrite=True)
 
     if is_in_databricks_runtime():
         # for pyspark, we activate autologging immediately, without waiting for a module import.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2401,7 +2401,7 @@ def autolog(
     if exclude_flavors:
         excluded_modules = [f"mlflow.{flavor}" for flavor in exclude_flavors]
         target_library_and_module = {
-            k: v for k, v in LIBRARY_TO_AUTOLOG_MODULE.items() if v not in excluded_modules
+            k: v for k, v in target_library_and_module.items() if v not in excluded_modules
         }
 
     def get_autologging_params(autolog_fn):
@@ -2462,7 +2462,7 @@ def autolog(
     # for each autolog library (except pyspark), register a post-import hook.
     # this way, we do not send any errors to the user until we know they are using the library.
     # the post-import hook also retroactively activates for previously-imported libraries.
-    for library in list(set(target_library_and_module) - {"pyspark", "pyspark.ml"}):
+    for library in sorted(set(target_library_and_module) - {"pyspark", "pyspark.ml"}):
         register_post_import_hook(setup_autologging, library, overwrite=True)
 
     if is_in_databricks_runtime():

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -10,8 +10,8 @@ fastai>=2.4.1
 # TODO: Remove `<3.8` once we bump the minimim supported python version of MLflow to 3.9.
 spacy>=3.3.0,<3.8
 # Required by mlflow.tensorflow
-tensorflow>=2.10.0
-# tensorflow-macos>=2.10.0  # Comment out the line above and uncomment this line if setting up dev
+# tensorflow>=2.10.0
+tensorflow-macos>=2.10.0  # Comment out the line above and uncomment this line if setting up dev
                             # environment on local ARM macOS.
                             # Only do this for the purpose of setting up the dev environment, do not
                             # commit this change to the repo.
@@ -75,3 +75,13 @@ langchain
 promptflow
 # Required by mlflow.sentence_transformers
 sentence-transformers
+# mlflow.anthropic
+anthropic
+# mlflow.autogen
+autogen
+# mlflow.dspy
+dspy
+# mlflow.litellm
+litellm
+# gemini
+google-generativeai

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -82,6 +82,6 @@ autogen
 # Required by mlflow.dspy
 dspy>=2.5.17
 # Required by mlflow.litellm
-litellm>=1.52.9
+litellm>=1.51.0
 # Required by mlflow.gemini
 google-generativeai

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -80,8 +80,8 @@ anthropic
 # Required by mlflow.autogen
 autogen
 # Required by mlflow.dspy
-dspy>=2.5.17
+dspy
 # Required by mlflow.litellm
-litellm>=1.51.0
+litellm
 # Required by mlflow.gemini
 google-generativeai

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -75,13 +75,13 @@ langchain
 promptflow
 # Required by mlflow.sentence_transformers
 sentence-transformers
-# mlflow.anthropic
+# Required by mlflow.anthropic
 anthropic
-# mlflow.autogen
+# Required by mlflow.autogen
 autogen
-# mlflow.dspy
+# Required by mlflow.dspy
 dspy
-# mlflow.litellm
-litellm
-# gemini
+# Required by mlflow.litellm
+litellm>=1.49.0
+# Required by mlflow.gemini
 google-generativeai

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -10,8 +10,8 @@ fastai>=2.4.1
 # TODO: Remove `<3.8` once we bump the minimim supported python version of MLflow to 3.9.
 spacy>=3.3.0,<3.8
 # Required by mlflow.tensorflow
-# tensorflow>=2.10.0
-tensorflow-macos>=2.10.0  # Comment out the line above and uncomment this line if setting up dev
+tensorflow>=2.10.0
+# tensorflow-macos>=2.10.0  # Comment out the line above and uncomment this line if setting up dev
                             # environment on local ARM macOS.
                             # Only do this for the purpose of setting up the dev environment, do not
                             # commit this change to the repo.

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -80,7 +80,7 @@ anthropic
 # Required by mlflow.autogen
 autogen
 # Required by mlflow.dspy
-dspy
+dspy>=2.5.17
 # Required by mlflow.litellm
 litellm>=1.52.9
 # Required by mlflow.gemini

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -82,6 +82,6 @@ autogen
 # Required by mlflow.dspy
 dspy
 # Required by mlflow.litellm
-litellm>=1.49.0
+litellm>=1.52.9
 # Required by mlflow.gemini
 google-generativeai

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -3,10 +3,18 @@ from collections import namedtuple
 from io import StringIO
 from unittest import mock
 
+import anthropic
+import autogen
+import dspy
 import fastai
+import google.generativeai
 import keras
+import langchain
 import lightgbm
 import lightning
+import litellm
+import llama_index.core
+import openai
 import pyspark
 import pyspark.ml
 import pytest
@@ -44,6 +52,14 @@ library_to_mlflow_module_without_spark_datasource = {
     lightning: mlflow.pytorch,
     transformers: mlflow.transformers,
     setfit: mlflow.transformers,
+    openai: mlflow.openai,
+    llama_index.core: mlflow.llama_index,
+    langchain: mlflow.langchain,
+    anthropic: mlflow.anthropic,
+    autogen: mlflow.autogen,
+    dspy: mlflow.dspy,
+    litellm: mlflow.litellm,
+    google.generativeai: mlflow.gemini,
 }
 
 library_to_mlflow_module = {
@@ -142,6 +158,7 @@ def test_universal_autolog_calls_specific_autologs_correctly(library, mlflow_mod
     args_to_test = {
         "log_models": False,
         "log_datasets": False,
+        "log_traces": False,
         "disable": True,
         "exclusive": True,
         "disable_for_unsupported_versions": True,

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -396,13 +396,13 @@ def test_autolog_excluded_flavors(library, mlflow_module):
 # Tests for auto tracing
 @pytest.fixture
 def mock_openai(monkeypatch):
-    monkeypatch.setenvs(
-        {
-            "OPENAI_API_KEY": "test",
-            "OPENAI_API_BASE": mock_openai,
-        }
-    )
     with start_mock_openai_server() as base_url:
+        monkeypatch.setenvs(
+            {
+                "OPENAI_API_KEY": "test",
+                "OPENAI_API_BASE": base_url,
+            }
+        )
         yield base_url
 
 

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -321,7 +321,7 @@ def test_autolog_success_message_obeys_disabled():
         autolog_logger_mock.assert_called()
 
 
-# Currently some genai integrations do not fully obey silent argument
+# Currently some GenAI integrations do not fully follow standard autolog annotation
 @pytest.mark.parametrize("library", library_to_mlflow_module_traditional_ai.keys())
 @pytest.mark.parametrize("disable", [False, True])
 @pytest.mark.parametrize("exclusive", [False, True])

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -393,7 +393,7 @@ def test_extra_tags_mlflow_autolog():
 
 @pytest.mark.parametrize(("library", "mlflow_module"), library_to_mlflow_module.items())
 def test_excluded_flavors(library, mlflow_module):
-    mlflow.autolog(excluded_flavors=[mlflow_module.__name__.replace("mlflow.", "")])
+    mlflow.autolog(exclude_flavors=[mlflow_module.__name__.replace("mlflow.", "")])
     mlflow.utils.import_hooks.notify_module_loaded(library)
 
     assert get_autologging_config(mlflow_module.autolog.integration_name, "disable") is None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/13913?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13913/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13913
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Add `log_traces arg` and `exclude_flavors` to mlflow.autolog.
- Include newly added GenAI integrations to mlflow.autolog
- Add `exclude_flavors` arg to partially optout from auto-logging

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Confirmed the following code created traces
```python
import openai
import mlflow

mlflow.autolog()
mlflow.set_experiment("OpenAI")

openai_client = openai.OpenAI()

messages = [
    {
        "role": "user",
        "content": "How can I improve my resting metabolic rate most effectively?",
    }
]

response = openai_client.chat.completions.create(
    model="gpt-4o",
    messages=messages,
    temperature=0.99,
)

print(response)
```

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
