### PR TITLE
Prevent notebook display of traces when display is disabled

### DIFF
--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -77,6 +77,11 @@ class Trace(_MlflowObject):
         which contains a JSON representation of the Trace object. This object is deserialized
         in Databricks notebooks to display the Trace object in a nicer UI.
         """
+        from mlflow.tracing.display import get_display_handler
+
+        if get_display_handler()._disabled:
+            return repr(self)
+
         return {
             "application/databricks.mlflow.trace": self._serialize_for_mimebundle(),
             "text/plain": repr(self),

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -81,7 +81,7 @@ class Trace(_MlflowObject):
 
         bundle = {"text/plain": repr(self)}
 
-        if not get_display_handler()._disabled:
+        if not get_display_handler().disabled:
             bundle["application/databricks.mlflow.trace"] = self._serialize_for_mimebundle()
 
         return bundle

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -79,13 +79,12 @@ class Trace(_MlflowObject):
         """
         from mlflow.tracing.display import get_display_handler
 
-        if get_display_handler()._disabled:
-            return repr(self)
+        bundle = { "text/plain": repr(self) }
 
-        return {
-            "application/databricks.mlflow.trace": self._serialize_for_mimebundle(),
-            "text/plain": repr(self),
-        }
+        if not get_display_handler()._disabled:
+            bundle["application/databricks.mlflow.trace"] = self._serialize_for_mimebundle()
+
+        return bundle
 
     def to_pandas_dataframe_row(self) -> dict[str, Any]:
         return {

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -79,7 +79,7 @@ class Trace(_MlflowObject):
         """
         from mlflow.tracing.display import get_display_handler
 
-        bundle = { "text/plain": repr(self) }
+        bundle = {"text/plain": repr(self)}
 
         if not get_display_handler()._disabled:
             bundle["application/databricks.mlflow.trace"] = self._serialize_for_mimebundle()

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -38,8 +38,8 @@ class IPythonTraceDisplayHandler:
     @classmethod
     def enable(cls):
         cls.disabled = False
-        if cls.instance is None:
-            cls.instance = IPythonTraceDisplayHandler()
+        if cls._instance is None:
+            cls._instance = IPythonTraceDisplayHandler()
 
     def __init__(self):
         # This only works in Databricks notebooks
@@ -64,7 +64,7 @@ class IPythonTraceDisplayHandler:
             _logger.debug("Failed to register post-run cell display hook", exc_info=True)
 
     def _display_traces_post_run(self, result):
-        if self._disabled:
+        if self.disabled:
             self.traces_to_display = {}
             return
 
@@ -108,7 +108,7 @@ class IPythonTraceDisplayHandler:
 
     def display_traces(self, traces: list["Trace"]):
         # This only works in Databricks notebooks
-        if not is_in_databricks_runtime() or self._disabled:
+        if not is_in_databricks_runtime() or self.disabled:
             return
 
         # this should do nothing if not in an IPython environment

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -23,7 +23,7 @@ def _serialize_trace_list(traces: list["Trace"]):
 
 class IPythonTraceDisplayHandler:
     _instance = None
-    _disabled = False
+    disabled = False
 
     @classmethod
     def get_instance(cls):
@@ -33,17 +33,13 @@ class IPythonTraceDisplayHandler:
 
     @classmethod
     def disable(cls):
-        cls._disabled = True
+        cls.disabled = True
 
     @classmethod
     def enable(cls):
-        cls._disabled = False
-        if cls._instance is None:
-            cls._instance = IPythonTraceDisplayHandler()
-
-    @property
-    def disabled(self):
-        return self._disabled
+        cls.disabled = False
+        if cls.instance is None:
+            cls.instance = IPythonTraceDisplayHandler()
 
     def __init__(self):
         # This only works in Databricks notebooks

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -41,6 +41,10 @@ class IPythonTraceDisplayHandler:
         if cls._instance is None:
             cls._instance = IPythonTraceDisplayHandler()
 
+    @property
+    def disabled(self):
+        return self._disabled
+
     def __init__(self):
         # This only works in Databricks notebooks
         if not is_in_databricks_runtime():

--- a/tests/tracing/display/test_ipython.py
+++ b/tests/tracing/display/test_ipython.py
@@ -209,6 +209,7 @@ def test_enable_and_disable_display(monkeypatch):
         "text/plain": repr(trace_a),
     }
 
+
 def test_mimebundle():
     # by default, it should contain the metadata
     # necessary for rendering the trace UI

--- a/tests/tracing/display/test_ipython.py
+++ b/tests/tracing/display/test_ipython.py
@@ -208,3 +208,25 @@ def test_enable_and_disable_display(monkeypatch):
         "application/databricks.mlflow.trace": trace_a._serialize_for_mimebundle(),
         "text/plain": repr(trace_a),
     }
+
+def test_mimebundle():
+    # by default, it should contain the metadata
+    # necessary for rendering the trace UI
+    trace = create_trace("a")
+    assert trace._repr_mimebundle_() == {
+        "application/databricks.mlflow.trace": trace._serialize_for_mimebundle(),
+        "text/plain": repr(trace),
+    }
+
+    # if trace display is disabled, only "text/plain" should exist
+    mlflow.tracing.disable_notebook_display()
+    assert trace._repr_mimebundle_() == {
+        "text/plain": repr(trace),
+    }
+
+    # re-enabling should bring the metadata back
+    mlflow.tracing.enable_notebook_display()
+    assert trace._repr_mimebundle_() == {
+        "application/databricks.mlflow.trace": trace._serialize_for_mimebundle(),
+        "text/plain": repr(trace),
+    }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/13936?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13936/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13936
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

#13883 disabled tracing display when it's triggered by things like `end_trace()`, etc, but not when it's explicitly displayed. For example, the since the result of `mlflow.get_last_active_trace()` is a Trace object, the mimebundle sent to the Jupyter output cell will still contain the metadata necessary to render the trace UI.

I think it's up for debate whether or not we actually need to disable this—from feedback it seems that users are mostly annoyed that it's auto-triggering. However, if they're trying to display a trace object, then probably the trace UI is more useful than the string repr. It's just that the `mlflow.tracing.disable_notebook_display()` API implies that the trace UI should never show up anymore.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
