### PR TITLE
return empty array when DatabricksSDKModelsArtifactRepository.list_artifacts is called on a file

### DIFF
--- a/mlflow/store/artifact/databricks_sdk_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_models_artifact_repo.py
@@ -1,6 +1,8 @@
 import posixpath
 from typing import Optional
 
+from databricks.sdk.errors.platform import NotFound
+
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.cloud_artifact_repo import CloudArtifactRepository
 
@@ -32,6 +34,11 @@ class DatabricksSDKModelsArtifactRepository(CloudArtifactRepository):
             dest_path = posixpath.join(dest_path, path)
 
         file_infos = []
+
+        # check if dest_path is file, if so return empty dir
+        if not self._is_dir(dest_path):
+            return file_infos
+
         resp = self.client.files.list_directory_contents(dest_path)
         for directory_entry in resp:
             relative_path = posixpath.relpath(directory_entry.path, self.model_base_path)
@@ -44,6 +51,13 @@ class DatabricksSDKModelsArtifactRepository(CloudArtifactRepository):
             )
 
         return sorted(file_infos, key=lambda f: f.path)
+
+    def _is_dir(self, artifact_path):
+        try:
+            self.client.files.get_directory_metadata(artifact_path)
+        except NotFound:
+            return False
+        return True
 
     def _upload_to_cloud(self, cloud_credential_info, src_file_path, artifact_file_path=None):
         dest_path = self.model_base_path

--- a/tests/store/artifact/test_databricks_sdk_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_sdk_models_artifact_repo.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors.platform import NotFound
 from databricks.sdk.service.files import DirectoryEntry, DownloadResponse
 
 from mlflow.entities.file_info import FileInfo
@@ -39,6 +40,12 @@ def mock_databricks_workspace_client():
 def test_list_artifacts_empty(mock_databricks_workspace_client):
     repo = DatabricksSDKModelsArtifactRepository(TEST_MODEL_NAME, TEST_MODEL_VERSION)
     mock_databricks_workspace_client.files.list_directory_contents.return_value = iter([])
+    assert repo.list_artifacts() == []
+
+
+def test_list_artifacts_listfile(mock_databricks_workspace_client):
+    repo = DatabricksSDKModelsArtifactRepository(TEST_MODEL_NAME, TEST_MODEL_VERSION)
+    mock_databricks_workspace_client.files.get_directory_metadata.side_effect = NotFound
     assert repo.list_artifacts() == []
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/shichengzhou-db/mlflow/pull/14027?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14027/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14027
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

In existing mlflow codebase, we rely on len(list_artifacts) > 0 to check if a path is directory or not(not great, but that's the current state). This caused a bug(list_artifacts throwing error) when trying to call get_model_info when DatabricksSDKModelsArtifactRepository is used for model registry.

Fix: check if artifact path is a directory or regular file. If it's regular file, return empty array as result of list_artifacts() call.


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
