### PR TITLE
Pyfunc data validation in predict

### DIFF
--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -24,6 +24,8 @@ class DspyModelWrapper(PythonModel):
             used at serving time.
     """
 
+    _skip_wrapping_predict = True
+
     def __init__(
         self,
         model: "dspy.Module",

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -395,11 +395,11 @@ def _infer_signature_from_type_hints(
     if type_hints.input is None:
         return None
 
-    _pyfunc_decorator_not_used = getattr(func, "_is_pyfunc", None) is not True
-    if _pyfunc_decorator_not_used:
+    _pyfunc_decorator_used = getattr(func, "_is_pyfunc", False)
+    if not _pyfunc_decorator_used:
         # stacklevel is 3 because we have a decorator
         warnings.warn(
-            "Decorate your callable with `@mlflow.pyfunc.utils.pyfunc` to enable auto "
+            "Decorate your function with `@mlflow.pyfunc.utils.pyfunc` to enable auto "
             "data validation against model input type hints.",
             stacklevel=3,
         )
@@ -434,8 +434,8 @@ def _infer_signature_from_type_hints(
 
     if input_example is not None:
         # only validate input example here if pyfunc decorator is not used
-        # otherwise func will validate the input
-        if _pyfunc_decorator_not_used and (
+        # because when the decorator is used, the input is validated in the predict function
+        if not _pyfunc_decorator_used and (
             msg := _get_example_validation_result(
                 example=input_example, type_hint=type_hints.input
             ).error_message

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2981,12 +2981,12 @@ def save_model(
                 )
         elif isinstance(python_model, PythonModel):
             saved_example = _save_example(mlflow_model, input_example, path, example_no_conversion)
-            type_hints = python_model._get_type_hints()
+            type_hints = python_model.predict_type_hints
             infer_signature_from_type_hints = _should_infer_signature_from_type_hints(type_hints)
             if infer_signature_from_type_hints:
                 signature_from_type_hints = _infer_signature_from_type_hints(
                     func=python_model.predict,
-                    type_hints=python_model._get_type_hints(),
+                    type_hints=python_model.predict_type_hints,
                     input_example=input_example,
                 )
             # only infer signature based on input example when signature

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -803,15 +803,8 @@ class PyFuncModel:
         self.params_schema = self.metadata.get_params_schema()
         # signature can only be inferred from type hints if the model is PythonModel
         if self.metadata._is_signature_from_type_hint():
-            from mlflow.types.type_hints import (
-                _convert_data_to_type_hint,
-                _validate_example_against_type_hint,
-            )
-
-            type_hints = self._model_impl.python_model._get_type_hints()
-            data = _convert_data_to_type_hint(data, type_hints.input)
-            # TODO: remove the validation here once we move the logic inside PythonModel
-            data = _validate_example_against_type_hint(data, type_hints.input)
+            # we don't need to validate on data as data validation
+            # will be done during PythonModel's predict call
             params = _enforce_params_schema(params, self.params_schema)
         else:
             data, params = _validate_prediction_input(

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -200,7 +200,7 @@ class _FunctionPythonModel(PythonModel):
     def __init__(self, func, signature=None):
         self.signature = signature
         # only wrap `func` if @pyfunc is not already applied
-        if getattr(func, "_is_pyfunc", False):
+        if not getattr(func, "_is_pyfunc", False):
             self.func = pyfunc(func)
         else:
             self.func = func

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -148,10 +148,10 @@ class PythonModel:
         # NB: subclasses of PythonModel in MLflow that has customized predict method
         # should set _skip_wrapping_predict = True to skip this wrapping
         if not getattr(cls, "_skip_wrapping_predict", False):
-            for attr_name, attr_value in cls.__dict__.items():
-                if attr_name == "predict" and callable(attr_value):
-                    type_hint = _get_type_hint_if_supported(attr_value)
-                    setattr(cls, attr_name, _wrap_predict_with_pyfunc(attr_value, type_hint))
+            predict_attr = cls.__dict__.get("predict")
+            if predict_attr is not None and callable(predict_attr):
+                type_hint = _get_type_hint_if_supported(predict_attr)
+                setattr(cls, "predict", _wrap_predict_with_pyfunc(predict_attr, type_hint))
 
     @abstractmethod
     def predict(self, context, model_input, params: Optional[dict[str, Any]] = None):

--- a/mlflow/pyfunc/utils/__init__.py
+++ b/mlflow/pyfunc/utils/__init__.py
@@ -1,0 +1,3 @@
+from mlflow.pyfunc.utils.data_validation import pyfunc
+
+__all__ = ["pyfunc"]

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -2,7 +2,11 @@ import warnings
 from functools import lru_cache, wraps
 from typing import Any, Optional
 
-from mlflow.models.signature import _extract_type_hints, _is_context_in_predict_function_signature
+from mlflow.models.signature import (
+    _extract_type_hints,
+    _is_context_in_predict_function_signature,
+    _TypeHints,
+)
 from mlflow.types.type_hints import (
     _convert_data_to_type_hint,
     _infer_schema_from_type_hint,
@@ -42,7 +46,7 @@ def pyfunc(func):
 
 
 @lru_cache(maxsize=1)
-def _get_type_hints(func):
+def _get_type_hints(func) -> _TypeHints:
     """
     Internal method to get type hints from the predict function signature.
     For PythonModel, the signature must be one of below:

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -1,0 +1,95 @@
+import warnings
+from functools import lru_cache, wraps
+
+from mlflow.models.signature import _extract_type_hints, _is_context_in_predict_function_signature
+from mlflow.types.type_hints import (
+    _convert_data_to_type_hint,
+    _infer_schema_from_type_hint,
+    _validate_example_against_type_hint,
+)
+from mlflow.utils.annotations import filter_user_warnings_once
+
+
+def pyfunc(func):
+    """
+    A decorator that forces data validation against type hint of the input data
+    in the wrapped method. It is no-op if the type hint is not supported by MLflow.
+
+    .. note::
+        The function that applies this decorator must be a valid `predict` function
+        of `mlflow.pyfunc.PythonModel`, or a callable that takes a single input.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if type_hint := _predict_type_hint_check(func):
+            args, kwargs = _validate_model_input(func, args, kwargs, type_hint)
+        return func(*args, **kwargs)
+
+    wrapper._is_pyfunc = True
+
+    return wrapper
+
+
+@lru_cache(maxsize=1)
+def _get_type_hints(func):
+    """
+    Internal method to get type hints from the predict function signature.
+    For PythonModel, the signature must be one of below:
+        - predict(self, context, model_input, params=None)
+        - predict(self, model_input, params=None)
+    For callables, the function must contain only one input argument.
+
+    Args:
+        func: the predict function. Default is None, which means self.predict will be used.
+    """
+    if _is_context_in_predict_function_signature(func=func):
+        return _extract_type_hints(func, input_arg_index=1)
+    else:
+        return _extract_type_hints(func, input_arg_index=0)
+
+
+@lru_cache
+@filter_user_warnings_once
+def _predict_type_hint_check(func):
+    """
+    Internal method to check if the predict function has type hints and if they are supported
+    by MLflow.
+    """
+    type_hint = _get_type_hints(func).input
+    if type_hint:
+        try:
+            _infer_schema_from_type_hint(type_hint)
+        except Exception as e:
+            warnings.warn(
+                "Type hint used in the model's predict function is not supported "
+                f"by MLflow, we cannot validate the input data. Error: {e}",
+                stacklevel=3,
+            )
+        else:
+            return type_hint
+
+
+def _validate_model_input(func, args, kwargs, type_hint):
+    model_input = None
+    input_pos = None
+    if "model_input" in kwargs:
+        model_input = kwargs["model_input"]
+        input_pos = "kwargs"
+    if _is_context_in_predict_function_signature(func=func):
+        if len(args) >= 2:
+            model_input = args[1]
+            input_pos = 1
+    elif len(args) >= 1:
+        model_input = args[0]
+        input_pos = 0
+    if model_input is not None:
+        data = _convert_data_to_type_hint(model_input, type_hint)
+        data = _validate_example_against_type_hint(data, type_hint)
+        if input_pos == "kwargs":
+            kwargs["model_input"] = data
+        elif input_pos == 1:
+            args = args[:1] + (data,) + args[2:]
+        elif input_pos == 0:
+            args = (data,) + args[1:]
+    return args, kwargs

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -5,6 +5,7 @@ from mlflow.models.signature import _extract_type_hints, _is_context_in_predict_
 from mlflow.types.type_hints import (
     _convert_data_to_type_hint,
     _infer_schema_from_type_hint,
+    _signature_cannot_be_inferred_from_type_hint,
     _validate_example_against_type_hint,
 )
 from mlflow.utils.annotations import filter_user_warnings_once
@@ -58,6 +59,8 @@ def _predict_type_hint_check(func):
     """
     type_hint = _get_type_hints(func).input
     if type_hint:
+        if _signature_cannot_be_inferred_from_type_hint(type_hint):
+            return
         try:
             _infer_schema_from_type_hint(type_hint)
         except Exception as e:

--- a/mlflow/recipes/utils/wrapped_recipe_model.py
+++ b/mlflow/recipes/utils/wrapped_recipe_model.py
@@ -8,8 +8,6 @@ from mlflow.pyfunc import PythonModel
 
 
 class WrappedRecipeModel(PythonModel):
-    _skip_wrapping_predict = True
-
     def __init__(
         self, predict_scores_for_all_classes, predict_prefix, target_column_class_labels=None
     ):

--- a/mlflow/recipes/utils/wrapped_recipe_model.py
+++ b/mlflow/recipes/utils/wrapped_recipe_model.py
@@ -8,6 +8,8 @@ from mlflow.pyfunc import PythonModel
 
 
 class WrappedRecipeModel(PythonModel):
+    _skip_wrapping_predict = True
+
     def __init__(
         self, predict_scores_for_all_classes, predict_prefix, target_column_class_labels=None
     ):

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -192,3 +192,15 @@ def keyword_only(func):
     wrapper.__doc__ = notice + wrapper.__doc__ if wrapper.__doc__ else notice
 
     return wrapper
+
+
+def filter_user_warnings_once(func):
+    """A decorator that filter user warnings to only show once in the wrapped method."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("once", category=UserWarning)
+            return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14130?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14130/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14130
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As decision 2 in the 1DD, we're going to apply data validation for PythonModel automatically, and for callables if @pyfunc decorator is used. This makes sure local testing of the model has same data validation experience as pyfunc model predict.

Docs update will be filed separately after we finish all type hints changes.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
