### PR TITLE
Support passing model alias for split_models_uri 

### DIFF
--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -83,6 +83,7 @@ class ModelsArtifactRepository(ArtifactRepository):
         Split 'models:/<name>@alias/path/to/model' into
         ('models:/<name>@alias', 'path/to/model').
         """
+        uri = uri.rstrip("/")
         path = urllib.parse.urlparse(uri).path
         if path.count("/") >= 2 and not path.endswith("/"):
             splits = path.split("/", 3)

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -80,12 +80,15 @@ class ModelsArtifactRepository(ArtifactRepository):
         """
         Split 'models:/<name>/<version>/path/to/model' into
         ('models:/<name>/<version>', 'path/to/model').
+        Split 'models:/<name>@alias/path/to/model' into
+        ('models:/<name>@alias', 'path/to/model').
         """
         path = urllib.parse.urlparse(uri).path
-        if path.count("/") >= 3 and not path.endswith("/"):
+        if path.count("/") >= 2 and not path.endswith("/"):
             splits = path.split("/", 3)
-            model_name_and_version = splits[:3]
-            artifact_path = splits[-1]
+            cut_index = 2 if "@" in splits[1] else 3
+            model_name_and_version = splits[:cut_index]
+            artifact_path = "/".join(splits[cut_index:])
             return "models:" + "/".join(model_name_and_version), artifact_path
         return uri, ""
 

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -251,13 +251,16 @@ def test_models_artifact_repo_does_not_add_meta_for_directory_without_mlmodel(tm
         add_meta_mock.assert_not_called()
 
 
-def test_split_models_uri():
-    assert ModelsArtifactRepository.split_models_uri("models:/model/1") == ("models:/model/1", "")
-    assert ModelsArtifactRepository.split_models_uri("models:/model/1/path") == (
-        "models:/model/1",
-        "path",
-    )
-    assert ModelsArtifactRepository.split_models_uri("models:/model/1/path/to/artifact") == (
-        "models:/model/1",
-        "path/to/artifact",
-    )
+@pytest.mark.parametrize(
+    ("model_uri", "expected_uri", "expected_path"),
+    [
+        ("models:/model/1", "models:/model/1", ""),
+        ("models:/model/1/path", "models:/model/1", "path"),
+        ("models:/model/1/path/to/artifact", "models:/model/1", "path/to/artifact"),
+        ("models:/model@alias", "models:/model@alias", ""),
+        ("models:/model@alias/path", "models:/model@alias", "path"),
+        ("models:/model@alias/path/to/artifact", "models:/model@alias", "path/to/artifact"),
+    ],
+)
+def test_split_models_uri(model_uri, expected_uri, expected_path):
+    assert ModelsArtifactRepository.split_models_uri(model_uri) == (expected_uri, expected_path)

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -255,9 +255,11 @@ def test_models_artifact_repo_does_not_add_meta_for_directory_without_mlmodel(tm
     ("model_uri", "expected_uri", "expected_path"),
     [
         ("models:/model/1", "models:/model/1", ""),
+        ("models:/model/1/", "models:/model/1", ""),
         ("models:/model/1/path", "models:/model/1", "path"),
         ("models:/model/1/path/to/artifact", "models:/model/1", "path/to/artifact"),
         ("models:/model@alias", "models:/model@alias", ""),
+        ("models:/model@alias/", "models:/model@alias", ""),
         ("models:/model@alias/path", "models:/model@alias", "path"),
         ("models:/model@alias/path/to/artifact", "models:/model@alias", "path/to/artifact"),
     ],


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/13989?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13989/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13989
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Title. Model alias should also work.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
