### PR TITLE
Add crewai to mlflow.autolog

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2387,6 +2387,7 @@ def autolog(
         "llama_index.core": "mlflow.llama_index",
         "langchain": "mlflow.langchain",
         "dspy": "mlflow.dspy",
+        "crewai": "mlflow.crewai",
     }
 
     # Currently, GenAI libraries are not enabled by `mlflow.autolog` in Databricks,

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -116,694 +116,714 @@ def task_2(simple_agent_2):
     )
 
 
-def test_kickoff_enable_disable_autolog(simple_agent_1, task_1):
-    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
-        mlflow.crewai.autolog()
-        crew = Crew(
-            agents=[
-                simple_agent_1,
-            ],
-            tasks=[task_1],
-        )
+def global_autolog():
+    # Libraries used within tests or crewai library
+    mlflow.autolog(exclude_flavors=["openai", "litellm"])
+    mlflow.utils.import_hooks.notify_module_loaded(crewai)
 
+
+def clear_autolog_state():
+    from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
+
+    for key in AUTOLOGGING_INTEGRATIONS.keys():
+        AUTOLOGGING_INTEGRATIONS[key].clear()
+    mlflow.utils.import_hooks._post_import_hooks = {}
+
+
+@pytest.fixture(params=[mlflow.crewai.autolog, global_autolog])
+def autolog(request):
+    clear_autolog_state()
+
+    yield request.param
+
+    clear_autolog_state()
+
+
+def test_kickoff_enable_disable_autolog(simple_agent_1, task_1, autolog):
+    crew = Crew(
+        agents=[
+            simple_agent_1,
+        ],
+        tasks=[task_1],
+    )
+    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
+        autolog()
         crew.kickoff()
 
-        traces = get_traces()
-        assert len(traces) == 1
-        assert traces[0].info.status == "OK"
-        assert len(traces[0].data.spans) == 5
-        # Crew
-        span_0 = traces[0].data.spans[0]
-        assert span_0.name == "Crew.kickoff"
-        assert span_0.span_type == SpanType.CHAIN
-        assert span_0.parent_id is None
-        assert span_0.inputs == {}
-        assert span_0.outputs == CREW_OUTPUT
-        # Task
-        span_1 = traces[0].data.spans[1]
-        assert span_1.name == "Task.execute_sync"
-        assert span_1.span_type == SpanType.CHAIN
-        assert span_1.parent_id is span_0.span_id
-        assert span_1.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_1.outputs == {
-            "agent": "City Selection Expert",
-            "description": "Analyze and select the best city for the trip",
-            "expected_output": "Detailed report on the chosen city",
-            "json_dict": None,
-            "name": None,
-            "output_format": "raw",
-            "pydantic": None,
-            "raw": "What about Tokyo?",
-            "summary": "Analyze and select the best city for the trip...",
-        }
-        # Agent
-        span_2 = traces[0].data.spans[2]
-        assert span_2.name == "Agent.execute_task"
-        assert span_2.span_type == SpanType.AGENT
-        assert span_2.parent_id is span_1.span_id
-        assert span_2.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_2.outputs == "What about Tokyo?"
-        # LLM
-        span_3 = traces[0].data.spans[3]
-        assert span_3.name == "LLM.call"
-        assert span_3.span_type == SpanType.LLM
-        assert span_3.parent_id is span_2.span_id
-        assert span_3.inputs["messages"] is not None
-        assert span_3.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert len(traces[0].data.spans) == 5
+    # Crew
+    span_0 = traces[0].data.spans[0]
+    assert span_0.name == "Crew.kickoff"
+    assert span_0.span_type == SpanType.CHAIN
+    assert span_0.parent_id is None
+    assert span_0.inputs == {}
+    assert span_0.outputs == CREW_OUTPUT
+    # Task
+    span_1 = traces[0].data.spans[1]
+    assert span_1.name == "Task.execute_sync"
+    assert span_1.span_type == SpanType.CHAIN
+    assert span_1.parent_id is span_0.span_id
+    assert span_1.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_1.outputs == {
+        "agent": "City Selection Expert",
+        "description": "Analyze and select the best city for the trip",
+        "expected_output": "Detailed report on the chosen city",
+        "json_dict": None,
+        "name": None,
+        "output_format": "raw",
+        "pydantic": None,
+        "raw": "What about Tokyo?",
+        "summary": "Analyze and select the best city for the trip...",
+    }
+    # Agent
+    span_2 = traces[0].data.spans[2]
+    assert span_2.name == "Agent.execute_task"
+    assert span_2.span_type == SpanType.AGENT
+    assert span_2.parent_id is span_1.span_id
+    assert span_2.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_2.outputs == "What about Tokyo?"
+    # LLM
+    span_3 = traces[0].data.spans[3]
+    assert span_3.name == "LLM.call"
+    assert span_3.span_type == SpanType.LLM
+    assert span_3.parent_id is span_2.span_id
+    assert span_3.inputs["messages"] is not None
+    assert span_3.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
 
-        # Create Long Term Memory
-        span_4 = traces[0].data.spans[4]
-        assert span_4.name == "CrewAgentExecutor._create_long_term_memory"
-        assert span_4.span_type == SpanType.RETRIEVER
-        assert span_4.parent_id is span_2.span_id
-        assert span_4.inputs == {
-            "output": {
-                "output": "What about Tokyo?",
-                "text": "Final Answer: What about Tokyo?",
-                "thought": "",
-            }
+    # Create Long Term Memory
+    span_4 = traces[0].data.spans[4]
+    assert span_4.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_4.span_type == SpanType.RETRIEVER
+    assert span_4.parent_id is span_2.span_id
+    assert span_4.inputs == {
+        "output": {
+            "output": "What about Tokyo?",
+            "text": "Final Answer: What about Tokyo?",
+            "thought": "",
         }
-        assert span_4.outputs is None
+    }
+    assert span_4.outputs is None
 
+    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
         mlflow.crewai.autolog(disable=True)
         crew.kickoff()
 
-        # No new trace should be created
-        traces = get_traces()
-        assert len(traces) == 1
+    # No new trace should be created
+    traces = get_traces()
+    assert len(traces) == 1
 
 
-def test_kickoff_failure(simple_agent_1, task_1):
+def test_kickoff_failure(simple_agent_1, task_1, autolog):
+    crew = Crew(
+        agents=[
+            simple_agent_1,
+        ],
+        tasks=[task_1],
+    )
     with patch("litellm.completion", side_effect=Exception("error")):
-        mlflow.crewai.autolog()
-        crew = Crew(
-            agents=[
-                simple_agent_1,
-            ],
-            tasks=[task_1],
-        )
+        autolog()
         with pytest.raises(Exception, match="error"):
             crew.kickoff()
-        traces = get_traces()
-        assert len(traces) == 1
-        assert traces[0].info.status == "ERROR"
-        assert len(traces[0].data.spans) == 4
-        # Crew
-        span_0 = traces[0].data.spans[0]
-        assert span_0.name == "Crew.kickoff"
-        assert span_0.span_type == SpanType.CHAIN
-        assert span_0.parent_id is None
-        assert span_0.inputs == {}
-        assert span_0.status.status_code == "ERROR"
-        # Task
-        span_1 = traces[0].data.spans[1]
-        assert span_1.name == "Task.execute_sync"
-        assert span_1.span_type == SpanType.CHAIN
-        assert span_1.parent_id is span_0.span_id
-        assert span_1.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_1.status.status_code == "ERROR"
-        # Agent
-        span_2 = traces[0].data.spans[2]
-        assert span_2.name == "Agent.execute_task"
-        assert span_2.span_type == SpanType.AGENT
-        assert span_2.parent_id is span_1.span_id
-        assert span_2.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_2.status.status_code == "ERROR"
-        # LLM
-        span_3 = traces[0].data.spans[3]
-        assert span_3.name == "LLM.call"
-        assert span_3.span_type == SpanType.LLM
-        assert span_3.parent_id is span_2.span_id
-        assert span_3.inputs["messages"] is not None
-        assert span_3.status.status_code == "ERROR"
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "ERROR"
+    assert len(traces[0].data.spans) == 4
+    # Crew
+    span_0 = traces[0].data.spans[0]
+    assert span_0.name == "Crew.kickoff"
+    assert span_0.span_type == SpanType.CHAIN
+    assert span_0.parent_id is None
+    assert span_0.inputs == {}
+    assert span_0.status.status_code == "ERROR"
+    # Task
+    span_1 = traces[0].data.spans[1]
+    assert span_1.name == "Task.execute_sync"
+    assert span_1.span_type == SpanType.CHAIN
+    assert span_1.parent_id is span_0.span_id
+    assert span_1.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_1.status.status_code == "ERROR"
+    # Agent
+    span_2 = traces[0].data.spans[2]
+    assert span_2.name == "Agent.execute_task"
+    assert span_2.span_type == SpanType.AGENT
+    assert span_2.parent_id is span_1.span_id
+    assert span_2.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_2.status.status_code == "ERROR"
+    # LLM
+    span_3 = traces[0].data.spans[3]
+    assert span_3.name == "LLM.call"
+    assert span_3.span_type == SpanType.LLM
+    assert span_3.parent_id is span_2.span_id
+    assert span_3.inputs["messages"] is not None
+    assert span_3.status.status_code == "ERROR"
 
 
-def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2):
+def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
+    crew = Crew(
+        agents=[
+            simple_agent_1,
+            simple_agent_2,
+        ],
+        tasks=[task_1, task_2],
+    )
     with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
-        mlflow.crewai.autolog()
-        crew = Crew(
-            agents=[
-                simple_agent_1,
-                simple_agent_2,
-            ],
-            tasks=[task_1, task_2],
-        )
-
+        autolog()
         crew.kickoff()
 
-        traces = get_traces()
-        assert len(traces) == 1
-        assert traces[0].info.status == "OK"
-        assert len(traces[0].data.spans) == 9
-        # Crew
-        span_0 = traces[0].data.spans[0]
-        assert span_0.name == "Crew.kickoff"
-        assert span_0.span_type == SpanType.CHAIN
-        assert span_0.parent_id is None
-        assert span_0.inputs == {}
-        assert span_0.outputs == {
-            "json_dict": None,
-            "pydantic": None,
-            "raw": "What about Tokyo?",
-            "tasks_output": [
-                {
-                    "agent": "City Selection Expert",
-                    "name": None,
-                    "description": "Analyze and select the best city for the trip",
-                    "expected_output": "Detailed report on the chosen city",
-                    "json_dict": None,
-                    "pydantic": None,
-                    "output_format": "raw",
-                    "raw": "What about Tokyo?",
-                    "summary": "Analyze and select the best city for the trip...",
-                },
-                {
-                    "agent": "Local Expert at this city",
-                    "description": "Compile an in-depth guide",
-                    "expected_output": "Comprehensive city guide",
-                    "json_dict": None,
-                    "name": None,
-                    "output_format": "raw",
-                    "pydantic": None,
-                    "raw": "What about Tokyo?",
-                    "summary": "Compile an in-depth guide...",
-                },
-            ],
-            "token_usage": {
-                "cached_prompt_tokens": 0,
-                "completion_tokens": 0,
-                "prompt_tokens": 0,
-                "successful_requests": 0,
-                "total_tokens": 0,
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert len(traces[0].data.spans) == 9
+    # Crew
+    span_0 = traces[0].data.spans[0]
+    assert span_0.name == "Crew.kickoff"
+    assert span_0.span_type == SpanType.CHAIN
+    assert span_0.parent_id is None
+    assert span_0.inputs == {}
+    assert span_0.outputs == {
+        "json_dict": None,
+        "pydantic": None,
+        "raw": "What about Tokyo?",
+        "tasks_output": [
+            {
+                "agent": "City Selection Expert",
+                "name": None,
+                "description": "Analyze and select the best city for the trip",
+                "expected_output": "Detailed report on the chosen city",
+                "json_dict": None,
+                "pydantic": None,
+                "output_format": "raw",
+                "raw": "What about Tokyo?",
+                "summary": "Analyze and select the best city for the trip...",
             },
-        }
-        # Task
-        span_1 = traces[0].data.spans[1]
-        assert span_1.name == "Task.execute_sync_1"
-        assert span_1.span_type == SpanType.CHAIN
-        assert span_1.parent_id is span_0.span_id
-        assert span_1.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_1.outputs == {
-            "agent": "City Selection Expert",
-            "description": "Analyze and select the best city for the trip",
-            "expected_output": "Detailed report on the chosen city",
-            "json_dict": None,
-            "name": None,
-            "output_format": "raw",
-            "pydantic": None,
-            "raw": "What about Tokyo?",
-            "summary": "Analyze and select the best city for the trip...",
-        }
-        # Agent
-        span_2 = traces[0].data.spans[2]
-        assert span_2.name == "Agent.execute_task_1"
-        assert span_2.span_type == SpanType.AGENT
-        assert span_2.parent_id is span_1.span_id
-        assert span_2.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_2.outputs == "What about Tokyo?"
-        # LLM
-        span_3 = traces[0].data.spans[3]
-        assert span_3.name == "LLM.call_1"
-        assert span_3.span_type == SpanType.LLM
-        assert span_3.parent_id is span_2.span_id
-        assert span_3.inputs["messages"] is not None
-        assert span_3.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+            {
+                "agent": "Local Expert at this city",
+                "description": "Compile an in-depth guide",
+                "expected_output": "Comprehensive city guide",
+                "json_dict": None,
+                "name": None,
+                "output_format": "raw",
+                "pydantic": None,
+                "raw": "What about Tokyo?",
+                "summary": "Compile an in-depth guide...",
+            },
+        ],
+        "token_usage": {
+            "cached_prompt_tokens": 0,
+            "completion_tokens": 0,
+            "prompt_tokens": 0,
+            "successful_requests": 0,
+            "total_tokens": 0,
+        },
+    }
+    # Task
+    span_1 = traces[0].data.spans[1]
+    assert span_1.name == "Task.execute_sync_1"
+    assert span_1.span_type == SpanType.CHAIN
+    assert span_1.parent_id is span_0.span_id
+    assert span_1.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_1.outputs == {
+        "agent": "City Selection Expert",
+        "description": "Analyze and select the best city for the trip",
+        "expected_output": "Detailed report on the chosen city",
+        "json_dict": None,
+        "name": None,
+        "output_format": "raw",
+        "pydantic": None,
+        "raw": "What about Tokyo?",
+        "summary": "Analyze and select the best city for the trip...",
+    }
+    # Agent
+    span_2 = traces[0].data.spans[2]
+    assert span_2.name == "Agent.execute_task_1"
+    assert span_2.span_type == SpanType.AGENT
+    assert span_2.parent_id is span_1.span_id
+    assert span_2.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_2.outputs == "What about Tokyo?"
+    # LLM
+    span_3 = traces[0].data.spans[3]
+    assert span_3.name == "LLM.call_1"
+    assert span_3.span_type == SpanType.LLM
+    assert span_3.parent_id is span_2.span_id
+    assert span_3.inputs["messages"] is not None
+    assert span_3.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
 
-        # Create Long Term Memory
-        span_4 = traces[0].data.spans[4]
-        assert span_4.name == "CrewAgentExecutor._create_long_term_memory_1"
-        assert span_4.span_type == SpanType.RETRIEVER
-        assert span_4.parent_id is span_2.span_id
-        assert span_4.inputs == {
-            "output": {
-                "output": "What about Tokyo?",
-                "text": "Final Answer: What about Tokyo?",
-                "thought": "",
-            }
+    # Create Long Term Memory
+    span_4 = traces[0].data.spans[4]
+    assert span_4.name == "CrewAgentExecutor._create_long_term_memory_1"
+    assert span_4.span_type == SpanType.RETRIEVER
+    assert span_4.parent_id is span_2.span_id
+    assert span_4.inputs == {
+        "output": {
+            "output": "What about Tokyo?",
+            "text": "Final Answer: What about Tokyo?",
+            "thought": "",
         }
-        assert span_4.outputs is None
+    }
+    assert span_4.outputs is None
 
-        # Task
-        span_5 = traces[0].data.spans[5]
-        assert span_5.name == "Task.execute_sync_2"
-        assert span_5.span_type == SpanType.CHAIN
-        assert span_5.parent_id is span_0.span_id
-        assert span_5.inputs == {
-            "context": "What about Tokyo?",
-            "tools": [],
+    # Task
+    span_5 = traces[0].data.spans[5]
+    assert span_5.name == "Task.execute_sync_2"
+    assert span_5.span_type == SpanType.CHAIN
+    assert span_5.parent_id is span_0.span_id
+    assert span_5.inputs == {
+        "context": "What about Tokyo?",
+        "tools": [],
+    }
+    assert span_5.outputs == {
+        "agent": "Local Expert at this city",
+        "description": "Compile an in-depth guide",
+        "expected_output": "Comprehensive city guide",
+        "json_dict": None,
+        "name": None,
+        "output_format": "raw",
+        "pydantic": None,
+        "raw": "What about Tokyo?",
+        "summary": "Compile an in-depth guide...",
+    }
+    # Agent
+    span_6 = traces[0].data.spans[6]
+    assert span_6.name == "Agent.execute_task_2"
+    assert span_6.span_type == SpanType.AGENT
+    assert span_6.parent_id is span_5.span_id
+    assert span_6.inputs == {
+        "context": "What about Tokyo?",
+        "tools": [],
+    }
+    assert span_6.outputs == "What about Tokyo?"
+    # LLM
+    span_7 = traces[0].data.spans[7]
+    assert span_7.name == "LLM.call_2"
+    assert span_7.span_type == SpanType.LLM
+    assert span_7.parent_id is span_6.span_id
+    assert span_7.inputs["messages"] is not None
+    assert span_7.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    # Create Long Term Memory
+    span_8 = traces[0].data.spans[8]
+    assert span_8.name == "CrewAgentExecutor._create_long_term_memory_2"
+    assert span_8.span_type == SpanType.RETRIEVER
+    assert span_8.parent_id is span_6.span_id
+    assert span_8.inputs == {
+        "output": {
+            "output": "What about Tokyo?",
+            "text": "Final Answer: What about Tokyo?",
+            "thought": "",
         }
-        assert span_5.outputs == {
-            "agent": "Local Expert at this city",
-            "description": "Compile an in-depth guide",
-            "expected_output": "Comprehensive city guide",
-            "json_dict": None,
-            "name": None,
-            "output_format": "raw",
-            "pydantic": None,
-            "raw": "What about Tokyo?",
-            "summary": "Compile an in-depth guide...",
-        }
-        # Agent
-        span_6 = traces[0].data.spans[6]
-        assert span_6.name == "Agent.execute_task_2"
-        assert span_6.span_type == SpanType.AGENT
-        assert span_6.parent_id is span_5.span_id
-        assert span_6.inputs == {
-            "context": "What about Tokyo?",
-            "tools": [],
-        }
-        assert span_6.outputs == "What about Tokyo?"
-        # LLM
-        span_7 = traces[0].data.spans[7]
-        assert span_7.name == "LLM.call_2"
-        assert span_7.span_type == SpanType.LLM
-        assert span_7.parent_id is span_6.span_id
-        assert span_7.inputs["messages"] is not None
-        assert span_7.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
-        # Create Long Term Memory
-        span_8 = traces[0].data.spans[8]
-        assert span_8.name == "CrewAgentExecutor._create_long_term_memory_2"
-        assert span_8.span_type == SpanType.RETRIEVER
-        assert span_8.parent_id is span_6.span_id
-        assert span_8.inputs == {
-            "output": {
-                "output": "What about Tokyo?",
-                "text": "Final Answer: What about Tokyo?",
-                "thought": "",
-            }
-        }
-        assert span_8.outputs is None
+    }
+    assert span_8.outputs is None
 
 
 @pytest.mark.skipif(
     Version(crewai.__version__) < Version("0.83.0"),
     reason=("Memory feature in the current style is not available before 0.83.0"),
 )
-def test_memory(simple_agent_1, task_1, monkeypatch):
+def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
     monkeypatch.setenv("OPENAI_API_KEY", "000")
+    crew = Crew(
+        agents=[
+            simple_agent_1,
+        ],
+        tasks=[task_1],
+        memory=True,
+    )
     with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
         with patch("openai.OpenAI") as client:
             client().embeddings.create.return_value = EMBEDDING
-            mlflow.crewai.autolog()
-            crew = Crew(
-                agents=[
-                    simple_agent_1,
-                ],
-                tasks=[task_1],
-                memory=True,
-            )
-
+            autolog()
             crew.kickoff()
 
-            traces = get_traces()
-            assert len(traces) == 1
-            assert traces[0].info.status == "OK"
-            assert len(traces[0].data.spans) == 9
-            # Crew
-            span_0 = traces[0].data.spans[0]
-            assert span_0.name == "Crew.kickoff"
-            assert span_0.span_type == SpanType.CHAIN
-            assert span_0.parent_id is None
-            assert span_0.inputs == {}
-            assert span_0.outputs == CREW_OUTPUT
-            # Task
-            span_1 = traces[0].data.spans[1]
-            assert span_1.name == "Task.execute_sync"
-            assert span_1.span_type == SpanType.CHAIN
-            assert span_1.parent_id is span_0.span_id
-            assert span_1.inputs == {
-                "context": "",
-                "tools": [],
-            }
-            assert span_1.outputs == {
-                "agent": "City Selection Expert",
-                "description": "Analyze and select the best city for the trip",
-                "expected_output": "Detailed report on the chosen city",
-                "json_dict": None,
-                "name": None,
-                "output_format": "raw",
-                "pydantic": None,
-                "raw": "What about Tokyo?",
-                "summary": "Analyze and select the best city for the trip...",
-            }
-            # Agent
-            span_2 = traces[0].data.spans[2]
-            assert span_2.name == "Agent.execute_task"
-            assert span_2.span_type == SpanType.AGENT
-            assert span_2.parent_id is span_1.span_id
-            assert span_2.inputs == {
-                "context": "",
-                "tools": [],
-            }
-            assert span_2.outputs == "What about Tokyo?"
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert len(traces[0].data.spans) == 9
+    # Crew
+    span_0 = traces[0].data.spans[0]
+    assert span_0.name == "Crew.kickoff"
+    assert span_0.span_type == SpanType.CHAIN
+    assert span_0.parent_id is None
+    assert span_0.inputs == {}
+    assert span_0.outputs == CREW_OUTPUT
+    # Task
+    span_1 = traces[0].data.spans[1]
+    assert span_1.name == "Task.execute_sync"
+    assert span_1.span_type == SpanType.CHAIN
+    assert span_1.parent_id is span_0.span_id
+    assert span_1.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_1.outputs == {
+        "agent": "City Selection Expert",
+        "description": "Analyze and select the best city for the trip",
+        "expected_output": "Detailed report on the chosen city",
+        "json_dict": None,
+        "name": None,
+        "output_format": "raw",
+        "pydantic": None,
+        "raw": "What about Tokyo?",
+        "summary": "Analyze and select the best city for the trip...",
+    }
+    # Agent
+    span_2 = traces[0].data.spans[2]
+    assert span_2.name == "Agent.execute_task"
+    assert span_2.span_type == SpanType.AGENT
+    assert span_2.parent_id is span_1.span_id
+    assert span_2.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_2.outputs == "What about Tokyo?"
 
-            # LongTermMemory
-            span_3 = traces[0].data.spans[3]
-            assert span_3.name == "LongTermMemory.search"
-            assert span_3.span_type == SpanType.RETRIEVER
-            assert span_3.parent_id is span_2.span_id
-            assert span_3.inputs == {
-                "latest_n": 2,
-                "task": "Analyze and select the best city for the trip",
-            }
-            assert span_3.outputs is None
+    # LongTermMemory
+    span_3 = traces[0].data.spans[3]
+    assert span_3.name == "LongTermMemory.search"
+    assert span_3.span_type == SpanType.RETRIEVER
+    assert span_3.parent_id is span_2.span_id
+    assert span_3.inputs == {
+        "latest_n": 2,
+        "task": "Analyze and select the best city for the trip",
+    }
+    assert span_3.outputs is None
 
-            # ShortTermMemory
-            span_4 = traces[0].data.spans[4]
-            assert span_4.name == "ShortTermMemory.search"
-            assert span_4.span_type == SpanType.RETRIEVER
-            assert span_4.parent_id is span_2.span_id
-            assert span_4.inputs == {"query": "Analyze and select the best city for the trip"}
-            assert span_4.outputs == []
+    # ShortTermMemory
+    span_4 = traces[0].data.spans[4]
+    assert span_4.name == "ShortTermMemory.search"
+    assert span_4.span_type == SpanType.RETRIEVER
+    assert span_4.parent_id is span_2.span_id
+    assert span_4.inputs == {"query": "Analyze and select the best city for the trip"}
+    assert span_4.outputs == []
 
-            # EntityMemory
-            span_5 = traces[0].data.spans[5]
-            assert span_5.name == "EntityMemory.search"
-            assert span_5.span_type == SpanType.RETRIEVER
-            assert span_5.parent_id is span_2.span_id
-            assert span_5.inputs == {
-                "query": "Analyze and select the best city for the trip",
-            }
-            assert span_5.outputs == []
+    # EntityMemory
+    span_5 = traces[0].data.spans[5]
+    assert span_5.name == "EntityMemory.search"
+    assert span_5.span_type == SpanType.RETRIEVER
+    assert span_5.parent_id is span_2.span_id
+    assert span_5.inputs == {
+        "query": "Analyze and select the best city for the trip",
+    }
+    assert span_5.outputs == []
 
-            # LLM
-            span_6 = traces[0].data.spans[6]
-            assert span_6.name == "LLM.call"
-            assert span_6.span_type == SpanType.LLM
-            assert span_6.parent_id is span_2.span_id
-            assert span_6.inputs["messages"] is not None
-            assert span_6.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    # LLM
+    span_6 = traces[0].data.spans[6]
+    assert span_6.name == "LLM.call"
+    assert span_6.span_type == SpanType.LLM
+    assert span_6.parent_id is span_2.span_id
+    assert span_6.inputs["messages"] is not None
+    assert span_6.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
 
-            # ShortTermMemory.save
-            span_7 = traces[0].data.spans[7]
-            assert span_7.name == "ShortTermMemory.save"
-            assert span_7.span_type == SpanType.RETRIEVER
-            assert span_7.parent_id is span_2.span_id
-            assert span_7.inputs == {
-                "agent": "City Selection Expert",
-                "metadata": {
-                    "observation": "Analyze and select the best city for the trip",
-                },
-                "value": "Final Answer: What about Tokyo?",
-            }
-            assert span_7.outputs is None
+    # ShortTermMemory.save
+    span_7 = traces[0].data.spans[7]
+    assert span_7.name == "ShortTermMemory.save"
+    assert span_7.span_type == SpanType.RETRIEVER
+    assert span_7.parent_id is span_2.span_id
+    assert span_7.inputs == {
+        "agent": "City Selection Expert",
+        "metadata": {
+            "observation": "Analyze and select the best city for the trip",
+        },
+        "value": "Final Answer: What about Tokyo?",
+    }
+    assert span_7.outputs is None
 
-            # Create Long Term Memory
-            span_8 = traces[0].data.spans[8]
-            assert span_8.name == "CrewAgentExecutor._create_long_term_memory"
-            assert span_8.span_type == SpanType.RETRIEVER
-            assert span_8.parent_id is span_2.span_id
-            assert span_8.inputs == {
-                "output": {
-                    "output": "What about Tokyo?",
-                    "text": "Final Answer: What about Tokyo?",
-                    "thought": "",
-                }
-            }
-            assert span_8.outputs is None
+    # Create Long Term Memory
+    span_8 = traces[0].data.spans[8]
+    assert span_8.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_8.span_type == SpanType.RETRIEVER
+    assert span_8.parent_id is span_2.span_id
+    assert span_8.inputs == {
+        "output": {
+            "output": "What about Tokyo?",
+            "text": "Final Answer: What about Tokyo?",
+            "thought": "",
+        }
+    }
+    assert span_8.outputs is None
 
 
 @pytest.mark.skipif(
-    Version(crewai.__version__) < Version("0.83.0"),
-    reason=("Knowledge feature in the current style is not available before 0.83.0"),
+    Version(crewai.__version__) < Version("0.83.0")
+    or Version(crewai.__version__) >= Version("0.85.0"),
+    reason=("Knowledge feature in the current style is available only with 0.83.0"),
 )
-def test_knowledge(simple_agent_1, task_1, monkeypatch):
+def test_knowledge(simple_agent_1, task_1, monkeypatch, autolog):
     monkeypatch.setenv("OPENAI_API_KEY", "000")
     from crewai.knowledge.source.string_knowledge_source import StringKnowledgeSource
 
     content = "Users name is John"
     string_source = StringKnowledgeSource(content=content, metadata={"preference": "personal"})
+    crew = Crew(
+        agents=[
+            simple_agent_1,
+        ],
+        tasks=[task_1],
+        knowledge={"sources": [string_source], "metadata": {"preference": "personal"}},
+    )
     with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
-        mlflow.crewai.autolog()
-        crew = Crew(
-            agents=[
-                simple_agent_1,
-            ],
-            tasks=[task_1],
-            knowledge={"sources": [string_source], "metadata": {"preference": "personal"}},
-        )
-
+        autolog()
         crew.kickoff()
 
-        traces = get_traces()
-        assert len(traces) == 1
-        assert traces[0].info.status == "OK"
-        assert len(traces[0].data.spans) == 6
-        # Crew
-        span_0 = traces[0].data.spans[0]
-        assert span_0.name == "Crew.kickoff"
-        assert span_0.span_type == SpanType.CHAIN
-        assert span_0.parent_id is None
-        assert span_0.inputs == {}
-        assert span_0.outputs == CREW_OUTPUT
-        # Task
-        span_1 = traces[0].data.spans[1]
-        assert span_1.name == "Task.execute_sync"
-        assert span_1.span_type == SpanType.CHAIN
-        assert span_1.parent_id is span_0.span_id
-        assert span_1.inputs == {
-            "context": "",
-            "tools": [],
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert len(traces[0].data.spans) == 6
+    # Crew
+    span_0 = traces[0].data.spans[0]
+    assert span_0.name == "Crew.kickoff"
+    assert span_0.span_type == SpanType.CHAIN
+    assert span_0.parent_id is None
+    assert span_0.inputs == {}
+    assert span_0.outputs == CREW_OUTPUT
+    # Task
+    span_1 = traces[0].data.spans[1]
+    assert span_1.name == "Task.execute_sync"
+    assert span_1.span_type == SpanType.CHAIN
+    assert span_1.parent_id is span_0.span_id
+    assert span_1.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_1.outputs == {
+        "agent": "City Selection Expert",
+        "description": "Analyze and select the best city for the trip",
+        "expected_output": "Detailed report on the chosen city",
+        "json_dict": None,
+        "name": None,
+        "output_format": "raw",
+        "pydantic": None,
+        "raw": "What about Tokyo?",
+        "summary": "Analyze and select the best city for the trip...",
+    }
+    # Agent
+    span_2 = traces[0].data.spans[2]
+    assert span_2.name == "Agent.execute_task"
+    assert span_2.span_type == SpanType.AGENT
+    assert span_2.parent_id is span_1.span_id
+    assert span_2.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_2.outputs == "What about Tokyo?"
+
+    # Knowledge
+    span_3 = traces[0].data.spans[3]
+    assert span_3.name == "Knowledge.query"
+    assert span_3.span_type == SpanType.RETRIEVER
+    assert span_3.parent_id is span_2.span_id
+    assert span_3.inputs["query"] is not None
+    assert span_3.outputs is not None
+
+    # LLM
+    span_4 = traces[0].data.spans[4]
+    assert span_4.name == "LLM.call"
+    assert span_4.span_type == SpanType.LLM
+    assert span_4.parent_id is span_2.span_id
+    assert span_4.inputs["messages"] is not None
+    assert span_4.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+
+    # Create Long Term Memory
+    span_5 = traces[0].data.spans[5]
+    assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_5.span_type == SpanType.RETRIEVER
+    assert span_5.parent_id is span_2.span_id
+    assert span_5.inputs == {
+        "output": {
+            "output": "What about Tokyo?",
+            "text": "Final Answer: What about Tokyo?",
+            "thought": "",
         }
-        assert span_1.outputs == {
-            "agent": "City Selection Expert",
-            "description": "Analyze and select the best city for the trip",
-            "expected_output": "Detailed report on the chosen city",
-            "json_dict": None,
-            "name": None,
-            "output_format": "raw",
-            "pydantic": None,
-            "raw": "What about Tokyo?",
-            "summary": "Analyze and select the best city for the trip...",
-        }
-        # Agent
-        span_2 = traces[0].data.spans[2]
-        assert span_2.name == "Agent.execute_task"
-        assert span_2.span_type == SpanType.AGENT
-        assert span_2.parent_id is span_1.span_id
-        assert span_2.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_2.outputs == "What about Tokyo?"
-
-        # Knowledge
-        span_3 = traces[0].data.spans[3]
-        assert span_3.name == "Knowledge.query"
-        assert span_3.span_type == SpanType.RETRIEVER
-        assert span_3.parent_id is span_2.span_id
-        assert span_3.inputs["query"] is not None
-        assert span_3.outputs is not None
-
-        # LLM
-        span_4 = traces[0].data.spans[4]
-        assert span_4.name == "LLM.call"
-        assert span_4.span_type == SpanType.LLM
-        assert span_4.parent_id is span_2.span_id
-        assert span_4.inputs["messages"] is not None
-        assert span_4.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
-
-        # Create Long Term Memory
-        span_5 = traces[0].data.spans[5]
-        assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
-        assert span_5.span_type == SpanType.RETRIEVER
-        assert span_5.parent_id is span_2.span_id
-        assert span_5.inputs == {
-            "output": {
-                "output": "What about Tokyo?",
-                "text": "Final Answer: What about Tokyo?",
-                "thought": "",
-            }
-        }
-        assert span_5.outputs is None
+    }
+    assert span_5.outputs is None
 
 
-def test_kickoff_for_each(simple_agent_1, task_1):
+def test_kickoff_for_each(simple_agent_1, task_1, autolog):
+    crew = Crew(
+        agents=[
+            simple_agent_1,
+        ],
+        tasks=[task_1],
+    )
     with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
-        mlflow.crewai.autolog()
-        crew = Crew(
-            agents=[
-                simple_agent_1,
-            ],
-            tasks=[task_1],
-        )
-
+        autolog()
         crew.kickoff_for_each([{}])
 
-        traces = get_traces()
-        assert len(traces) == 1
-        assert traces[0].info.status == "OK"
-        assert len(traces[0].data.spans) == 6
-        span_0 = traces[0].data.spans[0]
-        # kickoff_for_each
-        assert span_0.name == "Crew.kickoff_for_each"
-        assert span_0.span_type == SpanType.CHAIN
-        assert span_0.parent_id is None
-        assert span_0.inputs == {"inputs": [{}]}
-        assert span_0.outputs == [CREW_OUTPUT]
-        # Crew
-        span_1 = traces[0].data.spans[1]
-        assert span_1.name == "Crew.kickoff"
-        assert span_1.span_type == SpanType.CHAIN
-        assert span_1.parent_id == span_0.span_id
-        assert span_1.inputs == {
-            "inputs": {},
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert len(traces[0].data.spans) == 6
+    span_0 = traces[0].data.spans[0]
+    # kickoff_for_each
+    assert span_0.name == "Crew.kickoff_for_each"
+    assert span_0.span_type == SpanType.CHAIN
+    assert span_0.parent_id is None
+    assert span_0.inputs == {"inputs": [{}]}
+    assert span_0.outputs == [CREW_OUTPUT]
+    # Crew
+    span_1 = traces[0].data.spans[1]
+    assert span_1.name == "Crew.kickoff"
+    assert span_1.span_type == SpanType.CHAIN
+    assert span_1.parent_id == span_0.span_id
+    assert span_1.inputs == {
+        "inputs": {},
+    }
+    assert span_1.outputs == CREW_OUTPUT
+    # Task
+    span_2 = traces[0].data.spans[2]
+    assert span_2.name == "Task.execute_sync"
+    assert span_2.span_type == SpanType.CHAIN
+    assert span_2.parent_id is span_1.span_id
+    assert span_2.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_2.outputs == {
+        "agent": "City Selection Expert",
+        "description": "Analyze and select the best city for the trip",
+        "expected_output": "Detailed report on the chosen city",
+        "json_dict": None,
+        "name": None,
+        "output_format": "raw",
+        "pydantic": None,
+        "raw": "What about Tokyo?",
+        "summary": "Analyze and select the best city for the trip...",
+    }
+    # Agent
+    span_3 = traces[0].data.spans[3]
+    assert span_3.name == "Agent.execute_task"
+    assert span_3.span_type == SpanType.AGENT
+    assert span_3.parent_id is span_2.span_id
+    assert span_3.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_3.outputs == "What about Tokyo?"
+    # LLM
+    span_4 = traces[0].data.spans[4]
+    assert span_4.name == "LLM.call"
+    assert span_4.span_type == SpanType.LLM
+    assert span_4.parent_id is span_3.span_id
+    assert span_4.inputs["messages"] is not None
+    assert span_4.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    # Create Long Term Memory
+    span_5 = traces[0].data.spans[5]
+    assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_5.span_type == SpanType.RETRIEVER
+    assert span_5.parent_id is span_3.span_id
+    assert span_5.inputs == {
+        "output": {
+            "output": "What about Tokyo?",
+            "text": "Final Answer: What about Tokyo?",
+            "thought": "",
         }
-        assert span_1.outputs == CREW_OUTPUT
-        # Task
-        span_2 = traces[0].data.spans[2]
-        assert span_2.name == "Task.execute_sync"
-        assert span_2.span_type == SpanType.CHAIN
-        assert span_2.parent_id is span_1.span_id
-        assert span_2.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_2.outputs == {
-            "agent": "City Selection Expert",
-            "description": "Analyze and select the best city for the trip",
-            "expected_output": "Detailed report on the chosen city",
-            "json_dict": None,
-            "name": None,
-            "output_format": "raw",
-            "pydantic": None,
-            "raw": "What about Tokyo?",
-            "summary": "Analyze and select the best city for the trip...",
-        }
-        # Agent
-        span_3 = traces[0].data.spans[3]
-        assert span_3.name == "Agent.execute_task"
-        assert span_3.span_type == SpanType.AGENT
-        assert span_3.parent_id is span_2.span_id
-        assert span_3.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_3.outputs == "What about Tokyo?"
-        # LLM
-        span_4 = traces[0].data.spans[4]
-        assert span_4.name == "LLM.call"
-        assert span_4.span_type == SpanType.LLM
-        assert span_4.parent_id is span_3.span_id
-        assert span_4.inputs["messages"] is not None
-        assert span_4.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
-        # Create Long Term Memory
-        span_5 = traces[0].data.spans[5]
-        assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
-        assert span_5.span_type == SpanType.RETRIEVER
-        assert span_5.parent_id is span_3.span_id
-        assert span_5.inputs == {
-            "output": {
-                "output": "What about Tokyo?",
-                "text": "Final Answer: What about Tokyo?",
-                "thought": "",
-            }
-        }
-        assert span_5.outputs is None
+    }
+    assert span_5.outputs is None
 
 
-def test_flow(simple_agent_1, task_1):
+def test_flow(simple_agent_1, task_1, autolog):
+    crew = Crew(
+        agents=[
+            simple_agent_1,
+        ],
+        tasks=[task_1],
+    )
+
+    class TestFlow(Flow):
+        @start()
+        def start(self):
+            return crew.kickoff()
+
+    flow = TestFlow()
+
     with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
-        mlflow.crewai.autolog()
-        crew = Crew(
-            agents=[
-                simple_agent_1,
-            ],
-            tasks=[task_1],
-        )
-
-        class TestFlow(Flow):
-            @start()
-            def start(self):
-                return crew.kickoff()
-
-        flow = TestFlow()
-
+        autolog()
         flow.kickoff()
 
-        traces = get_traces()
-        assert len(traces) == 1
-        assert traces[0].info.status == "OK"
-        assert len(traces[0].data.spans) == 6
-        span_0 = traces[0].data.spans[0]
-        # kickoff_for_each
-        assert span_0.name == "TestFlow.kickoff"
-        assert span_0.span_type == SpanType.CHAIN
-        assert span_0.parent_id is None
-        assert span_0.inputs == {}
-        assert span_0.outputs == CREW_OUTPUT
-        # Crew
-        span_1 = traces[0].data.spans[1]
-        assert span_1.name == "Crew.kickoff"
-        assert span_1.span_type == SpanType.CHAIN
-        assert span_1.parent_id == span_0.span_id
-        assert span_1.inputs == {}
-        assert span_1.outputs == CREW_OUTPUT
-        # Task
-        span_2 = traces[0].data.spans[2]
-        assert span_2.name == "Task.execute_sync"
-        assert span_2.span_type == SpanType.CHAIN
-        assert span_2.parent_id is span_1.span_id
-        assert span_2.inputs == {
-            "context": "",
-            "tools": [],
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert len(traces[0].data.spans) == 6
+    span_0 = traces[0].data.spans[0]
+    # kickoff_for_each
+    assert span_0.name == "TestFlow.kickoff"
+    assert span_0.span_type == SpanType.CHAIN
+    assert span_0.parent_id is None
+    assert span_0.inputs == {}
+    assert span_0.outputs == CREW_OUTPUT
+    # Crew
+    span_1 = traces[0].data.spans[1]
+    assert span_1.name == "Crew.kickoff"
+    assert span_1.span_type == SpanType.CHAIN
+    assert span_1.parent_id == span_0.span_id
+    assert span_1.inputs == {}
+    assert span_1.outputs == CREW_OUTPUT
+    # Task
+    span_2 = traces[0].data.spans[2]
+    assert span_2.name == "Task.execute_sync"
+    assert span_2.span_type == SpanType.CHAIN
+    assert span_2.parent_id is span_1.span_id
+    assert span_2.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_2.outputs == {
+        "agent": "City Selection Expert",
+        "description": "Analyze and select the best city for the trip",
+        "expected_output": "Detailed report on the chosen city",
+        "json_dict": None,
+        "name": None,
+        "output_format": "raw",
+        "pydantic": None,
+        "raw": "What about Tokyo?",
+        "summary": "Analyze and select the best city for the trip...",
+    }
+    # Agent
+    span_3 = traces[0].data.spans[3]
+    assert span_3.name == "Agent.execute_task"
+    assert span_3.span_type == SpanType.AGENT
+    assert span_3.parent_id is span_2.span_id
+    assert span_3.inputs == {
+        "context": "",
+        "tools": [],
+    }
+    assert span_3.outputs == "What about Tokyo?"
+    # LLM
+    span_4 = traces[0].data.spans[4]
+    assert span_4.name == "LLM.call"
+    assert span_4.span_type == SpanType.LLM
+    assert span_4.parent_id is span_3.span_id
+    assert span_4.inputs["messages"] is not None
+    assert span_4.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    # Create Long Term Memory
+    span_5 = traces[0].data.spans[5]
+    assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_5.span_type == SpanType.RETRIEVER
+    assert span_5.parent_id is span_3.span_id
+    assert span_5.inputs == {
+        "output": {
+            "output": "What about Tokyo?",
+            "text": "Final Answer: What about Tokyo?",
+            "thought": "",
         }
-        assert span_2.outputs == {
-            "agent": "City Selection Expert",
-            "description": "Analyze and select the best city for the trip",
-            "expected_output": "Detailed report on the chosen city",
-            "json_dict": None,
-            "name": None,
-            "output_format": "raw",
-            "pydantic": None,
-            "raw": "What about Tokyo?",
-            "summary": "Analyze and select the best city for the trip...",
-        }
-        # Agent
-        span_3 = traces[0].data.spans[3]
-        assert span_3.name == "Agent.execute_task"
-        assert span_3.span_type == SpanType.AGENT
-        assert span_3.parent_id is span_2.span_id
-        assert span_3.inputs == {
-            "context": "",
-            "tools": [],
-        }
-        assert span_3.outputs == "What about Tokyo?"
-        # LLM
-        span_4 = traces[0].data.spans[4]
-        assert span_4.name == "LLM.call"
-        assert span_4.span_type == SpanType.LLM
-        assert span_4.parent_id is span_3.span_id
-        assert span_4.inputs["messages"] is not None
-        assert span_4.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
-        # Create Long Term Memory
-        span_5 = traces[0].data.spans[5]
-        assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
-        assert span_5.span_type == SpanType.RETRIEVER
-        assert span_5.parent_id is span_3.span_id
-        assert span_5.inputs == {
-            "output": {
-                "output": "What about Tokyo?",
-                "text": "Final Answer: What about Tokyo?",
-                "thought": "",
-            }
-        }
-        assert span_5.outputs is None
+    }
+    assert span_5.outputs is None

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -107,6 +107,9 @@ def reset_global_states():
         except Exception:
             pass
 
+    # TODO: Remove this when we run ci with Python >= 3.10
+    mlflow.utils.import_hooks._post_import_hooks.pop("crewai", None)
+
     assert all(v == {} for v in AUTOLOGGING_INTEGRATIONS.values())
     assert mlflow.utils.import_hooks._post_import_hooks == {}
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/13971?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13971/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13971
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
CrewAI integration was added, but it was not added to mlflow.autolog. So it is added in this PR.
Since our ci runs for flavor tests with Python 3.9, the change was verified by manual testing.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

It was confirmed that trace is created when running the following code 
```python
import mlflow
mlflow.autolog()
import crewai

### example code for crewai in https://github.com/mlflow/mlflow/blob/master/examples/crewai/tracing.py 
```

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
