### PR TITLE
Prevent unsafe checkout in `pull_request_target` workflows

### DIFF
--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -1,5 +1,7 @@
 package main
 
+import future.keywords.in
+
 deny_jobs_without_permissions[msg] {
     jobs_without_permissions := get_jobs_without_permissions(input.jobs)
     count(jobs_without_permissions) > 0
@@ -10,6 +12,15 @@ deny_jobs_without_permissions[msg] {
 deny_top_level_permissions[msg] {
     input.permissions
     msg := "Do not use top-level permissions. Set permissions on the job level."
+}
+
+deny_unsafe_checkout[msg] {
+    input["true"]["pull_request_target"]
+    some job in input["jobs"]
+    some step in job["steps"]
+    startswith(step["uses"], "actions/checkout@")
+    step["with"]["ref"]
+    msg := "An explicit checkout in a pull_request_target workflow is unsafe. See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ for more information."
 }
 
 ###########################   RULE HELPERS   ##################################

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -24,7 +24,7 @@ deny_unsafe_checkout[msg] {
     some step in job["steps"]
     startswith(step["uses"], "actions/checkout@")
     step["with"]["ref"]
-    msg := "Explicit checkout in a pull_request_target workflow is unsafe. See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ for more information."
+    msg := "Explicit checkout in a pull_request_target workflow is unsafe. See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests for more information."
 }
 
 ###########################   RULE HELPERS   ##################################

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -15,12 +15,16 @@ deny_top_level_permissions[msg] {
 }
 
 deny_unsafe_checkout[msg] {
+    # The "on" key gets transformed by conftest into "true" due to some legacy
+    # YAML standards, see https://stackoverflow.com/q/42283732/2148786 - so
+    # "on.push" becomes "true.push" which is why below statements use "true"
+    # instead of "on".
     input["true"]["pull_request_target"]
     some job in input["jobs"]
     some step in job["steps"]
     startswith(step["uses"], "actions/checkout@")
     step["with"]["ref"]
-    msg := "An explicit checkout in a pull_request_target workflow is unsafe. See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ for more information."
+    msg := "Explicit checkout in a pull_request_target workflow is unsafe. See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ for more information."
 }
 
 ###########################   RULE HELPERS   ##################################


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14085?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14085/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14085
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

As described in https://securitylab.github.com/resources/github-actions-preventing-pwn-requests, combining `pull_request_target` workflow trigger with an explicit checkout of an untrusted PR is a dangerous practice that may lead to repository compromise. This PR adds a check to prevent it.

```yml
on:
  pull_request_target

jobs:
  foo:
    steps:
      - uses: `actions/checkout@v4`
        with:
          ref: ${{ github.event.pull_request.head.sha }}
          # this allows an attacker to execute arbitrary code
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
