### PR TITLE
Fix `content` type in mock OpenAI server

### DIFF
--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -20,9 +20,20 @@ class TextContentBlock(BaseModel):
     text: str
 
 
+class ImageUrl(BaseModel):
+    url: str
+
+
+class ImageContentBlock(BaseModel):
+    type: Literal["image_url"]
+    image_url: ImageUrl
+
+
 class Message(BaseModel):
     role: str
-    content: Union[str, list[TextContentBlock]] = Field(union_mode="left_to_right")
+    content: Union[str, list[Union[TextContentBlock, ImageContentBlock]]] = Field(
+        union_mode="left_to_right"
+    )
 
 
 class ChatPayload(BaseModel):

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -35,11 +35,6 @@ class InputAudio(BaseModel):
     format: Literal["wav", "mp3"]
 
 
-class InputAudio(BaseModel):
-    data: str
-    format: Literal["wav", "mp3"]
-
-
 class AudioContentPart(BaseModel):
     type: Literal["input_audio"]
     input_audio: InputAudio

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -15,23 +15,39 @@ def health():
     return {"status": "healthy"}
 
 
-class TextContentBlock(BaseModel):
+class TextContentPart(BaseModel):
     type: Literal["text"]
     text: str
 
 
 class ImageUrl(BaseModel):
     url: str
+    detail: Literal["auto", "low", "high"]
 
 
-class ImageContentBlock(BaseModel):
+class ImageContentPart(BaseModel):
     type: Literal["image_url"]
     image_url: ImageUrl
 
 
+class InputAudio(BaseModel):
+    data: str
+    format: Literal["wav", "mp3"]
+
+
+class InputAudio(BaseModel):
+    data: str
+    format: Literal["wav", "mp3"]
+
+
+class AudioContentPart(BaseModel):
+    type: Literal["input_audio"]
+    input_audio: InputAudio
+
+
 class Message(BaseModel):
     role: str
-    content: Union[str, list[Union[TextContentBlock, ImageContentBlock]]] = Field(
+    content: Union[str, list[Union[TextContentPart, ImageContentPart, AudioContentPart]]] = Field(
         union_mode="left_to_right"
     )
 

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -1,8 +1,8 @@
 import json
-from typing import Union
+from typing import Literal, Union
 
 import fastapi
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.responses import StreamingResponse
 
 EMPTY_CHOICES = "EMPTY_CHOICES"
@@ -15,9 +15,14 @@ def health():
     return {"status": "healthy"}
 
 
+class TextContentBlock(BaseModel):
+    type: Literal["text"]
+    text: str
+
+
 class Message(BaseModel):
     role: str
-    content: str
+    content: Union[str, list[TextContentBlock]] = Field(union_mode="left_to_right")
 
 
 class ChatPayload(BaseModel):


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The `content` type used in the mock OpenAI server is incorrect. A list of objects can be passed to `content` as shown below:

```sh
curl https://api.openai.com/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "gpt-4o",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "What'\''s in this image?"
          },
          {
            "type": "image_url",
            "image_url": {
              "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
            }
          }
        ]
      }
    ],
    "max_tokens": 300
  }'

```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
