### PR TITLE
Auto approve workflows triggered by automation app

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -220,12 +220,13 @@ jobs:
             const needs = ${{ toJson(needs) }};
             const head_sha = '${{ needs.check-comment.outputs.head_sha }}'
             const autoformat = require('./.github/workflows/autoformat.js');
-            const push_head_sha = '${{ needs.push.outputs.head_sha }}';
-            if (push_head_sha) {
-              try {
+            // TODO: Remove try-catch block once we are confident that the code works fine.
+            try {
+              const push_head_sha = '${{ needs.push.outputs.head_sha }}';
+              if (push_head_sha) {
                 await autoformat.approveWorkflowRuns(context, github, push_head_sha);
-              } catch (error) {
-                core.warning(`Failed to approve workflow runs: ${error}`);
               }
+            } catch (error) {
+              core.warning(`Failed to approve workflow runs: ${error}`);
             }
             await autoformat.updateStatus(context, github, head_sha, needs);

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -206,7 +206,7 @@ jobs:
     needs: [check-comment, format, push]
     if: always() && needs.check-comment.outputs.should_autoformat == 'true'
     permissions:
-      statuses: write # To update the check status
+      statuses: write # To update check statuses
       actions: write # To approve workflow runs
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -157,6 +157,8 @@ jobs:
     needs: [check-comment, format]
     if: ${{ needs.format.outputs.reformatted == 'true' }}
     permissions: {}
+    outputs:
+      head_sha: ${{ steps.push.outputs.head_sha }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -191,9 +193,11 @@ jobs:
           path: /tmp
 
       - name: Apply patch and push
+        id: push
         run: |
           git apply /tmp/${{ github.run_id }}.diff
           git commit -sam "Autoformat: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "head_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           git push
 
   update-status:
@@ -202,7 +206,8 @@ jobs:
     needs: [check-comment, format, push]
     if: always() && needs.check-comment.outputs.should_autoformat == 'true'
     permissions:
-      statuses: write # autoformat.updateStatus
+      statuses: write # To update the check status
+      actions: write # To approve workflow runs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -215,4 +220,12 @@ jobs:
             const needs = ${{ toJson(needs) }};
             const head_sha = '${{ needs.check-comment.outputs.head_sha }}'
             const autoformat = require('./.github/workflows/autoformat.js');
+            const push_head_sha = '${{ needs.push.outputs.head_sha }}';
+            if (push_head_sha) {
+              try {
+                await autoformat.approveWorkflowRuns(context, github, push_head_sha);
+              } catch (error) {
+                core.warning(`Failed to approve workflow runs: ${error}`);
+              }
+            }
             await autoformat.updateStatus(context, github, head_sha, needs);


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14095?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14095/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14095
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

A follow-up for #14089. As automation up is not considered as a collaborator, it requires approval to run workflows as shown below.

![image](https://github.com/user-attachments/assets/4c8a83bd-c7fb-4af9-8dbe-31e3b84978a7)

This PR make changes to auto-approve them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
