### PR TITLE
Enable trace tab in runs page

### DIFF
--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -79,7 +79,7 @@ export const shouldEnableRelativeTimeDateAxis = () => false;
 export const shouldEnableNewDifferenceViewCharts = () => false;
 
 export const shouldEnableTracingUI = () => true;
-export const shouldEnableRunDetailsPageTracesTab = () => false;
+export const shouldEnableRunDetailsPageTracesTab = () => true;
 export const shouldUseCompressedExperimentViewSharedState = () => true;
 export const shouldEnableUnifiedChartDataTraceHighlight = () => true;
 export const shouldDeferLineChartRendering = () => true;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsModeSwitch.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsModeSwitch.tsx
@@ -210,7 +210,6 @@ export const ExperimentViewRunsModeSwitch = ({
                 defaultMessage="Traces"
                 description="A button enabling traces mode on the experiment page"
               />
-              <PreviewBadge />
             </span>
           }
           key="TRACES"

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
@@ -62,10 +62,12 @@ export const RunViewModeSwitch = () => {
         }
         key={RunPageTabName.SYSTEM_METRIC_CHARTS}
       />
-      <LegacyTabs.TabPane
-        tab={<FormattedMessage defaultMessage="Traces" description="Run details page > tab selector > Traces tab" />}
-        key={RunPageTabName.TRACES}
-      />
+      {shouldEnableRunDetailsPageTracesTab() && (
+        <LegacyTabs.TabPane
+          tab={<FormattedMessage defaultMessage="Traces" description="Run details page > tab selector > Traces tab" />}
+          key={RunPageTabName.TRACES}
+        />
+      )}
       <LegacyTabs.TabPane
         tab={
           <FormattedMessage defaultMessage="Artifacts" description="Run details page > tab selector > artifacts tab" />

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
@@ -62,12 +62,10 @@ export const RunViewModeSwitch = () => {
         }
         key={RunPageTabName.SYSTEM_METRIC_CHARTS}
       />
-      {shouldEnableRunDetailsPageTracesTab() && (
-        <LegacyTabs.TabPane
-          tab={<FormattedMessage defaultMessage="Traces" description="Run details page > tab selector > Traces tab" />}
-          key={RunPageTabName.TRACES}
-        />
-      )}
+      <LegacyTabs.TabPane
+        tab={<FormattedMessage defaultMessage="Traces" description="Run details page > tab selector > Traces tab" />}
+        key={RunPageTabName.TRACES}
+      />
       <LegacyTabs.TabPane
         tab={
           <FormattedMessage defaultMessage="Artifacts" description="Run details page > tab selector > artifacts tab" />

--- a/mlflow/server/js/src/experiment-tracking/components/traces/TraceDataDrawer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TraceDataDrawer.tsx
@@ -61,7 +61,7 @@ export const TraceDataDrawer = ({
       return getTraceDisplayName(traceInfoToUse as ModelTraceInfo);
     }
     return requestId;
-  }, [loadingTraceInfo, loadingInternalTracingInfo, traceInfoToUse, requestId, theme]);
+  }, [loadingTraceInfo, loadingInternalTracingInfo, traceInfoToUse, requestId]);
 
   // Construct the model trace object with the trace info and trace data
   const combinedModelTrace = useMemo(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14067?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14067/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14067
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As title, enable the trace tab in runs

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/b4d7d904-2442-496b-a757-ceb3e3d052af



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The traces tab is now available on the run view page in MLflow UI (rather than only being available on the experiment level).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
