### PR TITLE
Use `mean_squared_error` if `root_mean_squared_error` is unavailable

### DIFF
--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -275,11 +275,28 @@ def _mse_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
         return MetricValue(aggregate_results={"mean_squared_error": mse})
 
 
+def _root_mean_squared_error(*, y_true, y_pred, sample_weight):
+    try:
+        from sklearn.metrics import root_mean_squared_error
+    except ImportError:
+        # If root_mean_squared_error is unavailable, fall back to
+        # `mean_squared_error(..., squared=False)`, which is deprecated in scikit-learn >= 1.4.
+        pass
+    else:
+        return root_mean_squared_error(y_true=y_true, y_pred=y_pred, sample_weight=sample_weight)
+
+    from sklearn.metrics import mean_squared_error
+
+    return mean_squared_error(
+        y_true=y_true, y_pred=y_pred, sample_weight=sample_weight, squared=False
+    )
+
+
 def _rmse_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
-        from sklearn.metrics import root_mean_squared_error
-
-        rmse = root_mean_squared_error(targets, predictions, sample_weight=sample_weight)
+        rmse = _root_mean_squared_error(
+            y_true=targets, y_pred=predictions, sample_weight=sample_weight
+        )
         return MetricValue(aggregate_results={"root_mean_squared_error": rmse})
 
 

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -281,15 +281,13 @@ def _root_mean_squared_error(*, y_true, y_pred, sample_weight):
     except ImportError:
         # If root_mean_squared_error is unavailable, fall back to
         # `mean_squared_error(..., squared=False)`, which is deprecated in scikit-learn >= 1.4.
-        pass
+        from sklearn.metrics import mean_squared_error
+
+        return mean_squared_error(
+            y_true=y_true, y_pred=y_pred, sample_weight=sample_weight, squared=False
+        )
     else:
         return root_mean_squared_error(y_true=y_true, y_pred=y_pred, sample_weight=sample_weight)
-
-    from sklearn.metrics import mean_squared_error
-
-    return mean_squared_error(
-        y_true=y_true, y_pred=y_pred, sample_weight=sample_weight, squared=False
-    )
 
 
 def _rmse_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):

--- a/mlflow/models/evaluation/evaluators/regressor.py
+++ b/mlflow/models/evaluation/evaluators/regressor.py
@@ -65,6 +65,8 @@ class RegressorEvaluator(BuiltInEvaluator):
 
 
 def _get_regressor_metrics(y, y_pred, sample_weights):
+    from mlflow.metrics.metric_definitions import _root_mean_squared_error
+
     sum_on_target = (
         (np.array(y) * np.array(sample_weights)).sum() if sample_weights is not None else sum(y)
     )
@@ -76,9 +78,9 @@ def _get_regressor_metrics(y, y_pred, sample_weights):
         "mean_squared_error": sk_metrics.mean_squared_error(
             y, y_pred, sample_weight=sample_weights
         ),
-        "root_mean_squared_error": sk_metrics.root_mean_squared_error(
-            y,
-            y_pred,
+        "root_mean_squared_error": _root_mean_squared_error(
+            y_true=y,
+            y_pred=y_pred,
             sample_weight=sample_weights,
         ),
         "sum_on_target": sum_on_target,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14040?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14040/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14040
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Follow-up for #14028. `root_mean_squared_error` isn't available in `scikit-learn < 1.4`. `mean_squared_error` should be used in `scikit-learn < 1.4`.


```python
> python examples/evaluation/evaluate_on_regressor.py
...
Traceback (most recent call last):
  File "/Users/user/Desktop/repositories/mlflow/examples/evaluation/evaluate_on_regressor.py", line 19, in <module>
    result = mlflow.evaluate(
  File "/Users/user/Desktop/repositories/mlflow/mlflow/models/evaluation/base.py", line 1758, in evaluate
    evaluate_result = _evaluate(
  File "/Users/user/Desktop/repositories/mlflow/mlflow/models/evaluation/base.py", line 1025, in _evaluate
    eval_result = eval_.evaluator.evaluate(
  File "/Users/user/Desktop/repositories/mlflow/mlflow/models/evaluation/default_evaluator.py", line 869, in evaluate
    return self._evaluate(model, extra_metrics, custom_artifacts)
  File "/Users/user/Desktop/repositories/mlflow/mlflow/models/evaluation/evaluators/regressor.py", line 38, in _evaluate
    self._compute_buildin_metrics(model)
  File "/Users/user/Desktop/repositories/mlflow/mlflow/models/evaluation/evaluators/regressor.py", line 62, in _compute_buildin_metrics
    _get_regressor_metrics(self.y_true, self.y_pred, self.sample_weights)
  File "/Users/user/Desktop/repositories/mlflow/mlflow/models/evaluation/evaluators/regressor.py", line 79, in _get_regressor_metrics
    "root_mean_squared_error": sk_metrics.root_mean_squared_error(
AttributeError: module 'sklearn.metrics' has no attribute 'root_mean_squared_error'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```
pip install 'scikit-learn<1.4'
python examples/evaluation/evaluate_on_regressor.py
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
