### PR TITLE
Add missing `generic_visit`

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -378,9 +378,12 @@ class Linter(ast.NodeVisitor):
         if rules.UseSysExecutable.check(node):
             self._check(Location.from_node(node), rules.UseSysExecutable())
 
+        self.generic_visit(node)
+
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if rules.ImplicitOptional.check(node):
             self._check(Location.from_node(node), rules.ImplicitOptional())
+        self.generic_visit(node)
 
     @staticmethod
     def _is_os_environ(node: ast.AST) -> bool:
@@ -400,6 +403,8 @@ class Linter(ast.NodeVisitor):
             ):
                 self._check(Location.from_node(node), rules.OsEnvironSetInTest())
 
+        self.generic_visit(node)
+
     def visit_Delete(self, node: ast.Delete):
         if self._is_in_test():
             if (
@@ -408,6 +413,8 @@ class Linter(ast.NodeVisitor):
                 and self._is_os_environ(node.targets[0].value)
             ):
                 self._check(Location.from_node(node), rules.OsEnvironDeleteInTest())
+
+        self.generic_visit(node)
 
 
 def _lint_cell(path: Path, config: Config, cell: dict[str, Any], index: int) -> list[Violation]:

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -392,10 +392,7 @@ def test_autolog_set_retriever_schema():
             return self.prog(question=question)
 
     with mlflow.start_run():
-        model_info = mlflow.dspy.log_model(
-            dspy_model=CoT(),
-            artifact_path="model",
-        )
+        model_info = mlflow.dspy.log_model(CoT(), "model")
 
     # Reset retriever schema
     _clear_retriever_schema()

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -95,6 +95,8 @@ def test_mlflow_is_not_installed_unless_specified():
         # The following should fail because there should be no mlflow in the env:
         prc = subprocess.run(
             [
+                sys.executable,
+                "-m",
                 "mlflow",
                 "models",
                 "predict",
@@ -130,7 +132,7 @@ def test_model_with_no_deployable_flavors_fails_pollitely():
         m.save(tmp.path("model", "MLmodel"))
         # The following should fail because there should be no suitable flavor
         prc = subprocess.run(
-            ["mlflow", "models", "predict", "-m", tmp.path("model")],
+            [sys.executable, "-m", "mlflow", "models", "predict", "-m", tmp.path("model")],
             stderr=subprocess.PIPE,
             cwd=tmp.path(""),
             check=False,
@@ -300,6 +302,8 @@ def test_predict(iris_data, sk_model):
         # read from stdin, write to stdout.
         prc = subprocess.run(
             [
+                sys.executable,
+                "-m",
                 "mlflow",
                 "models",
                 "predict",
@@ -368,6 +372,8 @@ def test_predict_check_content_type(iris_data, sk_model, tmp_path):
     # Throw errors for invalid content_type
     prc = subprocess.run(
         [
+            sys.executable,
+            "-m",
             "mlflow",
             "models",
             "predict",
@@ -408,6 +414,8 @@ def test_predict_check_input_path(iris_data, sk_model, tmp_path):
     # Valid input path with space
     prc = subprocess.run(
         [
+            sys.executable,
+            "-m",
             "mlflow",
             "models",
             "predict",
@@ -431,6 +439,8 @@ def test_predict_check_input_path(iris_data, sk_model, tmp_path):
     # Throw errors for invalid input_path
     prc = subprocess.run(
         [
+            sys.executable,
+            "-m",
             "mlflow",
             "models",
             "predict",
@@ -455,6 +465,8 @@ def test_predict_check_input_path(iris_data, sk_model, tmp_path):
 
     prc = subprocess.run(
         [
+            sys.executable,
+            "-m",
             "mlflow",
             "models",
             "predict",
@@ -496,6 +508,8 @@ def test_predict_check_output_path(iris_data, sk_model, tmp_path):
 
     prc = subprocess.run(
         [
+            sys.executable,
+            "-m",
             "mlflow",
             "models",
             "predict",
@@ -572,6 +586,8 @@ def test_prepare_env_fails(sk_model):
         # With conda - should fail due to bad conda environment.
         prc = subprocess.run(
             [
+                sys.executable,
+                "-m",
                 "mlflow",
                 "models",
                 "prepare-env",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -599,8 +599,12 @@ def test_mlflow_artifact_only_prints_warning_for_configs():
 
 
 def test_mlflow_ui_is_alias_for_mlflow_server():
-    mlflow_ui_stdout = subprocess.check_output(["mlflow", "ui", "--help"], text=True)
-    mlflow_server_stdout = subprocess.check_output(["mlflow", "server", "--help"], text=True)
+    mlflow_ui_stdout = subprocess.check_output(
+        [sys.executable, "-m", "mlflow", "ui", "--help"], text=True
+    )
+    mlflow_server_stdout = subprocess.check_output(
+        [sys.executable, "-m", "mlflow", "server", "--help"], text=True
+    )
     assert (
         mlflow_ui_stdout.replace("Usage: mlflow ui", "Usage: mlflow server") == mlflow_server_stdout
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13926?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13926/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13926
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`visit_xxx` methods in the custom linter must have `self.generic_visit`. This PR adds it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
