### PR TITLE
Fix LlamaIndex module import failure after mlflow.autolog()

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -44,7 +44,10 @@ from mlflow.tracking.client import MlflowClient
 _logger = logging.getLogger(__name__)
 
 IS_PYDANTIC_V1 = Version(pydantic.__version__).major < 2
-LLAMA_INDEX_VERSION = Version(llama_index.core.__version__)
+
+
+def _get_llama_index_version() -> Version:
+    return Version(llama_index.core.__version__)
 
 
 def set_llama_index_tracer():
@@ -231,7 +234,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         span = llama_span._mlflow_span
         token = self._span_id_to_token.pop(span.span_id, None)
 
-        if LLAMA_INDEX_VERSION >= Version("0.10.59"):
+        if _get_llama_index_version() >= Version("0.10.59"):
             # LlamaIndex determines if a workflow is terminated or not by propagating an special
             # exception WorkflowDone. We should treat this exception as a successful termination.
             from llama_index.core.workflow.errors import WorkflowDone

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -55,6 +55,7 @@ pytorch:
 pytorch-lightning:
   package_info:
     pip_release: "pytorch-lightning"
+    module_name: "lightning"
     install_dev: |
       export PACKAGE_NAME=pytorch
       pip install git+https://github.com/PytorchLightning/pytorch-lightning.git

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -31,7 +31,8 @@ _ML_PACKAGE_VERSIONS = {
     },
     "pytorch-lightning": {
         "package_info": {
-            "pip_release": "pytorch-lightning"
+            "pip_release": "pytorch-lightning",
+            "module_name": "lightning"
         },
         "autologging": {
             "minimum": "1.9.0",
@@ -385,7 +386,7 @@ _ML_PACKAGE_VERSIONS = {
 FLAVOR_TO_MODULE_NAME = {
     "sklearn": "sklearn",
     "pytorch": "torch",
-    "pytorch-lightning": "pytorch-lightning",
+    "pytorch-lightning": "lightning",
     "keras": "keras",
     "tensorflow": "tensorflow",
     "xgboost": "xgboost",

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -85,5 +85,3 @@ dspy
 litellm
 # Required by mlflow.gemini
 google-generativeai
-# Required by mlflow.crewai
-crewai

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -85,3 +85,5 @@ dspy
 litellm
 # Required by mlflow.gemini
 google-generativeai
+# Required by mlflow.crewai
+crewai

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -470,7 +470,8 @@ def test_autolog_genai_import(disable, flavor_and_module):
     # pytorch-lightning is not valid flavor name.
     # gluon autologging is deprecated.
     # paddle autologging is not in the list of autologging integrations.
-    if flavor in {"gluon", "pytorch-lightning", "paddle"}:
+    # crewai requires Python 3.10+ (our CI runs on Python 3.9).
+    if flavor in {"gluon", "pytorch-lightning", "paddle", "crewai"}:
         return
 
     with reset_module_import():

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -1,3 +1,4 @@
+import contextlib
 import inspect
 import sys
 from collections import namedtuple
@@ -28,6 +29,7 @@ import transformers
 import xgboost
 
 import mlflow
+from mlflow.ml_package_versions import FLAVOR_TO_MODULE_NAME
 from mlflow.utils.autologging_utils import (
     AutologgingEventLogger,
     autologging_is_disabled,
@@ -440,3 +442,40 @@ def test_autolog_genai_auto_tracing(mock_openai, is_databricks, disable, other_l
         span = trace.data.spans[0]
         assert span.inputs == {"prompt": "test", "model": "gpt-4o-mini", "temperature": 0}
         assert span.outputs["id"] == "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7"
+
+
+@contextlib.contextmanager
+def reset_module_import():
+    """
+    Temporarily reset the module import state to simulate the module being not imported.
+    """
+    original_modules = {}
+    for module_name in FLAVOR_TO_MODULE_NAME.values():
+        original_modules[module_name] = sys.modules.get(module_name)
+
+    try:
+        yield
+    finally:
+        for module_name, original_module in original_modules.items():
+            if original_module is not None:
+                sys.modules[module_name] = original_module
+
+
+@pytest.mark.parametrize("flavor_and_module", FLAVOR_TO_MODULE_NAME.items())
+@pytest.mark.parametrize("disable", [False, True])
+@pytest.mark.do_not_disable_new_import_hook_firing_if_module_already_exists
+def test_autolog_genai_import(disable, flavor_and_module):
+    flavor, module = flavor_and_module
+
+    # pytorch-lightning is not valid flavor name.
+    # gluon autologging is deprecated.
+    # paddle autologging is not in the list of autologging integrations.
+    if flavor in {"gluon", "pytorch-lightning", "paddle"}:
+        return
+
+    with reset_module_import():
+        mlflow.autolog(disable=disable)
+
+        __import__(module)
+
+        assert get_autologging_config(flavor, "disable") == disable


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13960?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13960/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13960
```

</p>
</details>

### What changes are proposed in this pull request?

https://github.com/mlflow/mlflow/pull/13913 updated `mlflow.autolog()` to handle GenAI libraries such as LangChain, LlamaIndex. However, this introduced a bug where LlamaIndex cannot be imported after calling `mlflow.autolog()`.

```
>>> import mlflow
>>> mlflow.autolog()
2024/12/03 19:02:02 WARNING mlflow.spark: With Pyspark >= 3.2, PYSPARK_PIN_THREAD environment variable must be set to false for Spark datasource autologging to work.
2024/12/03 19:02:02 INFO mlflow.tracking.fluent: Autologging successfully enabled for pyspark.
>>> import llama_index.core
2024/12/03 19:02:06 INFO mlflow.tracking.fluent: Autologging successfully enabled for sklearn.
2024/12/03 19:02:07 WARNING mlflow.tracking.fluent: Exception raised while enabling autologging for llama_index.core: module 'llama_index' has no attribute 'core'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 627, in _load_backward_compatible
  File "/Users/yuki.watanabe/Workspace/mlflow/mlflow/utils/import_hooks/__init__.py", line 244, in load_module
    notify_module_loaded(module)
  File "/Users/yuki.watanabe/Workspace/mlflow/mlflow/utils/import_hooks/__init__.py", line 31, in new_fn
    return f(*args, **kwargs)
  File "/Users/yuki.watanabe/Workspace/mlflow/mlflow/utils/import_hooks/__init__.py", line 217, in notify_module_loaded
    hook(module)
  File "/Users/yuki.watanabe/Workspace/mlflow/mlflow/utils/autologging_utils/__init__.py", line 91, in wrapper
    return fn(*args, **kwargs)
  File "/Users/yuki.watanabe/Workspace/mlflow/mlflow/tracking/fluent.py", line 2444, in setup_autologging
    autolog_fn(**autologging_params)
  File "/Users/yuki.watanabe/Workspace/mlflow/mlflow/llama_index/__init__.py", line 572, in autolog
    from mlflow.llama_index.tracer import remove_llama_index_tracer, set_llama_index_tracer
  File "/Users/yuki.watanabe/Workspace/mlflow/mlflow/llama_index/tracer.py", line 47, in <module>
    LLAMA_INDEX_VERSION = Version(llama_index.core.__version__)
AttributeError: module 'llama_index' has no attribute 'core'
```

It seems their submodule structure like `llama_index.core` sometimes does not work nicely with the post register hook mechanism. This particular issue is resolved by removing the `llama_index.core` reference shown in the stacktrace.

Also adding test coverage to prevent import failure like this.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
>>> import mlflow
>>> mlflow.autolog()
2024/12/03 21:56:53 WARNING mlflow.spark: With Pyspark >= 3.2, PYSPARK_PIN_THREAD environment variable must be set to false for Spark datasource autologging to work.
2024/12/03 21:56:53 INFO mlflow.tracking.fluent: Autologging successfully enabled for pyspark.
>>> mlflow
KeyboardInterrupt
>>> import llama_index.core
2024/12/03 21:57:03 INFO mlflow.tracking.fluent: Autologging successfully enabled for sklearn.
2024/12/03 21:57:04 INFO mlflow.tracking.fluent: Autologging successfully enabled for llama_index.core.
```

also tested import for other libraries like langchain, dspy, openai, litellm, etc.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
