### PR TITLE
[DOC-FIX] Document that get and search methods/endpoints are case sensitive #11567

### DIFF
--- a/docs/source/python_api/mlflow.client.rst
+++ b/docs/source/python_api/mlflow.client.rst
@@ -7,3 +7,7 @@ mlflow.client
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. note:: 
+   **Case Sensitivity Warning:**
+   Many of the functions in this module (such as `get_registered_model`, `search_registered_models`, and others) are **case-sensitive** when using the `name` parameter. Please ensure you use the exact casing when providing these arguments.

--- a/docs/source/rest-api.rst
+++ b/docs/source/rest-api.rst
@@ -101,9 +101,9 @@ Search Experiments
 | ``2.0/mlflow/experiments/search`` | ``POST``    |
 +-----------------------------------+-------------+
 
-
-
-
+.. note::
+   - **Case-sensitive**: The filters provided in the request must match the case of the stored experiment names and other attributes in the MLflow system.
+   - Ensure that the filter string is constructed with exact case matching to avoid unexpected results.
 
 
 .. _mlflowSearchExperiments:
@@ -185,7 +185,9 @@ Get Experiment
 
 Get metadata for an experiment. This method works on deleted experiments.
 
-
+.. note::
+   - **Case-sensitive**: The filters provided in the request must match the case of the stored experiment names and other attributes in the MLflow system.
+   - Ensure that the filter string is constructed with exact case matching to avoid unexpected results.
 
 
 .. _mlflowGetExperiment:
@@ -1389,9 +1391,9 @@ Get RegisteredModel
 | ``2.0/mlflow/registered-models/get`` | ``GET``     |
 +--------------------------------------+-------------+
 
-
-
-
+.. note::
+   - **Case-sensitive**: The filters provided in the request must match the case of the stored experiment names and other attributes in the MLflow system.
+   - Ensure that the filter string is constructed with exact case matching to avoid unexpected results.
 
 
 .. _mlflowGetRegisteredModel:
@@ -1725,9 +1727,9 @@ Get ModelVersion
 | ``2.0/mlflow/model-versions/get`` | ``GET``     |
 +-----------------------------------+-------------+
 
-
-
-
+.. note::
+   - **Case-sensitive**: The filters provided in the request must match the case of the stored experiment names and other attributes in the MLflow system.
+   - Ensure that the filter string is constructed with exact case matching to avoid unexpected results.
 
 
 .. _mlflowGetModelVersion:
@@ -1888,9 +1890,9 @@ Search ModelVersions
 | ``2.0/mlflow/model-versions/search`` | ``GET``     |
 +--------------------------------------+-------------+
 
-
-
-
+.. note::
+   - **Case-sensitive**: The filters provided in the request must match the case of the stored experiment names and other attributes in the MLflow system.
+   - Ensure that the filter string is constructed with exact case matching to avoid unexpected results.
 
 
 .. _mlflowSearchModelVersions:
@@ -2084,9 +2086,9 @@ Search RegisteredModels
 | ``2.0/mlflow/registered-models/search`` | ``GET``     |
 +-----------------------------------------+-------------+
 
-
-
-
+.. note::
+   - **Case-sensitive**: The filters provided in the request must match the case of the stored experiment names and other attributes in the MLflow system.
+   - Ensure that the filter string is constructed with exact case matching to avoid unexpected results.
 
 
 .. _mlflowSearchRegisteredModels:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -167,7 +167,7 @@ lightgbm:
       bash build-python.sh install
 
   models:
-    minimum: "3.1.1"
+    minimum: "3.3.5"
     maximum: "4.5.0"
     requirements:
       ">= 0.0.0": ["scikit-learn"]
@@ -176,7 +176,7 @@ lightgbm:
       pytest tests/lightgbm/test_lightgbm_model_export.py
 
   autologging:
-    minimum: "3.1.1"
+    minimum: "3.3.5"
     maximum: "4.5.0"
     requirements:
       ">= 0.0.0": ["scikit-learn", "matplotlib"]

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -83,11 +83,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "lightgbm"
         },
         "models": {
-            "minimum": "3.1.1",
+            "minimum": "3.3.5",
             "maximum": "4.5.0"
         },
         "autologging": {
-            "minimum": "3.1.1",
+            "minimum": "3.3.5",
             "maximum": "4.5.0"
         }
     },


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/VARUN3WARE/mlflow/pull/14041?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14041/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14041
```

</p>
</details>

fixes #11567 

this pr tries to put notes in documentation for each of the case sensitive discussed in the above issue.

![Screenshot from 2024-12-10 16-04-00](https://github.com/user-attachments/assets/40d00140-8119-4d78-92d7-19d8d5b0d568)
![Screenshot from 2024-12-10 16-05-10](https://github.com/user-attachments/assets/94a9c165-bdff-4b52-9ae3-275e7804e011)

