### PR TITLE
Add pre-commit hook to detect trace iframe in ipynb files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         name: check-notebooks
         entry: dev/check-notebooks.sh
         language: system
-        types_or: [jupyter]
+        files: '\.ipynb$'
         stages: [pre-commit]
         require_serial: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,14 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: check-notebooks
+        name: check-notebooks
+        entry: dev/check-notebooks.sh
+        language: system
+        types_or: [jupyter]
+        stages: [pre-commit]
+        require_serial: true
+
       - id: custom-python-lint
         name: custom-python-lint
         entry: clint

--- a/dev/check-notebooks.sh
+++ b/dev/check-notebooks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+TRACE_UI_SRC="static-files/lib/notebook-trace-renderer/index.html"
+
+# If offending files are found, list them and throw an exception
+if grep -In $TRACE_UI_SRC --include="*.ipynb" "$@"; then
+    echo -e "\nError: Found the MLflow Trace UI iframe in the above notebooks."
+    echo "Please remove the iframe from the notebook source, as it will not render properly on previews or the website"
+    exit 1
+else
+  exit 0
+fi

--- a/dev/check-notebooks.sh
+++ b/dev/check-notebooks.sh
@@ -5,7 +5,8 @@ TRACE_UI_SRC="static-files/lib/notebook-trace-renderer/index.html"
 # If offending files are found, list them and throw an exception
 if grep -In $TRACE_UI_SRC --include="*.ipynb" "$@"; then
     echo -e "\nError: Found the MLflow Trace UI iframe in the above notebooks."
-    echo "Please remove the iframe from the notebook source, as it will not render properly on previews or the website"
+    echo "The trace UI in cell outputs will not render correctly in previews or the website"
+    echo "Please run \`mlflow.tracing.disable_notebook_display()\` and rerun the cell to remove the iframe."
     exit 1
 else
   exit 0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14072?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14072/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14072
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As title, pre-commit seemed like a good place to put this.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


sample output:

```
check-notebooks..........................................................Failed
- hook id: check-notebooks
- exit code: 1

demo-tracing.ipynb:288:       "    src=\"http://localhost:5000/static-files/lib/notebook-trace-renderer/index.html?trace_id=b08baa9694a742e4baddbe295ba16f93&experiment_id=0&version=2.19.1.dev0\"\n",

Error: Found the MLflow Trace UI iframe in the above notebooks.
The trace UI in cell outputs will not render correctly in previews or the website
Please run `mlflow.tracing.disable_notebook_display()` and rerun the cell to remove the iframe.
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
