### PR TITLE
Add private API to log a trace directly to backend

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -694,13 +694,14 @@ class MlflowClient:
 
         self.end_span(request_id, root_span_id, outputs, attributes, status, end_time_ns)
 
+    @experimental
     def _log_trace(self, trace: Trace) -> str:
         """
         Log the complete Trace object to the backend store.
 
-        This is currently used for allowing integrators to log a trace object generated in a
-        different context to the backend store directly. The proper way to create a trace is
-        to use the `start_trace` and `end_trace` methods.
+        # NB: Since the backend API is used directly here, customization of request ID's
+        # are not possible with this internal API. A backend-generated ID will be generated
+        # directly with this invocation, instead of the one from the given trace object.
 
         Args:
             trace: The trace object to log.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -694,13 +694,19 @@ class MlflowClient:
 
         self.end_span(request_id, root_span_id, outputs, attributes, status, end_time_ns)
 
-    def _log_trace(self, trace: Trace):
+    def _log_trace(self, trace: Trace) -> str:
         """
         Log the complete Trace object to the backend store.
 
         This is currently used for allowing integrators to log a trace object generated in a
         different context to the backend store directly. The proper way to create a trace is
         to use the `start_trace` and `end_trace` methods.
+
+        Args:
+            trace: The trace object to log.
+
+        Returns:
+            The request ID of the logged trace.
         """
         # Create trace info entry in the backend
         # Note that the backend generates a new request ID for the trace. Currently there is
@@ -723,6 +729,8 @@ class MlflowClient:
         # Upload trace data
         self._upload_trace_spans_as_tag(new_info, trace.data)
         self._upload_trace_data(new_info, trace.data)
+
+        return new_info.request_id
 
     def _upload_trace_spans_as_tag(self, trace_info: TraceInfo, trace_data: TraceData):
         # When a trace is logged, we set a mlflow.traceSpans tag via SetTraceTag API

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -694,6 +694,36 @@ class MlflowClient:
 
         self.end_span(request_id, root_span_id, outputs, attributes, status, end_time_ns)
 
+    def _log_trace(self, trace: Trace):
+        """
+        Log the complete Trace object to the backend store.
+
+        This is currently used for allowing integrators to log a trace object generated in a
+        different context to the backend store directly. The proper way to create a trace is
+        to use the `start_trace` and `end_trace` methods.
+        """
+        # Create trace info entry in the backend
+        # Note that the backend generates a new request ID for the trace. Currently there is
+        # no way to insert the trace with a specific request ID given by the user.
+        new_info = self._tracking_client.start_trace(
+            experiment_id=trace.info.experiment_id,
+            timestamp_ms=trace.info.timestamp_ms,
+            request_metadata={},
+            tags={},
+        )
+        self._tracking_client.end_trace(
+            request_id=new_info.request_id,
+            # Compute the end time of the original trace
+            timestamp_ms=trace.info.timestamp_ms + trace.info.execution_time_ms,
+            status=trace.info.status,
+            request_metadata=trace.info.request_metadata,
+            tags=trace.info.tags,
+        )
+
+        # Upload trace data
+        self._upload_trace_spans_as_tag(new_info, trace.data)
+        self._upload_trace_data(new_info, trace.data)
+
     def _upload_trace_spans_as_tag(self, trace_info: TraceInfo, trace_data: TraceData):
         # When a trace is logged, we set a mlflow.traceSpans tag via SetTraceTag API
         # https://databricks.atlassian.net/browse/ML-40306

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -813,12 +813,12 @@ def test_log_trace(tracking_uri):
     assert client.search_traces(experiment_ids=[experiment_id]) == []
 
     # Log the trace manually
-    client._log_trace(trace)
+    new_request_id = client._log_trace(trace)
 
     # Validate the trace is added to the backend
     backend_traces = client.search_traces(experiment_ids=[experiment_id])
     assert len(backend_traces) == 1
-    assert backend_traces[0].info.request_id != trace.info.request_id  # new request ID is assigned
+    assert backend_traces[0].info.request_id == new_request_id  # new request ID is assigned
     assert backend_traces[0].info.experiment_id == experiment_id
     assert backend_traces[0].info.status == trace.info.status
     assert backend_traces[0].info.tags["custom_tag"] == "tag_value"

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -794,6 +794,40 @@ def test_start_span_raise_error_when_parent_id_is_not_provided():
         mlflow.tracking.MlflowClient().start_span("span_name", request_id="test", parent_id=None)
 
 
+def test_log_trace(tracking_uri):
+    client = MlflowClient(tracking_uri)
+    experiment_id = client.create_experiment("test_experiment")
+
+    span = client.start_trace(
+        name="test",
+        span_type=SpanType.LLM,
+        experiment_id=experiment_id,
+        tags={"custom_tag": "tag_value"},
+    )
+    client.end_trace(span.request_id, status="OK")
+
+    trace = mlflow.get_last_active_trace()
+
+    # Purge all traces in the backend once
+    client.delete_traces(experiment_id=experiment_id, request_ids=[trace.info.request_id])
+    assert client.search_traces(experiment_ids=[experiment_id]) == []
+
+    # Log the trace manually
+    client._log_trace(trace)
+
+    # Validate the trace is added to the backend
+    backend_traces = client.search_traces(experiment_ids=[experiment_id])
+    assert len(backend_traces) == 1
+    assert backend_traces[0].info.request_id != trace.info.request_id  # new request ID is assigned
+    assert backend_traces[0].info.experiment_id == experiment_id
+    assert backend_traces[0].info.status == trace.info.status
+    assert backend_traces[0].info.tags["custom_tag"] == "tag_value"
+    assert backend_traces[0].data.request == trace.data.request
+    assert backend_traces[0].data.response == trace.data.response
+    assert len(backend_traces[0].data.spans) == len(trace.data.spans)
+    assert backend_traces[0].data.spans[0].name == trace.data.spans[0].name
+
+
 def test_ignore_exception_from_tracing_logic(monkeypatch, async_logging_enabled):
     exp_id = mlflow.set_experiment("test_experiment_1").experiment_id
     client = MlflowClient()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14069?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14069/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14069
```

</p>
</details>

### What changes are proposed in this pull request?

Add an API to log a trace directly to backend. This is primary for Databricks right now, to record a trace generated outside notebook.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
from mlflow import MlflowClient
from mlflow.entities import Trace

# 1. Create Trace object from JSON
trace = Trace.from_json('{"info": {"request_id": "tr-7217f528c4ab4aec82371ce109a0db31", "experiment_id":...')

# 2. Log the trace using the new API
new_request_id = MlflowClient()._log_trace(trace)

print(new_request_id)
# Output: tr-fcd7c36f7d61409390833e1c30b144bd
```
![Screenshot 2024-12-12 at 12 20 46](https://github.com/user-attachments/assets/4bbcb363-541c-4632-a0b4-d96e989564f2)

![Screenshot 2024-12-12 at 12 18 39](https://github.com/user-attachments/assets/4cd14c7c-0e1a-485b-8d50-e3f9c8110755)

Trace is logged properly, with the original timestam, tags, and span data.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
