### PR TITLE
Only test every 10 version of OpenAI

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -84,7 +84,7 @@ class TestConfig(BaseModel, extra="forbid"):
     run: str
     allow_unreleased_max_version: Optional[bool] = None
     pre_test: Optional[str] = None
-    test_every_n_versions: Optional[int] = 1
+    test_every_n_versions: int = 1
 
     class Config:
         arbitrary_types_allowed = True

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -569,7 +569,7 @@ def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[Matrix
 
             # Test every n minor versions if specified
             if cfg.test_every_n_versions > 1:
-                versions = versions[:: -cfg.test_every_n_versions][::-1]
+                versions = sorted(versions)[:: -cfg.test_every_n_versions][::-1]
 
             # Always test the minimum version
             if cfg.minimum not in versions:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -205,13 +205,7 @@ def get_latest_micro_versions(versions):
 
 
 def filter_versions(
-    flavor,
-    versions,
-    min_ver,
-    max_ver,
-    unsupported=None,
-    allow_unreleased_max_version=False,
-    test_every_n_versions=1,
+    flavor, versions, min_ver, max_ver, unsupported=None, allow_unreleased_max_version=False
 ):
     """
     Returns the versions that satisfy the following conditions:
@@ -250,7 +244,7 @@ def filter_versions(
             ],
             versions,
         )
-    )[::-test_every_n_versions][::-1]
+    )
 
 
 FLAVOR_FILE_PATTERN = re.compile(r"^(mlflow|tests)/(.+?)(_autolog(ging)?)?(\.py|/)")
@@ -570,9 +564,12 @@ def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[Matrix
                 cfg.maximum,
                 cfg.unsupported or [],
                 allow_unreleased_max_version=cfg.allow_unreleased_max_version or False,
-                test_every_n_versions=cfg.test_every_n_versions,
             )
             versions = get_latest_micro_versions(versions)
+
+            # Test every n minor versions if specified
+            if cfg.test_every_n_versions > 1:
+                versions = versions[:: -cfg.test_every_n_versions][::-1]
 
             # Always test the minimum version
             if cfg.minimum not in versions:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -84,6 +84,7 @@ class TestConfig(BaseModel, extra="forbid"):
     run: str
     allow_unreleased_max_version: Optional[bool] = None
     pre_test: Optional[str] = None
+    test_every_n_versions: Optional[int] = 1
 
     class Config:
         arbitrary_types_allowed = True
@@ -204,7 +205,13 @@ def get_latest_micro_versions(versions):
 
 
 def filter_versions(
-    flavor, versions, min_ver, max_ver, unsupported=None, allow_unreleased_max_version=False
+    flavor,
+    versions,
+    min_ver,
+    max_ver,
+    unsupported=None,
+    allow_unreleased_max_version=False,
+    test_every_n_versions=1,
 ):
     """
     Returns the versions that satisfy the following conditions:
@@ -243,7 +250,7 @@ def filter_versions(
             ],
             versions,
         )
-    )
+    )[::-test_every_n_versions][::-1]
 
 
 FLAVOR_FILE_PATTERN = re.compile(r"^(mlflow|tests)/(.+?)(_autolog(ging)?)?(\.py|/)")
@@ -563,6 +570,7 @@ def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[Matrix
                 cfg.maximum,
                 cfg.unsupported or [],
                 allow_unreleased_max_version=cfg.allow_unreleased_max_version or False,
+                test_every_n_versions=cfg.test_every_n_versions,
             )
             versions = get_latest_micro_versions(versions)
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -634,6 +634,9 @@ openai:
       "< 1.55.3": ["httpx<0.28.0"]
     run: |
       pytest tests/openai tests/openai/test_openai_model_export.py
+    # Our CI runs tests for every minor version of the library by default, which results in
+    # many test tasks for openai. Reducing the number of testing only for every 10 version.
+    test_every_n_versions: 10
   autologging:
     minimum: "1.17.0"
     maximum: "1.54.4"
@@ -656,6 +659,7 @@ openai:
         ]
     run: |
       pytest tests/openai/test_openai_autolog.py tests/openai/test_openai_agent_autolog.py
+    test_every_n_versions: 10
 
 dspy:
   package_info:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13916?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13916/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13916
```

</p>
</details>

### What changes are proposed in this pull request?

In our cross version tests, we test every minor version of each library. However, OpenAI releases a minor version frequently  (almost weekly), which increases the number of jobs to run (~80 jobs). 

https://github.com/mlflow-automation/mlflow/actions/runs/12051290923

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
