### PR TITLE
disable recipe-windows test

### DIFF
--- a/.github/workflows/recipe.yml
+++ b/.github/workflows/recipe.yml
@@ -51,44 +51,45 @@ jobs:
         run: |
           pytest tests/recipes
 
-  recipes-windows:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: windows-latest
-    timeout-minutes: 120
-    permissions: {}
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [1, 2]
-        include:
-          - splits: 2
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: ./.github/actions/untracked
-      - uses: ./.github/actions/setup-python
-      - uses: ./.github/actions/setup-pyenv
-      - name: Install python dependencies
-        run: |
-          pip install -r requirements/test-requirements.txt
-          pip install --no-dependencies tests/resources/mlflow-test-plugin
-          pip install .
-          # TODO: Importing datasets in a pandas UDF (created by mlflow.pyfunc.spark_udf) crashes
-          # the Python worker. To avoid this, uninstall `datasets`. This is a temporary workaround.
-          pip uninstall -y datasets
-          pip install 'numpy<2.0'
-      - name: Download Hadoop winutils for Spark
-        run: |
-          git clone https://github.com/cdarlint/winutils /tmp/winutils
-      - name: Run tests
-        env:
-          # The default pooling implmentation 'QueuePool' can lead to errors on Windows when
-          # multiple threads access the same SQLite database file simultaneously.
-          MLFLOW_SQLALCHEMYSTORE_POOLCLASS: "NullPool"
-        run: |
-          # Set Hadoop environment variables required for testing Spark integrations on Windows
-          export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
-          export PATH=$PATH:$HADOOP_HOME/bin
-          export MLFLOW_HOME=$(pwd)
-          pytest --splits ${{ matrix.splits }} --group ${{ matrix.group }} tests/recipes
+  # NB: Disable due to the flakiness of the tests which caused many false alerts in PRs.
+  #     We don't make many changes to the Recipe feature so the normal `recipes` job should be sufficient.
+  # recipes-windows:
+  #   if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+  #   runs-on: windows-latest
+  #   permissions: {}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       group: [1, 2]
+  #       include:
+  #         - splits: 2
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #     - uses: ./.github/actions/untracked
+  #     - uses: ./.github/actions/setup-python
+  #     - uses: ./.github/actions/setup-pyenv
+  #     - name: Install python dependencies
+  #       run: |
+  #         pip install -r requirements/test-requirements.txt
+  #         pip install --no-dependencies tests/resources/mlflow-test-plugin
+  #         pip install .
+  #         # TODO: Importing datasets in a pandas UDF (created by mlflow.pyfunc.spark_udf) crashes
+  #         # the Python worker. To avoid this, uninstall `datasets`. This is a temporary workaround.
+  #         pip uninstall -y datasets
+  #         pip install 'numpy<2.0'
+  #     - name: Download Hadoop winutils for Spark
+  #       run: |
+  #         git clone https://github.com/cdarlint/winutils /tmp/winutils
+  #     - name: Run tests
+  #       env:
+  #         # The default pooling implmentation 'QueuePool' can lead to errors on Windows when
+  #         # multiple threads access the same SQLite database file simultaneously.
+  #         MLFLOW_SQLALCHEMYSTORE_POOLCLASS: "NullPool"
+  #       run: |
+  #         # Set Hadoop environment variables required for testing Spark integrations on Windows
+  #         export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
+  #         export PATH=$PATH:$HADOOP_HOME/bin
+  #         export MLFLOW_HOME=$(pwd)
+  #         pytest --splits ${{ matrix.splits }} --group ${{ matrix.group }} tests/recipes


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14126?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14126/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14126
```

</p>
</details>

### What changes are proposed in this pull request?

The `recipe-windows` test has been flaky and caused many non-actionable failures on PRs (indeed IIRC they were always false alerts).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
