### PR TITLE
Disallow top-level `permissions` config in github actions workflows

### DIFF
--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -1,17 +1,14 @@
 package main
 
-deny[msg] {
+deny_jobs_without_permissions[msg] {
     jobs_without_permissions := get_jobs_without_permissions(input.jobs)
     count(jobs_without_permissions) > 0
-
     msg := sprintf("The following jobs are missing permissions: %s",
         [concat(", ", jobs_without_permissions)])
 }
 
-
-deny[msg] {
+deny_top_level_permissions[msg] {
     input.permissions
-
     msg := "Do not use top-level permissions. Set permissions on the job level."
 }
 

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -1,0 +1,23 @@
+package main
+
+deny[msg] {
+    count(jobs_without_timeout_minutes(input.jobs)) > 0
+
+    msg := sprintf("The following jobs are missing permissions: %s",
+        [concat(", ", jobs_without_timeout_minutes(input.jobs))])
+}
+
+
+deny[msg] {
+    input.permissions
+
+    msg := "Do not use top-level permissions"
+}
+
+###########################   RULE HELPERS   ##################################
+jobs_without_timeout_minutes(jobs) = jobs_without_timeout_minutes {
+    jobs_without_timeout_minutes := { job_id |
+        job := jobs[job_id]
+        not job["permissions"]
+    }
+}

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -12,7 +12,7 @@ deny[msg] {
 deny[msg] {
     input.permissions
 
-    msg := "Do not use top-level permissions"
+    msg := "Do not use top-level permissions. Set permissions on the job level."
 }
 
 ###########################   RULE HELPERS   ##################################

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -1,10 +1,11 @@
 package main
 
 deny[msg] {
-    count(jobs_without_timeout_minutes(input.jobs)) > 0
+    jobs_without_permissions := get_jobs_without_permissions(input.jobs)
+    count(jobs_without_permissions) > 0
 
     msg := sprintf("The following jobs are missing permissions: %s",
-        [concat(", ", jobs_without_timeout_minutes(input.jobs))])
+        [concat(", ", jobs_without_permissions)])
 }
 
 
@@ -15,8 +16,8 @@ deny[msg] {
 }
 
 ###########################   RULE HELPERS   ##################################
-jobs_without_timeout_minutes(jobs) = jobs_without_timeout_minutes {
-    jobs_without_timeout_minutes := { job_id |
+get_jobs_without_permissions(jobs) = jobs_without_permissions {
+    jobs_without_permissions := { job_id |
         job := jobs[job_id]
         not job["permissions"]
     }

--- a/.github/workflows/advice.yml
+++ b/.github/workflows/advice.yml
@@ -5,9 +5,6 @@ on:
     types:
       - opened
 
-permissions:
-  contents: read
-
 jobs:
   notify:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -5,9 +5,6 @@ on:
   issue_comment:
     types: [created, edited]
 
-permissions:
-  contents: read
-
 defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}
@@ -159,6 +156,7 @@ jobs:
     timeout-minutes: 5
     needs: [check-comment, format]
     if: ${{ needs.format.outputs.reformatted == 'true' }}
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -19,9 +19,6 @@ on:
         required: true
         default: "master"
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -35,6 +32,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -6,9 +6,6 @@ on:
     types:
       - closed
 
-permissions:
-  contents: read
-
 jobs:
   cancel:
     runs-on: ubuntu-latest

--- a/.github/workflows/cherry-picks-warn.yml
+++ b/.github/workflows/cherry-picks-warn.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - branch-[0-9]+.[0-9]+
 
-permissions:
-  contents: read
-
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/closing-pr.yml
+++ b/.github/workflows/closing-pr.yml
@@ -10,9 +10,6 @@ defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}
 
-permissions:
-  contents: read
-
 jobs:
   closing-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-version-test-runner.yml
+++ b/.github/workflows/cross-version-test-runner.yml
@@ -3,9 +3,6 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-
 defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -39,9 +39,6 @@ on:
     # Run this workflow daily at 13:00 UTC
     - cron: "0 13 * * *"
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -130,6 +127,7 @@ jobs:
     if: ${{ needs.set-matrix.outputs.is_matrix1_empty == 'false' }}
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 120
+    permissions: {}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix1) }}
@@ -176,6 +174,7 @@ jobs:
     if: ${{ needs.set-matrix.outputs.is_matrix2_empty == 'false' }}
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 120
+    permissions: {}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix2) }}

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -12,9 +12,6 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -28,6 +25,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/untracked

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -29,9 +29,6 @@ on:
         required: false
         default: ""
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -44,6 +41,7 @@ jobs:
   linux-env-setup:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions: {}
     if: github.event_name != 'schedule' || github.repository == 'mlflow-automation/mlflow'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -13,9 +13,6 @@ on:
     paths:
       - .devcontainer/**
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -26,9 +26,6 @@ on:
         required: false
         default: ""
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -45,6 +42,7 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     strategy:
       fail-fast: false
@@ -100,6 +98,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -12,9 +12,6 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -31,6 +28,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/untracked

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -18,9 +18,6 @@ on:
       - mlflow/server/js/**
       - .github/workflows/js.yml
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -28,6 +25,7 @@ concurrency:
 jobs:
   js:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -10,9 +10,6 @@ on:
       - opened
       - edited
 
-permissions:
-  contents: read
-
 defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
           dev/install-taplo.sh
           dev/install-typos.sh
           mkdir -p /tmp/conftest/bin
-          curl -s -L "https://github.com/open-policy-agent/conftest/releases/download/v0.56.0/conftest_0.56.0_Linux_x86_64.tar.gz" | tar xvz /tmp/conftest/bin/conftest
+          curl -s -L "https://github.com/open-policy-agent/conftest/releases/download/v0.56.0/conftest_0.56.0_Linux_x86_64.tar.gz" | tar -xz -C /tmp/conftest/bin
           echo "/tmp/conftest/bin" >> $GITHUB_PATH
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,6 +48,7 @@ jobs:
           uv pip install --system -r requirements/lint-requirements.txt
           dev/install-taplo.sh
           dev/install-typos.sh
+          mkdir -p /tmp/conftest/bin
           curl -s -L "https://github.com/open-policy-agent/conftest/releases/download/v0.56.0/conftest_0.56.0_Linux_x86_64.tar.gz" | tar xvz /tmp/conftest/bin/conftest
           echo "/tmp/conftest/bin" >> $GITHUB_PATH
       - uses: ./.github/actions/show-versions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,6 @@ on:
     types:
       - checks_requested
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -33,6 +30,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions: {}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +48,8 @@ jobs:
           uv pip install --system -r requirements/lint-requirements.txt
           dev/install-taplo.sh
           dev/install-typos.sh
+          curl -s -L "https://github.com/open-policy-agent/conftest/releases/download/v0.56.0/conftest_0.56.0_Linux_x86_64.tar.gz" | tar xvz /tmp/conftest/bin/conftest
+          echo "/tmp/conftest/bin" >> $GITHUB_PATH
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Install pre-commit hooks

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -3,12 +3,11 @@ name: Maintainer approval
 on:
   pull_request:
 
-permissions:
-  pull-requests: read
-
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,8 +12,7 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,8 +12,6 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
-permissions: {}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -42,6 +40,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,6 +58,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +100,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/untracked
@@ -121,6 +122,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -171,6 +173,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -192,6 +195,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -227,6 +231,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -260,6 +265,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -291,6 +297,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -329,6 +336,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -349,6 +357,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-latest
     timeout-minutes: 120
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -7,9 +7,6 @@ on:
       - edited
       - synchronize
 
-permissions:
-  contents: read
-
 defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -3,9 +3,6 @@ name: Preview docs
 on:
   pull_request_target:
 
-permissions:
-  contents: read
-
 jobs:
   main:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -14,9 +14,6 @@ on:
     types:
       - checks_requested
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -27,6 +24,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions:
+      checks: read # to read check statuses
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/protobuf-cross-test.yml
+++ b/.github/workflows/protobuf-cross-test.yml
@@ -18,9 +18,6 @@ on:
       - "mlflow/protos/**"
       - .github/workflows/protobuf-cross-test.yml
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -44,6 +41,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/protos.yml
+++ b/.github/workflows/protos.yml
@@ -20,9 +20,6 @@ on:
 env:
   MLFLOW_HOME: /home/runner/work/mlflow/mlflow
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -36,6 +33,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -6,9 +6,6 @@ on:
       - published
       - edited
 
-permissions:
-  contents: read
-
 jobs:
   push-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -15,9 +15,6 @@ on:
     # Run this workflow daily at 13:00 UTC
     - cron: "0 13 * * *"
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -29,6 +26,7 @@ jobs:
   r:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     if: github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     defaults:
       run:

--- a/.github/workflows/recipe-template.yml
+++ b/.github/workflows/recipe-template.yml
@@ -16,9 +16,6 @@ on:
         required: false
         default: ""
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -39,6 +36,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
@@ -68,6 +66,7 @@ jobs:
   recipe:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
@@ -88,6 +87,7 @@ jobs:
           cd ${{ github.event.inputs.repository }} && pytest tests --rootdir .
   recipe-windows:
     runs-on: windows-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4

--- a/.github/workflows/recipe.yml
+++ b/.github/workflows/recipe.yml
@@ -12,9 +12,6 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -38,6 +35,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,6 +54,7 @@ jobs:
   recipes-windows:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-latest
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -16,9 +16,6 @@ on:
     types:
       - closed
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -15,9 +15,6 @@ on:
   schedule:
     - cron: "0 13 * * *"
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -36,6 +33,7 @@ jobs:
   skinny:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions: {}
     if: (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4
@@ -60,6 +58,7 @@ jobs:
   core:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     if: (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rerun-cross-version-tests.yml
+++ b/.github/workflows/rerun-cross-version-tests.yml
@@ -10,9 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   set-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/rerun-workflow-run.yml
+++ b/.github/workflows/rerun-workflow-run.yml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   rerun:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -10,13 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   upload:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     if: github.event.review.state == 'approved' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
     steps:
       - name: Upload PR number

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -26,9 +26,6 @@ on:
     # Run this workflow daily at 13:00 UTC
     - cron: "0 13 * * *"
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -46,6 +43,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: {}
     if: (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     strategy:
       fail-fast: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,3 +138,11 @@ repos:
         language: system
         stages: [pre-commit]
         require_serial: true
+
+      - id: conftest
+        name: conftest
+        entry: conftest test --policy .github/policy.rego
+        files: '^\.github/workflows/.*\.yml$'
+        language: system
+        stages: [pre-commit]
+        require_serial: true


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14078?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14078/merge
```
#### Checkout with GitHub CLI

```
gh pr checkout 14078
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

https://github.com/ultralytics/ultralytics/issues/18027 (supply chain attack by exploiting an insecure GitHub Actions workflow to puppet a bot account for automation) might happen to mlflow. If it does, the damage would be massive. We should make the best effort to prevent that. The goal of this PR is to set up a check that allows us to detect insecure configuration files. To ensure that it works, I added a check to disallow the top-level `permissions` config and enforce that each job have a `permissions` config.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
