### PR TITLE
Fix hard-dependency to langchain package in autologging

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -12,7 +12,6 @@ LangChain (native) format
     https://python.langchain.com/en/latest/index.html
 """
 
-import contextlib
 import functools
 import importlib
 import inspect
@@ -934,7 +933,7 @@ def _inspect_module_and_patch_cls(module_name, inspected_modules, patched_classe
     Internal method to inspect the module and patch classes that are
     subclasses of Runnable for autologging.
     """
-    from langchain.schema.runnable import Runnable
+    from langchain_core.runnables import Runnable
 
     if module_name not in inspected_modules:
         inspected_modules.add(module_name)
@@ -952,8 +951,8 @@ def _inspect_module_and_patch_cls(module_name, inspected_modules, patched_classe
                 ):
                     _patch_runnable_cls(obj)
                     patched_classes.add(obj.__name__)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to patch module {module_name}. Error: {e}", exc_info=True)
 
 
 @experimental
@@ -1017,71 +1016,78 @@ def autolog(
             MlflowLangchainTracer as a callback during inference. If ``False``, no traces are
             collected during inference. Default to ``True``.
     """
-    with contextlib.suppress(ImportError):
-        from mlflow.langchain._langchain_autolog import patched_inference
+    from mlflow.langchain._langchain_autolog import patched_inference
 
-        # avoid duplicate patching
-        patched_classes = set()
-        # avoid infinite recursion
-        inspected_modules = set()
+    # avoid duplicate patching
+    patched_classes = set()
+    # avoid infinite recursion
+    inspected_modules = set()
 
-        # Get all installed LangChain packages
-        for pkg in importlib.metadata.distributions():
-            if pkg.metadata["Name"].startswith("langchain"):
-                module_name = pkg.metadata["Name"].replace("-", "_")
-                _inspect_module_and_patch_cls(module_name, inspected_modules, patched_classes)
+    # Get all installed LangChain packages
+    for pkg in importlib.metadata.distributions():
+        if pkg.metadata["Name"].startswith("langchain"):
+            module_name = pkg.metadata["Name"].replace("-", "_")
+            _inspect_module_and_patch_cls(module_name, inspected_modules, patched_classes)
 
-            # If LangGraph is installed, patch the classes. LangGraph does not define members
-            # under the top level module, so we need to hardcode the submodules to patch.
-            if pkg.metadata["Name"] == "langgraph":
-                langgraph_submodules = [
-                    "langgraph.graph",
-                    "langgraph.prebuilt",
-                    "langgraph.pregel",
-                ]
-                for submodule in langgraph_submodules:
-                    _inspect_module_and_patch_cls(submodule, inspected_modules, patched_classes)
+        # If LangGraph is installed, patch the classes. LangGraph does not define members
+        # under the top level module, so we need to hardcode the submodules to patch.
+        if pkg.metadata["Name"] == "langgraph":
+            langgraph_submodules = [
+                "langgraph.graph",
+                "langgraph.prebuilt",
+                "langgraph.pregel",
+            ]
+            for submodule in langgraph_submodules:
+                _inspect_module_and_patch_cls(submodule, inspected_modules, patched_classes)
 
-        if extra_model_classes:
-            from langchain_core.runnables import Runnable
+    if extra_model_classes:
+        from langchain_core.runnables import Runnable
 
-            unsupported_classes = []
-            for cls in extra_model_classes:
-                if cls.__name__ in patched_classes:
-                    continue
-                elif inspect.isclass(cls) and issubclass(cls, Runnable):
-                    _patch_runnable_cls(cls)
-                    patched_classes.add(cls.__name__)
-                else:
-                    unsupported_classes.append(cls.__name__)
-            if unsupported_classes:
-                logger.warning(
-                    f"Unsupported classes found in extra_model_classes: {unsupported_classes}. "
-                    "Only subclasses of Runnable are supported."
-                )
+        unsupported_classes = []
+        for cls in extra_model_classes:
+            if cls.__name__ in patched_classes:
+                continue
+            elif inspect.isclass(cls) and issubclass(cls, Runnable):
+                _patch_runnable_cls(cls)
+                patched_classes.add(cls.__name__)
+            else:
+                unsupported_classes.append(cls.__name__)
+        if unsupported_classes:
+            logger.warning(
+                f"Unsupported classes found in extra_model_classes: {unsupported_classes}. "
+                "Only subclasses of Runnable are supported."
+            )
 
-        try:
-            from langchain.agents.agent import AgentExecutor
-            from langchain.chains.base import Chain
+    try:
+        from langchain.agents.agent import AgentExecutor
+        from langchain.chains.base import Chain
 
-            for cls in [AgentExecutor, Chain]:
-                safe_patch(
-                    FLAVOR_NAME,
-                    cls,
-                    "__call__",
-                    functools.partial(patched_inference, "__call__"),
-                )
-        except ImportError:
-            pass
-
-        try:
-            from langchain_core.retrievers import BaseRetriever
-
+        for cls in [AgentExecutor, Chain]:
             safe_patch(
                 FLAVOR_NAME,
-                BaseRetriever,
-                "get_relevant_documents",
-                functools.partial(patched_inference, "get_relevant_documents"),
+                cls,
+                "__call__",
+                functools.partial(patched_inference, "__call__"),
             )
-        except ImportError:
-            pass
+    except ImportError:
+        logger.debug(
+            "AgentExecutor and Chain are not available in the current environment."
+            "Skipping patching for __call__ method.",
+            exc_info=True,
+        )
+
+    try:
+        from langchain_core.retrievers import BaseRetriever
+
+        safe_patch(
+            FLAVOR_NAME,
+            BaseRetriever,
+            "get_relevant_documents",
+            functools.partial(patched_inference, "get_relevant_documents"),
+        )
+    except ImportError:
+        logger.debug(
+            "BaseRetriever is not available in the current environment."
+            "Skipping patching for get_relevant_documents method.",
+            exc_info=True,
+        )

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -168,7 +168,7 @@ def _get_runnable_config_with_callback(
         original_config: the original RunnableConfig passed by the user
         new_callback: a new callback to be injected
     """
-    from langchain.schema.runnable.config import RunnableConfig
+    from langchain_core.runnables.config import RunnableConfig
 
     if original_config is None:
         _logger.debug("Injected MLflow callbacks into the model call args.")

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -3,9 +3,8 @@ import logging
 from typing import Any, Optional, Sequence, Union
 from uuid import UUID
 
-from langchain.callbacks.base import BaseCallbackHandler
-from langchain.schema.runnable import RunnableSequence
 from langchain_core.agents import AgentAction, AgentFinish
+from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.documents import Document
 from langchain_core.load.dump import dumps
 from langchain_core.messages import BaseMessage
@@ -14,6 +13,7 @@ from langchain_core.outputs import (
     GenerationChunk,
     LLMResult,
 )
+from langchain_core.runnables import RunnableSequence
 from tenacity import RetryCallState
 
 import mlflow

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -514,9 +514,10 @@ def autologging_is_disabled(integration_name):
 
     if (
         integration_name in FLAVOR_TO_MODULE_NAME
+        and get_autologging_config(integration_name, "disable_for_unsupported_versions", False)
         and not is_flavor_supported_for_associated_package_versions(integration_name)
     ):
-        return get_autologging_config(integration_name, "disable_for_unsupported_versions", False)
+        return True
 
     return False
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14125?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14125/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14125
```

</p>
</details>

### What changes are proposed in this pull request?

LangChain autologging logic hard depends on `langchain` package because of some legacy import statement. With their current directory structure, all basic interfaces are moved to `langchain-core` and `langchain` package only contains higher abstractions like `AgentExecutor`. Some users prefers to install the core only to avoid unnecessary dependency, especially in production environment, hence autolog (tracing) should work without `langchain` package.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
%pip list | grep langchain

langchain-core                     0.3.25
langchain-openai                   0.2.12
langchain-text-splitters           0.3.3
```
```
model.invoke("Hi")
```
<img width="1469" alt="Screenshot 2024-12-19 at 14 39 26" src="https://github.com/user-attachments/assets/e22a5f45-8357-4205-b867-9981377bb779" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Remove `langchain` from required dependency to enable LangChain auto tracing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
