### PR TITLE
Support tracing for Bedrock LLM calls

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -166,6 +166,7 @@ def pytest_ignore_collect(collection_path, config):
             "tests/anthropic",
             "tests/autogen",
             "tests/azureml",
+            "tests/bedrock",
             "tests/catboost",
             "tests/crewai",
             "tests/diviner",

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -50,6 +50,7 @@ from mlflow.utils.logging_utils import _configure_mlflow_loggers
 # Lazily load mlflow flavors to avoid excessive dependencies.
 anthropic = LazyLoader("mlflow.anthropic", globals(), "mlflow.anthropic")
 autogen = LazyLoader("mlflow.autogen", globals(), "mlflow.autogen")
+bedrock = LazyLoader("mlflow.bedrock", globals(), "mlflow.bedrock")
 catboost = LazyLoader("mlflow.catboost", globals(), "mlflow.catboost")
 crewai = LazyLoader("mlflow.crewai", globals(), "mlflow.crewai")
 diviner = LazyLoader("mlflow.diviner", globals(), "mlflow.diviner")

--- a/mlflow/bedrock/__init__.py
+++ b/mlflow/bedrock/__init__.py
@@ -1,3 +1,6 @@
+import gc
+import inspect
+
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
@@ -24,12 +27,18 @@ def autolog(
     """
     from botocore.client import ClientCreator
 
-    from mlflow.bedrock._autolog import patched_create_client
+    from mlflow.bedrock._autolog import patch_bedrock_runtime_client, patched_create_client
 
     # NB: In boto3, the client class for each service is dynamically created at
     # runtime via the ClientCreator factory class. Therefore, we cannot patch
     # the service client directly, and instead patch the factory to return
     # a patched client class.
-    # TODO: This logic only works when the client is created *after* the autologging
-    # is enabled. Add some logic to handle the opposite case.
     safe_patch(FLAVOR_NAME, ClientCreator, "create_client", patched_create_client)
+
+    # If the boto3 client has already been created, we need to patch them as well.
+    # This is a bit hacky, but since the class is generated dynamically, we need to
+    # check all existing objects to find the client class.
+    for obj in gc.get_objects():
+        if isinstance(obj, type) and obj.__name__ == "BedrockRuntime":
+            patch_bedrock_runtime_client(obj)
+            break

--- a/mlflow/bedrock/__init__.py
+++ b/mlflow/bedrock/__init__.py
@@ -1,4 +1,5 @@
 import gc
+import inspect
 
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
@@ -38,6 +39,9 @@ def autolog(
     # This is a bit hacky, but since the class is generated dynamically, we need to
     # check all existing objects to find the client class.
     for obj in gc.get_objects():
-        if isinstance(obj, type) and obj.__name__ == "BedrockRuntime":
-            patch_bedrock_runtime_client(obj)
-            break
+        try:
+            if inspect.isclass(obj) and obj.__name__ == "BedrockRuntime":
+                patch_bedrock_runtime_client(obj)
+                break
+        except Exception:
+            pass

--- a/mlflow/bedrock/__init__.py
+++ b/mlflow/bedrock/__init__.py
@@ -1,0 +1,35 @@
+from mlflow.utils.annotations import experimental
+from mlflow.utils.autologging_utils import autologging_integration, safe_patch
+
+FLAVOR_NAME = "bedrock"
+
+
+@experimental
+@autologging_integration(FLAVOR_NAME)
+def autolog(
+    log_traces: bool = True,
+    disable: bool = False,
+    silent: bool = False,
+):
+    """
+    Enables (or disables) and configures autologging from Amazon Bedrock to MLflow.
+    Only synchronous calls are supported. Asynchnorous APIs and streaming are not recorded.
+
+    Args:
+        log_traces: If ``True``, traces are logged for Bedrock models.
+            If ``False``, no traces are collected during inference. Default to ``True``.
+        disable: If ``True``, disables the Bedrock autologging. Default to ``False``.
+        silent: If ``True``, suppress all event logs and warnings from MLflow during Bedrock
+            autologging. If ``False``, show all events and warnings.
+    """
+    from botocore.client import ClientCreator
+
+    from mlflow.bedrock._autolog import patched_create_client
+
+    # NB: In boto3, the client class for each service is dynamically created at
+    # runtime via the ClientCreator factory class. Therefore, we cannot patch
+    # the service client directly, and instead patch the factory to return
+    # a patched client class.
+    # TODO: This logic only works when the client is created *after* the autologging
+    # is enabled. Add some logic to handle the opposite case.
+    safe_patch(FLAVOR_NAME, ClientCreator, "create_client", patched_create_client)

--- a/mlflow/bedrock/__init__.py
+++ b/mlflow/bedrock/__init__.py
@@ -1,5 +1,4 @@
 import gc
-import inspect
 
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch

--- a/mlflow/bedrock/_autolog.py
+++ b/mlflow/bedrock/_autolog.py
@@ -15,22 +15,6 @@ _BEDROCK_RUNTIME_SERVICE_NAME = "bedrock-runtime"
 _BEDROCK_SPAN_PREFIX = "BedrockRuntime."
 
 
-def _skip_if_trace_disabled(func: Callable[..., Any]) -> Callable[..., Any]:
-    """
-    A decorator to apply the function only if trace autologging is enabled.
-    This decorator is used to skip the test if the trace autologging is disabled.
-    """
-
-    def wrapper(original, self, *args, **kwargs):
-        config = AutoLoggingConfig.init(flavor_name=FLAVOR_NAME)
-        if not config.log_traces:
-            return original(self, *args, **kwargs)
-
-        return func(original, self, *args, **kwargs)
-
-    return wrapper
-
-
 def patched_create_client(original, self, *args, **kwargs):
     """
     Patched version of the boto3 ClientCreator.create_client method that returns
@@ -57,6 +41,22 @@ def patch_bedrock_runtime_client(client_class: type[BaseClient]):
         # with the consistent chat format.
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html
         safe_patch(FLAVOR_NAME, client_class, "converse", _patched_converse)
+
+
+def _skip_if_trace_disabled(func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    A decorator to apply the function only if trace autologging is enabled.
+    This decorator is used to skip the test if the trace autologging is disabled.
+    """
+
+    def wrapper(original, self, *args, **kwargs):
+        config = AutoLoggingConfig.init(flavor_name=FLAVOR_NAME)
+        if not config.log_traces:
+            return original(self, *args, **kwargs)
+
+        return func(original, self, *args, **kwargs)
+
+    return wrapper
 
 
 @_skip_if_trace_disabled

--- a/mlflow/bedrock/_autolog.py
+++ b/mlflow/bedrock/_autolog.py
@@ -1,6 +1,6 @@
 import io
 import json
-from typing import Any, Callable, Type, Union
+from typing import Any, Callable, Union
 
 from botocore.client import BaseClient
 from botocore.eventstream import EventStream
@@ -45,7 +45,7 @@ def patched_create_client(original, self, *args, **kwargs):
     return client
 
 
-def patch_bedrock_runtime_client(client_class: Type[BaseClient]):
+def patch_bedrock_runtime_client(client_class: type[BaseClient]):
     """
     Patch the BedrockRuntime client to log traces and models.
     """

--- a/mlflow/bedrock/_autolog.py
+++ b/mlflow/bedrock/_autolog.py
@@ -1,0 +1,120 @@
+import io
+import json
+from typing import Any, Callable, Union
+
+from botocore.eventstream import EventStream
+
+import mlflow
+from mlflow.bedrock import FLAVOR_NAME
+from mlflow.entities import SpanType
+from mlflow.utils.autologging_utils import safe_patch
+from mlflow.utils.autologging_utils.config import AutoLoggingConfig
+
+_BEDROCK_RUNTIME_SERVICE_NAME = "bedrock-runtime"
+_BEDROCK_SPAN_PREFIX = "BedrockRuntime."
+
+
+def skip_if_trace_disabled(func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Skip the test if trace autologging is disabled via log_trace=False.
+
+    This decorator is used to skip the test if the trace autologging is disabled.
+    """
+
+    def wrapper(original, self, *args, **kwargs):
+        config = AutoLoggingConfig.init(flavor_name=FLAVOR_NAME)
+        if not config.log_traces:
+            return original(self, *args, **kwargs)
+
+        return func(original, self, *args, **kwargs)
+
+    return wrapper
+
+
+def patched_create_client(original, self, *args, **kwargs):
+    """
+    Patched version of the boto3 ClientCreator.create method that returns
+    a patched client class.
+
+    """
+    if kwargs.get("service_name") != _BEDROCK_RUNTIME_SERVICE_NAME:
+        return original(self, *args, **kwargs)
+
+    client = original(self, *args, **kwargs)
+
+    # The most basic model invocation API
+    safe_patch(FLAVOR_NAME, client.__class__, "invoke_model", _patched_invoke_model)
+
+    if hasattr(client, "converse"):
+        # The new "converse" API was introduced in boto3 1.35 to access all models
+        # with the consistent chat format.
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html
+        safe_patch(FLAVOR_NAME, client.__class__, "converse", _patched_converse)
+
+    return client
+
+
+@skip_if_trace_disabled
+def _patched_invoke_model(original, self, *args, **kwargs):
+    if not AutoLoggingConfig.init(flavor_name=FLAVOR_NAME).log_traces:
+        return original(self, *args, **kwargs)
+
+    with mlflow.start_span(name=f"{_BEDROCK_SPAN_PREFIX}{original.__name__}") as span:
+        # NB: Bedrock client doesn't accept any positional arguments
+        span.set_inputs(kwargs)
+
+        result = original(self, *args, **kwargs)
+
+        result["body"] = _buffer_stream(result["body"])
+        parsed_response_body = _parse_invoke_model_response_body(result["body"])
+
+        # Determine the span type based on the key in the response body.
+        # As of 2024 Dec 9th, all supported embedding models in Bedrock returns the response body
+        # with the key "embedding". This might change in the future.
+        span_type = SpanType.EMBEDDING if "embedding" in parsed_response_body else SpanType.LLM
+        span.set_span_type(span_type)
+
+        span.set_outputs({**result, "body": parsed_response_body})
+
+        return result
+
+
+def _buffer_stream(raw_stream: EventStream) -> io.BytesIO:
+    """
+    Create a buffered stream from the raw byte stream.
+
+    The boto3's invoke_model() API returns the LLM response as a byte stream.
+    We need to read the stream data to set the span outputs, however, the stream
+    can only be read once and not seekable (https://github.com/boto/boto3/issues/564).
+    To work around this, we create a buffered stream that can be read multiple times.
+    """
+    buffered_response = io.BytesIO(raw_stream.read())
+    buffered_response.seek(0)
+    return buffered_response
+
+
+def _parse_invoke_model_response_body(response_body: dict[str, Any]) -> Union[dict[str, Any], str]:
+    content = response_body.read()
+    try:
+        return json.loads(content)
+    except Exception:
+        # When failed to parse the response body as JSON, return the raw response
+        return content
+    finally:
+        response_body.seek(0)
+
+
+@skip_if_trace_disabled
+def _patched_converse(original, self, *args, **kwargs):
+    if not AutoLoggingConfig.init(flavor_name=FLAVOR_NAME).log_traces:
+        return original(self, *args, **kwargs)
+
+    with mlflow.start_span(
+        name=f"{_BEDROCK_SPAN_PREFIX}{original.__name__}",
+        span_type=SpanType.CHAT_MODEL,
+    ) as span:
+        # NB: Bedrock client doesn't accept any positional arguments
+        span.set_inputs(kwargs)
+        result = original(self, *args, **kwargs)
+        span.set_outputs(result)
+        return result

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -300,6 +300,10 @@ class LiveSpan(Span):
         self._attributes.set(SpanAttributeKey.REQUEST_ID, request_id)
         self._attributes.set(SpanAttributeKey.SPAN_TYPE, span_type)
 
+    def set_span_type(self, span_type: str):
+        """Set the type of the span."""
+        self.set_attribute(SpanAttributeKey.SPAN_TYPE, span_type)
+
     def set_inputs(self, inputs: Any):
         """Set the input values to the span."""
         self.set_attribute(SpanAttributeKey.INPUTS, inputs)

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -918,3 +918,13 @@ litellm:
           "uvicorn",
         ]
     run: pytest tests/litellm
+
+  bedrock:
+    package_info:
+      pip_release: "boto3"
+      install_dev: |
+        pip install git+https://github.com/boto/boto3
+    autologging:
+      # BedrockRuntime client is added in boto3 1.33
+      minimum: "1.33.0"
+      maximum: "1.35.76"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -922,6 +922,7 @@ litellm:
 bedrock:
   package_info:
     pip_release: "boto3"
+    module_name: "boto3"
     install_dev: |
       pip install git+https://github.com/boto/boto3
   autologging:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -923,8 +923,6 @@ bedrock:
   package_info:
     pip_release: "boto3"
     module_name: "boto3"
-    install_dev: |
-      pip install git+https://github.com/boto/boto3
   autologging:
     # BedrockRuntime client is added in boto3 1.33
     minimum: "1.33.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -919,12 +919,13 @@ litellm:
         ]
     run: pytest tests/litellm
 
-  bedrock:
-    package_info:
-      pip_release: "boto3"
-      install_dev: |
-        pip install git+https://github.com/boto/boto3
-    autologging:
-      # BedrockRuntime client is added in boto3 1.33
-      minimum: "1.33.0"
-      maximum: "1.35.76"
+bedrock:
+  package_info:
+    pip_release: "boto3"
+    install_dev: |
+      pip install git+https://github.com/boto/boto3
+  autologging:
+    # BedrockRuntime client is added in boto3 1.33
+    minimum: "1.33.0"
+    maximum: "1.35.76"
+    run: pytest tests/bedrock

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -364,6 +364,15 @@ _ML_PACKAGE_VERSIONS = {
             "minimum": "1.52.9",
             "maximum": "1.54.1"
         }
+    },
+    "bedrock": {
+        "package_info": {
+            "pip_release": "boto3"
+        },
+        "autologging": {
+            "minimum": "1.33.0",
+            "maximum": "1.35.76"
+        }
     }
 }
 
@@ -392,5 +401,6 @@ FLAVOR_TO_MODULE_NAME = {
     "anthropic": "anthropic",
     "crewai": "crewai",
     "litellm": "litellm",
+    "bedrock": "bedrock",
     "pyspark.ml": "pyspark"
 }

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -367,7 +367,8 @@ _ML_PACKAGE_VERSIONS = {
     },
     "bedrock": {
         "package_info": {
-            "pip_release": "boto3"
+            "pip_release": "boto3",
+            "module_name": "boto3"
         },
         "autologging": {
             "minimum": "1.33.0",
@@ -401,6 +402,6 @@ FLAVOR_TO_MODULE_NAME = {
     "anthropic": "anthropic",
     "crewai": "crewai",
     "litellm": "litellm",
-    "bedrock": "bedrock",
+    "bedrock": "boto3",
     "pyspark.ml": "pyspark"
 }

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2393,6 +2393,7 @@ def autolog(
         "langchain": "mlflow.langchain",
         "dspy": "mlflow.dspy",
         "crewai": "mlflow.crewai",
+        "boto3": "mlflow.bedrock",
     }
 
     # Currently, GenAI libraries are not enabled by `mlflow.autolog` in Databricks,

--- a/tests/bedrock/test_bedrock_autolog.py
+++ b/tests/bedrock/test_bedrock_autolog.py
@@ -131,6 +131,18 @@ _META_LLAMA_RESPONSE = {
 }
 
 
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html
+_AMAZON_EMBEDDING_REQUEST = {
+    "inputText": "Hi",
+    "dimensions": 8,
+}
+
+_AMAZON_EMBEDDING_RESPONSE = {
+    "embedding": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+    "inputTextTokenCount": 15,
+}
+
+
 def _create_dummy_invoke_model_response(llm_response):
     llm_response_encoded = json.dumps(llm_response).encode("utf-8")
     return {
@@ -205,18 +217,6 @@ def test_bedrock_autolog_invoke_model_llm(model_id, llm_request, llm_response):
         "ResponseMetadata": response["ResponseMetadata"],
         "contentType": "application/json",
     }
-
-
-# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html
-_AMAZON_EMBEDDING_REQUEST = {
-    "inputText": "Hi",
-    "dimensions": 8,
-}
-
-_AMAZON_EMBEDDING_RESPONSE = {
-    "embedding": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
-    "inputTextTokenCount": 15,
-}
 
 
 def test_bedrock_autolog_invoke_model_embeddings():

--- a/tests/bedrock/test_bedrock_autolog.py
+++ b/tests/bedrock/test_bedrock_autolog.py
@@ -1,0 +1,358 @@
+import io
+import json
+from unittest import mock
+
+import boto3
+import pytest
+from botocore.exceptions import NoCredentialsError
+from botocore.response import StreamingBody
+from packaging.version import Version
+
+import mlflow
+
+from tests.tracing.helper import get_traces
+
+_IS_CONVERSE_API_AVAILABLE = Version(boto3.__version__) >= Version("1.35")
+
+
+def _create_dummy_invoke_model_response(llm_response):
+    llm_response_encoded = json.dumps(llm_response).encode("utf-8")
+    return {
+        "body": StreamingBody(io.BytesIO(llm_response_encoded), len(llm_response_encoded)),
+        "ResponseMetadata": {
+            "RequestId": "request-id-123",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {"content-type": "application/json"},
+            "RetryAttempts": 0,
+        },
+        "contentType": "application/json",
+    }
+
+
+# https://docs.aws.amazon.com/code-library/latest/ug/python_3_bedrock-runtime_code_examples.html#anthropic_claude
+_ANTHROPIC_REQUEST = {
+    "messages": [{"role": "user", "content": "Hi"}],
+    "max_tokens": 300,
+    "anthropic_version": "bedrock-2023-05-31",
+    "temperature": 0.1,
+    "top_p": 0.9,
+}
+
+_ANTHROPIC_RESPONSE = {
+    "id": "id-123",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-3-5-sonnet-20241022",
+    "content": [{"type": "text", "text": "Hello! How can I help you today?"}],
+    "stop_reason": "end_turn",
+    "stop_sequence": None,
+    "usage": {
+        "input_tokens": 8,
+        "output_tokens": 12,
+    },
+}
+
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jamba.html
+_AI21_JAMBA_REQUEST = {
+    "messages": [{"role": "user", "content": "Hi"}],
+    "max_tokens": 300,
+    "temperature": 0.1,
+}
+
+_AI21_JAMBA_RESPONSE = {
+    "id": "id-123",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "Hello! How can I help you today?",
+                "tool_calls": None,
+            },
+            "finish_reason": "stop",
+        },
+    ],
+    "usage": {
+        "prompt_tokens": 8,
+        "completion_tokens": 12,
+        "total_tokens": 20,
+    },
+    "model": "jamba-instruct",
+    "meta": {"requestDurationMillis": 288},
+}
+
+
+# https://docs.aws.amazon.com/nova/latest/userguide/using-invoke-api.html
+_AMAZON_NOVA_REQUEST = {
+    "messages": [{"role": "user", "content": [{"text": "Hi!"}]}],
+    "system": [{"text": "This is a system prompt"}],
+    "schemaVersion": "messages-v1",
+    "inferenceConfig": {
+        "max_new_tokens": 512,
+        "temperature": 0.5,
+    },
+}
+
+_AMAZON_NOVA_RESPONSE = {
+    "message": {
+        "role": "assistant",
+        "content": [{"text": "Sure! How can I help you today?"}],
+    },
+    "stopReason": "end_turn",
+    "usage": {
+        "inputTokens": 8,
+        "outputTokens": 12,
+        "totalTokens": 20,
+    },
+}
+
+# https://docs.aws.amazon.com/code-library/latest/ug/python_3_bedrock-runtime_code_examples.html#cohere_command
+_COHERE_REQUEST = {
+    "message": "Hi!",
+    "max_tokens": 512,
+    "temperature": 0.5,
+}
+
+_COHERE_RESPONSE = {
+    "response_id": "id-123",
+    "text": "Sure! How can I help you today?",
+    "generation_id": "generation-id-123",
+    "chat_history": [
+        {"role": "USER", "message": "Hi"},
+        {"role": "CHATBOT", "message": "Sure! How can I help you today?"},
+    ],
+    "finish_reason": "COMPLETE",
+}
+
+# https://docs.aws.amazon.com/code-library/latest/ug/python_3_bedrock-runtime_code_examples.html#meta_llama
+# (same as Mistral)
+_META_LLAMA_REQUEST = {
+    "prompt": """
+<|begin_of_text|><|start_header_id|>user<|end_header_id|>
+Hi!
+<|eot_id|>
+<|start_header_id|>assistant<|end_header_id|>
+""",
+    "max_gen_len": 300,
+    "temperature": 0.1,
+}
+
+_META_LLAMA_RESPONSE = {
+    "generation": "Hello! How can I help you today?",
+    "prompt_token_count": 2,
+    "generation_token_count": 12,
+    "stop_reason": "stop",
+}
+
+
+@pytest.mark.parametrize(
+    ("model_id", "llm_request", "llm_response"),
+    [
+        (
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            _ANTHROPIC_REQUEST,
+            _ANTHROPIC_RESPONSE,
+        ),
+        (
+            "ai21.jamba-instruct-v1:0",
+            _AI21_JAMBA_REQUEST,
+            _AI21_JAMBA_RESPONSE,
+        ),
+        (
+            "us.amazon.nova-lite-v1:0",
+            _AMAZON_NOVA_REQUEST,
+            _AMAZON_NOVA_RESPONSE,
+        ),
+        (
+            "cohere.command-r-plus-v1:0",
+            _COHERE_REQUEST,
+            _COHERE_RESPONSE,
+        ),
+        (
+            "meta.llama3-8b-instruct-v1:0",
+            _META_LLAMA_REQUEST,
+            _META_LLAMA_RESPONSE,
+        ),
+    ],
+)
+def test_bedrock_autolog_invoke_model_llm(model_id, llm_request, llm_response):
+    mlflow.bedrock.autolog()
+
+    client = boto3.client("bedrock-runtime", region_name="us-west-2")
+    request_body = json.dumps(llm_request)
+
+    # Ref: https://docs.getmoto.org/en/latest/docs/services/patching_other_services.html
+    with mock.patch(
+        "botocore.client.BaseClient._make_api_call",
+        return_value=_create_dummy_invoke_model_response(llm_response),
+    ):
+        response = client.invoke_model(body=request_body, modelId=model_id)
+
+    response_body = json.loads(response["body"].read())
+    assert response_body == llm_response
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+
+    assert len(traces[0].data.spans) == 1
+    span = traces[0].data.spans[0]
+    assert span.name == "BedrockRuntime.invoke_model"
+    assert span.span_type == "LLM"
+    assert span.inputs == {"body": request_body, "modelId": model_id}
+    assert span.outputs == {
+        "body": llm_response,
+        "ResponseMetadata": response["ResponseMetadata"],
+        "contentType": "application/json",
+    }
+
+
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html
+_AMAZON_EMBEDDING_REQUEST = {
+    "inputText": "Hi",
+    "dimensions": 8,
+}
+
+_AMAZON_EMBEDDING_RESPONSE = {
+    "embedding": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+    "inputTextTokenCount": 15,
+}
+
+
+def test_bedrock_autolog_invoke_model_embeddings():
+    mlflow.bedrock.autolog()
+
+    client = boto3.client("bedrock-runtime", region_name="us-west-2")
+
+    request_body = json.dumps(_AMAZON_EMBEDDING_REQUEST)
+    model_id = "amazon.titan-embed-text-v1"
+
+    # Ref: https://docs.getmoto.org/en/latest/docs/services/patching_other_services.html
+    with mock.patch(
+        "botocore.client.BaseClient._make_api_call",
+        return_value=_create_dummy_invoke_model_response(_AMAZON_EMBEDDING_RESPONSE),
+    ):
+        response = client.invoke_model(body=request_body, modelId=model_id)
+
+    response_body = json.loads(response["body"].read())
+    assert response_body == _AMAZON_EMBEDDING_RESPONSE
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+
+    assert len(traces[0].data.spans) == 1
+    span = traces[0].data.spans[0]
+    assert span.name == "BedrockRuntime.invoke_model"
+    assert span.span_type == "EMBEDDING"
+    assert span.inputs == {"body": request_body, "modelId": model_id}
+    assert span.outputs == {
+        "body": _AMAZON_EMBEDDING_RESPONSE,
+        "ResponseMetadata": response["ResponseMetadata"],
+        "contentType": "application/json",
+    }
+
+
+def test_bedrock_autolog_invoke_model_capture_exception():
+    mlflow.bedrock.autolog()
+
+    client = boto3.client("bedrock-runtime", region_name="us-west-2")
+
+    request_body = json.dumps(
+        {
+            # Invalid user role to trigger an exception
+            "messages": [{"role": "invalid-user", "content": "Hi"}],
+            "max_tokens": 300,
+            "anthropic_version": "bedrock-2023-05-31",
+            "temperature": 0.1,
+            "top_p": 0.9,
+        }
+    )
+
+    with pytest.raises(NoCredentialsError, match="Unable to locate credentials"):
+        client.invoke_model(
+            body=request_body,
+            modelId="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        )
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "ERROR"
+
+    assert len(traces[0].data.spans) == 1
+    span = traces[0].data.spans[0]
+    assert span.name == "BedrockRuntime.invoke_model"
+    assert span.status.status_code == "ERROR"
+    assert span.inputs == {
+        "body": request_body,
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    }
+    assert span.outputs is None
+    assert len(span.events) == 1
+    assert span.events[0].name == "exception"
+    assert span.events[0].attributes["exception.message"].startswith("Unable to locate credentials")
+
+
+@pytest.mark.parametrize("config", [{"disable": True}, {"log_traces": False}])
+def test_bedrock_autolog_trace_disabled(config):
+    mlflow.bedrock.autolog(**config)
+
+    client = boto3.client("bedrock-runtime", region_name="us-west-2")
+    request_body = json.dumps(_ANTHROPIC_REQUEST)
+
+    with mock.patch(
+        "botocore.client.BaseClient._make_api_call",
+        return_value=_create_dummy_invoke_model_response(_ANTHROPIC_RESPONSE),
+    ):
+        response = client.invoke_model(
+            body=request_body, modelId="anthropic.claude-3-5-sonnet-20241022-v2:0"
+        )
+
+    response_body = json.loads(response["body"].read())
+    assert response_body == _ANTHROPIC_RESPONSE
+
+    traces = get_traces()
+    assert len(traces) == 0
+
+
+@pytest.mark.skipif(not _IS_CONVERSE_API_AVAILABLE, reason="Converse API is not available")
+def test_bedrock_autolog_converse():
+    mlflow.bedrock.autolog()
+
+    client = boto3.client("bedrock-runtime", region_name="us-west-2")
+
+    dummy_response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Hello! How can I help you today?"}],
+            },
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 8, "outputTokens": 12},
+        "metrics": {"latencyMs": 551},
+    }
+
+    with mock.patch("botocore.client.BaseClient._make_api_call", return_value=dummy_response):
+        response = client.converse(
+            modelId="anthropic.claude-3-5-sonnet-20241022-v2:0",
+            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
+            inferenceConfig={
+                "maxTokens": 300,
+                "temperature": 0.1,
+                "topP": 0.9,
+            },
+        )
+
+    assert response["output"]["message"]["content"][0]["text"] == "Hello! How can I help you today?"
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+
+    assert len(traces[0].data.spans) == 1
+    span = traces[0].data.spans[0]
+    assert span.name == "BedrockRuntime.converse"
+    assert span.inputs["messages"] == [{"role": "user", "content": [{"text": "Hi"}]}]
+    assert span.inputs["modelId"] == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    assert span.outputs == dummy_response

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import anthropic
 import autogen
+import boto3
 import dspy
 import fastai
 import google.generativeai
@@ -67,6 +68,7 @@ library_to_mlflow_module_genai = {
     dspy: mlflow.dspy,
     litellm: mlflow.litellm,
     google.generativeai: mlflow.gemini,
+    boto3: mlflow.bedrock,
 }
 
 library_to_mlflow_module_traditional_ai = {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14018?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14018/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14018
```

</p>
</details>

## What changes are proposed in this pull request?

Support tracing Bedrock LLM invocation (via boto3). In this PR, we support the two `boto3` APIs:
1. [invoke_model](https://boto3.amazonaws.com/v1/documentation/api/1.35.0/reference/services/bedrock-runtime/client/invoke_model.html) - The original API to call Bedrock models.
2. [converse](https://boto3.amazonaws.com/v1/documentation/api/1.35.0/reference/services/bedrock-runtime/client/converse.html) - A new API that allow users to access any supported LLMs with the consistent chat API.

Several TODOs:
* Set custom attributes for chat messages after https://github.com/mlflow/mlflow/pull/14087
* Streaming is not supported yet. Will add it in the follow-up PR after chat message standardization.
* Will also support [invoke_agent](https://boto3.amazonaws.com/v1/documentation/api/1.35.6/reference/services/bedrock-agent-runtime/client/invoke_agent.html) that runs Bedrock Agent.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

`invoke_model`
![Screenshot 2024-12-10 at 9 41 44](https://github.com/user-attachments/assets/ae109c32-f469-4e1f-ad10-1da8b6926a46)

`converse`
![Screenshot 2024-12-10 at 9 42 02](https://github.com/user-attachments/assets/ed246755-ff1e-4ea3-ae2c-7010c74a90bf)

`invoke_model` for an embedding model
![Screenshot 2024-12-10 at 9 46 05](https://github.com/user-attachments/assets/63bb1ebb-20dd-4a46-b7de-8840ad7ec8df)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Will update documentation in a follow-up PR.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support tracing Amazon Bedrock.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
