### PR TITLE
[2/2] Type hint support in pyfunc models

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -332,7 +332,7 @@ jobs:
       - name: Run tests on pydantic v1
         run: |
           pip install 'pydantic<2'
-          pytest tests/types
+          pytest tests/types tests/pyfunc/test_pyfunc_model_with_type_hints.py
 
   sagemaker:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Run tests
         run: |
           python -c "import sys; assert sys.version_info[:2] == (3, 10), sys.version_info"
-          pytest tests/types/test_type_hints.py
+          pytest tests/types/test_type_hints.py tests/pyfunc/test_pyfunc_model_with_type_hints.py
 
   database:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -87,7 +87,7 @@ jobs:
           pip install $(git rev-parse --show-toplevel)
           H2O_VERSION=$(Rscript -e "print(packageVersion('h2o'))" | grep -Eo '[0-9][0-9.]+')
           # test-keras-model.R fails with tensorflow>=2.13.0
-          pip install xgboost 'tensorflow<2.13.0' "h2o==$H2O_VERSION"
+          pip install xgboost 'tensorflow<2.13.0' "h2o==$H2O_VERSION" "pydantic<3,>=1.0"
           Rscript -e 'source(".install-mlflow-r.R", echo=TRUE)'
       - name: Run tests
         env:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -87,7 +87,7 @@ jobs:
           pip install $(git rev-parse --show-toplevel)
           H2O_VERSION=$(Rscript -e "print(packageVersion('h2o'))" | grep -Eo '[0-9][0-9.]+')
           # test-keras-model.R fails with tensorflow>=2.13.0
-          pip install xgboost 'tensorflow<2.13.0' "h2o==$H2O_VERSION" "pydantic<3,>=1.0"
+          pip install xgboost 'tensorflow<2.13.0' "h2o==$H2O_VERSION"
           Rscript -e 'source(".install-mlflow-r.R", echo=TRUE)'
       - name: Run tests
         env:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -104,7 +104,6 @@ class ModelInfo:
         metadata: Optional[dict[str, Any]] = None,
         registered_model_version: Optional[int] = None,
         env_vars: Optional[list[str]] = None,
-        is_signature_from_type_hint: bool = False,
     ):
         self._artifact_path = artifact_path
         self._flavors = flavors
@@ -119,7 +118,6 @@ class ModelInfo:
         self._metadata = metadata
         self._registered_model_version = registered_model_version
         self._env_vars = env_vars
-        self._signature_from_type_hint = is_signature_from_type_hint
 
     @property
     def artifact_path(self) -> str:
@@ -328,17 +326,6 @@ class ModelInfo:
     def registered_model_version(self, value) -> None:
         self._registered_model_version = value
 
-    @property
-    def is_signature_from_type_hint(self) -> bool:
-        """
-        Whether the model signature was inferred from type hint.
-        """
-        return self._signature_from_type_hint
-
-    @is_signature_from_type_hint.setter
-    def is_signature_from_type_hint(self, value: bool) -> None:
-        self._signature_from_type_hint = value
-
 
 class Model:
     """
@@ -360,7 +347,6 @@ class Model:
         model_size_bytes: Optional[int] = None,
         resources: Optional[Union[str, list[Resource]]] = None,
         env_vars: Optional[list[str]] = None,
-        is_signature_from_type_hint: bool = False,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -376,7 +362,6 @@ class Model:
         self.model_size_bytes = model_size_bytes
         self.resources = resources
         self.env_vars = env_vars
-        self.is_signature_from_type_hint = is_signature_from_type_hint
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -607,7 +592,6 @@ class Model:
             mlflow_version=self.mlflow_version,
             metadata=self.metadata,
             env_vars=self.env_vars,
-            is_signature_from_type_hint=self.is_signature_from_type_hint,
         )
 
     def get_tags_dict(self) -> dict[str, Any]:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -625,6 +625,7 @@ class Model:
             res["databricks_runtime"] = databricks_runtime
         if self.signature is not None:
             res["signature"] = self.signature.to_dict()
+            res["_is_signature_from_type_hint"] = self.signature._is_signature_from_type_hint
         if self.saved_input_example_info is not None:
             res["saved_input_example_info"] = self.saved_input_example_info
         if self.mlflow_version is None and _MLFLOW_VERSION_KEY in res:
@@ -717,7 +718,12 @@ class Model:
 
         model_dict = model_dict.copy()
         if "signature" in model_dict and isinstance(model_dict["signature"], dict):
-            model_dict["signature"] = ModelSignature.from_dict(model_dict["signature"])
+            signature = ModelSignature.from_dict(model_dict["signature"])
+            if "_is_signature_from_type_hint" in model_dict:
+                signature._is_signature_from_type_hint = model_dict.pop(
+                    "_is_signature_from_type_hint"
+                )
+            model_dict["signature"] = signature
 
         if "model_uuid" not in model_dict:
             model_dict["model_uuid"] = None

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -574,6 +574,9 @@ class Model:
             raise TypeError(f"env_vars must be a list of strings. Got: {value}")
         self._env_vars = value
 
+    def _is_signature_from_type_hint(self):
+        return self.signature._is_signature_from_type_hint if self.signature is not None else False
+
     def get_model_info(self) -> ModelInfo:
         """
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -104,6 +104,7 @@ class ModelInfo:
         metadata: Optional[dict[str, Any]] = None,
         registered_model_version: Optional[int] = None,
         env_vars: Optional[list[str]] = None,
+        signature_from_type_hint: bool = False,
     ):
         self._artifact_path = artifact_path
         self._flavors = flavors
@@ -118,6 +119,7 @@ class ModelInfo:
         self._metadata = metadata
         self._registered_model_version = registered_model_version
         self._env_vars = env_vars
+        self._signature_from_type_hint = signature_from_type_hint
 
     @property
     def artifact_path(self) -> str:
@@ -326,6 +328,17 @@ class ModelInfo:
     def registered_model_version(self, value) -> None:
         self._registered_model_version = value
 
+    @property
+    def signature_from_type_hint(self) -> bool:
+        """
+        Whether the model signature was inferred from type hint.
+        """
+        return self._signature_from_type_hint
+
+    @signature_from_type_hint.setter
+    def signature_from_type_hint(self, value: bool) -> None:
+        self._signature_from_type_hint = value
+
 
 class Model:
     """
@@ -347,6 +360,7 @@ class Model:
         model_size_bytes: Optional[int] = None,
         resources: Optional[Union[str, list[Resource]]] = None,
         env_vars: Optional[list[str]] = None,
+        signature_from_type_hint: bool = False,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -362,6 +376,7 @@ class Model:
         self.model_size_bytes = model_size_bytes
         self.resources = resources
         self.env_vars = env_vars
+        self.signature_from_type_hint = signature_from_type_hint
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -592,6 +607,7 @@ class Model:
             mlflow_version=self.mlflow_version,
             metadata=self.metadata,
             env_vars=self.env_vars,
+            signature_from_type_hint=self.signature_from_type_hint,
         )
 
     def get_tags_dict(self) -> dict[str, Any]:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -104,7 +104,7 @@ class ModelInfo:
         metadata: Optional[dict[str, Any]] = None,
         registered_model_version: Optional[int] = None,
         env_vars: Optional[list[str]] = None,
-        signature_from_type_hint: bool = False,
+        is_signature_from_type_hint: bool = False,
     ):
         self._artifact_path = artifact_path
         self._flavors = flavors
@@ -119,7 +119,7 @@ class ModelInfo:
         self._metadata = metadata
         self._registered_model_version = registered_model_version
         self._env_vars = env_vars
-        self._signature_from_type_hint = signature_from_type_hint
+        self._signature_from_type_hint = is_signature_from_type_hint
 
     @property
     def artifact_path(self) -> str:
@@ -329,14 +329,14 @@ class ModelInfo:
         self._registered_model_version = value
 
     @property
-    def signature_from_type_hint(self) -> bool:
+    def is_signature_from_type_hint(self) -> bool:
         """
         Whether the model signature was inferred from type hint.
         """
         return self._signature_from_type_hint
 
-    @signature_from_type_hint.setter
-    def signature_from_type_hint(self, value: bool) -> None:
+    @is_signature_from_type_hint.setter
+    def is_signature_from_type_hint(self, value: bool) -> None:
         self._signature_from_type_hint = value
 
 
@@ -360,7 +360,7 @@ class Model:
         model_size_bytes: Optional[int] = None,
         resources: Optional[Union[str, list[Resource]]] = None,
         env_vars: Optional[list[str]] = None,
-        signature_from_type_hint: bool = False,
+        is_signature_from_type_hint: bool = False,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -376,7 +376,7 @@ class Model:
         self.model_size_bytes = model_size_bytes
         self.resources = resources
         self.env_vars = env_vars
-        self.signature_from_type_hint = signature_from_type_hint
+        self.is_signature_from_type_hint = is_signature_from_type_hint
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -607,7 +607,7 @@ class Model:
             mlflow_version=self.mlflow_version,
             metadata=self.metadata,
             env_vars=self.env_vars,
-            signature_from_type_hint=self.signature_from_type_hint,
+            is_signature_from_type_hint=self.is_signature_from_type_hint,
         )
 
     def get_tags_dict(self) -> dict[str, Any]:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -625,7 +625,7 @@ class Model:
             res["databricks_runtime"] = databricks_runtime
         if self.signature is not None:
             res["signature"] = self.signature.to_dict()
-            res["_is_signature_from_type_hint"] = self.signature._is_signature_from_type_hint
+            res["is_signature_from_type_hint"] = self.signature._is_signature_from_type_hint
         if self.saved_input_example_info is not None:
             res["saved_input_example_info"] = self.saved_input_example_info
         if self.mlflow_version is None and _MLFLOW_VERSION_KEY in res:
@@ -719,9 +719,9 @@ class Model:
         model_dict = model_dict.copy()
         if "signature" in model_dict and isinstance(model_dict["signature"], dict):
             signature = ModelSignature.from_dict(model_dict["signature"])
-            if "_is_signature_from_type_hint" in model_dict:
+            if "is_signature_from_type_hint" in model_dict:
                 signature._is_signature_from_type_hint = model_dict.pop(
-                    "_is_signature_from_type_hint"
+                    "is_signature_from_type_hint"
                 )
             model_dict["signature"] = signature
 

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -113,7 +113,6 @@ class ModelSignature:
             "inputs": self.inputs.to_json() if self.inputs else None,
             "outputs": self.outputs.to_json() if self.outputs else None,
             "params": self.params.to_json() if self.params else None,
-            "_is_signature_from_type_hint": self._is_signature_from_type_hint,
         }
 
     @classmethod
@@ -134,11 +133,7 @@ class ModelSignature:
         inputs = Schema.from_json(x) if (x := signature_dict.get("inputs")) else None
         outputs = Schema.from_json(x) if (x := signature_dict.get("outputs")) else None
         params = ParamSchema.from_json(x) if (x := signature_dict.get("params")) else None
-        signature = cls(inputs, outputs, params)
-        signature._is_signature_from_type_hint = signature_dict.get(
-            "_is_signature_from_type_hint", False
-        )
-        return signature
+        return cls(inputs, outputs, params)
 
     def __eq__(self, other) -> bool:
         return (

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -367,7 +367,9 @@ def _is_context_in_predict_function_signature(*, func=None, parameters=None):
     )
 
 
-def _infer_signature_from_type_hints(func, type_hints: _TypeHints, input_example=None):
+def _infer_signature_from_type_hints(
+    func, type_hints: _TypeHints, input_example=None
+) -> Optional[ModelSignature]:
     if type_hints.input is None:
         return None
 

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -374,7 +374,6 @@ def _infer_signature_from_type_hints(func, type_hints: _TypeHints, input_example
         warnings.warn(e.message, stacklevel=2)
         return None
     params_schema = _infer_param_schema(params) if params else None
-    # input_arg_name = _get_arg_names(func)[input_arg_index]
     if input_schema and input_example:
         try:
             _validate_example_against_type_hint(example=input_example, type_hint=type_hints.input)

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -8,6 +8,7 @@ for more details on Schema and data types.
 import inspect
 import logging
 import re
+import warnings
 from copy import deepcopy
 from dataclasses import dataclass, is_dataclass
 from typing import TYPE_CHECKING, Any, Optional, Union, get_type_hints
@@ -367,7 +368,11 @@ def _infer_signature_from_type_hints(func, type_hints: _TypeHints, input_example
     if _contains_params(input_example):
         input_example, params = input_example
 
-    input_schema = _infer_schema_from_type_hint(type_hints.input)
+    try:
+        input_schema = _infer_schema_from_type_hint(type_hints.input)
+    except InvalidTypeHintException as e:
+        warnings.warn(e.message, stacklevel=2)
+        return None
     params_schema = _infer_param_schema(params) if params else None
     # input_arg_name = _get_arg_names(func)[input_arg_index]
     if input_schema and input_example:

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -25,7 +25,12 @@ from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_artifact_to_uri
 from mlflow.types.schema import AnyType, ColSpec, ParamSchema, Schema, convert_dataclass_to_schema
-from mlflow.types.utils import _infer_param_schema, _infer_schema, _infer_schema_from_type_hint
+from mlflow.types.type_hints import (
+    InvalidTypeHintException,
+    _infer_schema_from_type_hint,
+    _validate_example_against_type_hint,
+)
+from mlflow.types.utils import _infer_param_schema, _infer_schema
 from mlflow.utils.uri import append_to_uri_path
 
 # At runtime, we don't need  `pyspark.sql.dataframe`
@@ -350,22 +355,45 @@ def _infer_signature_from_type_hints(func, input_arg_index, input_example=None):
     if _contains_params(input_example):
         input_example, params = input_example
 
-    input_schema = _infer_schema_from_type_hint(hints.input, input_example) if hints.input else None
+    try:
+        input_schema = _infer_schema_from_type_hint(hints.input)
+    except InvalidTypeHintException:
+        input_schema = None
     params_schema = _infer_param_schema(params) if params else None
     input_arg_name = _get_arg_names(func)[input_arg_index]
-    if input_example:
+    if input_schema and input_example:
+        try:
+            _validate_example_against_type_hint(example=input_example, type_hint=hints.input)
+        except Exception as e:
+            raise MlflowException.invalid_parameter_value(
+                "Input example is not compatible with the type hint of the `predict` function. "
+                f"Type hint: {hints.input}."
+            ) from e
         inputs = {input_arg_name: input_example}
         if params and params_key in inspect.signature(func).parameters:
             inputs[params_key] = params
         # This is for PythonModel's predict function
         if input_arg_index == 1:
             inputs["context"] = None
+        # Note: This has the assumption that input data is not converted at all
+        # TODO: should we catch exception here?
         output_example = func(**inputs)
     else:
         output_example = None
-    output_schema = (
-        _infer_schema_from_type_hint(hints.output, output_example) if hints.output else None
-    )
+    try:
+        output_schema = _infer_schema_from_type_hint(hints.output) if hints.output else None
+    except InvalidTypeHintException:
+        output_schema = None
+    if output_schema and output_example:
+        try:
+            _validate_example_against_type_hint(example=output_example, type_hint=hints.output)
+        except Exception:
+            _logger.warning(
+                f"Failed to validate output `{output_example}` against type hint `{hints.output}`. "
+                "Set the logging level to DEBUG to see the full traceback.",
+                exc_info=_logger.isEnabledFor(logging.DEBUG),
+            )
+            output_schema = None
     if not any([input_schema, output_schema, params_schema]):
         return None
     return ModelSignature(inputs=input_schema, outputs=output_schema, params=params_schema)

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -96,7 +96,15 @@ class ModelSignature:
         else:
             self.outputs = outputs
         self.params = params
-        self._is_signature_from_type_hint = False
+        self.__is_signature_from_type_hint = False
+
+    @property
+    def _is_signature_from_type_hint(self):
+        return self.__is_signature_from_type_hint
+
+    @_is_signature_from_type_hint.setter
+    def _is_signature_from_type_hint(self, value):
+        self.__is_signature_from_type_hint = value
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -396,9 +404,11 @@ def _infer_signature_from_type_hints(func, type_hints: _TypeHints, input_example
                 f"Error: {msg}"
             )
         else:
-            kwargs = {}
-            if params and params_key in inspect.signature(func).parameters:
-                kwargs[params_key] = params
+            kwargs = (
+                {params_key: params}
+                if params and params_key in inspect.signature(func).parameters
+                else {}
+            )
             # This is for PythonModel's predict function
             if _is_context_in_predict_function_signature(func=func):
                 inputs = [None, input_example]

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -409,7 +409,7 @@ def _infer_signature_from_type_hints(func, type_hints: _TypeHints, input_example
                 inputs = [None, input_example]
             else:
                 inputs = [input_example]
-            _logger.info("Running the predict function to infer output based on input example")
+            _logger.info("Running the predict function to generate output based on input example")
             try:
                 output_example = func(*inputs, **kwargs)
             except Exception:

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -367,10 +367,7 @@ def _infer_signature_from_type_hints(func, type_hints: _TypeHints, input_example
     if _contains_params(input_example):
         input_example, params = input_example
 
-    try:
-        input_schema = _infer_schema_from_type_hint(type_hints.input)
-    except InvalidTypeHintException:
-        input_schema = None
+    input_schema = _infer_schema_from_type_hint(type_hints.input)
     params_schema = _infer_param_schema(params) if params else None
     # input_arg_name = _get_arg_names(func)[input_arg_index]
     if input_schema and input_example:

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+import pydantic
 
 import mlflow
 from mlflow.exceptions import INVALID_PARAMETER_VALUE, MlflowException
@@ -301,6 +302,9 @@ class _Example:
             self.info[EXAMPLE_PARAMS_KEY] = "true"
         model_input = deepcopy(self._inference_data)
 
+        if isinstance(model_input, pydantic.BaseModel):
+            model_input = model_input.model_dump()
+
         is_unified_llm_input = False
         if isinstance(model_input, dict):
             """
@@ -383,6 +387,7 @@ class _Example:
                 "- list\n"
                 "- scalars\n"
                 "- datetime.datetime\n"
+                "- pydantic model instance\n"
                 f"but got '{type(model_input)}'",
             )
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -27,6 +27,7 @@ from mlflow.store.artifact.utils.models import get_model_name_and_version
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType, ParamSchema, ParamSpec, Schema, TensorSpec
 from mlflow.types.schema import AnyType, Array, Map, Object, Property
+from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER
 from mlflow.types.utils import (
     TensorsNotSupportedException,
     _infer_param_schema,
@@ -303,7 +304,7 @@ class _Example:
         model_input = deepcopy(self._inference_data)
 
         if isinstance(model_input, pydantic.BaseModel):
-            model_input = model_input.model_dump()
+            model_input = model_input.dict() if PYDANTIC_V1_OR_OLDER else model_input.model_dump()
 
         is_unified_llm_input = False
         if isinstance(model_input, dict):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -800,7 +800,7 @@ class PyFuncModel:
         # fetch the schema from metadata to avoid signature change after model is loaded
         self.input_schema = self.metadata.get_input_schema()
         self.params_schema = self.metadata.get_params_schema()
-        if self.metadata.signature_from_type_hint and isinstance(
+        if self.metadata.is_signature_from_type_hint and isinstance(
             self._model_impl, _PythonModelPyfuncWrapper
         ):
             from mlflow.types.type_hints import (
@@ -3023,7 +3023,7 @@ def save_model(
                 extra={"color": "red"},
             )
         mlflow_model.signature = signature_from_type_hints
-        mlflow_model.signature_from_type_hint = True
+        mlflow_model.is_signature_from_type_hint = True
     # TODO: if signature is provided, we should validate input_example against it
     elif signature:
         mlflow_model.signature = signature

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -803,12 +803,12 @@ class PyFuncModel:
         # signature can only be inferred from type hints if the model is PythonModel
         if self.metadata._is_signature_from_type_hint():
             from mlflow.types.type_hints import (
-                _convert_pandas_dataframe_to_hinted_type,
+                _convert_data_to_type_hint,
                 _validate_example_against_type_hint,
             )
 
             type_hints = self._model_impl.python_model._get_type_hints()
-            data = _convert_pandas_dataframe_to_hinted_type(data, type_hints.input)
+            data = _convert_data_to_type_hint(data, type_hints.input)
             # TODO: remove the validation here once we move the logic inside PythonModel
             data = _validate_example_against_type_hint(data, type_hints.input)
             params = _enforce_params_schema(params, self.params_schema)
@@ -2924,7 +2924,7 @@ def save_model(
         )
         # For ChatModel we set default metadata to indicate its task
         default_metadata = {TASK: _DEFAULT_CHAT_MODEL_METADATA_TASK}
-        mlflow_model.metadata = {**default_metadata, **(mlflow_model.metadata or {})}
+        mlflow_model.metadata = default_metadata | (mlflow_model.metadata or {})
 
         if input_example:
             input_example, input_params = _split_input_data_and_params(input_example)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -448,6 +448,7 @@ from mlflow.models.model import (
 )
 from mlflow.models.resources import Resource, _ResourceBuilder
 from mlflow.models.signature import (
+    _extract_type_hints,
     _infer_signature_from_input_example,
     _infer_signature_from_type_hints,
 )
@@ -2980,16 +2981,16 @@ def save_model(
             )
     elif python_model is not None:
         if callable(python_model):
-            input_arg_index = 0  # first argument
+            # first argument is the model input
+            type_hints = _extract_type_hints(python_model, input_arg_index=0)
             signature_from_type_hints = _infer_signature_from_type_hints(
-                python_model, input_arg_index, input_example=input_example
+                func=python_model, type_hints=type_hints, input_example=input_example
             )
         elif isinstance(python_model, PythonModel):
             saved_example = _save_example(mlflow_model, input_example, path, example_no_conversion)
-            input_arg_index = 1  # second argument
             signature_from_type_hints = _infer_signature_from_type_hints(
-                python_model.predict,
-                input_arg_index=input_arg_index,
+                func=python_model.predict,
+                type_hints=python_model._get_type_hints(),
                 input_example=input_example,
             )
             # only infer signature based on input example when signature

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2930,12 +2930,10 @@ def save_model(
             input_example, input_params = _split_input_data_and_params(input_example)
             valid_params = {}
             if isinstance(input_example, list):
-                messages = []
-                for each_message in input_example:
-                    if isinstance(each_message, ChatMessage):
-                        messages.append(each_message)
-                    else:
-                        messages.append(ChatMessage.from_dict(each_message))
+                messages = [
+                    message if isinstance(message, ChatMessage) else ChatMessage.from_dict(message)
+                    for message in input_example
+                ]
             else:
                 # If the input example is a dictionary, convert it to ChatMessage format
                 messages = [

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -801,7 +801,7 @@ class PyFuncModel:
         self.input_schema = self.metadata.get_input_schema()
         self.params_schema = self.metadata.get_params_schema()
         # signature can only be inferred from type hints if the model is PythonModel
-        if self.metadata.signature._is_signature_from_type_hint:
+        if self.metadata._is_signature_from_type_hint():
             from mlflow.types.type_hints import (
                 _convert_pandas_dataframe_to_hinted_type,
                 _validate_example_against_type_hint,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -799,9 +799,23 @@ class PyFuncModel:
         # fetch the schema from metadata to avoid signature change after model is loaded
         self.input_schema = self.metadata.get_input_schema()
         self.params_schema = self.metadata.get_params_schema()
-        data, params = _validate_prediction_input(
-            data, params, self.input_schema, self.params_schema, self.loader_module
-        )
+        if self.metadata.signature_from_type_hint and isinstance(
+            self._model_impl, _PythonModelPyfuncWrapper
+        ):
+            from mlflow.types.type_hints import (
+                _maybe_convert_data_for_type_hint,
+                _validate_example_against_type_hint,
+            )
+
+            type_hints = self._model_impl.python_model._get_type_hints()
+            data = _maybe_convert_data_for_type_hint(data, type_hints.input)
+            # TODO: remove the validation here once we move the logic inside PythonModel
+            data = _validate_example_against_type_hint(data, type_hints.input)
+            params = _enforce_params_schema(params, self.params_schema)
+        else:
+            data, params = _validate_prediction_input(
+                data, params, self.input_schema, self.params_schema, self.loader_module
+            )
         params_arg = inspect.signature(self._predict_fn).parameters.get("params")
         if params_arg and params_arg.kind != inspect.Parameter.VAR_KEYWORD:
             return self._predict_fn(data, params=params)
@@ -2895,95 +2909,96 @@ def save_model(
     if mlflow_model is None:
         mlflow_model = Model()
     saved_example = None
-
-    hints = None
-    if signature is not None:
-        if isinstance(python_model, ChatModel):
+    signature_from_type_hints = None
+    if isinstance(python_model, ChatModel):
+        if signature is not None:
             raise MlflowException(
                 "ChatModel subclasses have a standard signature that is set "
                 "automatically. Please remove the `signature` parameter from "
                 "the call to log_model() or save_model().",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        mlflow_model.signature = signature
+        mlflow_model.signature = ModelSignature(
+            CHAT_MODEL_INPUT_SCHEMA,
+            CHAT_MODEL_OUTPUT_SCHEMA,
+        )
+        # For ChatModel we set default metadata to indicate its task
+        default_metadata = {TASK: _DEFAULT_CHAT_MODEL_METADATA_TASK}
+        mlflow_model.metadata = {**default_metadata, **(mlflow_model.metadata or {})}
+
+        if input_example:
+            input_example, input_params = _split_input_data_and_params(input_example)
+            valid_params = {}
+            if isinstance(input_example, list):
+                messages = []
+                for each_message in input_example:
+                    if isinstance(each_message, ChatMessage):
+                        messages.append(each_message)
+                    else:
+                        messages.append(ChatMessage.from_dict(each_message))
+            else:
+                # If the input example is a dictionary, convert it to ChatMessage format
+                messages = [
+                    ChatMessage.from_dict(m) if isinstance(m, dict) else m
+                    for m in input_example["messages"]
+                ]
+                valid_params = {
+                    k: v
+                    for k, v in input_example.items()
+                    if k != "messages" and k in ChatParams.keys()
+                }
+            if valid_params or input_params:
+                _logger.warning(_CHAT_PARAMS_WARNING_MESSAGE)
+            input_example = {
+                "messages": [m.to_dict() for m in messages],
+                **valid_params,
+                **(input_params or {}),
+            }
+        else:
+            input_example = CHAT_MODEL_INPUT_EXAMPLE
+            _logger.warning(_CHAT_PARAMS_WARNING_MESSAGE)
+            messages = [ChatMessage.from_dict(m) for m in input_example["messages"]]
+        # extra params introduced by ChatParams will not be included in the
+        # logged input example file to avoid confusion
+        _save_example(mlflow_model, input_example, path, example_no_conversion)
+        params = ChatParams.from_dict(input_example)
+
+        # call load_context() first, as predict may depend on it
+        _logger.info("Predicting on input example to validate output")
+        context = PythonModelContext(artifacts, model_config)
+        python_model.load_context(context)
+        if "context" in inspect.signature(python_model.predict).parameters:
+            output = python_model.predict(context, messages, params)
+        else:
+            output = python_model.predict(messages, params)
+        if not isinstance(output, ChatCompletionResponse):
+            raise MlflowException(
+                "Failed to save ChatModel. Please ensure that the model's predict() method "
+                "returns a ChatCompletionResponse object. If your predict() method currently "
+                "returns a dict, you can instantiate a ChatCompletionResponse using "
+                "`from_dict()`, e.g. `ChatCompletionResponse.from_dict(output)`",
+            )
     elif python_model is not None:
         if callable(python_model):
             input_arg_index = 0  # first argument
-            if signature := _infer_signature_from_type_hints(
+            signature_from_type_hints = _infer_signature_from_type_hints(
                 python_model, input_arg_index, input_example=input_example
-            ):
-                mlflow_model.signature = signature
-        elif isinstance(python_model, ChatModel):
-            mlflow_model.signature = ModelSignature(
-                CHAT_MODEL_INPUT_SCHEMA,
-                CHAT_MODEL_OUTPUT_SCHEMA,
             )
-            # For ChatModel we set default metadata to indicate its task
-            default_metadata = {TASK: _DEFAULT_CHAT_MODEL_METADATA_TASK}
-            mlflow_model.metadata = {**default_metadata, **(mlflow_model.metadata or {})}
-
-            if input_example:
-                input_example, input_params = _split_input_data_and_params(input_example)
-                valid_params = {}
-                if isinstance(input_example, list):
-                    messages = []
-                    for each_message in input_example:
-                        if isinstance(each_message, ChatMessage):
-                            messages.append(each_message)
-                        else:
-                            messages.append(ChatMessage.from_dict(each_message))
-                else:
-                    # If the input example is a dictionary, convert it to ChatMessage format
-                    messages = [
-                        ChatMessage.from_dict(m) if isinstance(m, dict) else m
-                        for m in input_example["messages"]
-                    ]
-                    valid_params = {
-                        k: v
-                        for k, v in input_example.items()
-                        if k != "messages" and k in ChatParams.keys()
-                    }
-                if valid_params or input_params:
-                    _logger.warning(_CHAT_PARAMS_WARNING_MESSAGE)
-                input_example = {
-                    "messages": [m.to_dict() for m in messages],
-                    **valid_params,
-                    **(input_params or {}),
-                }
-            else:
-                input_example = CHAT_MODEL_INPUT_EXAMPLE
-                _logger.warning(_CHAT_PARAMS_WARNING_MESSAGE)
-                messages = [ChatMessage.from_dict(m) for m in input_example["messages"]]
-            # extra params introduced by ChatParams will not be included in the
-            # logged input example file to avoid confusion
-            _save_example(mlflow_model, input_example, path, example_no_conversion)
-            params = ChatParams.from_dict(input_example)
-
-            # call load_context() first, as predict may depend on it
-            _logger.info("Predicting on input example to validate output")
-            context = PythonModelContext(artifacts, model_config)
-            python_model.load_context(context)
-            if "context" in inspect.signature(python_model.predict).parameters:
-                output = python_model.predict(context, messages, params)
-            else:
-                output = python_model.predict(messages, params)
-            if not isinstance(output, ChatCompletionResponse):
-                raise MlflowException(
-                    "Failed to save ChatModel. Please ensure that the model's predict() method "
-                    "returns a ChatCompletionResponse object. If your predict() method currently "
-                    "returns a dict, you can instantiate a ChatCompletionResponse using "
-                    "`from_dict()`, e.g. `ChatCompletionResponse.from_dict(output)`",
-                )
         elif isinstance(python_model, PythonModel):
             saved_example = _save_example(mlflow_model, input_example, path, example_no_conversion)
             input_arg_index = 1  # second argument
-            if signature := _infer_signature_from_type_hints(
+            signature_from_type_hints = _infer_signature_from_type_hints(
                 python_model.predict,
                 input_arg_index=input_arg_index,
                 input_example=input_example,
+            )
+            # only infer signature based on input example when signature
+            # and type hints are not provided
+            if (
+                signature is None
+                and signature_from_type_hints is None
+                and saved_example is not None
             ):
-                mlflow_model.signature = signature
-            elif saved_example is not None:
                 try:
                     context = PythonModelContext(artifacts, model_config)
                     python_model.load_context(context)
@@ -2993,6 +3008,24 @@ def save_model(
                     )
                 except Exception as e:
                     _logger.warning(f"Failed to infer model signature from input example. {e}")
+
+    if signature_from_type_hints:
+        if signature and signature_from_type_hints != signature:
+            # TODO: drop this support and raise exception in the next release since this
+            # is a behavior change
+            _logger.warning(
+                "Provided signature does not match the signature inferred from the Python model's "
+                "`predict` function type hint. Signature inferred from type hint: "
+                f"`{signature_from_type_hints}`. Remove the `signature` parameter or ensure it "
+                "matches the inferred signature. Such behavior will not be allowed in a future "
+                "release. Using signature inferred from type hints for data validation.",
+                extra={"color": "red"},
+            )
+        mlflow_model.signature = signature_from_type_hints
+        mlflow_model.signature_from_type_hint = True
+    # TODO: if signature is provided, we should validate input_example against it
+    elif signature:
+        mlflow_model.signature = signature
 
     if metadata is not None:
         mlflow_model.metadata = metadata
@@ -3032,7 +3065,6 @@ def save_model(
         return mlflow.pyfunc.model._save_model_with_class_artifacts_params(
             path=path,
             signature=signature,
-            hints=hints,
             python_model=python_model,
             artifacts=artifacts,
             conda_env=conda_env,

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -375,9 +375,9 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
                 cloudpickle.dump(python_model, out)
         except Exception as e:
             raise MlflowException(
-                "Failed to serialize Python model. Please save the model as a python file "
-                "and use code-based logging method instead. For more information, see our "
-                "documentation at: https://mlflow.org/docs/latest/models.html#models-from-code"
+                "Failed to serialize Python model. Please save the model into a python file "
+                "and use code-based logging method instead. See"
+                "https://mlflow.org/docs/latest/models.html#models-from-code for more information."
             ) from e
 
         custom_model_config_kwargs[CONFIG_KEY_PYTHON_MODEL] = saved_python_model_subpath

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -28,7 +28,6 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.pyfunc.utils.input_converter import _hydrate_dataclass
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.llm import ChatCompletionChunk, ChatCompletionResponse, ChatMessage, ChatParams
-from mlflow.types.utils import _is_list_dict_str, _is_list_str
 from mlflow.utils.annotations import experimental
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -160,9 +159,8 @@ class _FunctionPythonModel(PythonModel):
     in an instance of this class.
     """
 
-    def __init__(self, func, hints=None, signature=None):
+    def __init__(self, func, signature=None):
         self.func = func
-        self.hints = hints
         self.signature = signature
 
     def _get_type_hints(self):
@@ -306,7 +304,6 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
     path,
     python_model,
     signature=None,
-    hints=None,
     artifacts=None,
     conda_env=None,
     code_paths=None,
@@ -363,7 +360,7 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
         CONFIG_KEY_CLOUDPICKLE_VERSION: cloudpickle.__version__,
     }
     if callable(python_model):
-        python_model = _FunctionPythonModel(python_model, hints, signature)
+        python_model = _FunctionPythonModel(func=python_model, signature=signature)
     saved_python_model_subpath = _SAVED_PYTHON_MODEL_SUBPATH
 
     # If model_code_path is defined, we load the model into python_model, but we don't want to
@@ -373,27 +370,11 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
             with open(os.path.join(path, saved_python_model_subpath), "wb") as out:
                 cloudpickle.dump(python_model, out)
         except Exception as e:
-            # cloudpickle sometimes raises TypeError instead of PicklingError.
-            # catching generic Exception and checking message to handle both cases.
-            if "cannot pickle" in str(e).lower():
-                raise MlflowException(
-                    "Failed to serialize Python model. Please audit your "
-                    "class variables (e.g. in `__init__()`) for any "
-                    "unpicklable objects. If you're trying to save an external model "
-                    "in your custom pyfunc, Please use the `artifacts` parameter "
-                    "in `mlflow.pyfunc.save_model()`, and load your external model "
-                    "in the `load_context()` method instead. For example:\n\n"
-                    "class MyModel(mlflow.pyfunc.PythonModel):\n"
-                    "    def load_context(self, context):\n"
-                    "        model_path = context.artifacts['my_model_path']\n"
-                    "        // custom load logic here\n"
-                    "        self.model = load_model(model_path)\n\n"
-                    "For more information, see our full tutorial at: "
-                    "https://mlflow.org/docs/latest/traditional-ml/creating-custom-pyfunc/index.html"
-                    f"\n\nFull serialization error: {e}"
-                ) from None
-            else:
-                raise e
+            raise MlflowException(
+                "Failed to serialize Python model. Please save the model as a python file "
+                "and use code-based logging method instead. For more information, see our "
+                "documentation at: https://mlflow.org/docs/latest/models.html#models-from-code"
+            ) from e
 
         custom_model_config_kwargs[CONFIG_KEY_PYTHON_MODEL] = saved_python_model_subpath
 
@@ -599,7 +580,7 @@ class _PythonModelPyfuncWrapper:
     predict(model_input: pd.DataFrame) -> model's output as pd.DataFrame (pandas DataFrame)
     """
 
-    def __init__(self, python_model, context, signature):
+    def __init__(self, python_model: PythonModel, context, signature):
         """
         Args:
             python_model: An instance of a subclass of :class:`~PythonModel`.
@@ -615,32 +596,7 @@ class _PythonModelPyfuncWrapper:
         import pandas as pd
 
         hints = self.python_model._get_type_hints()
-        if _is_list_str(hints.input):
-            if isinstance(model_input, pd.DataFrame):
-                first_string_column = _get_first_string_column(model_input)
-                if first_string_column is None:
-                    raise MlflowException.invalid_parameter_value(
-                        "Expected model input to contain at least one string column"
-                    )
-                return model_input[first_string_column].tolist()
-            elif isinstance(model_input, list):
-                if all(isinstance(x, dict) for x in model_input):
-                    return [next(iter(d.values())) for d in model_input]
-                elif all(isinstance(x, str) for x in model_input):
-                    return model_input
-        elif _is_list_dict_str(hints.input):
-            if isinstance(model_input, pd.DataFrame):
-                if (
-                    len(self.signature.inputs) == 1
-                    and next(iter(self.signature.inputs)).name is None
-                ):
-                    first_string_column = _get_first_string_column(model_input)
-                    return model_input[[first_string_column]].to_dict(orient="records")
-                return model_input.to_dict(orient="records")
-            elif isinstance(model_input, list) and all(isinstance(x, dict) for x in model_input):
-                keys = [x.name for x in self.signature.inputs]
-                return [{k: d[k] for k in keys} for d in model_input]
-        elif isinstance(hints.input, type) and (
+        if isinstance(hints.input, type) and (
             issubclass(hints.input, ChatCompletionRequest)
             or issubclass(hints.input, SplitChatMessagesRequest)
         ):

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -243,7 +243,7 @@ def _validate_example_against_type_hint(example: Any, type_hint: type[Any]) -> A
     if _is_pydantic_type_hint(type_hint):
         # if example is a pydantic model instance, convert it to a dictionary for validation
         if isinstance(example, pydantic.BaseModel):
-            example_dict = example.model_dump()
+            example_dict = example.dict() if PYDANTIC_V1_OR_OLDER else example.model_dump()
         elif isinstance(example, dict):
             example_dict = example
         else:

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -359,10 +359,10 @@ def _get_origin_type(type_hint: type[Any]) -> Any:
     return origin_type
 
 
-def _convert_pandas_dataframe_to_hinted_type(data: Any, type_hint: type[Any]) -> Any:
+def _convert_data_to_type_hint(data: Any, type_hint: type[Any]) -> Any:
     """
     Convert data to the expected format based on the type hint.
-    This function should only used with limited situations such as mlflow.evaluate.
+    This function should only used in limited situations such as mlflow.evaluate.
     Supported conversions:
         - pandas DataFrame with a single column + list[...] type hint -> list
     """

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -359,7 +359,7 @@ def _get_origin_type(type_hint: type[Any]) -> Any:
     return origin_type
 
 
-def _maybe_convert_data_for_type_hint(data: Any, type_hint: type[Any]) -> Any:
+def _convert_pandas_dataframe_to_hinted_type(data: Any, type_hint: type[Any]) -> Any:
     """
     Convert data to the expected format based on the type hint.
     This function should only used with limited situations such as mlflow.evaluate.

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from collections import defaultdict
-from typing import Any, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -651,6 +651,22 @@ def _validate_input_dictionary_contains_only_strings_and_lists_of_strings(data) 
             "numeric values, the data must be enclosed in a numpy.ndarray. The following keys "
             f"in the input dictionary are invalid: {invalid_values}",
         )
+
+
+def _is_list_str(type_hint: Any) -> bool:
+    return type_hint in [
+        List[str],  # noqa: UP006
+        list[str],
+    ]
+
+
+def _is_list_dict_str(type_hint: Any) -> bool:
+    return type_hint in [
+        List[Dict[str, str]],  # noqa: UP006
+        list[Dict[str, str]],  # noqa: UP006
+        List[dict[str, str]],  # noqa: UP006
+        list[dict[str, str]],
+    ]
 
 
 def _get_array_depth(l: Any) -> int:

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -1,13 +1,12 @@
 import logging
 import warnings
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
 
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.types import DataType
 from mlflow.types.schema import (
     HAS_PYSPARK,
@@ -652,143 +651,6 @@ def _validate_input_dictionary_contains_only_strings_and_lists_of_strings(data) 
             "numeric values, the data must be enclosed in a numpy.ndarray. The following keys "
             f"in the input dictionary are invalid: {invalid_values}",
         )
-
-
-def _is_all_string(x):
-    return all(isinstance(v, str) for v in x)
-
-
-def _validate_is_all_string(x):
-    if not _is_all_string(x):
-        raise MlflowException(f"Expected all values to be string, got {x}", INVALID_PARAMETER_VALUE)
-
-
-def _validate_all_keys_string(d):
-    keys = list(d.keys())
-    if not _is_all_string(keys):
-        raise MlflowException(
-            f"Expected example to be dict with string keys, got {keys}",
-            INVALID_PARAMETER_VALUE,
-        )
-
-
-def _validate_all_values_string(d):
-    values = list(d.values())
-    if not _is_all_string(values):
-        raise MlflowException(
-            f"Expected example to be dict with string values, got {values}", INVALID_PARAMETER_VALUE
-        )
-
-
-def _validate_keys_match(d, expected_keys):
-    if d.keys() != expected_keys:
-        raise MlflowException(
-            f"Expected example to be dict with keys {list(expected_keys)}, got {list(d.keys())}",
-            INVALID_PARAMETER_VALUE,
-        )
-
-
-def _validate_num_items(d, num_items):
-    actual_num_items = len(d)
-    if actual_num_items != num_items:
-        raise MlflowException(
-            f"Expected example to be dict with {num_items} items, got {actual_num_items}",
-            INVALID_PARAMETER_VALUE,
-        )
-
-
-def _validate_has_items(d):
-    num_items = len(d)
-    if num_items == 0:
-        raise MlflowException(
-            f"Expected example to be dict with at least one item, got {num_items}",
-            INVALID_PARAMETER_VALUE,
-        )
-
-
-def _validate_is_dict(d):
-    if not isinstance(d, dict):
-        raise MlflowException(
-            f"Expected each item in example to be dict, got {type(d).__name__}",
-            INVALID_PARAMETER_VALUE,
-        )
-
-
-def _validate_non_empty(examples):
-    num_items = len(examples)
-    if num_items == 0:
-        raise MlflowException(
-            f"Expected examples to be non-empty list, got {num_items}",
-            INVALID_PARAMETER_VALUE,
-        )
-
-
-def _validate_is_list(examples):
-    if not isinstance(examples, list):
-        raise MlflowException(
-            f"Expected examples to be list, got {type(examples).__name__}",
-            INVALID_PARAMETER_VALUE,
-        )
-
-
-def _validate_dict_examples(examples, num_items=None):
-    examples_iter = iter(examples)
-    first_example = next(examples_iter)
-    _validate_is_dict(first_example)
-    _validate_has_items(first_example)
-    if num_items is not None:
-        _validate_num_items(first_example, num_items)
-    _validate_all_keys_string(first_example)
-    _validate_all_values_string(first_example)
-    first_keys = first_example.keys()
-
-    for example in examples_iter:
-        _validate_is_dict(example)
-        _validate_has_items(example)
-        if num_items is not None:
-            _validate_num_items(example, num_items)
-        _validate_all_keys_string(example)
-        _validate_all_values_string(example)
-        _validate_keys_match(example, first_keys)
-
-
-def _is_list_str(type_hint: Any) -> bool:
-    return type_hint in [
-        List[str],  # noqa: UP006
-        list[str],
-    ]
-
-
-def _is_list_dict_str(type_hint: Any) -> bool:
-    return type_hint in [
-        List[Dict[str, str]],  # noqa: UP006
-        list[Dict[str, str]],  # noqa: UP006
-        List[dict[str, str]],  # noqa: UP006
-        list[dict[str, str]],
-    ]
-
-
-def _infer_schema_from_type_hint(type_hint, examples=None):
-    has_examples = examples is not None
-    if has_examples:
-        _validate_non_empty(examples)
-
-    if _is_list_str(type_hint):
-        if has_examples:
-            _validate_is_list(examples)
-            _validate_is_all_string(examples)
-        return Schema([ColSpec(type="string", name=None)])
-    elif _is_list_dict_str(type_hint):
-        if has_examples:
-            _validate_is_list(examples)
-            _validate_dict_examples(examples)
-            return Schema([ColSpec(type="string", name=name) for name in examples[0]])
-        else:
-            _logger.warning(f"Could not infer schema for {type_hint} because example is missing")
-            return Schema([ColSpec(type="string", name=None)])
-    else:
-        _logger.info("Unsupported type hint: %s, skipping schema inference", type_hint)
-        return None
 
 
 def _get_array_depth(l: Any) -> int:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
+import pydantic
 import pytest
 import sklearn.datasets
 import sklearn.neighbors
@@ -505,6 +506,28 @@ def test_save_load_input_example_without_conversion(tmp_path):
     assert loaded_model.saved_input_example_info["type"] == "json_object"
     loaded_example = loaded_model.load_input_example(local_path)
     assert loaded_example == input_example
+
+
+def test_save_load_input_example_with_pydantic_model(tmp_path):
+    class Message(pydantic.BaseModel):
+        role: str
+        content: str
+
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input: Message, params=None):
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "test_model",
+            python_model=MyModel(),
+            input_example=Message(role="user", content="Hello!"),
+        )
+    local_path = _download_artifact_from_uri(model_info.model_uri, output_path=tmp_path)
+    loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
+    assert loaded_model.saved_input_example_info["type"] == "json_object"
+    loaded_example = loaded_model.load_input_example(local_path)
+    assert loaded_example == {"role": "user", "content": "Hello!"}
 
 
 def test_model_saved_by_save_model_can_be_loaded(tmp_path, sklearn_knn_model):

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -52,6 +52,8 @@ from mlflow.tracking.artifact_utils import (
 from mlflow.tracking.artifact_utils import (
     get_artifact_uri as utils_get_artifact_uri,
 )
+from mlflow.types.schema import Array, ColSpec, Map, Schema
+from mlflow.types.type_hints import _infer_schema_from_type_hint
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -1237,66 +1239,8 @@ def test_functional_python_model_no_type_hints(tmp_path):
     assert model.signature is None
 
 
-def test_functional_python_model_only_input_type_hints(tmp_path):
-    def python_model(x: list[str]):
-        return x
-
-    mlflow.pyfunc.save_model(path=tmp_path, python_model=python_model, input_example=["a"])
-    model = Model.load(tmp_path)
-    assert model.signature.inputs.to_dict() == [{"type": "string", "required": True}]
-
-
-def test_functional_python_model_only_output_type_hints(tmp_path):
-    def python_model(x) -> list[str]:
-        return x
-
-    mlflow.pyfunc.save_model(path=tmp_path, python_model=python_model, input_example=["a"])
-    model = Model.load(tmp_path)
-    assert model.signature is None
-
-
-class CallableObject:
-    def __call__(self, x: list[str]) -> list[str]:
-        return x
-
-
-def test_functional_python_model_callable_object(tmp_path):
-    mlflow.pyfunc.save_model(path=tmp_path, python_model=CallableObject(), input_example=["a"])
-    model = Model.load(tmp_path)
-    assert model.signature.inputs.to_dict() == [{"type": "string", "required": True}]
-    assert model.signature.outputs.to_dict() == [{"type": "string", "required": True}]
-    loaded_model = mlflow.pyfunc.load_model(tmp_path)
-    assert loaded_model.predict(["a", "b"]) == ["a", "b"]
-
-
 def list_to_list(x: List[str]) -> List[str]:  # noqa: UP006
     return x
-
-
-def test_functional_python_model_list_to_list(tmp_path):
-    mlflow.pyfunc.save_model(path=tmp_path, python_model=list_to_list, input_example=["a"])
-    model = Model.load(tmp_path)
-    assert model.signature.inputs.to_dict() == [{"type": "string", "required": True}]
-    assert model.signature.outputs.to_dict() == [{"type": "string", "required": True}]
-    loaded_model = mlflow.pyfunc.load_model(tmp_path)
-    assert loaded_model.predict(["a", "b"]) == ["a", "b"]
-    # Dict with a single key is also a valid input
-    assert loaded_model.predict([{"a": "x"}, {"a": "y"}]) == ["x", "y"]
-
-
-def list_to_list_pep585(x: list[str]) -> list[str]:
-    return x
-
-
-def test_functional_python_model_list_to_list_pep585(tmp_path):
-    mlflow.pyfunc.save_model(path=tmp_path, python_model=list_to_list_pep585, input_example=["a"])
-    model = Model.load(tmp_path)
-    assert model.signature.inputs.to_dict() == [{"type": "string", "required": True}]
-    assert model.signature.outputs.to_dict() == [{"type": "string", "required": True}]
-    loaded_model = mlflow.pyfunc.load_model(tmp_path)
-    assert loaded_model.predict(["a", "b"]) == ["a", "b"]
-    # Dict with a single key is also a valid input
-    assert loaded_model.predict([{"x": "a"}, {"x": "b"}]) == ["a", "b"]
 
 
 def list_dict_to_list(x: List[Dict[str, str]]) -> List[str]:  # noqa: UP006
@@ -1308,45 +1252,40 @@ def test_functional_python_model_list_dict_to_list_without_example(tmp_path):
         path=tmp_path, python_model=list_dict_to_list, pip_requirements=["pandas"]
     )
     model = Model.load(tmp_path)
-    assert model.signature.inputs.to_dict() == [{"type": "string", "required": True}]
-    assert model.signature.outputs.to_dict() == [{"type": "string", "required": True}]
+    assert model.signature.inputs == Schema([ColSpec(Array(Map("string")))])
+    assert model.signature.outputs == Schema([ColSpec(Array("string"))])
     loaded_model = mlflow.pyfunc.load_model(tmp_path)
     assert loaded_model.predict([{"a": "x"}, {"a": "y"}]) == ["ax", "ay"]
 
 
 @pytest.mark.parametrize(
-    ("input_example", "expected_error_message"),
+    ("input_example"),
     [
-        ([], "non-empty"),
-        ([0], "to be string"),
-        ([{"a": "b"}], "to be string"),
+        [0],
+        [{"a": "b"}],
     ],
 )
-def test_functional_python_model_list_invalid_example(
-    tmp_path, input_example, expected_error_message
-):
-    with pytest.raises(MlflowException, match=expected_error_message):
+def test_functional_python_model_list_invalid_example(tmp_path, input_example):
+    with pytest.raises(
+        MlflowException, match=r"Input example is not compatible with the type hint"
+    ):
         mlflow.pyfunc.save_model(
             path=tmp_path, python_model=list_to_list, input_example=input_example
         )
 
 
 @pytest.mark.parametrize(
-    ("input_example", "expected_error_message"),
+    "input_example",
     [
-        ([], "non-empty"),
-        (["a"], "to be dict"),
-        ([{}], "at least one item"),
-        ([{0: "a"}], "string keys"),
-        ([{"a": 0}], "string values"),
-        ([{"a": "x"}, {"b": "y"}], r"dict with keys \['a'\]"),
-        ([{"a": "x"}, {"a": "y", "b": "z"}], r"dict with keys \['a'\]"),
+        ["a"],
+        [{0: "a"}],
+        [{"a": 0}],
     ],
 )
-def test_functional_python_model_list_dict_invalid_example(
-    tmp_path, input_example, expected_error_message
-):
-    with pytest.raises(MlflowException, match=expected_error_message):
+def test_functional_python_model_list_dict_invalid_example(tmp_path, input_example):
+    with pytest.raises(
+        MlflowException, match=r"Input example is not compatible with the type hint"
+    ):
         mlflow.pyfunc.save_model(
             path=tmp_path, python_model=list_dict_to_list, input_example=input_example
         )
@@ -1359,11 +1298,8 @@ def test_functional_python_model_list_dict_to_list(tmp_path):
         input_example=[{"a": "x", "b": "y"}],
     )
     model = Model.load(tmp_path)
-    assert model.signature.inputs.to_dict() == [
-        {"name": "a", "type": "string", "required": True},
-        {"name": "b", "type": "string", "required": True},
-    ]
-    assert model.signature.outputs.to_dict() == [{"type": "string", "required": True}]
+    assert model.signature.inputs == Schema([ColSpec(Array(Map("string")))])
+    assert model.signature.outputs == Schema([ColSpec(Array("string"))])
     loaded_model = mlflow.pyfunc.load_model(tmp_path)
     assert loaded_model.predict([{"a": "x", "b": "y"}]) == ["abxy"]
 
@@ -1381,12 +1317,10 @@ def test_functional_python_model_list_dict_to_list_dict():
         )
 
     assert model_info.signature.inputs.to_dict() == [
-        {"name": "a", "type": "string", "required": True},
-        {"name": "b", "type": "string", "required": True},
+        {"type": "array", "items": {"type": "map", "values": {"type": "string"}}, "required": True}
     ]
     assert model_info.signature.outputs.to_dict() == [
-        {"name": "x", "type": "string", "required": True},
-        {"name": "y", "type": "string", "required": True},
+        {"type": "array", "items": {"type": "map", "values": {"type": "string"}}, "required": True}
     ]
 
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -1405,10 +1339,7 @@ def test_list_dict_with_signature_override():
             python_model=CustomModel(),
             signature=signature,
         )
-    assert model_info.signature.inputs.to_dict() == [
-        {"name": "a", "type": "string", "required": True},
-        {"name": "b", "type": "string", "required": False},
-    ]
+    assert model_info.signature.inputs == _infer_schema_from_type_hint(list[dict[str, str]])
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_model.predict([{"a": "z"}]) == [{"a": "z"}]
 
@@ -1425,12 +1356,10 @@ def test_functional_python_model_list_dict_to_list_dict_with_example_pep585(tmp_
     )
     model = Model.load(tmp_path)
     assert model.signature.inputs.to_dict() == [
-        {"name": "a", "type": "string", "required": True},
-        {"name": "b", "type": "string", "required": True},
+        {"type": "array", "items": {"type": "map", "values": {"type": "string"}}, "required": True},
     ]
     assert model.signature.outputs.to_dict() == [
-        {"name": "x", "type": "string", "required": True},
-        {"name": "y", "type": "string", "required": True},
+        {"type": "array", "items": {"type": "map", "values": {"type": "string"}}, "required": True},
     ]
     loaded_model = mlflow.pyfunc.load_model(tmp_path)
     assert loaded_model.predict([{"a": "x", "b": "y"}]) == [{"x": "a", "y": "b"}]
@@ -1509,20 +1438,21 @@ class AnnotatedPythonModel(mlflow.pyfunc.PythonModel):
 def test_class_python_model_type_hints(tmp_path):
     mlflow.pyfunc.save_model(path=tmp_path, python_model=AnnotatedPythonModel())
     model = Model.load(tmp_path)
-    assert model.signature.inputs.to_dict() == [{"type": "string", "required": True}]
-    assert model.signature.outputs.to_dict() == [{"type": "string", "required": True}]
+    assert model.signature.inputs.to_dict() == [
+        {"type": "array", "items": {"type": "string"}, "required": True}
+    ]
+    assert model.signature.outputs.to_dict() == [
+        {"type": "array", "items": {"type": "string"}, "required": True}
+    ]
     model = mlflow.pyfunc.load_model(tmp_path)
     assert model.predict(["a", "b"]) == ["a", "b"]
 
 
 def test_python_model_predict_with_params():
-    signature = infer_signature(["input1", "input2"], params={"foo": [8]})
-
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(
             "test_model",
             python_model=AnnotatedPythonModel(),
-            signature=signature,
         )
 
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -1531,6 +1461,23 @@ def test_python_model_predict_with_params():
         "a",
         "b",
     ]
+
+
+def test_python_model_with_type_hint_errors_with_different_signature():
+    signature = infer_signature(["input1", "input2"], params={"foo": [8]})
+
+    with mock.patch("mlflow.pyfunc._logger.warning") as warn_mock:
+        with mlflow.start_run():
+            mlflow.pyfunc.log_model(
+                "test_model",
+                python_model=AnnotatedPythonModel(),
+                signature=signature,
+            )
+        assert warn_mock.call_count == 1
+        assert (
+            "Provided signature does not match the signature inferred from"
+            in warn_mock.call_args[0][0]
+        )
 
 
 def test_artifact_path_posix(sklearn_knn_model, main_scoped_model_class, tmp_path):
@@ -1574,7 +1521,7 @@ def test_load_model_fails_for_feature_store_models(tmp_path):
         mlflow.pyfunc.load_model(f"runs:/{run.info.run_id}/model")
 
 
-def test_pyfunc_model_infer_signature_from_type_hints(model_path):
+def test_pyfunc_model_infer_signature_from_type_hints():
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input: list[str], params=None) -> list[str]:
             return model_input
@@ -1586,9 +1533,7 @@ def test_pyfunc_model_infer_signature_from_type_hints(model_path):
             input_example=["a"],
         )
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert pyfunc_model.metadata.get_input_schema().to_dict() == [
-        {"type": "string", "required": True}
-    ]
+    assert pyfunc_model.metadata.get_input_schema() == Schema([ColSpec(Array("string"))])
     assert pyfunc_model.predict(["a", "b"]) == ["a", "b"]
 
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1266,12 +1266,11 @@ def test_functional_python_model_list_dict_to_list_without_example(tmp_path):
     ],
 )
 def test_functional_python_model_list_invalid_example(tmp_path, input_example):
-    with pytest.raises(
-        MlflowException, match=r"Input example is not compatible with the type hint"
-    ):
+    with mock.patch("mlflow.models.signature._logger.warning") as mock_warning:
         mlflow.pyfunc.save_model(
             path=tmp_path, python_model=list_to_list, input_example=input_example
         )
+        assert "Input example is not compatible with the type hint" in mock_warning.call_args[0][0]
 
 
 @pytest.mark.parametrize(
@@ -1283,12 +1282,11 @@ def test_functional_python_model_list_invalid_example(tmp_path, input_example):
     ],
 )
 def test_functional_python_model_list_dict_invalid_example(tmp_path, input_example):
-    with pytest.raises(
-        MlflowException, match=r"Input example is not compatible with the type hint"
-    ):
+    with mock.patch("mlflow.models.signature._logger.warning") as mock_warning:
         mlflow.pyfunc.save_model(
             path=tmp_path, python_model=list_dict_to_list, input_example=input_example
         )
+        assert "Input example is not compatible with the type hint" in mock_warning.call_args[0][0]
 
 
 def test_functional_python_model_list_dict_to_list(tmp_path):

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1466,14 +1466,14 @@ def test_python_model_predict_with_params():
 def test_python_model_with_type_hint_errors_with_different_signature():
     signature = infer_signature(["input1", "input2"], params={"foo": [8]})
 
-    with mock.patch("mlflow.pyfunc._logger.warning") as warn_mock:
-        with mlflow.start_run():
+    with mlflow.start_run():
+        with mock.patch("mlflow.pyfunc._logger.warning") as warn_mock:
             mlflow.pyfunc.log_model(
                 "test_model",
                 python_model=AnnotatedPythonModel(),
                 signature=signature,
             )
-        assert warn_mock.call_count == 1
+        warn_mock.assert_called_once()
         assert (
             "Provided signature does not match the signature inferred from"
             in warn_mock.call_args[0][0]

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1270,7 +1270,10 @@ def test_functional_python_model_list_invalid_example(tmp_path, input_example):
         mlflow.pyfunc.save_model(
             path=tmp_path, python_model=list_to_list, input_example=input_example
         )
-        assert "Input example is not compatible with the type hint" in mock_warning.call_args[0][0]
+        assert any(
+            "Input example is not compatible with the type hint" in call[0][0]
+            for call in mock_warning.call_args_list
+        )
 
 
 @pytest.mark.parametrize(
@@ -1286,7 +1289,10 @@ def test_functional_python_model_list_dict_invalid_example(tmp_path, input_examp
         mlflow.pyfunc.save_model(
             path=tmp_path, python_model=list_dict_to_list, input_example=input_example
         )
-        assert "Input example is not compatible with the type hint" in mock_warning.call_args[0][0]
+        assert any(
+            "Input example is not compatible with the type hint" in call[0][0]
+            for call in mock_warning.call_args_list
+        )
 
 
 def test_functional_python_model_list_dict_to_list(tmp_path):

--- a/tests/pyfunc/test_pyfunc_exceptions.py
+++ b/tests/pyfunc/test_pyfunc_exceptions.py
@@ -17,6 +17,6 @@ def test_pyfunc_unpicklable_exception(tmp_path):
 
     with pytest.raises(
         MlflowException,
-        match="Please save the model as a python file and use code-based logging method instead",
+        match="Please save the model into a python file and use code-based logging method instead",
     ):
         mlflow.pyfunc.save_model(python_model=model, path=tmp_path / "model")

--- a/tests/pyfunc/test_pyfunc_exceptions.py
+++ b/tests/pyfunc/test_pyfunc_exceptions.py
@@ -15,5 +15,8 @@ class UnpicklableModel(mlflow.pyfunc.PythonModel):
 def test_pyfunc_unpicklable_exception(tmp_path):
     model = UnpicklableModel(tmp_path / "model.pkl")
 
-    with pytest.raises(MlflowException, match="Please audit your class variables"):
+    with pytest.raises(
+        MlflowException,
+        match="Please save the model as a python file and use code-based logging method instead",
+    ):
         mlflow.pyfunc.save_model(python_model=model, path=tmp_path / "model")

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1,0 +1,358 @@
+import datetime
+import sys
+from typing import Any, Dict, List, NamedTuple, Optional, Union
+from unittest import mock
+
+import pydantic
+import pytest
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.models.signature import _extract_type_hints
+from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
+from mlflow.types.type_hints import _is_pydantic_type_hint
+
+
+class CustomExample(pydantic.BaseModel):
+    long_field: int
+    str_field: str
+    bool_field: bool
+    double_field: float
+    binary_field: bytes
+    datetime_field: datetime.datetime
+    any_field: Any
+    optional_str: Optional[str] = None
+
+
+class Message(pydantic.BaseModel):
+    role: str
+    content: str
+
+
+class CustomExample2(pydantic.BaseModel):
+    custom_field: dict[str, Any]
+    messages: list[Message]
+    optional_int: Optional[int] = None
+
+
+@pytest.mark.parametrize(
+    ("type_hint", "expected_schema", "input_example"),
+    [
+        # scalars
+        (int, Schema([ColSpec(type=DataType.long)]), 123),
+        (str, Schema([ColSpec(type=DataType.string)]), "string"),
+        (bool, Schema([ColSpec(type=DataType.boolean)]), True),
+        (float, Schema([ColSpec(type=DataType.double)]), 1.23),
+        (bytes, Schema([ColSpec(type=DataType.binary)]), b"bytes"),
+        (datetime.datetime, Schema([ColSpec(type=DataType.datetime)]), datetime.datetime.now()),
+        # lists
+        (list[str], Schema([ColSpec(type=Array(DataType.string))]), ["a", "b"]),
+        (List[str], Schema([ColSpec(type=Array(DataType.string))]), ["a"]),  # noqa: UP006
+        (
+            list[list[str]],
+            Schema([ColSpec(type=Array(Array(DataType.string)))]),
+            [["a", "b"], ["c"]],
+        ),
+        (List[List[str]], Schema([ColSpec(type=Array(Array(DataType.string)))]), [["a"], ["b"]]),  # noqa: UP006
+        (list[dict[str, str]], Schema([ColSpec(type=Array(Map(DataType.string)))]), [{"a": "b"}]),
+        # dictionaries
+        (dict[str, int], Schema([ColSpec(type=Map(DataType.long))]), {"a": 1}),
+        (Dict[str, int], Schema([ColSpec(type=Map(DataType.long))]), {"a": 1, "b": 2}),  # noqa: UP006
+        (dict[str, list[str]], Schema([ColSpec(type=Map(Array(DataType.string)))]), {"a": ["b"]}),
+        (
+            Dict[str, List[str]],  # noqa: UP006
+            Schema([ColSpec(type=Map(Array(DataType.string)))]),
+            {"a": ["a", "b"]},
+        ),
+        # Union
+        (Union[int, str], Schema([ColSpec(type=AnyType())]), [1, "a", 234]),
+        # Any
+        (list[Any], Schema([ColSpec(type=Array(AnyType()))]), [True, "abc", 123]),
+        # Pydantic Models
+        (
+            CustomExample,
+            Schema(
+                [
+                    ColSpec(
+                        type=Object(
+                            [
+                                Property(name="long_field", dtype=DataType.long),
+                                Property(name="str_field", dtype=DataType.string),
+                                Property(name="bool_field", dtype=DataType.boolean),
+                                Property(name="double_field", dtype=DataType.double),
+                                Property(name="binary_field", dtype=DataType.binary),
+                                Property(name="datetime_field", dtype=DataType.datetime),
+                                Property(name="any_field", dtype=AnyType()),
+                                Property(
+                                    name="optional_str", dtype=DataType.string, required=False
+                                ),
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            {
+                "long_field": 123,
+                "str_field": "abc",
+                "bool_field": True,
+                "double_field": 1.23,
+                "binary_field": b"bytes",
+                "datetime_field": datetime.datetime.now(),
+                "any_field": ["any", 123],
+                "optional_str": "optional",
+            },
+        ),
+        (
+            CustomExample2,
+            Schema(
+                [
+                    ColSpec(
+                        type=Object(
+                            [
+                                Property(name="custom_field", dtype=Map(AnyType())),
+                                Property(
+                                    name="messages",
+                                    dtype=Array(
+                                        Object(
+                                            [
+                                                Property(name="role", dtype=DataType.string),
+                                                Property(name="content", dtype=DataType.string),
+                                            ]
+                                        )
+                                    ),
+                                ),
+                                Property(name="optional_int", dtype=DataType.long, required=False),
+                            ]
+                        )
+                    )
+                ]
+            ),
+            {
+                "custom_field": {"a": 1},
+                "messages": [{"role": "admin", "content": "hello"}],
+                "optional_int": 123,
+            },
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("model_type", "has_input_example"),
+    # if python_model is callable, input_example should be provided
+    [("callable", True), ("python_model", True), ("python_model", False)],
+)
+def test_pyfunc_model_infer_signature_from_type_hints(
+    type_hint, expected_schema, input_example, has_input_example, model_type
+):
+    kwargs = {}
+    if model_type == "callable":
+
+        def predict(model_input: type_hint) -> type_hint:
+            return model_input
+
+        kwargs["python_model"] = predict
+    elif model_type == "python_model":
+
+        class TestModel(mlflow.pyfunc.PythonModel):
+            def predict(self, context, model_input: type_hint, params=None) -> type_hint:
+                return model_input
+
+        kwargs["python_model"] = TestModel()
+
+    if has_input_example:
+        kwargs["input_example"] = input_example
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model("test_model", **kwargs)
+    assert model_info.signature_from_type_hint is True
+    assert model_info.signature.inputs == expected_schema
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    if _is_pydantic_type_hint(type_hint):
+        assert pyfunc_model.predict(input_example).model_dump() == input_example
+    else:
+        assert pyfunc_model.predict(input_example) == input_example
+
+
+def test_pyfunc_model_infer_signature_from_type_hints_errors():
+    def predict(model_input: int) -> int:
+        return model_input
+
+    with pytest.raises(
+        MlflowException,
+        match=r"Input example is not compatible with the type hint of the `predict` function.",
+    ):
+        with mlflow.start_run():
+            mlflow.pyfunc.log_model("test_model", python_model=predict, input_example="string")
+
+    def predict(model_input: int) -> str:
+        return model_input
+
+    output_hints = _extract_type_hints(predict, 0).output
+    with mock.patch("mlflow.models.signature._logger.warning") as mock_warning:
+        with mlflow.start_run():
+            model_info = mlflow.pyfunc.log_model(
+                "test_model", python_model=predict, input_example=123
+            )
+        mock_warning.assert_called_once_with(
+            f"Failed to validate output `123` against type hint `{output_hints}`. "
+            "Set the logging level to DEBUG to see the full traceback.",
+            exc_info=False,
+        )
+        assert model_info.signature.inputs == Schema([ColSpec(type=DataType.long)])
+        assert model_info.signature.outputs is None
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
+def test_pyfunc_model_infer_signature_from_type_hints_for_python_3_10():
+    def predict(model_input: int | str) -> int | str:
+        return model_input
+
+    with mlflow.start_run():
+        model_info1 = mlflow.pyfunc.log_model("test_model", python_model=predict, input_example=123)
+        model_info2 = mlflow.pyfunc.log_model(
+            "test_model", python_model=predict, input_example="string"
+        )
+
+    assert model_info1.signature.inputs == Schema([ColSpec(type=AnyType())])
+    assert model_info2.signature.outputs == Schema([ColSpec(type=AnyType())])
+    assert model_info1.signature == model_info2.signature
+    assert model_info1.signature_from_type_hint is True
+    assert model_info2.signature_from_type_hint is True
+
+
+def save_model_file_for_code_based_logging(
+    type_hint, tmp_path, model_type, extra_import="", extra_def=""
+):
+    if model_type == "callable":
+        model_def = f"""
+def predict(model_input: {type_hint}) -> {type_hint}:
+    return model_input
+
+set_model(predict)
+"""
+    elif model_type == "python_model":
+        model_def = f"""
+class TestModel(mlflow.pyfunc.PythonModel):
+    def predict(self, context, model_input: {type_hint}, params=None) -> {type_hint}:
+        return model_input
+
+set_model(TestModel())
+"""
+    file_content = f"""
+import mlflow
+from mlflow.models import set_model
+{extra_import}
+
+{extra_def}
+{model_def}
+"""
+    model_path = tmp_path / "model.py"
+    model_path.write_text(file_content)
+    return {"python_model": model_path}
+
+
+class TypeHintExample(NamedTuple):
+    type_hint: str
+    input_example: Any
+    extra_import: str = ""
+    extra_def: str = ""
+
+
+@pytest.mark.parametrize(
+    "type_hint_example",
+    [
+        TypeHintExample("int", 123),
+        TypeHintExample("str", "string"),
+        TypeHintExample("bool", True),
+        TypeHintExample("float", 1.23),
+        TypeHintExample("bytes", b"bytes"),
+        TypeHintExample("datetime.datetime", datetime.datetime.now(), "import datetime"),
+        TypeHintExample("Any", "any", "from typing import Any"),
+        TypeHintExample("list[str]", ["a", "b"]),
+        TypeHintExample("dict[str, int]", {"a": 1}),
+        TypeHintExample("Union[int, str]", 123, "from typing import Union"),
+        TypeHintExample(
+            "CustomExample2",
+            CustomExample2(
+                custom_field={"a": 1},
+                messages=[Message(role="admin", content="hello")],
+                optional_int=123,
+            ),
+            "import pydantic\nfrom typing import Any, Optional",
+            """
+class Message(pydantic.BaseModel):
+    role: str
+    content: str
+
+
+class CustomExample2(pydantic.BaseModel):
+    custom_field: dict[str, Any]
+    messages: list[Message]
+    optional_int: Optional[int] = None
+""",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("model_type", "has_input_example"),
+    # if python_model is callable, input_example should be provided
+    [("callable", True), ("python_model", True), ("python_model", False)],
+)
+def test_pyfunc_model_with_type_hints_code_based_logging(
+    tmp_path, type_hint_example, model_type, has_input_example
+):
+    kwargs = save_model_file_for_code_based_logging(
+        type_hint_example.type_hint,
+        tmp_path,
+        model_type,
+        type_hint_example.extra_import,
+        type_hint_example.extra_def,
+    )
+    input_example = type_hint_example.input_example
+    if has_input_example:
+        kwargs["input_example"] = input_example
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model("test_model", **kwargs)
+
+    assert model_info.signature_from_type_hint is True
+    assert model_info.signature is not None
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert pyfunc_model.predict(input_example) == input_example
+
+
+def test_functional_python_model_only_input_type_hints():
+    def python_model(x: list[str]):
+        return x
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "model", python_model=python_model, input_example=["a"]
+        )
+    assert model_info.signature.inputs == Schema([ColSpec(type=Array(DataType.string))])
+    assert model_info.signature.outputs is None
+
+
+def test_functional_python_model_only_output_type_hints():
+    def python_model(x) -> list[str]:
+        return x
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "model", python_model=python_model, input_example=["a"]
+        )
+    assert model_info.signature is None
+
+
+class CallableObject:
+    def __call__(self, x: list[str]) -> list[str]:
+        return x
+
+
+def test_functional_python_model_callable_object():
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "model", python_model=CallableObject(), input_example=["a"]
+        )
+    assert model_info.signature.inputs == Schema([ColSpec(type=Array(DataType.string))])
+    assert model_info.signature.outputs == Schema([ColSpec(type=Array(DataType.string))])
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert loaded_model.predict(["a", "b"]) == ["a", "b"]

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -9,7 +9,7 @@ import pytest
 import mlflow
 from mlflow.models.signature import _extract_type_hints
 from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
-from mlflow.types.type_hints import _is_pydantic_type_hint
+from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER, _is_pydantic_type_hint
 
 
 class CustomExample(pydantic.BaseModel):
@@ -178,7 +178,10 @@ def test_pyfunc_model_infer_signature_from_type_hints(
     assert model_info.signature.inputs == expected_schema
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     if _is_pydantic_type_hint(type_hint):
-        assert pyfunc_model.predict(input_example).model_dump() == input_example
+        if PYDANTIC_V1_OR_OLDER:
+            assert pyfunc_model.predict(input_example).dict() == input_example
+        else:
+            assert pyfunc_model.predict(input_example).model_dump() == input_example
     else:
         assert pyfunc_model.predict(input_example) == input_example
 

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -187,8 +187,8 @@ def test_pyfunc_model_infer_signature_from_type_hints_errors():
     def predict(model_input: int) -> int:
         return model_input
 
-    with mock.patch("mlflow.models.signature._logger.warning") as mock_warning:
-        with mlflow.start_run():
+    with mlflow.start_run():
+        with mock.patch("mlflow.models.signature._logger.warning") as mock_warning:
             mlflow.pyfunc.log_model("test_model", python_model=predict, input_example="string")
         assert (
             "Input example is not compatible with the type hint of the `predict` function."
@@ -199,8 +199,8 @@ def test_pyfunc_model_infer_signature_from_type_hints_errors():
         return model_input
 
     output_hints = _extract_type_hints(predict, 0).output
-    with mock.patch("mlflow.models.signature._logger.warning") as mock_warning:
-        with mlflow.start_run():
+    with mlflow.start_run():
+        with mock.patch("mlflow.models.signature._logger.warning") as mock_warning:
             model_info = mlflow.pyfunc.log_model(
                 "test_model", python_model=predict, input_example=123
             )
@@ -375,8 +375,8 @@ def test_invalid_type_hint_in_python_model():
         def predict(self, model_input: list[object], params=None) -> str:
             return model_input[0]
 
-    with mock.patch("mlflow.models.signature.warnings.warn") as mock_warning:
-        with mlflow.start_run():
+    with mlflow.start_run():
+        with mock.patch("mlflow.models.signature.warnings.warn") as mock_warning:
             mlflow.pyfunc.log_model("model", python_model=MyModel())
-        assert mock_warning.call_count == 1
+        mock_warning.assert_called_once()
         assert "Unsupported type hint" in mock_warning.call_args[0][0]

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -374,7 +374,5 @@ def test_invalid_type_hint_in_python_model():
             return model_input[0]
 
     with mlflow.start_run():
-        with mock.patch("mlflow.models.signature.warnings.warn") as mock_warning:
+        with pytest.warns(UserWarning, match=r"Unsupported type hint"):
             mlflow.pyfunc.log_model("model", python_model=MyModel())
-        mock_warning.assert_called_once()
-        assert "Unsupported type hint" in mock_warning.call_args[0][0]

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -175,7 +175,7 @@ def test_pyfunc_model_infer_signature_from_type_hints(
         kwargs["input_example"] = input_example
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model("test_model", **kwargs)
-    assert model_info.signature_from_type_hint is True
+    assert model_info.is_signature_from_type_hint is True
     assert model_info.signature.inputs == expected_schema
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     if _is_pydantic_type_hint(type_hint):
@@ -227,8 +227,8 @@ def test_pyfunc_model_infer_signature_from_type_hints_for_python_3_10():
     assert model_info1.signature.inputs == Schema([ColSpec(type=AnyType())])
     assert model_info2.signature.outputs == Schema([ColSpec(type=AnyType())])
     assert model_info1.signature == model_info2.signature
-    assert model_info1.signature_from_type_hint is True
-    assert model_info2.signature_from_type_hint is True
+    assert model_info1.is_signature_from_type_hint is True
+    assert model_info2.is_signature_from_type_hint is True
 
 
 def save_model_file_for_code_based_logging(
@@ -326,7 +326,7 @@ def test_pyfunc_model_with_type_hints_code_based_logging(
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model("test_model", **kwargs)
 
-    assert model_info.signature_from_type_hint is True
+    assert model_info.is_signature_from_type_hint is True
     assert model_info.signature is not None
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     assert pyfunc_model.predict(input_example) == input_example

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -138,7 +138,13 @@ class CustomExample2(pydantic.BaseModel):
 @pytest.mark.parametrize(
     ("model_type", "has_input_example"),
     # if python_model is callable, input_example should be provided
-    [("callable", True), ("python_model", True), ("python_model", False)],
+    [
+        ("callable", True),
+        ("python_model", True),
+        ("python_model", False),
+        ("python_model_no_context", True),
+        ("python_model_no_context", False),
+    ],
 )
 def test_pyfunc_model_infer_signature_from_type_hints(
     type_hint, expected_schema, input_example, has_input_example, model_type
@@ -154,6 +160,13 @@ def test_pyfunc_model_infer_signature_from_type_hints(
 
         class TestModel(mlflow.pyfunc.PythonModel):
             def predict(self, context, model_input: type_hint, params=None) -> type_hint:
+                return model_input
+
+        kwargs["python_model"] = TestModel()
+    elif model_type == "python_model_no_context":
+
+        class TestModel(mlflow.pyfunc.PythonModel):
+            def predict(self, model_input: type_hint, params=None) -> type_hint:
                 return model_input
 
         kwargs["python_model"] = TestModel()

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -12,7 +12,7 @@ from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, 
 from mlflow.types.type_hints import (
     PYDANTIC_V1_OR_OLDER,
     InvalidTypeHintException,
-    _convert_pandas_dataframe_to_hinted_type,
+    _convert_data_to_type_hint,
     _infer_schema_from_type_hint,
     _validate_example_against_type_hint,
 )
@@ -413,18 +413,14 @@ def test_type_hint_for_python_3_10():
 )
 def test_maybe_convert_data_for_type_hint(data, type_hint, expected_data):
     if isinstance(expected_data, pd.DataFrame):
-        pd.testing.assert_frame_equal(
-            _convert_pandas_dataframe_to_hinted_type(data, type_hint), expected_data
-        )
+        pd.testing.assert_frame_equal(_convert_data_to_type_hint(data, type_hint), expected_data)
     else:
-        assert _convert_pandas_dataframe_to_hinted_type(data, type_hint) == expected_data
+        assert _convert_data_to_type_hint(data, type_hint) == expected_data
 
 
 def test_maybe_convert_data_for_type_hint_errors():
     with mock.patch("mlflow.types.type_hints._logger.warning") as mock_warning:
-        _convert_pandas_dataframe_to_hinted_type(
-            pd.DataFrame({"a": ["x", "y"], "b": ["c", "d"]}), list[str]
-        )
+        _convert_data_to_type_hint(pd.DataFrame({"a": ["x", "y"], "b": ["c", "d"]}), list[str])
         assert mock_warning.call_count == 1
         assert (
             "The data will be converted to a list of the first column."
@@ -435,4 +431,4 @@ def test_maybe_convert_data_for_type_hint_errors():
         MlflowException,
         match=r"Only `list\[...\]` or `Any` type hint supports pandas DataFrame input",
     ):
-        _convert_pandas_dataframe_to_hinted_type(pd.DataFrame([["a", "b"]]), str)
+        _convert_data_to_type_hint(pd.DataFrame([["a", "b"]]), str)

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -12,8 +12,8 @@ from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, 
 from mlflow.types.type_hints import (
     PYDANTIC_V1_OR_OLDER,
     InvalidTypeHintException,
+    _convert_pandas_dataframe_to_hinted_type,
     _infer_schema_from_type_hint,
-    _maybe_convert_data_for_type_hint,
     _validate_example_against_type_hint,
 )
 
@@ -414,15 +414,15 @@ def test_type_hint_for_python_3_10():
 def test_maybe_convert_data_for_type_hint(data, type_hint, expected_data):
     if isinstance(expected_data, pd.DataFrame):
         pd.testing.assert_frame_equal(
-            _maybe_convert_data_for_type_hint(data, type_hint), expected_data
+            _convert_pandas_dataframe_to_hinted_type(data, type_hint), expected_data
         )
     else:
-        assert _maybe_convert_data_for_type_hint(data, type_hint) == expected_data
+        assert _convert_pandas_dataframe_to_hinted_type(data, type_hint) == expected_data
 
 
 def test_maybe_convert_data_for_type_hint_errors():
     with mock.patch("mlflow.types.type_hints._logger.warning") as mock_warning:
-        _maybe_convert_data_for_type_hint(
+        _convert_pandas_dataframe_to_hinted_type(
             pd.DataFrame({"a": ["x", "y"], "b": ["c", "d"]}), list[str]
         )
         assert mock_warning.call_count == 1
@@ -435,4 +435,4 @@ def test_maybe_convert_data_for_type_hint_errors():
         MlflowException,
         match=r"Only `list\[...\]` or `Any` type hint supports pandas DataFrame input",
     ):
-        _maybe_convert_data_for_type_hint(pd.DataFrame([["a", "b"]]), str)
+        _convert_pandas_dataframe_to_hinted_type(pd.DataFrame([["a", "b"]]), str)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14100?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14100/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14100
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
After https://github.com/mlflow/mlflow/pull/14099 is merged, this PR is for applying type hint into pyfunc models.
1. Use the new functions for inferring schemas from type hints and validating data against them
2. Apply decision 3 in 1DD to use signature inferred from type hint when logging the model
3. When pickle fails to save the pyfunc model, update the error message to ask customers try models-from-code
4. ~Remove all the old logics inside `_convert_input` as we no longer convert data to pd.DF when type hint is used~ (We still need to keep them for backwards compatibility)
5. Update _infer_signature_from_type_hints to adapt context change in `predict` function as well

<!-- Please fill in changes proposed in this PR. -->


### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
