### PR TITLE
Add `typing-extensions` as a dependency

### DIFF
--- a/dev/clint/src/clint/config.py
+++ b/dev/clint/src/clint/config.py
@@ -10,6 +10,7 @@ class Config:
     exclude: list[str]
     # Path -> List of modules that should not be imported globally under that path
     forbidden_top_level_imports: dict[str, list[str]]
+    typing_extensions_allowlist: list[str]
 
     @classmethod
     def load(cls) -> Config:
@@ -17,4 +18,9 @@ class Config:
             data = tomli.load(f)
             exclude = data["tool"]["clint"]["exclude"]
             forbidden_imports = data["tool"]["clint"]["forbidden-top-level-imports"]
-            return cls(exclude, forbidden_imports)
+            typing_extensions_allowlist = data["tool"]["clint"]["typing-extensions-allowlist"]
+            return cls(
+                exclude,
+                forbidden_imports,
+                typing_extensions_allowlist,
+            )

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -352,36 +352,43 @@ class Linter(ast.NodeVisitor):
         self.stack.pop()
 
     def visit_Import(self, node: ast.Import) -> None:
-        if self._is_in_function():
-            for alias in node.names:
-                if alias.name.split(".", 1)[0] in BUILTIN_MODULES:
-                    self._check(Location.from_node(node), rules.LazyBuiltinImport())
+        for alias in node.names:
+            root_module = alias.name.split(".", 1)[0]
+            if self._is_in_function() and root_module in BUILTIN_MODULES:
+                self._check(Location.from_node(node), rules.LazyBuiltinImport())
 
-                if (
-                    alias.name.split(".", 1)[0] == "typing_extensions"
-                    and alias.name not in rules.TypingExtensions.ALLOWLIST
-                ):
-                    self._check(
-                        Location.from_node(node), rules.TypingExtensions(full_name=alias.name)
-                    )
+            if (
+                alias.name.split(".", 1)[0] == "typing_extensions"
+                and alias.name not in self.config.typing_extensions_allowlist
+            ):
+                self._check(
+                    Location.from_node(node),
+                    rules.TypingExtensions(
+                        full_name=alias.name,
+                        allowlist=self.config.typing_extensions_allowlist,
+                    ),
+                )
 
-        if self._is_at_top_level():
-            for alias in node.names:
-                self._check_forbidden_top_level_import(node, alias.name.split(".", 1)[0])
+            if self._is_at_top_level():
+                self._check_forbidden_top_level_import(node, root_module)
 
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        if self._is_in_function() and node.module.split(".", 1)[0] in BUILTIN_MODULES:
+        root_module = node.module and node.module.split(".", 1)[0]
+        if self._is_in_function() and root_module in BUILTIN_MODULES:
             self._check(Location.from_node(node), rules.LazyBuiltinImport())
 
-        if node.module and node.module.split(".", 1)[0] == "typing_extensions":
+        if root_module == "typing_extensions":
             for alias in node.names:
                 full_name = f"{node.module}.{alias.name}"
-                if full_name not in rules.TypingExtensions.ALLOWLIST:
+                if full_name not in self.config.typing_extensions_allowlist:
                     self._check(
                         Location.from_node(node),
-                        rules.TypingExtensions(full_name=full_name),
+                        rules.TypingExtensions(
+                            full_name=full_name,
+                            allowlist=self.config.typing_extensions_allowlist,
+                        ),
                     )
 
         if self._is_at_top_level():

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -305,20 +305,17 @@ class IncorrectTypeAnnotation(Rule):
 
 
 class TypingExtensions(Rule):
-    ALLOWLIST = [
-        # Reference: https://typing-extensions.readthedocs.io/en/latest/
-        "typing_extensions.Self",  # added in 4.0.0
-    ]
-
-    def __init__(self, full_name: str) -> None:
+    def __init__(self, *, full_name: str, allowlist: list[str]) -> None:
         self.full_name = full_name
+        self.allowlist = allowlist
 
     def _id(self) -> str:
         return "MLF0017"
 
     def _message(self) -> str:
         return (
-            f"`{self.full_name}` is not allowed to use. Only {self.ALLOWLIST} are allowed. "
-            "You can extend the allowlist if needed but please make sure that the version "
-            "requirement for `typing-extensions` in pyproject.toml covers the added types."
+            f"`{self.full_name}` is not allowed to use. Only {self.allowlist} are allowed. "
+            "You can extend `tool.clint.typing-extensions-allowlist` in `pyproject.toml` if needed "
+            "but make sure that the version requirement for `typing-extensions` is compatible with "
+            "the added types."
         )

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -302,3 +302,23 @@ class IncorrectTypeAnnotation(Rule):
         raise ValueError(
             f"Unexpected type: {self.type_hint}. It must be one of {list(self.MAPPING)}."
         )
+
+
+class TypingExtensions(Rule):
+    ALLOWLIST = [
+        # Reference: https://typing-extensions.readthedocs.io/en/latest/
+        "typing_extensions.Self",  # added in 4.0.0
+    ]
+
+    def __init__(self, full_name: str) -> None:
+        self.full_name = full_name
+
+    def _id(self) -> str:
+        return "MLF0017"
+
+    def _message(self) -> str:
+        return (
+            f"`{self.full_name}` is not allowed to use. Only {self.ALLOWLIST} are allowed. "
+            "You can extend the allowlist if needed but please make sure that the version "
+            "requirement for `typing-extensions` in pyproject.toml covers the added types."
+        )

--- a/mlflow/data/code_dataset_source.py
+++ b/mlflow/data/code_dataset_source.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from typing_extensions import Self
+
 from mlflow.data.dataset_source import DatasetSource
 
 
@@ -25,14 +27,14 @@ class CodeDatasetSource(DatasetSource):
         return False
 
     @classmethod
-    def _resolve(cls, raw_source: str) -> "CodeDatasetSource":
+    def _resolve(cls, raw_source: str) -> Self:
         raise NotImplementedError
 
     def to_dict(self) -> dict[Any, Any]:
         return {"tags": self._tags}
 
     @classmethod
-    def from_dict(cls, source_dict: dict[Any, Any]) -> "CodeDatasetSource":
+    def from_dict(cls, source_dict: dict[Any, Any]) -> Self:
         return cls(
             tags=source_dict.get("tags"),
         )

--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -36,6 +36,7 @@ dependencies = [
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",
   "sqlparse<1,>=0.4.0",
+  "typing-extensions<5,>=4.0.0",
 ]
 [[project.maintainers]]
 name = "Databricks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   "scipy<2",
   "sqlalchemy<3,>=1.4.0",
   "sqlparse<1,>=0.4.0",
+  "typing-extensions<5,>=4.0.0",
   "waitress<4; platform_system == 'Windows'",
 ]
 [[project.maintainers]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,6 +271,10 @@ exclude = [
   "mlflow/store/db_migrations",
   "tests/protos",
 ]
+typing-extensions-allowlist = [
+  # Docs: https://typing-extensions.readthedocs.io/en/latest/
+  "typing_extensions.Self", # Added in 4.0.0
+]
 
 [tool.clint.forbidden-top-level-imports]
 "mlflow/gateway/providers/*" = ["fastapi", "starlette"]

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -16,3 +16,4 @@ opentelemetry-api<3,>=1.9.0
 opentelemetry-sdk<3,>=1.9.0
 databricks-sdk<1,>=0.20.0
 pydantic<3,>=1.0
+typing-extensions<5,>=4.0.0

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -79,3 +79,8 @@ pydantic:
   pip_release: pydantic
   minimum: "1.0"
   max_major_version: 2
+
+typing-extensions:
+  pip_release: typing-extensions
+  minimum: "4.0.0"
+  max_major_version: 4


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14112?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14112/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14112
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR adds `typing-extentions` as a mlflow dependency, which allows us to use type annotations only available in newer python versions ([`Self`](https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.Self) is a good example). One risk of relying on `typing_extensions` is `ImportError`. See the following example:

```python
from typing_extensions import SomeType # only exists in the latest version of `typing_extensions`.
```

This PR also adds a guardrail to prevent this.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
