### PR TITLE
Support predict function without context param for PythonModel and ChatModel

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -857,7 +857,7 @@ class PyFuncModel:
                 )
             data = data[0]
 
-        if inspect.signature(self._predict_stream_fn).parameters.get("params"):
+        if "params" in inspect.signature(self._predict_stream_fn).parameters:
             return self._predict_stream_fn(data, params=params)
 
         _log_warning_if_params_not_in_predict_signature(_logger, params)
@@ -1117,7 +1117,7 @@ class _ServedPyFuncModel(PyFuncModel):
         Returns:
             Model predictions.
         """
-        if inspect.signature(self._client.invoke).parameters.get("params"):
+        if "params" in inspect.signature(self._client.invoke).parameters:
             result = self._client.invoke(data, params=params).get_predictions()
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)
@@ -2502,7 +2502,7 @@ Compound types:
                     raise MlflowException(err_msg) from e
 
                 def batch_predict_fn(pdf, params=None):
-                    if inspect.signature(client.invoke).parameters.get("params"):
+                    if "params" in inspect.signature(client.invoke).parameters:
                         return client.invoke(pdf, params=params).get_predictions()
                     _log_warning_if_params_not_in_predict_signature(_logger, params)
                     return client.invoke(pdf).get_predictions()
@@ -2535,7 +2535,7 @@ Compound types:
                     )
 
                 def batch_predict_fn(pdf, params=None):
-                    if inspect.signature(loaded_model.predict).parameters.get("params"):
+                    if "params" in inspect.signature(loaded_model.predict).parameters:
                         return loaded_model.predict(pdf, params=params)
                     _log_warning_if_params_not_in_predict_signature(_logger, params)
                     return loaded_model.predict(pdf)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2965,7 +2965,7 @@ def save_model(
             context = PythonModelContext(artifacts, model_config)
             python_model.load_context(context)
             if "context" in inspect.signature(python_model.predict).parameters:
-                _logger.info(_DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO)
+                _logger.info(_DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO.format(func_name="predict"))
                 output = python_model.predict(context, messages, params)
             else:
                 output = python_model.predict(messages, params)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2964,7 +2964,7 @@ def save_model(
             _logger.info("Predicting on input example to validate output")
             context = PythonModelContext(artifacts, model_config)
             python_model.load_context(context)
-            if inspect.signature(python_model.predict).parameters.get("context"):
+            if "context" in inspect.signature(python_model.predict).parameters:
                 _logger.info(_DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO)
                 output = python_model.predict(context, messages, params)
             else:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -481,7 +481,6 @@ from mlflow.pyfunc.dbconnect_artifact_cache import (
     archive_directory,
     extract_archive_to_dir,
 )
-from mlflow.pyfunc.loaders.chat_model import _DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO
 from mlflow.pyfunc.model import (
     _DEFAULT_CHAT_MODEL_METADATA_TASK,
     ChatModel,
@@ -2965,7 +2964,6 @@ def save_model(
             context = PythonModelContext(artifacts, model_config)
             python_model.load_context(context)
             if "context" in inspect.signature(python_model.predict).parameters:
-                _logger.info(_DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO.format(func_name="predict"))
                 output = python_model.predict(context, messages, params)
             else:
                 output = python_model.predict(messages, params)

--- a/mlflow/pyfunc/loaders/chat_model.py
+++ b/mlflow/pyfunc/loaders/chat_model.py
@@ -11,12 +11,6 @@ from mlflow.pyfunc.model import (
 from mlflow.types.llm import ChatCompletionChunk, ChatCompletionResponse, ChatMessage, ChatParams
 from mlflow.utils.annotations import experimental
 
-_DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO = (
-    "Since MLflow 2.20.0, `context` parameter can be removed from `{func_name}` function "
-    "signature if it's not used. "
-    "`def {func_name}(self, messages: list[ChatMessage], params: ChatParams)` is a valid "
-    "{func_name} function."
-)
 _logger = logging.getLogger(__name__)
 
 
@@ -86,7 +80,6 @@ class _ChatModelPyfuncWrapper:
         messages, params = self._convert_input(model_input)
         parameters = inspect.signature(self.chat_model.predict).parameters
         if "context" in parameters or len(parameters) == 3:
-            _logger.info(_DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO.format(func_name="predict"))
             response = self.chat_model.predict(self.context, messages, params)
         else:
             response = self.chat_model.predict(messages, params)
@@ -126,9 +119,6 @@ class _ChatModelPyfuncWrapper:
         messages, params = self._convert_input(model_input)
         parameters = inspect.signature(self.chat_model.predict_stream).parameters
         if "context" in parameters or len(parameters) == 3:
-            _logger.info(
-                _DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO.format(func_name="predict_stream")
-            )
             stream = self.chat_model.predict_stream(self.context, messages, params)
         else:
             stream = self.chat_model.predict_stream(messages, params)

--- a/mlflow/pyfunc/loaders/chat_model.py
+++ b/mlflow/pyfunc/loaders/chat_model.py
@@ -85,7 +85,7 @@ class _ChatModelPyfuncWrapper:
         """
         messages, params = self._convert_input(model_input)
         parameters = inspect.signature(self.chat_model.predict).parameters
-        if parameters.get("context") or len(parameters) == 3:
+        if "context" in parameters or len(parameters) == 3:
             _logger.info(
                 _DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO.replace("<FUNCTION_NAME>", "predict")
             )
@@ -127,7 +127,7 @@ class _ChatModelPyfuncWrapper:
         """
         messages, params = self._convert_input(model_input)
         parameters = inspect.signature(self.chat_model.predict_stream).parameters
-        if parameters.get("context") or len(parameters) == 3:
+        if "context" in parameters or len(parameters) == 3:
             _logger.info(
                 _DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO.replace(
                     "<FUNCTION_NAME>", "predict_stream"

--- a/mlflow/pyfunc/loaders/chat_model.py
+++ b/mlflow/pyfunc/loaders/chat_model.py
@@ -84,7 +84,8 @@ class _ChatModelPyfuncWrapper:
             Model predictions in :py:class:`~ChatCompletionResponse` format.
         """
         messages, params = self._convert_input(model_input)
-        if inspect.signature(self.chat_model.predict).parameters.get("context"):
+        parameters = inspect.signature(self.chat_model.predict).parameters
+        if parameters.get("context") or len(parameters) == 3:
             _logger.info(
                 _DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO.replace("<FUNCTION_NAME>", "predict")
             )
@@ -125,7 +126,8 @@ class _ChatModelPyfuncWrapper:
             Generator over model predictions in :py:class:`~ChatCompletionChunk` format.
         """
         messages, params = self._convert_input(model_input)
-        if inspect.signature(self.chat_model.predict).parameters.get("context"):
+        parameters = inspect.signature(self.chat_model.predict_stream).parameters
+        if parameters.get("context") or len(parameters) == 3:
             _logger.info(
                 _DROP_CONTEXT_IN_CHAT_MODEL_PREDICT_INFO.replace(
                     "<FUNCTION_NAME>", "predict_stream"

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -672,7 +672,7 @@ class _PythonModelPyfuncWrapper:
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)
         if (
-            parameters.get("context")
+            "context" in parameters
             or len([param for param in parameters if param != "params"]) == 2
         ):
             _logger.info(
@@ -700,7 +700,7 @@ class _PythonModelPyfuncWrapper:
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)
         if (
-            parameters.get("context")
+            "context" in parameters
             or len([param for param in parameters if param != "params"]) == 2
         ):
             _logger.info(

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -666,7 +666,9 @@ class _PythonModelPyfuncWrapper:
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)
         if (
+            # predict(self, context, model_input, ...)
             "context" in parameters
+            # predict(self, ctx, model_input, ...) ctx can be any parameter name
             or len([param for param in parameters if param != "params"]) == 2
         ):
             return self.python_model.predict(
@@ -691,7 +693,9 @@ class _PythonModelPyfuncWrapper:
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)
         if (
+            # predict_stream(self, context, model_input, ...)
             "context" in parameters
+            # predict_stream(self, ctx, model_input, ...) ctx can be any parameter name
             or len([param for param in parameters if param != "params"]) == 2
         ):
             return self.python_model.predict_stream(

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -671,7 +671,10 @@ class _PythonModelPyfuncWrapper:
             kwargs["params"] = params
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)
-        if parameters.get("context"):
+        if (
+            parameters.get("context")
+            or len([param for param in parameters if param != "params"]) == 2
+        ):
             _logger.info(
                 _DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO.replace("<FUNCTION_NAME>", "predict")
             )
@@ -690,13 +693,16 @@ class _PythonModelPyfuncWrapper:
         Returns:
             Streaming predictions.
         """
-        parameters = inspect.signature(self.python_model.predict).parameters
+        parameters = inspect.signature(self.python_model.predict_stream).parameters
         kwargs = {}
         if parameters.get("params"):
             kwargs["params"] = params
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)
-        if parameters.get("context"):
+        if (
+            parameters.get("context")
+            or len([param for param in parameters if param != "params"]) == 2
+        ):
             _logger.info(
                 _DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO.replace(
                     "<FUNCTION_NAME>", "predict_stream"

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -52,9 +52,9 @@ _SAVED_PYTHON_MODEL_SUBPATH = "python_model.pkl"
 _DEFAULT_CHAT_MODEL_METADATA_TASK = "agent/v1/chat"
 
 _DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO = (
-    "Since MLflow 2.20.0, `context` parameter can be dropped from `<FUNCTION_NAME>` function "
-    "signature if it's not used. `def <FUNCTION_NAME>(self, model_input, params=None)` is a "
-    "valid <FUNCTION_NAME> function."
+    "Since MLflow 2.20.0, `context` parameter can be removed from `{func_name}` function "
+    "signature if it's not used. `def {func_name}(self, model_input, params=None)` is a "
+    "valid {func_name} function."
 )
 
 _logger = logging.getLogger(__name__)
@@ -131,7 +131,7 @@ class PythonModel:
             params: Additional parameters to pass to the model for inference.
 
         .. warning::
-            Since MLflow 2.20.0, `context` parameter can be dropped from `predict` function
+            Since MLflow 2.20.0, `context` parameter can be removed from `predict` function
             signature if it's not used. `def predict(self, model_input, params=None)` is valid.
         """
 
@@ -147,7 +147,7 @@ class PythonModel:
             params: Additional parameters to pass to the model for inference.
 
         .. warning::
-            Since MLflow 2.20.0, `context` parameter can be dropped from `predict_stream` function
+            Since MLflow 2.20.0, `context` parameter can be removed from `predict_stream` function
             signature if it's not used.
             `def predict_stream(self, model_input, params=None)` is valid.
         """
@@ -259,7 +259,7 @@ class ChatModel(PythonModel, metaclass=ABCMeta):
                 inference.
 
         .. warning::
-            Since MLflow 2.20.0, `context` parameter can be dropped from `predict` function
+            Since MLflow 2.20.0, `context` parameter can be removed from `predict` function
             signature if it's not used.
             `def predict(self, messages: list[ChatMessage], params: ChatParams)` is valid.
 
@@ -287,7 +287,7 @@ class ChatModel(PythonModel, metaclass=ABCMeta):
                 inference.
 
         .. warning::
-            Since MLflow 2.20.0, `context` parameter can be dropped from `predict_stream` function
+            Since MLflow 2.20.0, `context` parameter can be removed from `predict_stream` function
             signature if it's not used.
             `def predict_stream(self, messages: list[ChatMessage], params: ChatParams)` is valid.
 
@@ -675,9 +675,7 @@ class _PythonModelPyfuncWrapper:
             "context" in parameters
             or len([param for param in parameters if param != "params"]) == 2
         ):
-            _logger.info(
-                _DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO.replace("<FUNCTION_NAME>", "predict")
-            )
+            _logger.info(_DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO.format(func_name="predict"))
             return self.python_model.predict(
                 self.context, self._convert_input(model_input), **kwargs
             )
@@ -704,9 +702,7 @@ class _PythonModelPyfuncWrapper:
             or len([param for param in parameters if param != "params"]) == 2
         ):
             _logger.info(
-                _DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO.replace(
-                    "<FUNCTION_NAME>", "predict_stream"
-                )
+                _DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO.format(func_name="predict_stream")
             )
             return self.python_model.predict_stream(
                 self.context, self._convert_input(model_input), **kwargs

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -51,12 +51,6 @@ CONFIG_KEY_CLOUDPICKLE_VERSION = "cloudpickle_version"
 _SAVED_PYTHON_MODEL_SUBPATH = "python_model.pkl"
 _DEFAULT_CHAT_MODEL_METADATA_TASK = "agent/v1/chat"
 
-_DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO = (
-    "Since MLflow 2.20.0, `context` parameter can be removed from `{func_name}` function "
-    "signature if it's not used. `def {func_name}(self, model_input, params=None)` is a "
-    "valid {func_name} function."
-)
-
 _logger = logging.getLogger(__name__)
 
 
@@ -675,7 +669,6 @@ class _PythonModelPyfuncWrapper:
             "context" in parameters
             or len([param for param in parameters if param != "params"]) == 2
         ):
-            _logger.info(_DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO.format(func_name="predict"))
             return self.python_model.predict(
                 self.context, self._convert_input(model_input), **kwargs
             )
@@ -701,9 +694,6 @@ class _PythonModelPyfuncWrapper:
             "context" in parameters
             or len([param for param in parameters if param != "params"]) == 2
         ):
-            _logger.info(
-                _DROP_CONTEXT_IN_PYTHON_MODEL_PREDICT_INFO.format(func_name="predict_stream")
-            )
             return self.python_model.predict_stream(
                 self.context, self._convert_input(model_input), **kwargs
             )

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -130,7 +130,7 @@ class PythonModel:
             model_input: A pyfunc-compatible input for the model to evaluate.
             params: Additional parameters to pass to the model for inference.
 
-        .. warning::
+        .. tip::
             Since MLflow 2.20.0, `context` parameter can be removed from `predict` function
             signature if it's not used. `def predict(self, model_input, params=None)` is valid.
         """
@@ -146,7 +146,7 @@ class PythonModel:
             model_input: A pyfunc-compatible input for the model to evaluate.
             params: Additional parameters to pass to the model for inference.
 
-        .. warning::
+        .. tip::
             Since MLflow 2.20.0, `context` parameter can be removed from `predict_stream` function
             signature if it's not used.
             `def predict_stream(self, model_input, params=None)` is valid.
@@ -181,7 +181,7 @@ class _FunctionPythonModel(PythonModel):
         Returns:
             Model predictions.
         """
-        if inspect.signature(self.func).parameters.get("params"):
+        if "params" in inspect.signature(self.func).parameters:
             return self.func(model_input, params=params)
         _log_warning_if_params_not_in_predict_signature(_logger, params)
         return self.func(model_input)
@@ -258,7 +258,7 @@ class ChatModel(PythonModel, metaclass=ABCMeta):
                 containing various parameters used to modify model behavior during
                 inference.
 
-        .. warning::
+        .. tip::
             Since MLflow 2.20.0, `context` parameter can be removed from `predict` function
             signature if it's not used.
             `def predict(self, messages: list[ChatMessage], params: ChatParams)` is valid.
@@ -286,7 +286,7 @@ class ChatModel(PythonModel, metaclass=ABCMeta):
                 containing various parameters used to modify model behavior during
                 inference.
 
-        .. warning::
+        .. tip::
             Since MLflow 2.20.0, `context` parameter can be removed from `predict_stream` function
             signature if it's not used.
             `def predict_stream(self, messages: list[ChatMessage], params: ChatParams)` is valid.
@@ -667,7 +667,7 @@ class _PythonModelPyfuncWrapper:
         """
         parameters = inspect.signature(self.python_model.predict).parameters
         kwargs = {}
-        if parameters.get("params"):
+        if "params" in parameters:
             kwargs["params"] = params
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)
@@ -693,7 +693,7 @@ class _PythonModelPyfuncWrapper:
         """
         parameters = inspect.signature(self.python_model.predict_stream).parameters
         kwargs = {}
-        if parameters.get("params"):
+        if "params" in parameters:
             kwargs["params"] = params
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -362,7 +362,7 @@ def invocations(data, content_type, model, input_schema):
     # NB: utils._validate_serving_input mimic the scoring process here to validate input_example
     # work for serving, so any changes here should be reflected there as well
     try:
-        if inspect.signature(model.predict).parameters.get("params"):
+        if "params" in inspect.signature(model.predict).parameters:
             raw_predictions = model.predict(data, params=params)
         else:
             _log_warning_if_params_not_in_predict_signature(_logger, params)
@@ -497,7 +497,7 @@ def _predict(model_uri, input_path, output_path, content_type):
     else:
         raise Exception(f"Unknown content type '{content_type}'")
 
-    if inspect.signature(pyfunc_model.predict).parameters.get("params"):
+    if "params" in inspect.signature(pyfunc_model.predict).parameters:
         raw_predictions = pyfunc_model.predict(df, params=params)
     else:
         _log_warning_if_params_not_in_predict_signature(_logger, params)

--- a/mlflow/pyfunc/stdin_server.py
+++ b/mlflow/pyfunc/stdin_server.py
@@ -31,7 +31,7 @@ for line in sys.stdin:
     data = scoring_server.infer_and_parse_data(data, input_schema)
 
     _logger.info("Making predictions")
-    if inspect.signature(model.predict).parameters.get("params"):
+    if "params" in inspect.signature(model.predict).parameters:
         preds = model.predict(data, params=params)
     else:
         _log_warning_if_params_not_in_predict_signature(_logger, params)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2171,3 +2171,33 @@ def test_environment_variables_used_during_model_logging(monkeypatch):
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model("model", python_model=MyModel(), input_example="data")
     assert model_info.env_vars is None
+
+
+def test_pyfunc_model_without_context_in_predict():
+    class Model(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input, params=None):
+            return model_input
+
+        def predict_stream(self, model_input, params=None):
+            yield model_input
+
+    m = Model()
+    assert m.predict("abc") == "abc"
+    assert next(iter(m.predict_stream("abc"))) == "abc"
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model("model", python_model=m, input_example="abc")
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert pyfunc_model.predict("abc") is not None
+    assert next(iter(pyfunc_model.predict_stream("abc"))) is not None
+
+
+def test_callable_python_model_without_context_in_predict():
+    def predict(model_input):
+        return model_input
+
+    assert predict("abc") == "abc"
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model("model", python_model=predict, input_example="abc")
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert pyfunc_model.predict("abc") is not None

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -1293,7 +1293,7 @@ def test_enforce_params_schema_with_success():
     assert _enforce_params_schema(test_parameters, test_schema) == {"1": 1.0}
 
 
-def test__enforce_params_schema_add_default_values():
+def test_enforce_params_schema_add_default_values():
     class MyModel(mlflow.pyfunc.PythonModel):
         def predict(self, ctx, model_input, params):
             return list(params.values())


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14059?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14059/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14059
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We've been defining the `predict` function signature for PythonModel and ChatModel to contain `context` param, but context parameter is not needed for lots of development, or at least not needed within the predict function.
This PR supports the case when `predict` function doesn't include `context` parameter.
```
import mlflow

class Model(mlflow.pyfunc.PythonModel):
        def predict(self, model_input, params=None):
            return model_input
```
This example will become a valid custom PythonModel.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
