### PR TITLE
Add warning if `predict` method has different signature

### DIFF
--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -341,7 +341,7 @@ within a model signature and demonstrates their application in model inference.
 
 
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, ctx, model_input, params):
+        def predict(self, context, model_input, params):
             return list(params.values())
 
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -360,7 +360,7 @@ To use Aliyun OSS as an artifact store, an OSS URI of the form ``oss://<bucket>/
 
 
         class Mod(mlflow.pyfunc.PythonModel):
-            def predict(self, ctx, inp, params=None):
+            def predict(self, context, model_input, params=None):
                 return 7
 
 
@@ -396,7 +396,7 @@ To use XetHub as an artifact store, an XetHub URI of the form ``xet://<username>
 
 
         class Mod(mlflow.pyfunc.PythonModel):
-            def predict(self, ctx, inp, params=None):
+            def predict(self, context, model_input, params=None):
                 return 7
 
 

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -671,6 +671,7 @@ class _PythonModelPyfuncWrapper:
                 _INVALID_SIGNATURE_ERROR_MSG.format(
                     func_name="predict", invalid_params=invalid_params
                 ),
+                FutureWarning,
                 stacklevel=2,
             )
         kwargs = {}
@@ -705,6 +706,7 @@ class _PythonModelPyfuncWrapper:
                 _INVALID_SIGNATURE_ERROR_MSG.format(
                     func_name="predict_stream", invalid_params=invalid_params
                 ),
+                FutureWarning,
                 stacklevel=2,
             )
         kwargs = {}

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import os
 import shutil
+import warnings
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import Any, Generator, Optional, Union
@@ -50,6 +51,11 @@ CONFIG_KEY_PYTHON_MODEL = "python_model"
 CONFIG_KEY_CLOUDPICKLE_VERSION = "cloudpickle_version"
 _SAVED_PYTHON_MODEL_SUBPATH = "python_model.pkl"
 _DEFAULT_CHAT_MODEL_METADATA_TASK = "agent/v1/chat"
+_INVALID_SIGNATURE_ERROR_MSG = (
+    "The underlying model's `{func_name}` method contains invalid parameters: {invalid_params}. "
+    "Only the following parameter names are allowed: context, model_input, and params. "
+    "Note that invalid parameters will no longer be permitted in future versions."
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -660,6 +666,13 @@ class _PythonModelPyfuncWrapper:
             dict or string. Chunk dict fields are determined by the model implementation.
         """
         parameters = inspect.signature(self.python_model.predict).parameters
+        if invalid_params := set(parameters) - {"context", "model_input", "params"}:
+            warnings.warn(
+                _INVALID_SIGNATURE_ERROR_MSG.format(
+                    func_name="predict", invalid_params=invalid_params
+                ),
+                stacklevel=2,
+            )
         kwargs = {}
         if "params" in parameters:
             kwargs["params"] = params
@@ -687,6 +700,13 @@ class _PythonModelPyfuncWrapper:
             Streaming predictions.
         """
         parameters = inspect.signature(self.python_model.predict_stream).parameters
+        if invalid_params := set(parameters) - {"context", "model_input", "params"}:
+            warnings.warn(
+                _INVALID_SIGNATURE_ERROR_MSG.format(
+                    func_name="predict_stream", invalid_params=invalid_params
+                ),
+                stacklevel=2,
+            )
         kwargs = {}
         if "params" in parameters:
             kwargs["params"] = params

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -361,8 +361,8 @@ def test_mlflow_evaluate_logs_traces():
 def test_pyfunc_evaluate_logs_traces():
     class Model(mlflow.pyfunc.PythonModel):
         @mlflow.trace()
-        def predict(self, _, inputs):
-            return self.add(inputs, inputs)
+        def predict(self, context, model_input):
+            return self.add(model_input, model_input)
 
         @mlflow.trace()
         def add(self, x, y):

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -785,7 +785,7 @@ def test_env_manager_unsupported_value():
 
 def test_host_invalid_value():
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, ctx, model_input):
+        def predict(self, context, model_input):
             return model_input
 
     with mlflow.start_run():

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2201,3 +2201,31 @@ def test_callable_python_model_without_context_in_predict():
         model_info = mlflow.pyfunc.log_model("model", python_model=predict, input_example="abc")
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_model.predict("abc") is not None
+
+
+def test_pyfunc_model_with_wrong_predict_signature_warning():
+    class Model(mlflow.pyfunc.PythonModel):
+        def predict(self, ctx, model_input, params=None):
+            return model_input
+
+        def predict_stream(self, _, model_input, params=None):
+            yield model_input
+
+    m = Model()
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model("model", python_model=m, input_example="abc")
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    with mock.patch("mlflow.pyfunc.model.warnings.warn") as warn_mock:
+        pyfunc_model.predict("abc")
+        assert warn_mock.call_count == 1
+        assert (
+            "The underlying model's `predict` method contains invalid parameters: {'ctx'}"
+            in warn_mock.call_args[0][0]
+        )
+
+        pyfunc_model.predict_stream("abc")
+        assert warn_mock.call_count == 2
+        assert (
+            "The underlying model's `predict_stream` method contains invalid parameters: {'_'}"
+            in warn_mock.call_args[0][0]
+        )

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -1295,7 +1295,7 @@ def test_enforce_params_schema_with_success():
 
 def test_enforce_params_schema_add_default_values():
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, ctx, model_input, params):
+        def predict(self, context, model_input, params):
             return list(params.values())
 
     params = {"str_param": "string", "int_array": [1, 2, 3]}
@@ -1420,7 +1420,7 @@ def test_enforce_params_schema_errors():
 
 def test_enforce_params_schema_warns_with_model_without_params():
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, ctx, model_input, params=None):
+        def predict(self, context, model_input, params=None):
             return list(params.values()) if isinstance(params, dict) else None
 
     params = {"str_param": "string", "int_array": [1, 2, 3], "123": 123}
@@ -1442,7 +1442,7 @@ def test_enforce_params_schema_warns_with_model_without_params():
 
 def test_enforce_params_schema_errors_with_model_with_params():
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, ctx, model_input, params=None):
+        def predict(self, context, model_input, params=None):
             return list(params.values()) if isinstance(params, dict) else None
 
     params = {"str_param": "string", "int_array": [1, 2, 3], "123": 123}
@@ -1723,7 +1723,7 @@ def test_python_model_serving_compatible(tmp_path):
     from mlflow.models import infer_signature
 
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, ctx, model_input):
+        def predict(self, context, model_input):
             return model_input
 
     with mlflow.start_run():
@@ -1773,7 +1773,7 @@ cloudpickle==2.2.1
     )
 
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, ctx, model_input):
+        def predict(self, context, model_input):
             return model_input
 
     python_model = MyModel()

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -635,7 +635,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
         def load_context(self, context):
             self.pytorch_model = mlflow.pytorch.load_model(context.artifacts["pytorch_model"])
 
-        def predict(self, _, model_input, params=None):
+        def predict(self, context, model_input, params=None):
             with torch.no_grad():
                 input_tensor = torch.from_numpy(model_input.values.astype(np.float32))
                 output_tensor = self.pytorch_model(input_tensor)

--- a/tests/store/lineage/test_downstream_lineage.py
+++ b/tests/store/lineage/test_downstream_lineage.py
@@ -26,7 +26,7 @@ from mlflow.utils.proto_json_utils import message_to_json
 
 
 class SimpleModel(mlflow.pyfunc.PythonModel):
-    def predict(self, _, model_input):
+    def predict(self, context, model_input):
         return model_input.applymap(lambda x: x * 2)
 
 

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -456,7 +456,7 @@ def test_capture_imported_modules_include_deps_by_params():
 )
 def test_capture_imported_modules_includes_gateway_extra(module_to_import, should_capture_extra):
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, _, inputs, params=None):
+        def predict(self, context, inputs, params=None):
             importlib.import_module(module_to_import)
 
             return inputs
@@ -477,10 +477,10 @@ def test_capture_imported_modules_includes_gateway_extra(module_to_import, shoul
 
 def test_gateway_extra_not_captured_when_importing_deployment_client_only():
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, _, inputs, params=None):
+        def predict(self, context, model_input, params=None):
             from mlflow.deployments import get_deploy_client  # noqa: F401
 
-            return inputs
+            return model_input
 
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14086?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14086/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14086
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Users might override the PythonModel's predict/predict_stream method with a different signature, we should warn them in such case
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
