### PR TITLE
Remove deprecated squared parameter

### DIFF
--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -277,9 +277,9 @@ def _mse_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
 
 def _rmse_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
-        from sklearn.metrics import mean_squared_error
+        from sklearn.metrics import root_mean_squared_error
 
-        rmse = mean_squared_error(targets, predictions, squared=False, sample_weight=sample_weight)
+        rmse = root_mean_squared_error(targets, predictions, sample_weight=sample_weight)
         return MetricValue(aggregate_results={"root_mean_squared_error": rmse})
 
 

--- a/mlflow/models/evaluation/evaluators/regressor.py
+++ b/mlflow/models/evaluation/evaluators/regressor.py
@@ -76,8 +76,8 @@ def _get_regressor_metrics(y, y_pred, sample_weights):
         "mean_squared_error": sk_metrics.mean_squared_error(
             y, y_pred, sample_weight=sample_weights
         ),
-        "root_mean_squared_error": sk_metrics.mean_squared_error(
-            y, y_pred, sample_weight=sample_weights, squared=False
+        "root_mean_squared_error": sk_metrics.root_mean_squared_error(
+            y, y_pred, sample_weight=sample_weights,
         ),
         "sum_on_target": sum_on_target,
         "mean_on_target": sum_on_target / len(y),

--- a/mlflow/models/evaluation/evaluators/regressor.py
+++ b/mlflow/models/evaluation/evaluators/regressor.py
@@ -77,7 +77,9 @@ def _get_regressor_metrics(y, y_pred, sample_weights):
             y, y_pred, sample_weight=sample_weights
         ),
         "root_mean_squared_error": sk_metrics.root_mean_squared_error(
-            y, y_pred, sample_weight=sample_weights,
+            y,
+            y_pred,
+            sample_weight=sample_weights,
         ),
         "sum_on_target": sum_on_target,
         "mean_on_target": sum_on_target / len(y),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14028?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14028/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14028
```

</p>
</details>

### Related Issues/PRs

Fix errors like https://github.com/mlflow/mlflow/actions/runs/12235806077/job/34162684718?pr=14023

### What changes are proposed in this pull request?

Scikit-learn 1.6 removes the deprecated `squared` parameter from the `mean_squared_error` function (see [1.5.x doc](https://scikit-learn.org/1.5/modules/generated/sklearn.metrics.mean_squared_error.html) for details). Replacing the usage with the new `root_mean_squared_error` function.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Replace the deprecated `squared` parameter usage in the scikit-learn MSE metric upon its removal in 1.6.0.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
