### PR TITLE
Suppress "Failed to detach context" warning from OpenTelemetry

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -184,6 +184,17 @@ def _setup_tracer_provider(disabled=False):
     tracer_provider.add_span_processor(processor)
     _MLFLOW_TRACER_PROVIDER = tracer_provider
 
+    from mlflow.tracing.utils.token import suppress_token_detach_warning_to_debug_level
+
+    # Demote the "Failed to detach context" log raised by the OpenTelemetry logger to DEBUG
+    # level so that it does not show up in the user's console. This warning may indicate
+    # some incorrect context handling, but in many cases just false positive that does not
+    # cause any issue in the generated trace.
+    # Note that we need to apply it permanently rather than just the scope of prediction call,
+    # because the exception can happen for streaming case, where the error log might be
+    # generated when the iterator is consumed and we don't know when it will happen.
+    suppress_token_detach_warning_to_debug_level()
+
 
 @raise_as_trace_exception
 def disable():

--- a/mlflow/tracing/utils/token.py
+++ b/mlflow/tracing/utils/token.py
@@ -31,9 +31,10 @@ class LogDemotionFilter(logging.Filter):
             record.levelno = logging.DEBUG  # Change the log level to DEBUG
             record.levelname = "DEBUG"
 
-        # Check the log level for the logger is debug or not
-        logger = logging.getLogger(self.module)
-        return logger.isEnabledFor(logging.DEBUG)
+            # Check the log level for the logger is debug or not
+            logger = logging.getLogger(self.module)
+            return logger.isEnabledFor(logging.DEBUG)
+        return True
 
 
 def suppress_token_detach_warning_to_debug_level():

--- a/mlflow/tracing/utils/token.py
+++ b/mlflow/tracing/utils/token.py
@@ -1,4 +1,5 @@
 import contextvars
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
@@ -17,3 +18,31 @@ class SpanWithToken:
 
     span: LiveSpan
     token: Optional[contextvars.Token] = None
+
+
+class LogDemotionFilter(logging.Filter):
+    def __init__(self, module: str, message: str):
+        super().__init__()
+        self.module = module
+        self.message = message
+
+    def filter(self, record):
+        if record.name == self.module and self.message in record.getMessage():
+            record.levelno = logging.DEBUG  # Change the log level to DEBUG
+            record.levelname = "DEBUG"
+
+        # Check the log level for the logger is debug or not
+        logger = logging.getLogger(self.module)
+        return logger.isEnabledFor(logging.DEBUG)
+
+
+def suppress_token_detach_warning_to_debug_level():
+    """
+    Convert the "Failed to detach context" log raised by the OpenTelemetry logger to DEBUG
+    level so that it does not show up in the user's console.
+    """
+    from opentelemetry.context import logger as otel_logger
+
+    if not any(isinstance(f, LogDemotionFilter) for f in otel_logger.filters):
+        log_filter = LogDemotionFilter("opentelemetry.context", "Failed to detach context")
+        otel_logger.addFilter(log_filter)

--- a/mlflow/tracing/utils/token.py
+++ b/mlflow/tracing/utils/token.py
@@ -26,7 +26,7 @@ class LogDemotionFilter(logging.Filter):
         self.module = module
         self.message = message
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         if record.name == self.module and self.message in record.getMessage():
             record.levelno = logging.DEBUG  # Change the log level to DEBUG
             record.levelname = "DEBUG"

--- a/tests/tracing/utils/test_token.py
+++ b/tests/tracing/utils/test_token.py
@@ -1,0 +1,22 @@
+import logging
+
+from mlflow.tracing.utils.token import suppress_token_detach_warning_to_debug_level
+
+
+def test_suppress_token_detach_warning(caplog):
+    logger = logging.getLogger("opentelemetry.context")
+
+    logger.exception("Failed to detach context")
+    assert caplog.records[0].message == "Failed to detach context"
+    assert caplog.records[0].levelname == "ERROR"
+
+    suppress_token_detach_warning_to_debug_level()
+
+    logger.exception("Failed to detach context")  # This should be logged as DEBUG level
+    logger.exception("Another error")  # This should be logged as is
+
+    assert caplog.records[1].message == "Failed to detach context"
+    assert caplog.records[1].levelname == "DEBUG"
+
+    assert caplog.records[2].message == "Another error"
+    assert caplog.records[2].levelname == "ERROR"

--- a/tests/tracing/utils/test_token.py
+++ b/tests/tracing/utils/test_token.py
@@ -5,6 +5,7 @@ from mlflow.tracing.utils.token import suppress_token_detach_warning_to_debug_le
 
 def test_suppress_token_detach_warning(caplog):
     logger = logging.getLogger("opentelemetry.context")
+    logger.setLevel(logging.INFO)
 
     logger.exception("Failed to detach context")
     assert caplog.records[0].message == "Failed to detach context"

--- a/tests/tracing/utils/test_token.py
+++ b/tests/tracing/utils/test_token.py
@@ -12,11 +12,17 @@ def test_suppress_token_detach_warning(caplog):
 
     suppress_token_detach_warning_to_debug_level()
 
-    logger.exception("Failed to detach context")  # This should be logged as DEBUG level
-    logger.exception("Another error")  # This should be logged as is
+    logger.exception("Failed to detach context")
+    assert len(caplog.records) == 1  # If the log level is not debug, the log shouldn't be recorded
 
-    assert caplog.records[1].message == "Failed to detach context"
-    assert caplog.records[1].levelname == "DEBUG"
+    logger.exception("Another error")  # Other type of error log should still be recorded
+    assert len(caplog.records) == 2
+    assert caplog.records[1].message == "Another error"
 
-    assert caplog.records[2].message == "Another error"
-    assert caplog.records[2].levelname == "ERROR"
+    # If we change the log level to debug, the log should be recorded at the debug level
+    logger.setLevel(logging.DEBUG)
+
+    logger.exception("Failed to detach context")
+
+    assert caplog.records[2].message == "Failed to detach context"
+    assert caplog.records[2].levelname == "DEBUG"

--- a/tests/tracing/utils/test_token.py
+++ b/tests/tracing/utils/test_token.py
@@ -6,6 +6,7 @@ from mlflow.tracing.utils.token import suppress_token_detach_warning_to_debug_le
 def test_suppress_token_detach_warning(caplog):
     logger = logging.getLogger("opentelemetry.context")
     logger.setLevel(logging.INFO)
+    logger.removeFilter(logger.filters[0])
 
     logger.exception("Failed to detach context")
     assert caplog.records[0].message == "Failed to detach context"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13914?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13914/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13914
```

</p>
</details>

### What changes are proposed in this pull request?

When OpenTelemetry span is created in one thread (or async task) and then finished in another thread, it raises the following warning:

```
ValueError: <Token var=<ContextVar name='current_context' default={} at 0x7ff7c4a1be20> at 0x7ff79095f540> was created in a different Context
```

OpenTelemetry manages active span via [ContextVar](https://docs.python.org/3/library/contextvars.html), which is isolated between threads or async tasks. This warning claims the span is created with one context, but then finished in different context.

While this is sometimes problematic, it does not necessarily has impact to the tracing. For example, LangChain does many tricky handling for context e.g., run some code within a cloned context, even if it is not multi-thread or async execution. In such case, this warning is shown but the trace is created perfectly, which will confuse users.

Since it is not realistic for us to workaround all of those different context hacks in 3P libraries, this PR just address the issue by demoting the warning to debug level, so it won't be surfaced to users at least.

In case if this issue actually break tracing, it should be captured by current test suites (we also have a [validation](https://github.com/mlflow/mlflow/blob/b527225ff53e82c9d7a0c425f079fc5382d2bb58/tests/conftest.py#L74-L91) for 'leaked' span context at every test case).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Before**:
![Screenshot 2024-11-29 at 14 08 20](https://github.com/user-attachments/assets/2f5d239d-36a6-4c7a-a8aa-17fd4afdd92a)

**After**:
![Screenshot 2024-11-29 at 14 08 13](https://github.com/user-attachments/assets/5e776a48-9730-4d1f-9222-6a674ef861d3)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
