### PR TITLE
Dictionary param support

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -856,6 +856,13 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
         )
 
 
+_ALLOWED_CONVERSIONS_FOR_PARAMS = {
+    DataType.integer: (DataType.long, DataType.float, DataType.double),
+    DataType.long: (DataType.float, DataType.double),
+    DataType.float: (DataType.double,),
+}
+
+
 def _enforce_param_datatype(value: Any, dtype: DataType):
     """
     Enforce the value matches the data type. This is used to enforce params datatype.
@@ -901,15 +908,9 @@ def _enforce_param_datatype(value: Any, dtype: DataType):
     if DataType.check_type(dtype, value):
         return dtype.to_python()(value)
 
-    if (
-        (
-            DataType.check_type(DataType.integer, value)
-            and dtype in (DataType.long, DataType.float, DataType.double)
-        )
-        or (
-            DataType.check_type(DataType.long, value) and dtype in (DataType.float, DataType.double)
-        )
-        or (DataType.check_type(DataType.float, value) and dtype == DataType.double)
+    if any(
+        DataType.check_type(allowed_type, value) and dtype in expected_types
+        for allowed_type, expected_types in _ALLOWED_CONVERSIONS_FOR_PARAMS.items()
     ):
         try:
             return dtype.to_python()(value)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -858,7 +858,7 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
 
 # dtype -> possible value types mapping
 _ALLOWED_CONVERSIONS_FOR_PARAMS = {
-    DataType.long: (DataType.integer),
+    DataType.long: (DataType.integer,),
     DataType.float: (DataType.integer, DataType.long),
     DataType.double: (DataType.integer, DataType.long, DataType.float),
 }

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1325,16 +1325,15 @@ def _enforce_datatype(data: Any, dtype: DataType, required=True, enforce_param=F
         raise MlflowException(f"Expected data to be scalar, got {type(data).__name__}")
     if enforce_param:
         return _enforce_param_datatype(data, dtype)
-    else:
-        # Reuse logic in _enforce_mlflow_datatype for type conversion
-        pd_series = pd.Series(data)
-        try:
-            pd_series = _enforce_mlflow_datatype("", pd_series, dtype)
-        except MlflowException:
-            raise MlflowException(
-                f"Failed to enforce schema of data `{data}` with dtype `{dtype.name}`"
-            )
-        return pd_series[0]
+    # Reuse logic in _enforce_mlflow_datatype for type conversion
+    pd_series = pd.Series(data)
+    try:
+        pd_series = _enforce_mlflow_datatype("", pd_series, dtype)
+    except MlflowException:
+        raise MlflowException(
+            f"Failed to enforce schema of data `{data}` with dtype `{dtype.name}`"
+        )
+    return pd_series[0]
 
 
 def _enforce_array(data: Any, arr: Array, required: bool = True, enforce_param: bool = False):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -856,17 +856,18 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
         )
 
 
+# dtype -> possible value types mapping
 _ALLOWED_CONVERSIONS_FOR_PARAMS = {
-    DataType.integer: (DataType.long, DataType.float, DataType.double),
-    DataType.long: (DataType.float, DataType.double),
-    DataType.float: (DataType.double,),
+    DataType.long: (DataType.integer),
+    DataType.float: (DataType.integer, DataType.long),
+    DataType.double: (DataType.integer, DataType.long, DataType.float),
 }
 
 
 def _enforce_param_datatype(value: Any, dtype: DataType):
     """
     Enforce the value matches the data type. This is used to enforce params datatype.
-    The returned data type is a python native type.
+    The returned data is of python built-in type or a datetime object.
 
     The following type conversions are allowed:
 
@@ -908,9 +909,8 @@ def _enforce_param_datatype(value: Any, dtype: DataType):
     if DataType.check_type(dtype, value):
         return dtype.to_python()(value)
 
-    if any(
-        DataType.check_type(allowed_type, value) and dtype in expected_types
-        for allowed_type, expected_types in _ALLOWED_CONVERSIONS_FOR_PARAMS.items()
+    if dtype in _ALLOWED_CONVERSIONS_FOR_PARAMS and any(
+        DataType.check_type(t, value) for t in _ALLOWED_CONVERSIONS_FOR_PARAMS[dtype]
     ):
         try:
             return dtype.to_python()(value)

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -1183,7 +1183,9 @@ class ParamSpec:
                 if isinstance(value_type, DataType):
                     return _enforce_param_datatype(value, value_type)
                 elif isinstance(value_type, Object):
-                    return _enforce_object(value, value_type, enforce_param=True)
+                    # deepcopy to make sure the value is not mutated
+                    _enforce_object(deepcopy(value), value_type)
+                    return value
             elif shape == (-1,):
                 return [_enforce_param_datatype(v, value_type) for v in value]
         except Exception as e:

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -1123,8 +1123,8 @@ class ParamSpec:
     def __init__(
         self,
         name: str,
-        dtype: Union[DataType, str],
-        default: Union[DataType, list[DataType], None],
+        dtype: Union[DataType, Object, str],
+        default: Any,
         shape: Optional[tuple[int, ...]] = None,
     ):
         self._name = str(name)
@@ -1138,11 +1138,8 @@ class ParamSpec:
                 f"Unsupported type '{dtype}', expected instance of DataType or "
                 f"one of {supported_types}",
             )
-        if not isinstance(self.dtype, DataType):
-            raise TypeError(
-                "Expected mlflow.models.signature.Datatype or str for the 'dtype' "
-                f"argument, but got {self.dtype.__class__}"
-            )
+        if not isinstance(self.dtype, (DataType, Object)):
+            raise TypeError(f"'dtype' must be DataType, Object or str, got {self.dtype}")
         if self.dtype == DataType.binary:
             raise MlflowException.invalid_parameter_value(
                 f"Binary type is not supported for parameters, ParamSpec '{self.name}'"
@@ -1154,115 +1151,50 @@ class ParamSpec:
         self._default = self.validate_type_and_shape(repr(self), default, self.dtype, self.shape)
 
     @classmethod
-    def validate_param_spec(
-        cls, value: Union[DataType, list[DataType], None], param_spec: "ParamSpec"
-    ):
+    def validate_param_spec(cls, value: Any, param_spec: "ParamSpec"):
         return cls.validate_type_and_shape(
             repr(param_spec), value, param_spec.dtype, param_spec.shape
-        )
-
-    @classmethod
-    def enforce_param_datatype(cls, name, value, dtype: DataType):
-        """
-        Enforce the value matches the data type.
-
-        The following type conversions are allowed:
-
-        1. int -> long, float, double
-        2. long -> float, double
-        3. float -> double
-        4. any -> datetime (try conversion)
-
-        Any other type mismatch will raise error.
-
-        Args:
-            name: parameter name
-            value: parameter value
-            dtype: expected data type
-        """
-        if value is None:
-            return
-
-        if dtype == DataType.datetime:
-            try:
-                datetime_value = np.datetime64(value).item()
-                if isinstance(datetime_value, int):
-                    raise MlflowException.invalid_parameter_value(
-                        f"Invalid value for param {name}, it should "
-                        f"be convertible to datetime.date/datetime, got {value}"
-                    )
-                return datetime_value
-            except ValueError as e:
-                raise MlflowException.invalid_parameter_value(
-                    f"Failed to convert value {value} from type {type(value).__name__} "
-                    f"to {dtype} for param {name}"
-                ) from e
-
-        # Note that np.isscalar(datetime.date(...)) is False
-        if not np.isscalar(value):
-            raise MlflowException.invalid_parameter_value(
-                f"Value should be a scalar for param {name}, got {value}"
-            )
-
-        # Always convert to python native type for params
-        if DataType.check_type(dtype, value):
-            return dtype.to_python()(value)
-
-        if (
-            (
-                DataType.check_type(DataType.integer, value)
-                and dtype in (DataType.long, DataType.float, DataType.double)
-            )
-            or (
-                DataType.check_type(DataType.long, value)
-                and dtype in (DataType.float, DataType.double)
-            )
-            or (DataType.check_type(DataType.float, value) and dtype == DataType.double)
-        ):
-            try:
-                return dtype.to_python()(value)
-            except ValueError as e:
-                raise MlflowException.invalid_parameter_value(
-                    f"Failed to convert value {value} from type {type(value).__name__} "
-                    f"to {dtype} for param {name}"
-                ) from e
-
-        raise MlflowException.invalid_parameter_value(
-            f"Incompatible types for param {name}. Can not safely convert {type(value).__name__} "
-            f"to {dtype}.",
         )
 
     @classmethod
     def validate_type_and_shape(
         cls,
         spec: str,
-        value: Union[DataType, list[DataType], None],
-        value_type: DataType,
+        value: Any,
+        value_type: Union[DataType, Object],
         shape: Optional[tuple[int, ...]],
     ):
         """
         Validate that the value has the expected type and shape.
         """
+        from mlflow.models.utils import _enforce_object, _enforce_param_datatype
 
         def _is_1d_array(value):
             return isinstance(value, (list, np.ndarray)) and np.array(value).ndim == 1
 
-        if shape is None:
-            return cls.enforce_param_datatype(f"{spec} with shape None", value, value_type)
-        elif shape == (-1,):
-            if not _is_1d_array(value):
-                raise MlflowException.invalid_parameter_value(
-                    f"Value must be a 1D array with shape (-1,) for param {spec}, "
-                    f"received {type(value).__name__} with ndim {np.array(value).ndim}",
-                )
-            return [
-                cls.enforce_param_datatype(f"{spec} internal values", v, value_type) for v in value
-            ]
-        else:
+        if shape == (-1,) and not _is_1d_array(value):
             raise MlflowException.invalid_parameter_value(
-                "Shape must be None for scalar value or (-1,) for 1D array value "
-                f"for ParamSpec {spec}), received {shape}",
+                f"Value must be a 1D array with shape (-1,) for param {spec}, "
+                f"received {type(value).__name__} with ndim {np.array(value).ndim}",
             )
+
+        try:
+            if shape is None:
+                if isinstance(value_type, DataType):
+                    return _enforce_param_datatype(value, value_type)
+                elif isinstance(value_type, Object):
+                    return _enforce_object(value, value_type, enforce_param=True)
+            elif shape == (-1,):
+                return [_enforce_param_datatype(v, value_type) for v in value]
+        except Exception as e:
+            raise MlflowException.invalid_parameter_value(
+                f"Failed to validate type and shape for {spec}, error: {e}"
+            )
+
+        raise MlflowException.invalid_parameter_value(
+            "Shape must be None for scalar or dictionary value, or (-1,) for 1D array value "
+            f"for ParamSpec {spec}), received {shape}",
+        )
 
     @property
     def name(self) -> str:
@@ -1270,12 +1202,12 @@ class ParamSpec:
         return self._name
 
     @property
-    def dtype(self) -> DataType:
+    def dtype(self) -> Union[DataType, Object]:
         """The parameter data type."""
         return self._dtype
 
     @property
-    def default(self) -> Union[DataType, list[DataType], None]:
+    def default(self) -> Any:
         """Default value of the parameter."""
         return self._default
 
@@ -1295,21 +1227,27 @@ class ParamSpec:
 
     def to_dict(self) -> ParamSpecTypedDict:
         if self.shape is None:
-            default_value = (
-                self.default.isoformat() if self.dtype.name == "datetime" else self.default
-            )
+            if isinstance(self.dtype, DataType) and self.dtype.name == "datetime":
+                default_value = self.default.isoformat()
+            else:
+                default_value = self.default
         elif self.shape == (-1,):
             default_value = (
                 [v.isoformat() for v in self.default]
                 if self.dtype.name == "datetime"
                 else self.default
             )
-        return {
+        result = {
             "name": self.name,
-            "type": self.dtype.name,
             "default": default_value,
             "shape": self.shape,
         }
+        if isinstance(self.dtype, DataType):
+            type_dict = {"type": self.dtype.name}
+        elif isinstance(self.dtype, Object):
+            type_dict = self.dtype.to_dict()
+        result.update(type_dict)
+        return result
 
     def __eq__(self, other) -> bool:
         if isinstance(other, ParamSpec):
@@ -1342,9 +1280,10 @@ class ParamSpec:
                 f"Received keys: {kwargs.keys()}"
             )
         dtype = kwargs.get("type") or kwargs.get("dtype")
+        dtype = Object.from_json_dict(**kwargs) if dtype == OBJECT_TYPE else DataType[dtype]
         return cls(
             name=str(kwargs["name"]),
-            dtype=DataType[dtype],
+            dtype=dtype,
             default=kwargs["default"],
             shape=kwargs.get("shape"),
         )

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -1187,6 +1187,8 @@ class ParamSpec:
                     # use _enforce_object to validate that the value matches the object schema.
                     # return the original value to preserve its type, as validation may cast it
                     # to a numpy type, but models require the original parameter type.
+                    # TODO: we will drop data conversion for params in the future, including
+                    # the current allowed conversions in _enforce_param_datatype
                     _enforce_object(deepcopy(value), value_type)
                     return value
             elif shape == (-1,):

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -1184,6 +1184,9 @@ class ParamSpec:
                     return _enforce_param_datatype(value, value_type)
                 elif isinstance(value_type, Object):
                     # deepcopy to make sure the value is not mutated
+                    # use _enforce_object to validate that the value matches the object schema.
+                    # return the original value to preserve its type, as validation may cast it
+                    # to a numpy type, but models require the original parameter type.
                     _enforce_object(deepcopy(value), value_type)
                     return value
             elif shape == (-1,):

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -30,6 +30,7 @@ from mlflow.environment_variables import (
 )
 from mlflow.tracing.export.inference_table import pop_trace
 from mlflow.tracing.provider import reset_tracer_setup
+from mlflow.types.schema import Object, ParamSchema, ParamSpec, Property
 
 from tests.tracing.helper import get_traces
 
@@ -3663,3 +3664,35 @@ def test_pyfunc_converts_chat_request_correctly(
     else:
         assert inspect.isgenerator(response)
         assert list(response) == ["Databricks"], list(response)
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.2.0"),
+    reason="Langgraph are not supported the way we want in earlier versions",
+)
+def test_langgraph_model_invoke_with_dictionary_params(monkeypatch):
+    input_example = {"messages": [{"role": "user", "content": "What's the weather in nyc?"}]}
+    params = {"config": {"configurable": {"thread_id": "1"}}}
+
+    monkeypatch.setenv("MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN", "false")
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            "tests/langchain/sample_code/langgraph_prebuilt.py",
+            "model",
+            input_example=(input_example, params),
+        )
+    assert model_info.signature.params == ParamSchema(
+        [
+            ParamSpec(
+                "config",
+                Object([Property("configurable", Object([Property("thread_id", "string")]))]),
+                params["config"],
+            )
+        ]
+    )
+    langchain_model = mlflow.langchain.load_model(model_info.model_uri)
+    result = langchain_model.invoke(input_example, **params)
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert len(pyfunc_model.predict(input_example, params)[0]["messages"]) == len(
+        result["messages"]
+    )

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -275,7 +275,7 @@ def test_signature_construction():
     assert signature.to_dict() == {
         "inputs": None,
         "outputs": None,
-        "params": '[{"name": "param1", "type": "string", "default": "test", "shape": null}]',
+        "params": '[{"name": "param1", "default": "test", "shape": null, "type": "string"}]',
     }
 
 

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -1339,7 +1339,8 @@ def test_enforce_params_schema_errors():
         [ParamSpec("datetime_param", DataType.datetime, np.datetime64("2023-06-06"))]
     )
     with pytest.raises(
-        MlflowException, match=r"Failed to convert value 1.0 from type float to DataType.datetime"
+        MlflowException,
+        match=r"Failed to convert value `1.0` from type `<class 'float'>` to `DataType.datetime`",
     ):
         _enforce_params_schema({"datetime_param": 1.0}, test_schema)
     # With array
@@ -1354,25 +1355,30 @@ def test_enforce_params_schema_errors():
         ]
     )
     with pytest.raises(
-        MlflowException, match=r"Failed to convert value 1.0 from type float to DataType.datetime"
+        MlflowException,
+        match=r"Failed to convert value `1.0` from type `<class 'float'>` to `DataType.datetime`",
     ):
         _enforce_params_schema({"datetime_array": [1.0, 2.0]}, test_schema)
 
     # Raise error when failing to convert value to DataType.float
     test_schema = ParamSchema([ParamSpec("float_param", DataType.float, np.float32(1))])
-    with pytest.raises(MlflowException, match=r"Incompatible types for param 'float_param'"):
+    with pytest.raises(
+        MlflowException, match=r"Failed to validate type and shape for 'float_param'"
+    ):
         _enforce_params_schema({"float_param": "a"}, test_schema)
     # With array
     test_schema = ParamSchema(
         [ParamSpec("float_array", DataType.float, np.array([np.float32(1), np.float32(2)]), (-1,))]
     )
-    with pytest.raises(MlflowException, match=r"Incompatible types for param 'float_array'"):
+    with pytest.raises(
+        MlflowException, match=r"Failed to validate type and shape for 'float_array'"
+    ):
         _enforce_params_schema(
             {"float_array": [np.float32(1), np.float32(2), np.float64(3)]}, test_schema
         )
 
     # Raise error for any other conversions
-    error_msg = r"Incompatible types for param 'int_param'"
+    error_msg = r"Failed to validate type and shape for 'int_param'"
     test_schema = ParamSchema([ParamSpec("int_param", DataType.long, np.int32(1))])
     with pytest.raises(MlflowException, match=error_msg):
         _enforce_params_schema({"int_param": np.float32(1)}, test_schema)
@@ -1381,7 +1387,7 @@ def test_enforce_params_schema_errors():
     with pytest.raises(MlflowException, match=error_msg):
         _enforce_params_schema({"int_param": np.datetime64("2023-06-06")}, test_schema)
 
-    error_msg = r"Incompatible types for param 'str_param'"
+    error_msg = r"Failed to validate type and shape for 'str_param'"
     test_schema = ParamSchema([ParamSpec("str_param", DataType.string, "1")])
     with pytest.raises(MlflowException, match=error_msg):
         _enforce_params_schema({"str_param": np.float32(1)}, test_schema)
@@ -1498,13 +1504,13 @@ def test_param_spec_with_success():
 
 def test_param_spec_errors():
     # Raise error if default value can not be converted to specified type
-    with pytest.raises(MlflowException, match=r"Incompatible types for param 'a'"):
+    with pytest.raises(MlflowException, match=r"Failed to validate type and shape for 'a'"):
         ParamSpec("a", DataType.integer, "1.0")
-    with pytest.raises(MlflowException, match=r"Incompatible types for param 'a'"):
+    with pytest.raises(MlflowException, match=r"Failed to validate type and shape for 'a'"):
         ParamSpec("a", DataType.integer, [1.0, 2.0], (-1,))
-    with pytest.raises(MlflowException, match=r"Incompatible types for param 'a'"):
+    with pytest.raises(MlflowException, match=r"Failed to validate type and shape for 'a'"):
         ParamSpec("a", DataType.string, True)
-    with pytest.raises(MlflowException, match=r"Incompatible types for param 'a'"):
+    with pytest.raises(MlflowException, match=r"Failed to validate type and shape for 'a'"):
         ParamSpec("a", DataType.string, [1.0, 2.0], (-1,))
     with pytest.raises(MlflowException, match=r"Binary type is not supported for parameters"):
         ParamSpec("a", DataType.binary, 1.0)
@@ -1512,22 +1518,18 @@ def test_param_spec_errors():
         ParamSpec("a", DataType.datetime, 1.0)
     with pytest.raises(MlflowException, match=r"Failed to convert value"):
         ParamSpec("a", DataType.datetime, [1.0, 2.0], (-1,))
-    with pytest.raises(MlflowException, match=r"Invalid value for param 'a'"):
+    with pytest.raises(MlflowException, match=r"Failed to convert value to `DataType.datetime`"):
         ParamSpec("a", DataType.datetime, np.datetime64("20230606"))
 
     # Raise error if shape is not specified for list value
     with pytest.raises(
         MlflowException,
-        match=re.escape(
-            "Value should be a scalar for param 'a': long (default: [1, 2, 3]) with shape None"
-        ),
+        match=re.escape("Value must be a scalar for type `DataType.long`"),
     ):
         ParamSpec("a", DataType.long, [1, 2, 3], shape=None)
     with pytest.raises(
         MlflowException,
-        match=re.escape(
-            "Value should be a scalar for param 'a': integer (default: [1 2 3]) with shape None"
-        ),
+        match=re.escape("Value must be a scalar for type `DataType.integer`"),
     ):
         ParamSpec("a", DataType.integer, np.array([1, 2, 3]), shape=None)
 
@@ -1543,7 +1545,9 @@ def test_param_spec_errors():
 
     # Raise error if shape specified is not allowed
     with pytest.raises(
-        MlflowException, match=r"Shape must be None for scalar value or \(-1,\) for 1D array value"
+        MlflowException,
+        match=r"Shape must be None for scalar or dictionary value, "
+        r"or \(-1,\) for 1D array value",
     ):
         ParamSpec("a", DataType.boolean, [True, False], (2,))
 
@@ -1702,7 +1706,7 @@ def test_enforce_schema_in_python_model_serving(sample_params_basic):
     )
     assert response.status_code == 400
     assert (
-        "Incompatible types for param 'double_param'"
+        "Failed to validate type and shape for 'double_param'"
         in json.loads(response.content.decode("utf-8"))["message"]
     )
 
@@ -1941,14 +1945,19 @@ def test_enforce_schema_with_arrays_in_python_model_predict(sample_params_with_a
 
     # Raise error if failing to convert the type
     with pytest.raises(
-        MlflowException, match=r"Failed to convert value 1.0 from type float to DataType.datetime"
+        MlflowException,
+        match=r"Failed to convert value `1.0` from type `<class 'float'>` to `DataType.datetime`",
     ):
         loaded_model.predict(["a", "b"], params={"datetime_array": [1.0, 2.0]})
-    with pytest.raises(MlflowException, match=r"Incompatible types for param 'int_array'"):
+    with pytest.raises(MlflowException, match=r"Failed to validate type and shape for 'int_array'"):
         loaded_model.predict(["a", "b"], params={"int_array": np.array([1.0, 2.0])})
-    with pytest.raises(MlflowException, match=r"Incompatible types for param 'float_array'"):
+    with pytest.raises(
+        MlflowException, match=r"Failed to validate type and shape for 'float_array'"
+    ):
         loaded_model.predict(["a", "b"], params={"float_array": [True, False]})
-    with pytest.raises(MlflowException, match=r"Incompatible types for param 'double_array'"):
+    with pytest.raises(
+        MlflowException, match=r"Failed to validate type and shape for 'double_array'"
+    ):
         loaded_model.predict(["a", "b"], params={"double_array": [1.0, "2.0"]})
 
 
@@ -1984,7 +1993,7 @@ def test_enforce_schema_with_arrays_in_python_model_serving(sample_params_with_a
         )
         assert response.status_code == 400
         assert (
-            "Failed to convert value 1.0 from type float to DataType.datetime"
+            "Failed to convert value `1.0` from type `<class 'float'>` to `DataType.datetime`"
             in json.loads(response.content.decode("utf-8"))["message"]
         )
 
@@ -1994,7 +2003,7 @@ def test_enforce_schema_with_arrays_in_python_model_serving(sample_params_with_a
         )
         assert response.status_code == 400
         assert (
-            "Incompatible types for param 'int_array'"
+            "Failed to validate type and shape for 'int_array'"
             in json.loads(response.content.decode("utf-8"))["message"]
         )
 
@@ -2004,7 +2013,7 @@ def test_enforce_schema_with_arrays_in_python_model_serving(sample_params_with_a
         )
         assert response.status_code == 400
         assert (
-            "Incompatible types for param 'float_array'"
+            "Failed to validate type and shape for 'float_array'"
             in json.loads(response.content.decode("utf-8"))["message"]
         )
 
@@ -2014,7 +2023,7 @@ def test_enforce_schema_with_arrays_in_python_model_serving(sample_params_with_a
         )
         assert response.status_code == 400
         assert (
-            "Incompatible types for param 'double_array'"
+            "Failed to validate type and shape for 'double_array'"
             in json.loads(response.content.decode("utf-8"))["message"]
         )
 

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -1152,6 +1152,7 @@ def test_enforce_params_schema_with_success():
         "datetime_param": np.datetime64("2023-06-26 00:00:00"),
         "str_list": ["a", "b", "c"],
         "bool_list": [True, False],
+        "object": {"a": 1, "b": ["x", "y"], "c": {"d": 2}},
     }
     test_schema = ParamSchema(
         [
@@ -1166,6 +1167,18 @@ def test_enforce_params_schema_with_success():
             ),
             ParamSpec("str_list", DataType.string, ["a", "b", "c"], (-1,)),
             ParamSpec("bool_list", DataType.boolean, [True, False], (-1,)),
+            ParamSpec(
+                "object",
+                Object(
+                    [
+                        Property("a", DataType.long),
+                        Property("b", Array(DataType.string)),
+                        Property("c", Object([Property("d", DataType.long)])),
+                    ]
+                ),
+                {"a": 1, "b": ["x", "y"], "c": {"d": 2}},
+                None,
+            ),
         ]
     )
     assert _enforce_params_schema(test_parameters, test_schema) == test_parameters

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -675,9 +675,8 @@ def test_serving_model_with_param_schema(sklearn_model, model_path):
     )
     expect_status_code(response, 400)
     assert (
-        "Failed to convert value invalid_value1 from type str to "
-        "DataType.datetime for param 'param1'"
-        in json.loads(response.content.decode("utf-8"))["message"]
+        " Failed to convert value `invalid_value1` from type `<class 'str'>` "
+        "to `DataType.datetime`" in json.loads(response.content.decode("utf-8"))["message"]
     )
 
     # Ignore parameters specified in payload if it is not defined in ParamSchema

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1035,14 +1035,13 @@ def test_infer_param_schema():
     with pytest.raises(MlflowException, match=r"Binary type is not supported for parameters"):
         _infer_param_schema({"a": b"str_a"})
 
-    # Raise error for invalid parameters types - tuple, 2D array, dictionary
+    # Raise error for invalid parameters types - tuple, 2D array
     test_parameters = {
         "a": "str_a",
         "b": (1, 2, 3),
         "c": True,
         "d": [[1, 2], [3, 4]],
         "e": [[[1, 2], [3], []]],
-        "f": {"a": 1, "b": 2},
     }
     with pytest.raises(MlflowException, match=r".*") as e:
         _infer_param_schema(test_parameters)
@@ -1065,12 +1064,52 @@ def test_infer_param_schema():
             "to be 1D array or scalar, got 3D array'))"
         )
     )
-    assert e.match(
-        re.escape(
-            "('f', {'a': 1, 'b': 2}, MlflowException('Expected parameters "
-            "to be 1D array or scalar, got dict'))"
-        )
+
+
+def test_param_schema_for_dicts():
+    data = {
+        "config": {
+            "thread_id": "1",
+            "batch_size": 32,
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+    }
+    schema = _infer_param_schema(data)
+    object_schema = Object(
+        [
+            Property("thread_id", DataType.string),
+            Property("batch_size", DataType.long),
+            Property(
+                "messages",
+                Array(
+                    Object(
+                        [
+                            Property("role", DataType.string),
+                            Property("content", DataType.string),
+                        ]
+                    )
+                ),
+            ),
+        ]
     )
+    assert schema == ParamSchema(
+        [
+            ParamSpec(
+                "config",
+                object_schema,
+                data["config"],
+            )
+        ]
+    )
+    assert schema.to_dict() == [
+        {
+            "name": "config",
+            "default": data["config"],
+            "shape": None,
+        }
+        | object_schema.to_dict()
+    ]
+    assert ParamSchema.from_json(json.dumps(schema.to_dict())) == schema
 
 
 def test_infer_param_schema_with_errors():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14091?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14091/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14091
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
1. Params in `predict` function used to only support scalars and 1D array with scalars, this PR adds support for dictionaries. It reuses `Object` schema that's been supported in inputs/outputs.
2. This PR also refactors ParamSpec a bit by moving a classMethod to a utility function.
3. Add `enforce_param` parameter to `_enforce_xxx` functions, when it is set to True, we use `_enforce_param_datatype` to validate scalar values against dataType instead of `_enforce_mlflow_datatype`. This is because there're lots of data conversion inside `_enforce_mlflow_datatype` and it accepts numpy types, while for params we should always use pure python types.


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
