### PR TITLE
Enable ruff `UP007` 

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -8,7 +8,7 @@ import textwrap
 import tokenize
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, Union
+from typing import Any, Iterator
 
 from clint import rules
 from clint.builtin import BUILTIN_MODULES
@@ -373,7 +373,7 @@ class Linter(ast.NodeVisitor):
         self.generic_visit(node)
 
     def _check_forbidden_top_level_import(
-        self, node: Union[ast.Import, ast.ImportFrom], module: str
+        self, node: ast.Import | ast.ImportFrom, module: str
     ) -> None:
         for file_pat, libs in self.config.forbidden_top_level_imports.items():
             if fnmatch.fnmatch(str(self.path), file_pat) and module in libs:

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Any
 
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.span import Span, SpanType
@@ -121,7 +121,7 @@ class Trace(_MlflowObject):
             return value
 
     def search_spans(
-        self, span_type: Optional[SpanType] = None, name: Optional[Union[str, re.Pattern]] = None
+        self, span_type: SpanType | None = None, name: str | re.Pattern | None = None
     ) -> list[Span]:
         """
         Search for spans that match the given criteria within the trace.

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -24,7 +24,7 @@ import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Any
 
 import langchain.chains
 from langchain.callbacks.base import BaseCallbackHandler
@@ -106,7 +106,7 @@ class APIRequest:
     did_perform_chat_conversion: bool
     stream: bool
     params: dict[str, Any]
-    prediction_context: Optional[Context] = None
+    prediction_context: Context | None = None
 
     def _predict_single_input(self, single_input, callback_handlers, **kwargs):
         config = kwargs.pop("config", {})
@@ -126,7 +126,7 @@ class APIRequest:
         else:
             return try_transform_response_to_chat_format(response)
 
-    def single_call_api(self, callback_handlers: Optional[list[BaseCallbackHandler]]):
+    def single_call_api(self, callback_handlers: list[BaseCallbackHandler] | None):
         from langchain.schema import BaseRetriever
 
         from mlflow.langchain.utils import langgraph_types, lc_runnables_types
@@ -190,7 +190,7 @@ class APIRequest:
         return convert_to_serializable(response)
 
     def call_api(
-        self, status_tracker: StatusTracker, callback_handlers: Optional[list[BaseCallbackHandler]]
+        self, status_tracker: StatusTracker, callback_handlers: list[BaseCallbackHandler] | None
     ):
         """
         Calls the LangChain API and stores results.
@@ -213,11 +213,11 @@ class APIRequest:
 
 def process_api_requests(
     lc_model,
-    requests: Optional[list[Union[Any, dict[str, Any]]]] = None,
+    requests: list[Any | dict[str, Any]] | None = None,
     max_workers: int = 10,
-    callback_handlers: Optional[list[BaseCallbackHandler]] = None,
+    callback_handlers: list[BaseCallbackHandler] | None = None,
     convert_chat_responses: bool = False,
-    params: Optional[dict[str, Any]] = None,
+    params: dict[str, Any] | None = None,
 ):
     """
     Processes API requests in parallel.
@@ -294,10 +294,10 @@ def process_api_requests(
 
 def process_stream_request(
     lc_model,
-    request_json: Union[Any, dict[str, Any]],
-    callback_handlers: Optional[list[BaseCallbackHandler]] = None,
+    request_json: Any | dict[str, Any],
+    callback_handlers: list[BaseCallbackHandler] | None = None,
     convert_chat_responses: bool = False,
-    params: Optional[dict[str, Any]] = None,
+    params: dict[str, Any] | None = None,
 ):
     """
     Process single stream request.

--- a/mlflow/langchain/retriever_chain.py
+++ b/mlflow/langchain/retriever_chain.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 import yaml
 from langchain.callbacks.manager import AsyncCallbackManagerForChainRun, CallbackManagerForChainRun
@@ -61,7 +61,7 @@ class _RetrieverChain(Chain):
     def _call(
         self,
         inputs: dict[str, Any],
-        run_manager: Optional[CallbackManagerForChainRun] = None,
+        run_manager: CallbackManagerForChainRun | None = None,
     ) -> dict[str, Any]:
         """Run _get_docs on input query.
         Returns the retrieved documents under the key 'source_documents'.
@@ -86,7 +86,7 @@ class _RetrieverChain(Chain):
     async def _acall(
         self,
         inputs: dict[str, Any],
-        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+        run_manager: AsyncCallbackManagerForChainRun | None = None,
     ) -> dict[str, Any]:
         """Run _get_docs on input query.
         Returns the retrieved documents under the key 'source_documents'.
@@ -110,7 +110,7 @@ class _RetrieverChain(Chain):
         return "retriever_chain"
 
     @classmethod
-    def load(cls, file: Union[str, Path], **kwargs: Any) -> _RetrieverChain:
+    def load(cls, file: str | Path, **kwargs: Any) -> _RetrieverChain:
         """Load a _RetrieverChain from a file."""
         # Convert file to Path object.
         file_path = Path(file) if isinstance(file, str) else file

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -4,7 +4,7 @@ import os
 import re
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import cloudpickle
 import yaml
@@ -103,7 +103,7 @@ def _load_model_from_path(path: str, model_config=None):
     raise MlflowException(f"Unsupported model load key {model_load_fn}")
 
 
-def _validate_path(file_path: Union[str, Path]):
+def _validate_path(file_path: str | Path):
     load_path = Path(file_path)
     if not load_path.exists() or not load_path.is_dir():
         raise MlflowException(
@@ -112,7 +112,7 @@ def _validate_path(file_path: Union[str, Path]):
     return load_path
 
 
-def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
+def _load_runnable_with_steps(file_path: Path | str, model_type: str):
     """Load the model
 
     Args:
@@ -162,7 +162,7 @@ def runnable_sequence_from_steps(steps):
     return RunnableSequence(first=first, middle=middle, last=last)
 
 
-def _load_runnable_branch(file_path: Union[Path, str]):
+def _load_runnable_branch(file_path: Path | str):
     """Load the model
 
     Args:
@@ -205,7 +205,7 @@ def _load_runnable_branch(file_path: Union[Path, str]):
     return RunnableBranch(*branches)
 
 
-def _load_runnable_assign(file_path: Union[Path, str]):
+def _load_runnable_assign(file_path: Path | str):
     """Load the model
 
     Args:
@@ -221,7 +221,7 @@ def _load_runnable_assign(file_path: Union[Path, str]):
     return RunnableAssign(mapper)
 
 
-def _load_runnable_binding(file_path: Union[Path, str]):
+def _load_runnable_binding(file_path: Path | str):
     """
     Load runnable binding model from the path
     """
@@ -299,7 +299,7 @@ def _warning_if_imported_from_lc_partner_pkg(runnable):
         )
 
 
-def _save_runnable_with_steps(model, file_path: Union[Path, str], loader_fn=None, persist_dir=None):  # noqa: D417
+def _save_runnable_with_steps(model, file_path: Path | str, loader_fn=None, persist_dir=None):  # noqa: D417
     """Save the model with steps. Currently it supports saving RunnableSequence and
     RunnableParallel.
 

--- a/mlflow/recipes/cards/__init__.py
+++ b/mlflow/recipes/cards/__init__.py
@@ -10,7 +10,6 @@ import random
 import re
 import string
 from io import StringIO
-from typing import Optional, Union
 
 from packaging.version import Version
 
@@ -83,8 +82,8 @@ class CardTab:
         self,
         name: str,
         image_file_path: str,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        width: int | None = None,
+        height: int | None = None,
     ) -> None:
         if not os.path.exists(image_file_path):
             self.add_html(name, "Image Unavailable")
@@ -166,7 +165,7 @@ class BaseCard:
         self._tabs.append((name, tab))
         return tab
 
-    def get_tab(self, name) -> Union[CardTab, None]:
+    def get_tab(self, name) -> CardTab | None:
         """
         Returns an existing tab with the specified name. Returns None if not found.
 

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -6,7 +6,7 @@ import importlib
 import inspect
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Generator, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Generator
 
 from cachetools import TTLCache
 from opentelemetry import trace as trace_api
@@ -55,10 +55,10 @@ TRACE_BUFFER = TTLCache(
 
 
 def trace(
-    func: Optional[Callable] = None,
-    name: Optional[str] = None,
+    func: Callable | None = None,
+    name: str | None = None,
     span_type: str = SpanType.UNKNOWN,
-    attributes: Optional[dict[str, Any]] = None,
+    attributes: dict[str, Any] | None = None,
 ) -> Callable:
     """
     A decorator that creates a new span for the decorated function.
@@ -182,8 +182,8 @@ def trace(
 @contextlib.contextmanager
 def start_span(
     name: str = "span",
-    span_type: Optional[str] = SpanType.UNKNOWN,
-    attributes: Optional[dict[str, Any]] = None,
+    span_type: str | None = SpanType.UNKNOWN,
+    attributes: dict[str, Any] | None = None,
 ) -> Generator[LiveSpan, None, None]:
     """
     Context manager to create a new span and start it as the current span in the context.
@@ -281,7 +281,7 @@ def start_span(
             )
 
 
-def get_trace(request_id: str) -> Optional[Trace]:
+def get_trace(request_id: str) -> Trace | None:
     """
     Get a trace by the given request ID if it exists.
 
@@ -326,12 +326,12 @@ def get_trace(request_id: str) -> Optional[Trace]:
 
 @experimental
 def search_traces(
-    experiment_ids: Optional[list[str]] = None,
-    filter_string: Optional[str] = None,
-    max_results: Optional[int] = None,
-    order_by: Optional[list[str]] = None,
-    extract_fields: Optional[list[str]] = None,
-    run_id: Optional[str] = None,
+    experiment_ids: list[str] | None = None,
+    filter_string: str | None = None,
+    max_results: int | None = None,
+    order_by: list[str] | None = None,
+    extract_fields: list[str] | None = None,
+    run_id: str | None = None,
 ) -> "pandas.DataFrame":
     """
     Return traces that match the given list of search expressions within the experiments.
@@ -473,7 +473,7 @@ def search_traces(
     return traces_df
 
 
-def get_current_active_span() -> Optional[LiveSpan]:
+def get_current_active_span() -> LiveSpan | None:
     """
     Get the current active span in the global context.
 
@@ -512,7 +512,7 @@ def get_current_active_span() -> Optional[LiveSpan]:
     return trace_manager.get_span_from_id(request_id, encode_span_id(otel_span.context.span_id))
 
 
-def get_last_active_trace() -> Optional[Trace]:
+def get_last_active_trace() -> Trace | None:
     """
     Get the last active trace in the same process if exists.
 
@@ -573,7 +573,7 @@ def get_last_active_trace() -> Optional[Trace]:
 
 @experimental
 def update_current_trace(
-    tags: Optional[dict[str, str]] = None,
+    tags: dict[str, str] | None = None,
 ):
     """
     Update the current active trace with the given tags.
@@ -617,7 +617,7 @@ def update_current_trace(
 
 
 @experimental
-def add_trace(trace: Union[Trace, dict[str, Any]], target: Optional[LiveSpan] = None):
+def add_trace(trace: Trace | dict[str, Any], target: LiveSpan | None = None):
     """
     Add a completed trace object into another trace.
 

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -8,7 +8,7 @@ import uuid
 from collections import Counter
 from dataclasses import asdict, is_dataclass
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from opentelemetry import trace as trace_api
 from packaging.version import Version
@@ -176,7 +176,7 @@ def deduplicate_span_names_in_place(spans: list[LiveSpan]):
             span._span._name = f"{span.name}_{count}"
 
 
-def get_otel_attribute(span: trace_api.Span, key: str) -> Optional[str]:
+def get_otel_attribute(span: trace_api.Span, key: str) -> str | None:
     """
     Get the attribute value from the OpenTelemetry span in a decoded format.
 
@@ -205,7 +205,7 @@ def _try_get_prediction_context():
     return get_prediction_context()
 
 
-def maybe_get_request_id(is_evaluate=False) -> Optional[str]:
+def maybe_get_request_id(is_evaluate=False) -> str | None:
     """Get the request ID if the current prediction is as a part of MLflow model evaluation."""
     context = _try_get_prediction_context()
     if not context or (is_evaluate and not context.is_evaluate):
@@ -221,7 +221,7 @@ def maybe_get_request_id(is_evaluate=False) -> Optional[str]:
     return context.request_id
 
 
-def maybe_get_dependencies_schemas() -> Optional[dict]:
+def maybe_get_dependencies_schemas() -> dict | None:
     context = _try_get_prediction_context()
     if context:
         return context.dependencies_schemas

--- a/mlflow/tracing/utils/search.py
+++ b/mlflow/tracing/utils/search.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -29,9 +29,9 @@ def traces_to_df(traces: list[Trace]) -> "pandas.DataFrame":
 
 
 def extract_span_inputs_outputs(
-    traces: Union[list["mlflow.entities.Trace"], "pandas.DataFrame"],
+    traces: list["mlflow.entities.Trace"] | "pandas.DataFrame",
     fields: list[str],
-    col_name: Optional[str] = None,
+    col_name: str | None = None,
 ) -> "pandas.DataFrame":
     """
     Extracts the specified input and output fields from the spans contained in the specified traces.
@@ -113,7 +113,7 @@ class _ParsedField(NamedTuple):
 
     span_name: str
     field_type: Literal["inputs", "outputs"]
-    field_name: Optional[str]
+    field_name: str | None
 
     def __str__(self) -> str:
         return (
@@ -140,7 +140,7 @@ class _FieldParser:
     def has_next(self) -> bool:
         return self.peek() is not None
 
-    def consume_until_char_or_end(self, stop_char: Optional[str] = None) -> str:
+    def consume_until_char_or_end(self, stop_char: str | None = None) -> str:
         """
         Consume characters until the specified character is encountered or the end of the
         string. If char is None, consume until the end of the string.
@@ -253,7 +253,7 @@ def _extract_from_traces_pandas_df(
     return df_with_new_fields
 
 
-def _find_matching_value(field: _ParsedField, spans: list["mlflow.entities.Span"]) -> Optional[Any]:
+def _find_matching_value(field: _ParsedField, spans: list["mlflow.entities.Span"]) -> Any | None:
     """
     Find the value of the field in the list of spans. If the field is not found, return None.
     """
@@ -270,7 +270,7 @@ def _find_matching_value(field: _ParsedField, spans: list["mlflow.entities.Span"
 
 
 def _extract_spans_from_row(
-    row_content: Optional[list[dict[str, Any]]],
+    row_content: list[dict[str, Any]] | None,
 ) -> list["mlflow.entities.Span"]:
     """
     Parses and extracts MLflow Spans from the row content of a traces pandas DataFrame.

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -19,7 +19,7 @@ import string
 import sys
 from collections import namedtuple
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 from urllib.parse import urlparse
 
 import numpy as np
@@ -274,21 +274,21 @@ def save_model(
     transformers_model,
     path: str,
     processor=None,
-    task: Optional[str] = None,
-    torch_dtype: Optional[torch.dtype] = None,
+    task: str | None = None,
+    torch_dtype: torch.dtype | None = None,
     model_card=None,
-    inference_config: Optional[dict[str, Any]] = None,
-    code_paths: Optional[list[str]] = None,
-    mlflow_model: Optional[Model] = None,
-    signature: Optional[ModelSignature] = None,
-    input_example: Optional[ModelInputExample] = None,
-    pip_requirements: Optional[Union[list[str], str]] = None,
-    extra_pip_requirements: Optional[Union[list[str], str]] = None,
+    inference_config: dict[str, Any] | None = None,
+    code_paths: list[str] | None = None,
+    mlflow_model: Model | None = None,
+    signature: ModelSignature | None = None,
+    input_example: ModelInputExample | None = None,
+    pip_requirements: list[str] | str | None = None,
+    extra_pip_requirements: list[str] | str | None = None,
     conda_env=None,
-    metadata: Optional[dict[str, Any]] = None,
-    model_config: Optional[dict[str, Any]] = None,
-    example_no_conversion: Optional[bool] = None,
-    prompt_template: Optional[str] = None,
+    metadata: dict[str, Any] | None = None,
+    model_config: dict[str, Any] | None = None,
+    example_no_conversion: bool | None = None,
+    prompt_template: str | None = None,
     save_pretrained: bool = True,
     **kwargs,  # pylint: disable=unused-argument
 ) -> None:
@@ -794,22 +794,22 @@ def log_model(
     transformers_model,
     artifact_path: str,
     processor=None,
-    task: Optional[str] = None,
-    torch_dtype: Optional[torch.dtype] = None,
+    task: str | None = None,
+    torch_dtype: torch.dtype | None = None,
     model_card=None,
-    inference_config: Optional[dict[str, Any]] = None,
-    code_paths: Optional[list[str]] = None,
-    registered_model_name: Optional[str] = None,
-    signature: Optional[ModelSignature] = None,
-    input_example: Optional[ModelInputExample] = None,
+    inference_config: dict[str, Any] | None = None,
+    code_paths: list[str] | None = None,
+    registered_model_name: str | None = None,
+    signature: ModelSignature | None = None,
+    input_example: ModelInputExample | None = None,
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
-    pip_requirements: Optional[Union[list[str], str]] = None,
-    extra_pip_requirements: Optional[Union[list[str], str]] = None,
+    pip_requirements: list[str] | str | None = None,
+    extra_pip_requirements: list[str] | str | None = None,
     conda_env=None,
-    metadata: Optional[dict[str, Any]] = None,
-    model_config: Optional[dict[str, Any]] = None,
-    example_no_conversion: Optional[bool] = None,
-    prompt_template: Optional[str] = None,
+    metadata: dict[str, Any] | None = None,
+    model_config: dict[str, Any] | None = None,
+    example_no_conversion: bool | None = None,
+    prompt_template: str | None = None,
     save_pretrained: bool = True,
     **kwargs,
 ):
@@ -1051,7 +1051,7 @@ def log_model(
 @experimental
 @docstring_version_compatibility_warning(integration_name=FLAVOR_NAME)
 def load_model(
-    model_uri: str, dst_path: Optional[str] = None, return_type="pipeline", device=None, **kwargs
+    model_uri: str, dst_path: str | None = None, return_type="pipeline", device=None, **kwargs
 ):
     """
     Load a ``transformers`` object from a local file or a run.
@@ -1473,7 +1473,7 @@ def _get_supported_pretrained_model_types():
     return supported_model_types
 
 
-def _build_pipeline_from_model_input(model_dict: dict[str, Any], task: Optional[str]) -> Pipeline:
+def _build_pipeline_from_model_input(model_dict: dict[str, Any], task: str | None) -> Pipeline:
     """
     Utility for generating a pipeline from component parts. If required components are not
     specified, use the transformers library pipeline component validation to force raising an
@@ -1647,7 +1647,7 @@ def _get_model_config(local_path, pyfunc_config):
         return pyfunc_config or {}
 
 
-def _load_pyfunc(path, model_config: Optional[dict[str, Any]] = None):
+def _load_pyfunc(path, model_config: dict[str, Any] | None = None):
     """
     Loads the model as pyfunc model
     """
@@ -1831,7 +1831,7 @@ class _TransformersWrapper:
                 ) from e
             raise
 
-    def predict(self, data, params: Optional[dict[str, Any]] = None):
+    def predict(self, data, params: dict[str, Any] | None = None):
         """
         Args:
             data: Model input data.
@@ -2783,8 +2783,8 @@ class _TransformersWrapper:
         return input_data
 
     def _convert_audio_input(
-        self, data: Union[AudioInput, list[dict[int, list[AudioInput]]]]
-    ) -> Union[AudioInput, list[AudioInput]]:
+        self, data: AudioInput | list[dict[int, list[AudioInput]]]
+    ) -> AudioInput | list[AudioInput]:
         """
         Convert the input data into the format that the Transformers pipeline expects.
 

--- a/mlflow/transformers/flavor_config.py
+++ b/mlflow/transformers/flavor_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import ALREADY_EXISTS, INVALID_PARAMETER_VALUE
@@ -125,8 +125,8 @@ def _get_component_config(
     component: Any,
     key: str,
     save_pretrained: bool = True,
-    default_repo: Optional[str] = None,
-    commit_sha: Optional[str] = None,
+    default_repo: str | None = None,
+    commit_sha: str | None = None,
 ):
     conf = {FlavorKey.COMPONENT_TYPE.format(key): _get_instance_type(component)}
 

--- a/mlflow/transformers/llm_inference_utils.py
+++ b/mlflow/transformers/llm_inference_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 import uuid
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -65,7 +65,7 @@ _LLM_INFERENCE_TASK_TO_DATA_FIELD = {
 
 
 def infer_signature_from_llm_inference_task(
-    inference_task: str, signature: Optional[ModelSignature] = None
+    inference_task: str, signature: ModelSignature | None = None
 ) -> ModelSignature:
     """
     Infers the signature according to the MLflow inference task.
@@ -104,9 +104,9 @@ def convert_messages_to_prompt(messages: list[dict], tokenizer) -> str:
 
 
 def preprocess_llm_inference_input(
-    data: Union[pd.DataFrame, dict],
-    params: Optional[dict[str, Any]] = None,
-    flavor_config: Optional[dict[str, Any]] = None,
+    data: pd.DataFrame | dict,
+    params: dict[str, Any] | None = None,
+    flavor_config: dict[str, Any] | None = None,
 ) -> tuple[list[Any], dict[str, Any]]:
     """
     When a MLflow inference task is given, return updated `data` and `params` that
@@ -162,7 +162,7 @@ def preprocess_llm_inference_input(
     return update_data, params
 
 
-def _get_stopping_criteria(stop: Optional[Union[str, list[str]]], model_name: Optional[str] = None):
+def _get_stopping_criteria(stop: str | list[str] | None, model_name: str | None = None):
     """Return a list of Hugging Face stopping criteria objects for the given stop sequences."""
     from transformers import AutoTokenizer, StoppingCriteria
 
@@ -360,7 +360,7 @@ def _get_finish_reason(total_tokens: int, completion_tokens: int, model_config):
     return finish_reason
 
 
-def _get_default_task_for_llm_inference_task(llm_inference_task: Optional[str]) -> Optional[str]:
+def _get_default_task_for_llm_inference_task(llm_inference_task: str | None) -> str | None:
     """
     Get corresponding original Transformers task for the given LLM inference task.
 
@@ -374,7 +374,7 @@ def _get_default_task_for_llm_inference_task(llm_inference_task: Optional[str]) 
 
 
 def preprocess_llm_embedding_params(
-    data: Union[pd.DataFrame, dict[str, Any]],
+    data: pd.DataFrame | dict[str, Any],
 ) -> tuple[list[str], dict[str, Any]]:
     """
     When `llm/v1/embeddings` task is given, extract the input data (with "input" key) and

--- a/mlflow/transformers/torch_utils.py
+++ b/mlflow/transformers/torch_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 _TORCH_DTYPE_KEY = "torch_dtype"
 
 
-def _extract_torch_dtype_if_set(pipeline) -> Optional[torch.dtype]:
+def _extract_torch_dtype_if_set(pipeline) -> torch.dtype | None:
     """
     Extract the torch datatype argument if set and return as a string encoded value.
     """

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Annotated, Any, Literal, Optional, Union
 
 from pydantic import BaseModel as _BaseModel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ select = [
   "TRY203",  # useless-try-except
   "UP004",   # useless-object-inheritance
   "UP006",   # non-pep585-annotation
+  "UP007",   # non-pep604-annotation
   "UP008",   # super-call-with-parameters
   "UP011",   # lru-cache-without-parameters
   "UP012",   # unecessary-encode-utf8


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14110?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14110/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14110
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Enable [UP007](https://docs.astral.sh/ruff/rules/non-pep604-annotation/) to enforce the following rule in files that has `from __future__ import annotations`:

Good

```python
from __future__ import annotations

from typing import Union

foo: Union[int, str] = 1
```

Bad

```python
from __future__ import annotations

foo: int | str = 1
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
