### PR TITLE
Implement message and tools standard for OpenAI auto-tracing

### DIFF
--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -1,0 +1,39 @@
+import logging
+from typing import Any
+
+from mlflow.entities import SpanType
+from mlflow.entities.span import LiveSpan
+from mlflow.exceptions import MlflowException
+from mlflow.tracing import set_span_chat_messages, set_span_chat_tools
+
+_logger = logging.getLogger(__name__).setLevel(logging.DEBUG)
+
+
+def set_span_chat_attributes(span: LiveSpan, inputs: dict[str, Any], output: Any):
+    from openai.types.chat import ChatCompletion
+
+    if span.span_type not in (SpanType.CHAT_MODEL, SpanType.LLM):
+        return
+
+    messages = []
+    if "messages" in inputs:
+        messages.extend(inputs["messages"])
+
+    if isinstance(output, ChatCompletion):
+        messages.append(output.choices[0].message)
+    elif isinstance(output, str):
+        messages.append({"role": "assistant", "content": output})
+
+    try:
+        set_span_chat_messages(span, messages)
+    except MlflowException:
+        _logger.debug(
+            "Failed to set chat messages on span",
+            exc_info=True,
+        )
+
+    if "tools" in inputs:
+        try:
+            set_span_chat_tools(span, inputs["tools"])
+        except MlflowException:
+            _logger.debug("Failed to set chat tools on span", exc_info=True)

--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -20,7 +20,7 @@ def set_span_chat_attributes(span: LiveSpan, inputs: dict[str, Any], output: Any
         messages.extend(inputs["messages"])
 
     if isinstance(output, ChatCompletion):
-        messages.append(output.choices[0].message)
+        messages.append(output.choices[0].message.to_dict(exclude_none=True))
     elif isinstance(output, str):
         messages.append({"role": "assistant", "content": output})
 
@@ -32,7 +32,7 @@ def set_span_chat_attributes(span: LiveSpan, inputs: dict[str, Any], output: Any
             exc_info=True,
         )
 
-    if "tools" in inputs:
+    if "tools" in inputs and inputs["tools"] is not None:
         try:
             set_span_chat_tools(span, inputs["tools"])
         except MlflowException:

--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -8,6 +8,7 @@ from mlflow.tracing import set_span_chat_messages, set_span_chat_tools
 
 _logger = logging.getLogger(__name__)
 
+
 def set_span_chat_attributes(span: LiveSpan, inputs: dict[str, Any], output: Any):
     from openai.types.chat import ChatCompletion
 

--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -6,8 +6,7 @@ from mlflow.entities.span import LiveSpan
 from mlflow.exceptions import MlflowException
 from mlflow.tracing import set_span_chat_messages, set_span_chat_tools
 
-_logger = logging.getLogger(__name__).setLevel(logging.DEBUG)
-
+_logger = logging.getLogger(__name__)
 
 def set_span_chat_attributes(span: LiveSpan, inputs: dict[str, Any], output: Any):
     from openai.types.chat import ChatCompletion
@@ -32,8 +31,8 @@ def set_span_chat_attributes(span: LiveSpan, inputs: dict[str, Any], output: Any
             exc_info=True,
         )
 
-    if "tools" in inputs and inputs["tools"] is not None:
+    if tools := inputs.get("tools"):
         try:
-            set_span_chat_tools(span, inputs["tools"])
+            set_span_chat_tools(span, tools)
         except MlflowException:
             _logger.debug("Failed to set chat tools on span", exc_info=True)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14140?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14140/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14140
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR implements the chat completions span standard for the OpenAI flavor. As the `mlflow.chat.messages` attribute is meant to represent all messages in a span, the output message from the LLM is appended to the array.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added new cases to unit test.


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
