### PR TITLE
Fix request/response field in the search_traces output

### DIFF
--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -10,6 +11,8 @@ from mlflow.entities.trace_info import TraceInfo
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
+
+_logger = logging.getLogger(__name__)
 
 @dataclass
 class Trace(_MlflowObject):
@@ -93,12 +96,20 @@ class Trace(_MlflowObject):
             "timestamp_ms": self.info.timestamp_ms,
             "status": self.info.status,
             "execution_time_ms": self.info.execution_time_ms,
-            "request": self.data.request,
-            "response": self.data.response,
+            "request": self._deserialize_json_attr(self.data.request),
+            "response": self._deserialize_json_attr(self.data.response),
             "request_metadata": self.info.request_metadata,
             "spans": [span.to_dict() for span in self.data.spans],
             "tags": self.info.tags,
         }
+
+
+    def _deserialize_json_attr(self, value: str):
+        try:
+            return json.loads(value)
+        except Exception:
+            _logger.debug(f"Failed to deserialize JSON attribute: {value}", exc_info=True)
+            return value
 
     @staticmethod
     def pandas_dataframe_columns() -> list[str]:

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -11,8 +11,8 @@ from mlflow.entities.trace_info import TraceInfo
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
-
 _logger = logging.getLogger(__name__)
+
 
 @dataclass
 class Trace(_MlflowObject):
@@ -102,7 +102,6 @@ class Trace(_MlflowObject):
             "spans": [span.to_dict() for span in self.data.spans],
             "tags": self.info.tags,
         }
-
 
     def _deserialize_json_attr(self, value: str):
         try:

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -37,7 +37,7 @@ from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 from mlflow.utils.file_utils import local_file_uri_to_path
 from mlflow.utils.os import is_windows
 
-from tests.tracing.helper import create_test_trace_info, create_trace, get_traces
+from tests.tracing.helper import create_test_trace_info, get_traces
 
 
 class DefaultTestModel:

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -774,15 +774,20 @@ def test_search_traces_with_default_experiment_id(mock_client):
 
 
 def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
-    traces_to_return = [create_trace("a"), create_trace("b"), create_trace("c")]
+    model = DefaultTestModel()
+    client = mlflow.MlflowClient()
+    expected_traces = []
+    for _ in range(10):
+        model.predict(2, 5)
+        time.sleep(0.1)
 
-    class MockMlflowClient:
-        def search_traces(self, *args, **kwargs):
-            return traces_to_return
+        # The in-memory trace returned from get_last_active_trace() is not guaranteed to be
+        # exactly same as the trace stored in the backend (e.g., tags created by the backend).
+        # Therefore, we fetch the trace from the backend to compare the results.
+        trace = client.get_trace(mlflow.get_last_active_trace().info.request_id)
+        expected_traces.append(trace)
 
-    monkeypatch.setattr("mlflow.tracing.fluent.MlflowClient", MockMlflowClient)
-
-    df = mlflow.search_traces()
+    df = mlflow.search_traces(max_results=10, order_by=["timestamp ASC"])
     assert df.columns.tolist() == [
         "request_id",
         "trace",
@@ -795,16 +800,16 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
         "spans",
         "tags",
     ]
-    for idx, trace in enumerate(traces_to_return):
+    for idx, trace in enumerate(expected_traces):
         assert df.iloc[idx].request_id == trace.info.request_id
-        assert df.iloc[idx].trace == trace
+        assert df.iloc[idx].trace.info.request_id == trace.info.request_id
         assert df.iloc[idx].timestamp_ms == trace.info.timestamp_ms
         assert df.iloc[idx].status == trace.info.status
         assert df.iloc[idx].execution_time_ms == trace.info.execution_time_ms
-        assert df.iloc[idx].request == trace.data.request
-        assert df.iloc[idx].response == trace.data.response
+        assert df.iloc[idx].request == json.loads(trace.data.request)
+        assert df.iloc[idx].response == json.loads(trace.data.response)
         assert df.iloc[idx].request_metadata == trace.info.request_metadata
-        assert df.iloc[idx].spans == trace.data.spans
+        assert df.iloc[idx].spans == [s.to_dict() for s in trace.data.spans]
         assert df.iloc[idx].tags == trace.info.tags
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13985?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13985/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13985
```

</p>
</details>

### What changes are proposed in this pull request?

`mlflow.search_traces` returns Pandas Dataframe that unpacks fields from trace.

<img width="1072" alt="Screenshot 2024-12-05 at 12 58 58" src="https://github.com/user-attachments/assets/4a67289d-75a8-4813-a24c-28beb2d0053a">

Currently, `request` and `response` columns contain JSON-encoded string (double quoting), which is hard to use (need to run `apply(lambda x: json.loads(x))` to convert to columns to the actual request and response. This happens because these columns are derived from the `trace.data.request` and `trace.data.response`, which stores JSON-encoded values for frontend rendering. We should not put them into the DataFrame as is and this PR fixes the issue.



### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="1087" alt="Screenshot 2024-12-05 at 13 04 13" src="https://github.com/user-attachments/assets/e1094ca8-d198-4072-856c-2d1fd5a88a6a">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
