### PR TITLE
Add warning to use AnyType if infer_signature fails

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -232,10 +232,14 @@ def infer_signature(
                     convert_dataclass_to_schema(data) if is_dataclass(data) else _infer_schema(data)
                 )
             except Exception:
+                extra_msg = (
+                    ("Note that MLflow doesn't validate data types during inference for AnyType. ")
+                    if key == "inputs"
+                    else ""
+                )
                 _logger.warning(
-                    f"Failed to infer schema for {data}. "
-                    "Setting schema to `Schema([ColSpec(type=AnyType())]` as default. "
-                    "Note that MLflow doesn't validate data types during inference for AnyType. "
+                    f"Failed to infer schema for {key}. "
+                    f"Setting schema to `Schema([ColSpec(type=AnyType())]` as default. {extra_msg}"
                     "To see the full traceback, set logging level to DEBUG.",
                     exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -224,24 +224,25 @@ def infer_signature(
     Returns:
       ModelSignature
     """
-    if model_input is not None:
-        inputs = (
-            convert_dataclass_to_schema(model_input)
-            if is_dataclass(model_input)
-            else _infer_schema(model_input)
-        )
-    else:
-        inputs = None
-    if model_output is not None:
-        outputs = (
-            convert_dataclass_to_schema(model_output)
-            if is_dataclass(model_output)
-            else _infer_schema(model_output)
-        )
-    else:
-        outputs = None
-    params = _infer_param_schema(params) if params else None
-    return ModelSignature(inputs, outputs, params)
+    schemas = {"inputs": model_input, "outputs": model_output}
+    for key, data in schemas.items():
+        if data is not None:
+            try:
+                schemas[key] = (
+                    convert_dataclass_to_schema(data) if is_dataclass(data) else _infer_schema(data)
+                )
+            except Exception:
+                _logger.warning(
+                    f"Failed to infer schema for {data}. If the data type "
+                    "is not supported, manually set schema to `Schema([ColSpec(type=AnyType())]` "
+                    "to represent the data type. Note that MLflow doesn't validate data "
+                    "types during inference for AnyType."
+                )
+                raise
+        else:
+            schemas[key] = None
+    schemas["params"] = _infer_param_schema(params) if params else None
+    return ModelSignature(**schemas)
 
 
 # `t\w*\.` matches the `typing` module or its alias

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -233,12 +233,13 @@ def infer_signature(
                 )
             except Exception:
                 _logger.warning(
-                    f"Failed to infer schema for {data}. If the data type "
-                    "is not supported, manually set schema to `Schema([ColSpec(type=AnyType())]` "
-                    "to represent the data type. Note that MLflow doesn't validate data "
-                    "types during inference for AnyType."
+                    f"Failed to infer schema for {data}. "
+                    "Setting schema to `Schema([ColSpec(type=AnyType())]` as default. "
+                    "Note that MLflow doesn't validate data types during inference for AnyType. "
+                    "To see the full traceback, set logging level to DEBUG.",
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
-                raise
+                schemas[key] = Schema([ColSpec(type=AnyType())])
         else:
             schemas[key] = None
     schemas["params"] = _infer_param_schema(params) if params else None

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -244,8 +244,6 @@ def infer_signature(
                     exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
                 schemas[key] = Schema([ColSpec(type=AnyType())])
-        else:
-            schemas[key] = None
     schemas["params"] = _infer_param_schema(params) if params else None
     return ModelSignature(**schemas)
 

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -56,6 +56,7 @@ from mlflow.pyfunc import (
 from mlflow.pyfunc.spark_model_cache import SparkModelCache
 from mlflow.types import ColSpec, Schema, TensorSpec
 from mlflow.types.schema import Array, DataType, Object, Property
+from mlflow.types.utils import _infer_schema
 from mlflow.utils._spark_utils import modified_environ
 
 import tests
@@ -1369,7 +1370,7 @@ def test_spark_df_schema_inference_for_map_type(spark):
     with pytest.raises(
         MlflowException, match=r"Please construct spark DataFrame with schema using StructType"
     ):
-        infer_signature(complex_df)
+        _infer_schema(complex_df)
 
 
 def test_spark_udf_structs_and_arrays(spark, tmp_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13968?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13968/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13968
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
If users don't care about data validation, and the data type is not supported by existing schemas, we emit a warning to ask them to use AnyType explicitly.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
