### PR TITLE
Replace `harupy/auto-labeling` with `actions/github-script`

### DIFF
--- a/.github/workflows/labeling.js
+++ b/.github/workflows/labeling.js
@@ -1,0 +1,73 @@
+module.exports = async ({ github, context }) => {
+  const { owner, repo } = context.repo;
+  const { body, number: issue_number } = context.payload.issue || context.payload.pull_request;
+  const pattern = /- \[(.*?)\]\s*`(.+?)`/g;
+  // Labels extracted from the issue/PR body
+  const bodyLabels = [];
+  let match;
+  while ((match = pattern.exec(body)) !== null) {
+    bodyLabels.push({ checked: match[1].trim().toLowerCase() === "x", name: match[2].trim() });
+  }
+
+  const events = await github.paginate(github.rest.issues.listEvents, {
+    owner,
+    repo,
+    issue_number,
+  });
+  // Labels added or removed by a user
+  const userLabels = events
+    .filter(({ event, actor }) => ["labeled", "unlabeled"].includes(event) && actor.type === "User")
+    .map(({ label }) => label.name);
+
+  // Labels available in the repository
+  const repoLabels = (
+    await github.paginate(github.rest.issues.listLabelsForRepo, {
+      owner,
+      repo,
+    })
+  ).map(({ name }) => name);
+
+  // Exclude labels that are not available in the repository or have been added/removed by a user
+  const labels = bodyLabels.filter(
+    ({ name }) => repoLabels.includes(name) && !userLabels.includes(name)
+  );
+
+  const existingLabels = (
+    await github.paginate(
+      github.rest.issues.listLabelsOnIssue({
+        owner,
+        repo,
+        issue_number,
+      })
+    )
+  ).map(({ name }) => name);
+
+  const labelsToAdd = labels
+    .filter(({ name, checked }) => checked && !existingLabels.includes(name))
+    .map(({ name }) => name);
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number,
+    labels: labelsToAdd,
+  });
+
+  const labelsToRemove = labels
+    .filter(({ name, checked }) => !checked && existingLabels.includes(name))
+    .map(({ name }) => name);
+  const results = await Promise.allSettled(
+    labelsToRemove.map((name) =>
+      github.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number,
+        name,
+      })
+    )
+  );
+  for (const { status, reason } of results) {
+    if (status === "rejected") {
+      console.error(reason);
+    }
+  }
+};

--- a/.github/workflows/labeling.js
+++ b/.github/workflows/labeling.js
@@ -44,6 +44,7 @@ module.exports = async ({ github, context }) => {
       })
     )
   ).map(({ name }) => name);
+  console.log("Existing labels:", existingLabels);
 
   const labelsToAdd = labels
     .filter(({ name, checked }) => checked && !existingLabels.includes(name))

--- a/.github/workflows/labeling.js
+++ b/.github/workflows/labeling.js
@@ -36,13 +36,11 @@ module.exports = async ({ github, context }) => {
   console.log("Labels to add/remove:", labels);
 
   const existingLabels = (
-    await github.paginate(
-      github.rest.issues.listLabelsOnIssue({
-        owner,
-        repo,
-        issue_number,
-      })
-    )
+    await github.paginate(github.rest.issues.listLabelsOnIssue, {
+      owner,
+      repo,
+      issue_number,
+    })
   ).map(({ name }) => name);
   console.log("Existing labels:", existingLabels);
 

--- a/.github/workflows/labeling.js
+++ b/.github/workflows/labeling.js
@@ -48,30 +48,34 @@ module.exports = async ({ github, context }) => {
     .filter(({ name, checked }) => checked && !existingLabels.includes(name))
     .map(({ name }) => name);
   console.log("Labels to add:", labelsToAdd);
-  await github.rest.issues.addLabels({
-    owner,
-    repo,
-    issue_number,
-    labels: labelsToAdd,
-  });
+  if (labelsToAdd.length > 0) {
+    await github.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number,
+      labels: labelsToAdd,
+    });
+  }
 
   const labelsToRemove = labels
     .filter(({ name, checked }) => !checked && existingLabels.includes(name))
     .map(({ name }) => name);
   console.log("Labels to remove:", labelsToRemove);
-  const results = await Promise.allSettled(
-    labelsToRemove.map((name) =>
-      github.rest.issues.removeLabel({
-        owner,
-        repo,
-        issue_number,
-        name,
-      })
-    )
-  );
-  for (const { status, reason } of results) {
-    if (status === "rejected") {
-      console.error(reason);
+  if (labelsToRemove.length > 0) {
+    const results = await Promise.allSettled(
+      labelsToRemove.map((name) =>
+        github.rest.issues.removeLabel({
+          owner,
+          repo,
+          issue_number,
+          name,
+        })
+      )
+    );
+    for (const { status, reason } of results) {
+      if (status === "rejected") {
+        console.error(reason);
+      }
     }
   }
 };

--- a/.github/workflows/labeling.js
+++ b/.github/workflows/labeling.js
@@ -45,6 +45,7 @@ module.exports = async ({ github, context }) => {
   const labelsToAdd = labels
     .filter(({ name, checked }) => checked && !existingLabels.includes(name))
     .map(({ name }) => name);
+  console.log("Labels to add:", labelsToAdd);
   await github.rest.issues.addLabels({
     owner,
     repo,
@@ -55,6 +56,7 @@ module.exports = async ({ github, context }) => {
   const labelsToRemove = labels
     .filter(({ name, checked }) => !checked && existingLabels.includes(name))
     .map(({ name }) => name);
+  console.log("Labels to remove:", labelsToRemove);
   const results = await Promise.allSettled(
     labelsToRemove.map((name) =>
       github.rest.issues.removeLabel({

--- a/.github/workflows/labeling.js
+++ b/.github/workflows/labeling.js
@@ -8,6 +8,7 @@ module.exports = async ({ github, context }) => {
   while ((match = pattern.exec(body)) !== null) {
     bodyLabels.push({ checked: match[1].trim().toLowerCase() === "x", name: match[2].trim() });
   }
+  console.log("Body labels:", bodyLabels);
 
   const events = await github.paginate(github.rest.issues.listEvents, {
     owner,
@@ -18,6 +19,7 @@ module.exports = async ({ github, context }) => {
   const userLabels = events
     .filter(({ event, actor }) => ["labeled", "unlabeled"].includes(event) && actor.type === "User")
     .map(({ label }) => label.name);
+  console.log("User labels:", userLabels);
 
   // Labels available in the repository
   const repoLabels = (
@@ -31,6 +33,7 @@ module.exports = async ({ github, context }) => {
   const labels = bodyLabels.filter(
     ({ name }) => repoLabels.includes(name) && !userLabels.includes(name)
   );
+  console.log("Labels to add/remove:", labels);
 
   const existingLabels = (
     await github.paginate(

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -30,5 +30,5 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const script = require('./.github/workflows/protect.js');
+            const script = require('./.github/workflows/labeling.js');
             await script({ github, context });

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
       - edited
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -19,14 +19,16 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write # harupy/auto-labeling
-      issues: write # harupy/auto-labeling
-    timeout-minutes: 120
+      pull-requests: write
+      issues: write
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
-      - uses: harupy/auto-labeling@master
+          sparse-checkout: |
+            .github
+      - uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          label-pattern: '- \[(.*?)\] ?`(.+?)`'
+          script: |
+            const script = require('./.github/workflows/protect.js');
+            await script({ github, context });

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
       - edited
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14128?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14128/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14128
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR replaces `harupy/auto-labeling` with `actions/github-script`. Relying on an external action is a security concern. It might allow attackers to attack mlflow. To mitigate that risk, use `actions/github-script` with a small JS script.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
