### PR TITLE
Implement `delete_artifacts` in `mlflow/store/artifact/azure_blob_artifact_repo.py`

### DIFF
--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -213,8 +213,6 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                 container_client.delete_blob(blob.name)
         except ResourceNotFoundError:
             raise MlflowException(f"No such file or directory: '{dest_path}'")
-        except Exception as e:
-            raise MlflowException(f"Failed to delete artifacts at '{dest_path}': {e}")
 
     def create_multipart_upload(self, local_file, num_parts=1, artifact_path=None):
         from azure.storage.blob import BlobSasPermissions, generate_blob_sas

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -198,6 +198,7 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
     def delete_artifacts(self, artifact_path=None):
         from azure.core.exceptions import ResourceNotFoundError
+
         (container, _, dest_path, _) = self.parse_wasbs_uri(self.artifact_uri)
         container_client = self.client.get_container_client(container)
         if artifact_path:

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -15,7 +15,6 @@ from mlflow.environment_variables import MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository, MultipartUploadMixin
 from mlflow.utils.credentials import get_default_host_creds
-from azure.core.exceptions import ResourceNotFoundError
 
 
 def encode_base64(data: Union[str, bytes]) -> str:
@@ -198,6 +197,7 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             blob.readinto(file)
 
     def delete_artifacts(self, artifact_path=None):
+        from azure.core.exceptions import ResourceNotFoundError
         (container, _, dest_path, _) = self.parse_wasbs_uri(self.artifact_uri)
         container_client = self.client.get_container_client(container)
         if artifact_path:

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -419,3 +419,96 @@ def test_trace_data(mock_client, tmp_path):
         side_effect=lambda x: try_read_trace_data(trace_data_path),
     ):
         assert repo.download_trace_data() == mock_trace_data
+
+
+def test_delete_artifacts_single_file(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, mock_client)
+
+    # Mock the list_blobs method to return a single file
+    blob_props = BlobProperties()
+    blob_props.name = posixpath.join(TEST_ROOT_PATH, "file")
+    mock_client.get_container_client().list_blobs.return_value = [blob_props]
+
+    repo.delete_artifacts("file")
+
+    mock_client.get_container_client().delete_blob.assert_called_with(blob_props.name)
+
+
+def test_delete_artifacts_directory(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, mock_client)
+
+    # Mock the list_blobs method to return multiple files in a directory
+    blob_props_1 = BlobProperties()
+    blob_props_1.name = posixpath.join(TEST_ROOT_PATH, "dir/file1")
+    blob_props_2 = BlobProperties()
+    blob_props_2.name = posixpath.join(TEST_ROOT_PATH, "dir/file2")
+    mock_client.get_container_client().list_blobs.return_value = [blob_props_1, blob_props_2]
+
+    repo.delete_artifacts("dir")
+
+    mock_client.get_container_client().delete_blob.assert_any_call(blob_props_1.name)
+    mock_client.get_container_client().delete_blob.assert_any_call(blob_props_2.name)
+
+
+def test_delete_artifacts_nonexistent_path(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, mock_client)
+
+    # Mock the list_blobs method to return an empty list
+    mock_client.get_container_client().list_blobs.return_value = []
+
+    with pytest.raises(MlflowException, match="No such file or directory"):
+        repo.delete_artifacts("nonexistent_path")
+
+
+def test_delete_artifacts_failure(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, mock_client)
+
+    # Mock the list_blobs method to return a single file
+    blob_props = BlobProperties()
+    blob_props.name = posixpath.join(TEST_ROOT_PATH, "file")
+    mock_client.get_container_client().list_blobs.return_value = [blob_props]
+
+    # Mock the delete_blob method to raise an exception
+    mock_client.get_container_client().delete_blob.side_effect = Exception("Deletion failed")
+
+    with pytest.raises(MlflowException, match="Failed to delete artifacts"):
+        repo.delete_artifacts("file")
+
+
+def test_delete_artifacts_folder(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, mock_client)
+
+    # Mock the list_blobs method to return multiple files in a folder
+    blob_props_1 = BlobProperties()
+    blob_props_1.name = posixpath.join(TEST_ROOT_PATH, "folder/file1")
+    blob_props_2 = BlobProperties()
+    blob_props_2.name = posixpath.join(TEST_ROOT_PATH, "folder/file2")
+    mock_client.get_container_client().list_blobs.return_value = [blob_props_1, blob_props_2]
+
+    repo.delete_artifacts("folder")
+
+    mock_client.get_container_client().delete_blob.assert_any_call(blob_props_1.name)
+    mock_client.get_container_client().delete_blob.assert_any_call(blob_props_2.name)
+
+
+def test_delete_artifacts_folder_with_nested_folders_and_files(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, mock_client)
+
+    # Mock the list_blobs method to return multiple files in a folder with nested folders and files
+    blob_props_1 = BlobProperties()
+    blob_props_1.name = posixpath.join(TEST_ROOT_PATH, "folder/nested_folder/file1")
+    blob_props_2 = BlobProperties()
+    blob_props_2.name = posixpath.join(TEST_ROOT_PATH, "folder/nested_folder/file2")
+    blob_props_3 = BlobProperties()
+    blob_props_3.name = posixpath.join(TEST_ROOT_PATH, "folder/nested_folder/nested_file")
+    mock_client.get_container_client().list_blobs.return_value = [
+        blob_props_1,
+        blob_props_2,
+        blob_props_3,
+    ]
+
+    repo.delete_artifacts("folder")
+
+    mock_client.get_container_client().delete_blob.assert_any_call(blob_props_1.name)
+    mock_client.get_container_client().delete_blob.assert_any_call(blob_props_2.name)
+    mock_client.get_container_client().delete_blob.assert_any_call(blob_props_3.name)

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 from azure.storage.blob import BlobPrefix, BlobProperties, BlobServiceClient
+from azure.core.exceptions import ResourceNotFoundError
 
 from mlflow.entities.multipart_upload import MultipartUploadPart
 from mlflow.exceptions import MlflowException, MlflowTraceDataCorrupted
@@ -469,9 +470,9 @@ def test_delete_artifacts_failure(mock_client):
     mock_client.get_container_client().list_blobs.return_value = [blob_props]
 
     # Mock the delete_blob method to raise an exception
-    mock_client.get_container_client().delete_blob.side_effect = Exception("Deletion failed")
+    mock_client.get_container_client().delete_blob.side_effect = ResourceNotFoundError("Deletion failed")
 
-    with pytest.raises(MlflowException, match="Failed to delete artifacts"):
+    with pytest.raises(MlflowException, match=f"No such file or directory: '{blob_props.name}'"):
         repo.delete_artifacts("file")
 
 

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -5,8 +5,8 @@ import posixpath
 from unittest import mock
 
 import pytest
-from azure.storage.blob import BlobPrefix, BlobProperties, BlobServiceClient
 from azure.core.exceptions import ResourceNotFoundError
+from azure.storage.blob import BlobPrefix, BlobProperties, BlobServiceClient
 
 from mlflow.entities.multipart_upload import MultipartUploadPart
 from mlflow.exceptions import MlflowException, MlflowTraceDataCorrupted
@@ -470,7 +470,9 @@ def test_delete_artifacts_failure(mock_client):
     mock_client.get_container_client().list_blobs.return_value = [blob_props]
 
     # Mock the delete_blob method to raise an exception
-    mock_client.get_container_client().delete_blob.side_effect = ResourceNotFoundError("Deletion failed")
+    mock_client.get_container_client().delete_blob.side_effect = ResourceNotFoundError(
+        "Deletion failed"
+    )
 
     with pytest.raises(MlflowException, match=f"No such file or directory: '{blob_props.name}'"):
         repo.delete_artifacts("file")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/benglewis/mlflow/pull/13992?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/13992/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 13992
```

</p>
</details>

Implement the `delete_artifacts` method in `mlflow/store/artifact/azure_blob_artifact_repo.py` to support the deletion of artifacts in Azure Blob Storage.

* **Azure Blob Artifact Repository:**
  - Import `ResourceNotFoundError` from `azure.core.exceptions`.
  - Implement `delete_artifacts` method to delete single files and directories recursively using Azure Blob Storage SDK.
  - Add error handling for cases where the specified artifact path does not exist or the deletion fails.

* **Unit Tests:**
  - Add unit tests for `delete_artifacts` method in `AzureBlobArtifactRepository`.
  - Test single file deletion, directory deletion, and error handling.
  - Test folder deletion.
  - Test folder with nested folders and files deletion.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/benglewis/mlflow?shareId=90fd5e0e-e700-4e87-9779-3047f980fba6).

### Related Issues/PRs

Close #8759


### What changes are proposed in this pull request?

Add support for `delete_artifacts` when using Azure blob storage.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

I don't think so since the existing storage platforms that do support it don't have documentation 🤷 

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add support for `delete_artifacts` when using Azure blob storage.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [x] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
