### PR TITLE
Fix links to CLI reference

### DIFF
--- a/docs/docs/deployment/deploy-model-locally/index.mdx
+++ b/docs/docs/deployment/deploy-model-locally/index.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 1
 ---
 
+import Link from "@docusaurus/Link";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { APILink } from "@site/src/components/APILink";
@@ -20,7 +21,7 @@ first to understand the basic concepts of MLflow models and deployments.
 Before deploying, you must have an MLflow Model. If you don't have one, you can create a sample scikit-learn model by following the [MLflow Tracking Quickstart](/getting-started).
 Remember to note down the model URI, such as `runs:/<run_id>/<artifact_path>` (or `models:/<model_name>/<model_version>` if you registered the model in the [MLflow Model Registry](/model-registry)).
 
-Once you have the model ready, deploying to a local server is straightforward. Use the [mlflow models serve](/cli#mlflow-models-serve) command for a one-step deployment.
+Once you have the model ready, deploying to a local server is straightforward. Use the <Link to="/api_reference/cli.html#mlflow-models-serve" target="_blank">mlflow models serve</Link> command for a one-step deployment.
 This command starts a local server that listens on the specified port and serves your model.
 
 ```bash
@@ -36,7 +37,7 @@ curl http://127.0.0.1:5000/invocations -H "Content-Type:application/json"  --dat
 Several command line options are available to customize the server's behavior. For instance, the `--env-manager` option allows you to
 choose a specific environment manager, like Anaconda, to create the virtual environment. The `mlflow models` module also provides
 additional useful commands, such as building a Docker image or generating a Dockerfile. For comprehensive details, please refer
-to the [MLflow CLI Reference](/cli#mlflow-models).
+to the <Link to="/api_reference/cli.html#mlflow-models" target="_blank">MLflow CLI Reference</Link>.
 
 ## Inference Server Specification \{#local-inference-server-spec}
 
@@ -313,7 +314,7 @@ You can also find guides to deploy MLflow models to a Kubernetes cluster using M
 ## Running Batch Inference
 
 Instead of running an online inference endpoint, you can execute a single batch inference job on local files using
-the [mlflow models predict](/cli#mlflow-models-predict) command. The following command runs the model
+the <Link to="/api_reference/cli.html#mlflow-models-predict" target="_blank">mlflow models predict</Link> command. The following command runs the model
 prediction on `input.csv` and outputs the results to `output.csv`.
 
 <Tabs>

--- a/docs/docs/deployment/deploy-model-to-kubernetes/index.mdx
+++ b/docs/docs/deployment/deploy-model-to-kubernetes/index.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 3
 ---
 
+import Link from "@docusaurus/Link";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { CardGroup, PageCard } from "@site/src/components/Card";
@@ -29,8 +30,8 @@ The essential step to deploy an MLflow model to Kubernetes is to build a Docker 
     ```bash
     mlflow models build-docker -m runs:/<run_id>/model -n <image_name> --enable-mlserver
     ```
-    If you want to use the bare-bones Flask server instead of MLServer, remove the ``--enable-mlserver`` flag. For other options, see the
-    [build-docker](/cli#mlflow-models-build-docker) command documentation.
+    If you want to use the bare-bones Flask server instead of MLServer, remove the ``--enable-mlserver`` flag. For other options, see
+    the <Link to="/api_reference/cli.html#mlflow-models-build-docker" target="_blank">build-docker</Link> command documentation.
   </TabItem>
   <TabItem label="Python" value="python">
     ```python

--- a/docs/docs/deployment/deploy-model-to-kubernetes/tutorial/index.mdx
+++ b/docs/docs/deployment/deploy-model-to-kubernetes/tutorial/index.mdx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { APILink } from "@site/src/components/APILink";
@@ -14,7 +15,7 @@ This guide demonstrates how to use MLflow end-to-end for:
 - Training a linear regression model with [MLflow Tracking](/tracking).
 - Conducting hyper-parameter tuning to find the best model.
 - Packaging the model weights and dependencies as an [MLflow Model](/models).
-- Testing model serving locally with [mlserver](https://mlserver.readthedocs.io/en/latest/) using the [mlflow models serve](/cli#mlflow-models-serve) command.
+- Testing model serving locally with [mlserver](https://mlserver.readthedocs.io/en/latest/) using the <Link to="/api_reference/cli.html#mlflow-models-serve" target="_blank">mlflow models serve</Link> command.
 - Deploying the model to a Kubernetes cluster using [KServe](https://kserve.github.io/website/) with MLflow.
 
 We will cover an end-to-end model development process including model training and testing within this tutorial.

--- a/docs/docs/deployment/deploy-model-to-sagemaker/index.mdx
+++ b/docs/docs/deployment/deploy-model-to-sagemaker/index.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 2
 ---
 
+import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 
 # Deploy MLflow Model to Amazon SageMaker
@@ -78,7 +79,7 @@ curl -X POST -H "Content-Type:application/json; format=pandas-split" --data '{"c
 
 ### Step 2: Build a Docker Image and Push to ECR
 
-The [mlflow sagemaker build-and-push-container](/cli#mlflow-sagemaker-build-and-push-container)
+The <Link to="/api_reference/cli.html#mlflow-sagemaker-build-and-push-container" target="_blank">mlflow sagemaker build-and-push-container</Link>
 command builds a Docker image compatible with SageMaker and uploads it to ECR.
 
 ```bash
@@ -95,7 +96,7 @@ command deploys the model to an Amazon SageMaker endpoint. MLflow uploads the Py
 initiates an Amazon SageMaker endpoint serving the model.
 
 Various command-line options are available to customize the deployment, such as instance type, count, IAM role, etc.
-Refer to the [CLI reference](/cli#mlflow-sagemaker) for a complete list of options.
+Refer to the <Link to="/api_reference/cli.html#mlflow-sagemaker" target="_blank">CLI reference</Link> for a complete list of options.
 
 ```bash
 $ mlflow deployments create -t sagemaker -m runs:/<run_id>/model \
@@ -109,7 +110,7 @@ $ mlflow deployments create -t sagemaker -m runs:/<run_id>/model \
 
 You have two options for deploying a model to SageMaker: using the CLI or the Python API.
 
-- [CLI Reference](/cli#mlflow-sagemaker)
+- {""}<Link to="/api_reference/cli.html#mlflow-sagemaker" target="_blank">CLI Reference</Link>
 - <APILink fn="mlflow.sagemaker">Python API Documentation</APILink>
 
 ## Useful Links \{#deployment-sagemaker-references}

--- a/docs/docs/deployment/index.mdx
+++ b/docs/docs/deployment/index.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 10
 ---
 
+import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 import { CardGroup, LogoCard } from "@site/src/components/Card";
 
@@ -99,11 +100,11 @@ MLflow offers support for a variety of deployment targets. For detailed informat
 
 Deployment-related commands are primarily categorized under two modules:
 
-- [mlflow models](/cli#mlflow-models) - typically used for local deployment.
-- [mlflow deployments](/cli.html#mlflow-deployments) - typically used for deploying to custom targets.
+- {""}<Link to="/api_reference/cli.html#mlflow-models" target="_blank">mlflow models</Link> - typically used for local deployment.
+- {""}<Link to="/api_reference/cli.html#mlflow-deployments" target="_blank">mlflow deployments</Link> - typically used for deploying to custom targets.
 
 Note that these categories are not strictly separated and may overlap. Furthermore, certain targets require
-custom modules or plugins, for example, [mlflow sagemaker](/cli#mlflow-sagemaker) is used for Amazon
+custom modules or plugins, for example, <Link to="/api_reference/cli.html#mlflow-sagemaker" target="_blank">mlflow sagemaker</Link> is used for Amazon
 SageMaker deployments, and the [azureml-mlflow](https://pypi.org/project/azureml-mlflow) library is required for Azure ML.
 
 Therefore, it is advisable to consult the specific documentation for your chosen target to identify the appropriate commands.

--- a/docs/docs/llms/prompt-engineering/index.mdx
+++ b/docs/docs/llms/prompt-engineering/index.mdx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 
 # Prompt Engineering UI (Experimental)
@@ -34,7 +35,7 @@ Tracking Server. To connect the MLflow AI Gateway with the MLflow Tracking Serve
 `MLFLOW_DEPLOYMENTS_TARGET` environment variable in the environment where the server is running and
 restart the server. For example, if the MLflow AI Gateway is running at `http://localhost:7000`, you
 can start an MLflow Tracking Server in a shell on your local machine and connect it to the
-MLflow AI Gateway using the [mlflow server](/cli) command as follows:
+MLflow AI Gateway using the <Link to="/api_reference/cli.html" target="_blank">mlflow server</Link> command as follows:
 
 ```bash
 export MLFLOW_DEPLOYMENTS_TARGET="http://127.0.0.1:7000"
@@ -343,7 +344,7 @@ can deploy the corresponding MLflow Model for real-time serving as follows:
 
    - `MLFLOW_DEPLOYMENTS_TARGET`: The URL of the MLflow AI Gateway
 
-3. Use the [mlflow models serve](/cli) command to start the MLflow Model Server. For example,
+3. Use the <Link to="/api_reference/cli.html" target="_blank">mlflow models serve</Link> command to start the MLflow Model Server. For example,
    running the following command from a shell on your local machine will serve the model
    on port 8000:
 

--- a/docs/docs/llms/sentence-transformers/index.mdx
+++ b/docs/docs/llms/sentence-transformers/index.mdx
@@ -83,8 +83,8 @@ An example high-level architecture for such an application stack is shown below:
 
 Once a model is trained, it needs to be deployed for inference. MLflow's integration with Sentence Transformers simplifies this by providing
 functions such as <APILink fn="mlflow.sentence_transformers.load_model" /> and <APILink fn="mlflow.pyfunc.load_model" />, which allow for easy model serving.
-You can read more about [deploying models with MLflow](/deployment), find further information on
-[using the deployments API](/cli#mlflow-deployments), and [starting a local model serving endpoint](/cli#mlflow-models-serve) to get a
+You can read more about [deploying models with MLflow](/deployment), find further information
+on <Link to="/api_reference/cli.html#mlflow-deployments" target="_blank">using the deployments API</Link>, and <Link to="/api_reference/cli.html#mlflow-models-serve" target="_blank">starting a local model serving endpoint</Link> to get a
 deeper understanding of the deployment options that MLflow has available.
 
 ## Getting Started with the MLflow Sentence Transformers Flavor - Tutorials and Guides \{#getting-started-with-the-mlflow-sentence-transformers-flavor-tutorials-and-guides}

--- a/docs/docs/model/dependencies/index.mdx
+++ b/docs/docs/model/dependencies/index.mdx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import TOCInline from "@theme/TOCInline";
@@ -561,7 +562,7 @@ If you find any dependency issues during validation, please follow the guidance 
 You can use MLflow Models **predict** API via Python or CLI to make test predictions with your model.
 This will load your model from the model URI, create a virtual environment with the model dependencies (defined in MLflow Model),
 and run offline predictions with the model.
-Please refer to <APILink fn="mlflow.models.predict" /> or the [CLI reference](/cli#mlflow-models) for more detailed usage for the predict API.
+Please refer to <APILink fn="mlflow.models.predict" /> or the <Link to="/api_reference/cli.html#mlflow-models" target="_blank">CLI reference</Link> for more detailed usage for the predict API.
 
 :::note
 The Python API is available since MLflow 2.10.0. If you are using an older version, please use the CLI option.
@@ -604,7 +605,7 @@ python List, scipy.sparse matrix, and spark data frame.
 If you want to test your model by actually running the online inference server, you can use the MLflow `serve` API.
 This will create a virtual environment with your model and dependencies, similarly to the `predict` API, but will start the inference server
 and expose the REST endpoints. Then you can send a test request and validate the response.
-Please refer to the [CLI reference](/cli#mlflow-models) for more detailed usage for the `serve` API.
+Please refer to the <Link to="/api_reference/cli.html#mlflow-models" target="_blank">CLI reference</Link> for more detailed usage for the `serve` API.
 
 ```bash
 mlflow models serve -m runs:/<run_id>/model -p <port>
@@ -627,7 +628,7 @@ Linux environments on Mac or Windows.
 MLflow `build-docker` API for CLI and Python is capable of building an Ubuntu-based Docker image for serving your model.
 The image will contain your model and dependencies, as well as having an entrypoint that is used to start the inference server. Similarly to the _serve_ API,
 you can send a test request and validate the response.
-Please refer to the [CLI reference](/cli#mlflow-models) for more detailed usage for the `build-docker` API.
+Please refer to the <Link to="/api_reference/cli.html#mlflow-models" target="_blank">CLI reference</Link> for more detailed usage for the `build-docker` API.
 
 ```bash
 mlflow models build-docker -m runs:/<run_id>/model -n <image_name>
@@ -724,7 +725,7 @@ mlflow.models.update_model_requirements(
 Note that you can also leverage the CLI to update the model requirements:
 
 ```bash
-mlflow models update-pip-requirements -m runs:/<run_id>/<model_path> add "opencv-python==4.8.0" 
+mlflow models update-pip-requirements -m runs:/<run_id>/<model_path> add "opencv-python==4.8.0"
 ```
 
 Alternatively, you can log a new model with the updated dependencies by specifying the `extra_pip_requirements` option when logging the model.

--- a/docs/docs/model/models-from-code/index.mdx
+++ b/docs/docs/model/models-from-code/index.mdx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { APILink } from "@site/src/components/APILink";
@@ -506,7 +507,7 @@ including sensitive data such as access keys or other authorization-based secret
 key defined directly in your script when logging your model, it is advisable to:
 
 1. Delete the MLflow run that contains the leaked key. You can do this via the UI or through <APILink fn="mlflow.client.MlflowClient.delete_run">the delete_run API</APILink>.
-2. Delete the artifacts associated with the run. You can do this via the [mlflow gc](/cli#mlflow-gc) cli command.
+2. Delete the artifacts associated with the run. You can do this via the <Link to="/api_reference/cli.html#mlflow-gc" target="_blank">mlflow gc</Link> cli command.
 3. Rotate your sensitive keys by generating a new key and deleting the leaked secret from the source system administration interface.
 4. Re-log the model to a new run, making sure to not set sensitive keys in your model definition script.
 

--- a/docs/docs/models/index.mdx
+++ b/docs/docs/models/index.mdx
@@ -4210,11 +4210,11 @@ print(f"\nPyfunc 'predict_interval':\n${response.json()}")
 After logging your model with MLflow Tracking, it is highly recommended to validate the model locally before deploying it to production.
 The <APILink fn="mlflow.models.predict" /> API provides a convenient way to test your model in a virtual environment, offering isolated execution and several advantages:
 
-* Model dependencies validation: The API helps ensure that the dependencies logged with the model are correct and sufficient by executing the model with an input example in a virtual environment.
+- Model dependencies validation: The API helps ensure that the dependencies logged with the model are correct and sufficient by executing the model with an input example in a virtual environment.
   For more details, refer to [Validating Environment for Prediction](/model/dependecies/#validating-environment-for-prediction>).
-* Input data validation: The API can be used to validate the input data interacts with the model as expected by simulating the same data processing during model serving.
+- Input data validation: The API can be used to validate the input data interacts with the model as expected by simulating the same data processing during model serving.
   Ensure that the input data is a valid example that aligns with the pyfunc model’s predict function requirements.
-* Extra environment variables validation: By specifying the `extra_envs` parameter, you can test whether additional environment variables are required for the model to run successfully.
+- Extra environment variables validation: By specifying the `extra_envs` parameter, you can test whether additional environment variables are required for the model to run successfully.
   Note that all existing environment variables in `os.environ` are automatically passed into the virtual environment.
 
 ```python
@@ -4245,10 +4245,10 @@ mlflow.models.predict(
 
 The <APILink fn="mlflow.models.predict" /> API supports the following environment managers to create the virtual environment for prediction:
 
-* [virtualenv](https://virtualenv.pypa.io/en/latest/): The default environment manager.
-* [uv](https://docs.astral.sh/uv/): An **extremely fast** environment manager written in Rust. **This is an experimental feature since MLflow 2.20.0.**
-* [conda](https://docs.conda.io/projects/conda/): uses conda to create environment.
-* `local`: uses the current environment to run the model. Note that `pip_requirements_override` is not supported in this mode.
+- [virtualenv](https://virtualenv.pypa.io/en/latest/): The default environment manager.
+- [uv](https://docs.astral.sh/uv/): An **extremely fast** environment manager written in Rust. **This is an experimental feature since MLflow 2.20.0.**
+- [conda](https://docs.conda.io/projects/conda/): uses conda to create environment.
+- `local`: uses the current environment to run the model. Note that `pip_requirements_override` is not supported in this mode.
 
 :::tip
 Starting from MLflow 2.20.0, `uv` is available, and **it is extremely fast**.
@@ -4435,7 +4435,7 @@ pyfunc_udf = mlflow.pyfunc.spark_udf(
 ## Deployment to Custom Targets \{#deployment_plugin}
 
 In addition to the built-in deployment tools, MLflow provides a pluggable <APILink fn="mlflow.deployments" />
-and [mlflow deployments CLI](/cli#mlflow-deployments) for deploying models to custom targets and environments.
+and <Link to="/api_reference/cli.html#mlflow-deployments" target="_blank">mlflow deployments CLI</Link> for deploying models to custom targets and environments.
 To deploy to a custom target, you must first install an appropriate third-party Python plugin. See the list of
 known community-maintained plugins [here](/plugins#deployment-plugins).
 
@@ -4444,14 +4444,14 @@ known community-maintained plugins [here](/plugins#deployment-plugins).
 The `mlflow deployments` CLI contains the following commands, which can also be invoked programmatically
 using the <APILink fn="mlflow.deployments">mlflow.deployments Python API</APILink>:
 
-- [Create](/cli#mlflow-deployments-create): Deploy an MLflow model to a specified custom target
-- [Delete](/cli#mlflow-deployments-delete): Delete a deployment
-- [Update](/cli#mlflow-deployments-update): Update an existing deployment, for example to
+- {""}<Link to="/api_reference/cli.html#mlflow-deployments-create" target="_blank">Create</Link>: Deploy an MLflow model to a specified custom target
+- {""}<Link to="/api_reference/cli.html#mlflow-deployments-delete" target="_blank">Delete</Link>: Delete a deployment
+- {""}<Link to="/api_reference/cli.html#mlflow-deployments-update" target="_blank">Update</Link>: Update an existing deployment, for example to
   deploy a new model version or change the deployment's configuration (e.g. increase replica count)
-- [List](/cli#mlflow-deployments-list): List IDs of all deployments
-- [Get](/cli#mlflow-deployments-get): Print a detailed description of a particular deployment
-- [Run Local](/cli#mlflow-deployments-run-local): Deploy the model locally for testing
-- [Help](/cli#mlflow-deployments-help): Show the help string for the specified target
+- {""}<Link to="/api_reference/cli.html#mlflow-deployments-list" target="_blank">List</Link>: List IDs of all deployments
+- {""}<Link to="/api_reference/cli.html#mlflow-deployments-get" target="_blank">Get</Link>: Print a detailed description of a particular deployment
+- {""}<Link to="/api_reference/cli.html#mlflow-deployments-run-local" target="_blank">Run Local</Link>: Deploy the model locally for testing
+- {""}<Link to="/api_reference/cli.html#mlflow-deployments-help" target="_blank">Help</Link>: Show the help string for the specified target
 
 For more info, see:
 

--- a/docs/docs/plugins/index.mdx
+++ b/docs/docs/plugins/index.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 17
 ---
 
+import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 
 # MLflow Plugins
@@ -439,7 +440,7 @@ and the conda.yaml file associated with the model.
 The following known plugins provide support for deploying models to custom serving tools using
 MLflow's [model deployment APIs](/models#deployment-plugin). See the individual plugin pages
 for installation instructions, and see the <APILink fn="mlflow.deployments">Python API docs</APILink>
-and [CLI docs](/cli#mlflow-deployments) for usage instructions and examples.
+and <Link to="/api_reference/cli.html#mlflow-deployments" target="_blank">CLI docs</Link> for usage instructions and examples.
 
 - [mlflow-redisai](https://github.com/RedisAI/mlflow-redisai)
 - [mlflow-torchserve](https://github.com/mlflow/mlflow-torchserve)

--- a/docs/docs/projects/index.mdx
+++ b/docs/docs/projects/index.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 13
 ---
 
+import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 import TOCInline from "@theme/TOCInline";
 
@@ -435,7 +436,7 @@ data to local files). Any undeclared parameters are treated as `string`. The par
 
 ## Running Projects
 
-MLflow provides two ways to run projects: the `mlflow run` [command-line tool](/cli), or
+MLflow provides two ways to run projects: the `mlflow run` <Link to="/api_reference/cli.html" target="_blank">command-line tool</Link>, or
 the <APILink fn="mlflow.projects.run" /> Python API. Both tools take the following parameters:
 
 <dl>

--- a/docs/docs/recipes/index.mdx
+++ b/docs/docs/recipes/index.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 16
 ---
 
+import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
@@ -98,7 +99,7 @@ To build and score models for your own use cases, we recommend using the
   used to solve an ML problem or perform an MLOps task, such as developing a
   regression model or performing batch model scoring on production data.
   MLflow Recipes provides <APILink fn="mlflow.recipes.Recipe">API</APILink>
-  and a [CLI](/cli) for running recipes and inspecting their results.
+  and a <Link to="/api_reference/cli.html" target="_blank">CLI</Link> for running recipes and inspecting their results.
 
 <a class="anchor-with-sticky-navbar" name="recipe-templates-key-concept" />
 

--- a/docs/docs/tracking/artifacts-stores/index.mdx
+++ b/docs/docs/tracking/artifacts-stores/index.mdx
@@ -2,6 +2,7 @@
 sidebar_label: Artifact Store
 ---
 
+import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 
 # Artifact Stores
@@ -192,7 +193,7 @@ The HDFS artifact store is accessed using the `pyarrow.fs` module, refer to the
 ## Deletion Behavior
 
 In order to allow MLflow Runs to be restored, Run metadata and artifacts are not automatically removed
-from the backend store or artifact store when a Run is deleted. The [mlflow gc](/cli) CLI is provided
+from the backend store or artifact store when a Run is deleted. The <Link to="/api_reference/cli.html" target="_blank">mlflow gc</Link> CLI is provided
 for permanently removing Run metadata and artifacts for deleted runs.
 
 ## Multipart upload for proxied artifact access

--- a/docs/docs/tracking/backend-stores/index.mdx
+++ b/docs/docs/tracking/backend-stores/index.mdx
@@ -2,6 +2,7 @@
 sidebar_label: Backend Store
 ---
 
+import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 
 # Backend Stores
@@ -64,7 +65,7 @@ is a non-invertible migration script that increases the cap in existing database
 ## Deletion Behavior
 
 In order to allow MLflow Runs to be restored, Run metadata and artifacts are not automatically removed
-from the backend store or artifact store when a Run is deleted. The [mlflow gc](/cli) CLI is provided
+from the backend store or artifact store when a Run is deleted. The <Link to="/api_reference/cli.html" target="_blank">mlflow gc</Link> CLI is provided
 for permanently removing Run metadata and artifacts for deleted runs.
 
 ## SQLAlchemy Options

--- a/docs/docs/tracking/tracking-api/index.mdx
+++ b/docs/docs/tracking/tracking-api/index.mdx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 
 # MLflow Tracking APIs
@@ -127,7 +128,7 @@ If you specify both a timestamp and a step, metrics are recorded against both ax
 ### Organizing Runs in Experiments
 
 MLflow allows you to group runs under experiments, which can be useful for comparing runs intended
-to tackle a particular task. You can create experiments via multiple way - MLflow UI, the [Command-Line Interface](/cli) (`mlflow experiments`),
+to tackle a particular task. You can create experiments via multiple way - MLflow UI, the <Link to="/api_reference/cli.html" target="_blank">Command-Line Interface</Link> (`mlflow experiments`),
 or the <APILink fn="mlflow.create_experiment" /> Python API. You can pass the experiment name for an individual run
 using the CLI (for example, `mlflow run ... --experiment-name [name]`) or the `MLFLOW_EXPERIMENT_NAME`
 environment variable. Alternatively, you can use the experiment ID instead, via the


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ed-sa-ma/mlflow/pull/14141?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14141/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14141
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR fixes all instances of links pointing to the CLI API reference that were written originally with the format `[...](/cli.html...)` to use Docusaurus Link component instead to point to the static folder `api_reference/`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
