### PR TITLE
Added warning as mlflow.transformers.generate_signature_output is deprecated  #13327

### DIFF
--- a/examples/transformers/simple.py
+++ b/examples/transformers/simple.py
@@ -13,18 +13,11 @@ input_example = ["prompt 1", "prompt 2", "prompt 3"]
 
 parameters = {"max_length": 512, "do_sample": True}
 
-signature = mlflow.models.infer_signature(
-    input_example,
-    mlflow.transformers.generate_signature_output(generation_pipeline, input_example),
-    parameters,
-)
-
 with mlflow.start_run() as run:
     model_info = mlflow.transformers.log_model(
         transformers_model=generation_pipeline,
         artifact_path="text_generator",
-        input_example=["prompt 1", "prompt 2", "prompt 3"],
-        signature=signature,
+        input_example=(["prompt 1", "prompt 2", "prompt 3"], parameters),
     )
 
 sentence_generator = mlflow.pyfunc.load_model(model_info.model_uri)

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -181,6 +181,7 @@ def generate_signature_output(pipeline, data, model_config=None, flavor_config=N
     # Lazy import to avoid circular dependencies. Ideally we should move _TransformersWrapper
     # out from __init__.py to avoid this.
     from mlflow.transformers import _TransformersWrapper
+
     return _TransformersWrapper(
         pipeline=pipeline, model_config=model_config, flavor_config=flavor_config
     ).predict(data, params=params)

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -9,6 +9,7 @@ from mlflow.models.utils import _contains_params
 from mlflow.types.schema import ColSpec, DataType, Schema, TensorSpec
 from mlflow.utils.os import is_windows
 from mlflow.utils.timeout import MlflowTimeoutError, run_with_timeout
+from mlflow.utils.annotations import deprecated
 
 _logger = logging.getLogger(__name__)
 
@@ -173,16 +174,15 @@ def format_input_example_for_special_cases(input_example, pipeline):
     return input_data if not isinstance(input_example, tuple) else (input_data, input_example[1])
 
 
+@deprecated(
+    alternative="input_example in mlflow.transformers.log_model with parameters",
+    since="2.19.0"
+)
 def generate_signature_output(pipeline, data, model_config=None, flavor_config=None, params=None):
     # Lazy import to avoid circular dependencies. Ideally we should move _TransformersWrapper
     # out from __init__.py to avoid this.
     from mlflow.transformers import _TransformersWrapper
-
-    _logger.warning(
-                    "`generate_signature_output` function is deprecated."
-                    "Instead directly use `input_example` parameter in `mlflow.transformers.log_model` with parameters and mlflow willdirectly inferthe signature."
-                )
-
+    
     return _TransformersWrapper(
         pipeline=pipeline, model_config=model_config, flavor_config=flavor_config
     ).predict(data, params=params)

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -178,6 +178,11 @@ def generate_signature_output(pipeline, data, model_config=None, flavor_config=N
     # out from __init__.py to avoid this.
     from mlflow.transformers import _TransformersWrapper
 
+    _logger.warning(
+                    "`generate_signature_output` function is deprecated."
+                    "Instead directly use `input_example` parameter in `mlflow.transformers.log_model` with parameters and mlflow willdirectly inferthe signature."
+                )
+
     return _TransformersWrapper(
         pipeline=pipeline, model_config=model_config, flavor_config=flavor_config
     ).predict(data, params=params)

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -175,7 +175,7 @@ def format_input_example_for_special_cases(input_example, pipeline):
 
 
 @deprecated(
-    alternative="input_example in mlflow.transformers.log_model with parameters",
+    alternative="the `input_example` parameter in mlflow.transformers.log_model",
     since="2.19.0"
 )
 def generate_signature_output(pipeline, data, model_config=None, flavor_config=None, params=None):

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -7,9 +7,9 @@ from mlflow.environment_variables import MLFLOW_INPUT_EXAMPLE_INFERENCE_TIMEOUT
 from mlflow.models.signature import ModelSignature, infer_signature
 from mlflow.models.utils import _contains_params
 from mlflow.types.schema import ColSpec, DataType, Schema, TensorSpec
+from mlflow.utils.annotations import deprecated
 from mlflow.utils.os import is_windows
 from mlflow.utils.timeout import MlflowTimeoutError, run_with_timeout
-from mlflow.utils.annotations import deprecated
 
 _logger = logging.getLogger(__name__)
 
@@ -175,14 +175,12 @@ def format_input_example_for_special_cases(input_example, pipeline):
 
 
 @deprecated(
-    alternative="the `input_example` parameter in mlflow.transformers.log_model",
-    since="2.19.0"
+    alternative="the `input_example` parameter in mlflow.transformers.log_model", since="2.19.0"
 )
 def generate_signature_output(pipeline, data, model_config=None, flavor_config=None, params=None):
     # Lazy import to avoid circular dependencies. Ideally we should move _TransformersWrapper
     # out from __init__.py to avoid this.
     from mlflow.transformers import _TransformersWrapper
-    
     return _TransformersWrapper(
         pipeline=pipeline, model_config=model_config, flavor_config=flavor_config
     ).predict(data, params=params)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/justsomerandomdude264/mlflow/pull/13942?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13942/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13942
```

</p>
</details>

**Issue Number #13327**


Added a warning as `mlflow.transformers.generate_signature_output` is deprecated.

The warning to be logged whenever the function is called is
```
`generate_signature_output` function is deprecated.
Instead directly use `input_example` parameter in `mlflow.transformers.log_model` with parameters and mlflow will directly infer the signature.
```
