### PR TITLE
Optimize tracing enablement logic for evaluation

### DIFF
--- a/mlflow/models/evaluation/utils/trace.py
+++ b/mlflow/models/evaluation/utils/trace.py
@@ -21,7 +21,7 @@ _logger = logging.getLogger(__name__)
 
 
 # This flag is used to display the message only once when tracing is enabled during the evaluation.
-_IS_TRACE_MESSAGE_DISPLAYED = False
+_SHOWN_TRACE_MESSAGE_BEFORE = False
 
 
 @contextlib.contextmanager
@@ -54,7 +54,7 @@ def configure_autologging_for_evaluation(enable_tracing: bool = True):
 
         # NB: Using post-import hook to configure the autologging lazily when the target
         # flavor's module is imported, rather than configuring it immediately. This is
-        # because the evaluation code usually only use a subset of the supported flavors,
+        # because the evaluation code usually only uses a subset of the supported flavors,
         # hence we want to avoid unnecessary overhead of configuring all flavors.
         @autologging_conf_lock
         def _setup_autolog(module):
@@ -72,7 +72,7 @@ def configure_autologging_for_evaluation(enable_tracing: bool = True):
                     global _IS_TRACE_MESSAGE_DISPLAYED
                     if not _IS_TRACE_MESSAGE_DISPLAYED:
                         _logger.info(
-                            "Tracing is temporarily enabled during the model evaluation "
+                            "Auto tracing is temporarily enabled during the model evaluation "
                             "for computing some metrics and debugging. To disable tracing, call "
                             "`mlflow.autolog(disable=True)`."
                         )
@@ -83,8 +83,8 @@ def configure_autologging_for_evaluation(enable_tracing: bool = True):
             except Exception:
                 _logger.debug(f"Failed to update autologging config for {flavor}.", exc_info=True)
 
+        module = FLAVOR_TO_MODULE_NAME[flavor]
         try:
-            module = FLAVOR_TO_MODULE_NAME[flavor]
             original_import_hooks[module] = get_post_import_hooks(module)
             new_import_hooks[module] = _setup_autolog
             register_post_import_hook(_setup_autolog, module, overwrite=True)

--- a/mlflow/models/evaluation/utils/trace.py
+++ b/mlflow/models/evaluation/utils/trace.py
@@ -8,9 +8,20 @@ from mlflow.utils.autologging_utils import (
     AUTOLOGGING_INTEGRATIONS,
     autologging_conf_lock,
     get_autolog_function,
+    is_autolog_supported,
+)
+from mlflow.utils.autologging_utils.safety import revert_patches
+from mlflow.utils.import_hooks import (
+    _post_import_hooks,
+    get_post_import_hooks,
+    register_post_import_hook,
 )
 
 _logger = logging.getLogger(__name__)
+
+
+# This flag is used to display the message only once when tracing is enabled during the evaluation.
+_IS_TRACE_MESSAGE_DISPLAYED = False
 
 
 @contextlib.contextmanager
@@ -24,87 +35,118 @@ def configure_autologging_for_evaluation(enable_tracing: bool = True):
     Args:
         enable_tracing (bool): Whether to enable tracing for the supported flavors during eval.
     """
-    flavor_to_original_config = {}
-    trace_enabled_flavors = []
+    original_import_hooks = {}
+    new_import_hooks = {}
 
     # AUTOLOGGING_INTEGRATIONS can change during we iterate over flavors and enable/disable
     # autologging, therefore, we snapshot the current configuration to restore it later.
     global_config_snapshot = AUTOLOGGING_INTEGRATIONS.copy()
+
     for flavor in FLAVOR_TO_MODULE_NAME:
-        try:
-            if autolog := get_autolog_function(flavor):
-                original_config = global_config_snapshot.get(flavor, {}).copy()
+        if not is_autolog_supported(flavor):
+            continue
 
-                # If autologging is explicitly disabled, do nothing.
-                if original_config.get("disable", False):
-                    continue
+        original_config = global_config_snapshot.get(flavor, {}).copy()
 
-                elif enable_tracing and _is_trace_autologging_supported(flavor):
-                    # set all log_xyz params to False except log_traces
+        # If autologging is explicitly disabled, do nothing.
+        if original_config.get("disable", False):
+            continue
+
+        # NB: Using post-import hook to configure the autologging lazily when the target
+        # flavor's module is imported, rather than configuring it immediately. This is
+        # because the evaluation code usually only use a subset of the supported flavors,
+        # hence we want to avoid unnecessary overhead of configuring all flavors.
+        @autologging_conf_lock
+        def _setup_autolog(module):
+            try:
+                autolog = get_autolog_function(flavor)
+
+                # If tracing is supported and not explicitly disabled, enable it.
+                if enable_tracing and _should_enable_tracing(flavor, global_config_snapshot):
                     new_config = {
                         k: False if k.startswith("log_") else v for k, v in original_config.items()
                     }
-
-                    # TODO: This check is a temporary fix for Databricks. This line explicitly
-                    # checks if the autolog is globally disabled via mlflow.autolog(disable=True).
-                    # In normal case, this is reflected to each flavor's configuration. However,
-                    # when user explicitly enables it for a specific flavor via
-                    # mlflow.<flavor>.autolog(), the global disablement does not take precedence,
-                    # which is intended.
-                    # However, in Databricks, sometimes mlflow.<flavor>.autolog() is automatically
-                    # called in the kernel startup, which is confused with the user's action. In
-                    # such cases, even when user disables autologging globally, the flavor-specific
-                    # autologging remains enabled. We are going to fix the Databricks side issue,
-                    # but until then we need to check the global configuration explicitly here.
-                    trace_disabled = global_config_snapshot.get("mlflow", {}).get("disable", False)
-
-                    new_config |= {"log_traces": not trace_disabled, "silent": True}
+                    new_config |= {"log_traces": True, "silent": True}
                     _kwargs_safe_invoke(autolog, new_config)
-                    trace_enabled_flavors.append(flavor)
-                elif flavor in AUTOLOGGING_INTEGRATIONS:
-                    # For flavors that do not support tracing, disable autologging
+
+                    global _IS_TRACE_MESSAGE_DISPLAYED
+                    if not _IS_TRACE_MESSAGE_DISPLAYED:
+                        _logger.info(
+                            "Tracing is temporarily enabled during the model evaluation "
+                            "for computing some metrics and debugging. To disable tracing, call "
+                            "`mlflow.autolog(disable=True)`."
+                        )
+                        _IS_TRACE_MESSAGE_DISPLAYED = True
+                else:
                     autolog(disable=True)
 
-                flavor_to_original_config[flavor] = original_config
+            except Exception:
+                _logger.debug(f"Failed to update autologging config for {flavor}.", exc_info=True)
 
-        except Exception as e:
-            if isinstance(e, ImportError):
-                _logger.debug(
-                    f"Flavor {flavor} is not installed. Skip updating autologging. Error: {e!r}"
-                )
-            else:
-                _logger.info(
-                    f"Failed to update autologging configuration for flavor {flavor}. Error: {e!r}"
-                )
-
-            # Autologging configuration might be updated before the exception is raised,
-            # which needs to be reverted.
-            AUTOLOGGING_INTEGRATIONS.pop(flavor, None)
-
-    if trace_enabled_flavors:
-        _logger.info(
-            "Tracing is temporarily enabled during the model evaluation for computing some "
-            "metrics and debugging. To disable tracing, call `mlflow.autolog(disable=True)`."
-        )
+        try:
+            module = FLAVOR_TO_MODULE_NAME[flavor]
+            original_import_hooks[module] = get_post_import_hooks(module)
+            new_import_hooks[module] = _setup_autolog
+            register_post_import_hook(_setup_autolog, module, overwrite=True)
+        except Exception:
+            _logger.debug(f"Failed to register post-import hook for {flavor}.", exc_info=True)
 
     try:
         yield
     finally:
-        # Restore original autologging configurations.
-        for flavor, original_config in flavor_to_original_config.items():
-            autolog = get_autolog_function(flavor)
-            try:
-                if original_config:
-                    _kwargs_safe_invoke(autolog, original_config)
-                    AUTOLOGGING_INTEGRATIONS[flavor] = original_config
-                else:
-                    # If the original configuration is empty, autologging was not enabled before
-                    autolog(disable=True)
-                    # We also need to remove the configuration entry from AUTOLOGGING_INTEGRATIONS,
-                    # so as not to confuse with the case user explicitly disabled autologging.
-                    AUTOLOGGING_INTEGRATIONS.pop(flavor, None)
-            except ImportError:
-                pass
+        # Remove post-import hooks and patches the are registered during the evaluation.
+        for module, hooks in new_import_hooks.items():
+            # Restore original post-import hooks if any. Note that we don't use
+            # register_post_import_hook method to bypass some pre-checks and just
+            # restore the original state.
+            if hooks is None:
+                _post_import_hooks.pop(module, None)
+            else:
+                _post_import_hooks[module] = original_import_hooks[module]
+
+        # If any autologging configuration is updated, restore original autologging configurations.
+        for flavor, new_config in AUTOLOGGING_INTEGRATIONS.copy().items():
+            original_config = global_config_snapshot.get(flavor)
+            if original_config != new_config:
+                try:
+                    autolog = get_autolog_function(flavor)
+                    if original_config:
+                        _kwargs_safe_invoke(autolog, original_config)
+                        AUTOLOGGING_INTEGRATIONS[flavor] = original_config
+                    else:
+                        # If the original configuration is empty, autologging was not enabled before
+                        autolog(disable=True)
+                        # Remove all safe_patch applied by autologging
+                        revert_patches(flavor)
+                        # We also need to remove the config entry from AUTOLOGGING_INTEGRATIONS,
+                        # so as not to confuse with the case user explicitly disabled autologging.
+                        AUTOLOGGING_INTEGRATIONS.pop(flavor, None)
+                except ImportError:
+                    pass
+
+
+def _should_enable_tracing(flavor: str, autologging_config: dict[str, Any]) -> bool:
+    """
+    Check if tracing should be enabled for the given flavor during the model evaluation.
+    """
+    # 1. Check if the autologging or tracing is globally disabled
+    # TODO: This check should not take precedence over the flavor-specific configuration
+    # set by the explicit mlflow.<flavor>.autolog() call by users.
+    # However, in Databricks, sometimes mlflow.<flavor>.autolog() is automatically
+    # called in the kernel startup, which is confused with the user's action. In
+    # such cases, even when user disables autologging globally, the flavor-specific
+    # autologging remains enabled. We are going to fix the Databricks side issue,
+    # and after that, we should move this check down after the flavor-specific check.
+    global_config = autologging_config.get("mlflow", {})
+    if global_config.get("disable", False) or (not global_config.get("log_traces", True)):
+        return False
+
+    if not _is_trace_autologging_supported(flavor):
+        return False
+
+    # 3. Check if tracing is explicitly disabled for the flavor
+    flavor_config = autologging_config.get(flavor, {})
+    return flavor_config.get("log_traces", True)
 
 
 def _kwargs_safe_invoke(func: Callable[..., Any], kwargs: dict[str, Any]):

--- a/mlflow/models/evaluation/utils/trace.py
+++ b/mlflow/models/evaluation/utils/trace.py
@@ -69,14 +69,14 @@ def configure_autologging_for_evaluation(enable_tracing: bool = True):
                     new_config |= {"log_traces": True, "silent": True}
                     _kwargs_safe_invoke(autolog, new_config)
 
-                    global _IS_TRACE_MESSAGE_DISPLAYED
-                    if not _IS_TRACE_MESSAGE_DISPLAYED:
+                    global _SHOWN_TRACE_MESSAGE_BEFORE
+                    if not _SHOWN_TRACE_MESSAGE_BEFORE:
                         _logger.info(
                             "Auto tracing is temporarily enabled during the model evaluation "
                             "for computing some metrics and debugging. To disable tracing, call "
                             "`mlflow.autolog(disable=True)`."
                         )
-                        _IS_TRACE_MESSAGE_DISPLAYED = True
+                        _SHOWN_TRACE_MESSAGE_BEFORE = True
                 else:
                     autolog(disable=True)
 

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -521,7 +521,7 @@ def autologging_is_disabled(integration_name):
     return False
 
 
-def is_autolog_supported(integration_name):
+def is_autolog_supported(integration_name: str) -> bool:
     """
     Whether the specified autologging integration is supported by the current environment.
 

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -17,7 +17,7 @@ from mlflow.utils.validation import MAX_METRICS_PER_BATCH
 _logger = logging.getLogger(__name__)
 
 # Import autologging utilities used by this module
-from mlflow.ml_package_versions import FLAVOR_TO_MODULE_NAME
+from mlflow.ml_package_versions import _ML_PACKAGE_VERSIONS, FLAVOR_TO_MODULE_NAME
 from mlflow.utils.autologging_utils.client import MlflowAutologgingQueueingClient  # noqa: F401
 from mlflow.utils.autologging_utils.events import AutologgingEventLogger
 from mlflow.utils.autologging_utils.logging_and_warnings import (
@@ -521,12 +521,24 @@ def autologging_is_disabled(integration_name):
     return False
 
 
+def is_autolog_supported(integration_name):
+    """
+    Whether the specified autologging integration is supported by the current environment.
+
+    Args:
+        integration_name: An autologging integration flavor name.
+    """
+    # NB: We don't check for the presence of autolog() function as it requires importing
+    #   the flavor module, which may cause import error or overhead.
+    return "autologging" in _ML_PACKAGE_VERSIONS.get(integration_name, {})
+
+
 def get_autolog_function(integration_name: str) -> Optional[Callable[..., Any]]:
     """
     Get the autolog() function for the specified integration.
     Returns None if the flavor does not have an autolog() function.
     """
-    flavor_module = getattr(mlflow, integration_name, None)
+    flavor_module = importlib.import_module(f"mlflow.{integration_name}")
     return getattr(flavor_module, "autolog", None)
 
 

--- a/mlflow/utils/import_hooks/__init__.py
+++ b/mlflow/utils/import_hooks/__init__.py
@@ -167,6 +167,11 @@ def register_post_import_hook(hook, name, overwrite=True):
     register_generic_import_hook(hook, name, _post_import_hooks, overwrite)
 
 
+@synchronized(_post_import_hooks_lock)
+def get_post_import_hooks(name):
+    return _post_import_hooks.get(name)
+
+
 # Register post import hooks defined as package entry points.
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/13987?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13987/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13987
```

</p>
</details>

### What changes are proposed in this pull request?

https://github.com/mlflow/mlflow/pull/13897 introduced auto-tracing during evaluation for supported flavors such as OpenAI, LlamaIndex, DSPy. This is done by iteratively invoke `mlflow.<flavor>.autolog()` for all trace-enabled flavors, because we don't know what library is used in users' model. However, this added a certain overhead (~10 seconds) for some environment, which is not desirable UX (see [this thread](https://github.com/mlflow/mlflow/pull/13897#discussion_r1868976044) for more details).

This PR optimize the logic to **lazily enable tracing**, by applying the post import hook mechanism we use in `mlflow.autolog()`. Basically, the new logic only call `mlflow.<flavor>.autolog()` when the corresponding library is imported. This effectively avoid the unnecessary overhead for enabling autolog for unused libraries.

Some benchmarks for evaluating different models with a small dataset, within Databricks MLR notebook:

|Model| 2.18.0 | 2.19.0rc0 | This PR |
|:--|:--|:--|:--|
|Scikit-learn + OSS eval ([code](https://mlflow.org/docs/latest/models.html#model-evaluation)) | 10.71 sec | 15.11 sec | 10.86 sec |
|LangChain + DB Agent eval (*1)| 13.63 sec | 18.70 sec | 14.66 sec |

(*1) Langchain eval time heavily depends on external factors like LLM calls hence I observed high variance (even ~10 sec) regardless of mlflow versions. Therefore, the relative comparison here is non-sense, but just showing as a reference.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
