### PR TITLE
Stringify param values in client.log_batch()

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1861,6 +1861,10 @@ class MlflowClient:
         synchronous = (
             synchronous if synchronous is not None else not MLFLOW_ENABLE_ASYNC_LOGGING.get()
         )
+
+        # Stringify the values of the params
+        params = [Param(key=param.key, value=str(param.value)) for param in params]
+
         return self._tracking_client.log_batch(
             run_id, metrics, params, tags, synchronous=synchronous
         )

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -219,7 +219,11 @@ def test_metric_timestamp():
 
 def test_log_batch():
     expected_metrics = {"metric-key0": 1.0, "metric-key1": 4.0}
-    expected_params = {"param-key0": "param-val0", "param-key1": "param-val1"}
+    expected_params = {
+        "param-key0": "param-val0",
+        "param-key1": 123,
+        "param-key2": None,
+    }
     exact_expected_tags = {"tag-key0": "tag-val0", "tag-key1": "tag-val1"}
     approx_expected_tags = {
         MLFLOW_USER,
@@ -259,7 +263,7 @@ def test_log_batch():
         else:
             assert exact_expected_tags[tag_key] == tag_value
     # Validate params
-    assert finished_run.data.params == expected_params
+    assert finished_run.data.params == {k: str(v) for k, v in expected_params.items()}
     # test that log_batch works with fewer params
     new_tags = {"1": "2", "3": "4", "5": "6"}
     tags = [RunTag(key=key, value=value) for key, value in new_tags.items()]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14015?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14015/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14015
```

</p>
</details>

### Related Issues/PRs

Resolve https://github.com/mlflow/mlflow/issues/13588

### What changes are proposed in this pull request?

In MLflow backend, the parameter values are stored as string. When users pass non-string value to APIs like `mlflow.log_param()`, `MlflowClient().log_param()`, MLflow stringify it before sending to the backend ([code](https://github.com/mlflow/mlflow/blob/master/mlflow/tracking/_tracking_service/client.py#L605)). 

However, this conversion is not done when users call the `MlflowClient().log_batch()`, which is confusing.

```
# This works
with mlflow.start_run() as run:
    mlflow.log_param("a", 1)
    mlflow.log_param("b", None)

# This doesn't
MlflowClient().log_batch(
    run_id=run.info.run_id,
    params=[
        Param(key="a", value=1),
        Param(key="b", value= None)
    ]
)
# > TypeError: bad argument type for built-in operation
```

This PR addresses this inconsistency by adding similar stringification logic within client's `log_batch()` method.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested in both OSS and Databricks.

```
import mlflow

mlflow.set_tracking_uri("http://localhost:5000")

with mlflow.start_run() as run:
    mlflow.log_param("a", 1)
    mlflow.log_param("b", None)

MlflowClient().log_batch(
    run_id=run.info.run_id,
    params=[
        Param(key="c", value="2"),
        Param(key="d", value=1.23),
        Param(key="e", value= None)
    ]
)
```

![Screenshot 2024-12-09 at 14 26 54](https://github.com/user-attachments/assets/e0cbaafb-a6ac-4c11-a641-aa5fe97de834)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support non-string param values in `log_batch()` API.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
