### PR TITLE
Deflake `test_litellm_tracing_async_streaming`

### DIFF
--- a/tests/litellm/test_litellm_autolog.py
+++ b/tests/litellm/test_litellm_autolog.py
@@ -162,8 +162,13 @@ async def test_litellm_tracing_async_streaming(is_in_databricks):
         messages=[{"role": "system", "content": "Hello"}],
         stream=True,
     )
+    chunks: list[str] = []
+    async for c in response:
+        chunks.append(c.choices[0].delta.content)
+        # Adding a sleep here to ensure that `content` in the span outputs is
+        # consistently 'Hello World', not 'Hello' or ''.
+        await asyncio.sleep(0.1)
 
-    chunks = [c.choices[0].delta.content async for c in response]
     assert chunks == ["Hello", " world", None]
 
     # Await the logger task to ensure that the trace is logged.

--- a/tests/litellm/test_litellm_autolog.py
+++ b/tests/litellm/test_litellm_autolog.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from typing import Optional
 from unittest import mock
 
 import litellm
@@ -162,7 +163,7 @@ async def test_litellm_tracing_async_streaming(is_in_databricks):
         messages=[{"role": "system", "content": "Hello"}],
         stream=True,
     )
-    chunks: list[str] = []
+    chunks: list[Optional[str]] = []
     async for c in response:
         chunks.append(c.choices[0].delta.content)
         # Adding a sleep here to ensure that `content` in the span outputs is

--- a/tests/litellm/test_litellm_autolog.py
+++ b/tests/litellm/test_litellm_autolog.py
@@ -153,9 +153,8 @@ async def test_litellm_tracing_async(is_in_databricks):
     assert spans[0].attributes["usage"] is not None
 
 
-@pytest.mark.parametrize("x", range(100))
 @pytest.mark.asyncio
-async def test_litellm_tracing_async_streaming(x, is_in_databricks):
+async def test_litellm_tracing_async_streaming(is_in_databricks):
     mlflow.litellm.autolog()
 
     response = await litellm.acompletion(

--- a/tests/litellm/test_litellm_autolog.py
+++ b/tests/litellm/test_litellm_autolog.py
@@ -153,8 +153,9 @@ async def test_litellm_tracing_async(is_in_databricks):
     assert spans[0].attributes["usage"] is not None
 
 
+@pytest.mark.parametrize("x", range(100))
 @pytest.mark.asyncio
-async def test_litellm_tracing_async_streaming(is_in_databricks):
+async def test_litellm_tracing_async_streaming(x, is_in_databricks):
     mlflow.litellm.autolog()
 
     response = await litellm.acompletion(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/13957?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13957/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13957
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow-automation/mlflow/actions/runs/12120366531/job/33804229363#step:12:263:

```
__________________ test_litellm_tracing_async_streaming[True] __________________

is_in_databricks = True

    @pytest.mark.asyncio
    async def test_litellm_tracing_async_streaming(is_in_databricks):
        mlflow.litellm.autolog()
    
        response = await litellm.acompletion(
            model="gpt-4o-mini",
            messages=[{"role": "system", "content": "Hello"}],
            stream=True,
        )
    
        chunks = [c.choices[0].delta.content async for c in response]
        assert chunks == ["Hello", " world", None]
    
        # Await the logger task to ensure that the trace is logged.
        logger_task = next(
            task
            for task in asyncio.all_tasks()
            if "async_success_handler" in getattr(task.get_coro(), "__name__", "")
        )
        await logger_task
    
        trace = mlflow.get_last_active_trace()
        assert trace.info.status == "OK"
    
        spans = trace.data.spans
        assert len(spans) == 1
        assert spans[0].name == "litellm-acompletion"
        assert spans[0].status.status_code == "OK"
>       assert spans[0].outputs["choices"][0]["message"]["content"] == "Hello world"
E       AssertionError: assert 'Hello' == 'Hello world'
E         
E         - Hello world
E         + Hello

chunks     = ['Hello', ' world', None]
is_in_databricks = True
logger_task = <Task finished name='Task-33' coro=<Logging.async_success_handler() done, defined at /opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/litellm/litellm_core_utils/litellm_logging.py:1398> result=None>
response   = <litellm.litellm_core_utils.streaming_handler.CustomStreamWrapper object at 0x7f06381a6d00>
spans      = [Span(name='litellm-acompletion', request_id='656be1b3c2a24d[55](https://github.com/mlflow-automation/mlflow/actions/runs/12120366531/job/33804229363#step:12:56)aab87c9913a685ca', span_id='0xd688d905f6430bfb', parent_id=None)]
trace      = Trace(request_id=6[56](https://github.com/mlflow-automation/mlflow/actions/runs/12120366531/job/33804229363#step:12:57)be1b3c2a24d55aab87c9913a685ca)
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
