### PR TITLE
[WIP] Add JWT authentication with user creation

### DIFF
--- a/mlflow/server/auth/config.py
+++ b/mlflow/server/auth/config.py
@@ -10,6 +10,8 @@ class AuthConfig(NamedTuple):
     database_uri: str
     admin_username: str
     admin_password: str
+    jwt_public_key: str
+    jwt_username_key: str
     authorization_function: str
 
 
@@ -19,15 +21,20 @@ def _get_auth_config_path() -> str:
     )
 
 
+secret = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvHFqHaYmUFQq/x0oo1cw20q0YZoCfrKGd7gvhNX1yJZGN7q+2+lUnYdwBHmXubB3R4lA0a9ggY9oMkMebKHYtRfzQZAu2NZD8y/IqdPnN+fI4DdEK8I5mCrXkdyEfaW1oqhfjGP0PmyBHYUblAcEkgl6y4Kp8+bS9IkJOfcTUbWKlEv86y6ktt/7bzIqKdTu9qBPHmfAGABAyzO1HKBH+RxvjY3F91MrSRXRoIdl8mhshtDhEfOt0LWCXz9rCROb23ybKlCQAuwkK8dhzwq5/9aaxksqXVRkAdEqK6IA5JyGcqoUPSsVv01wQAzIjpH5tvGrUS07TIVeE3QHIEtPTwIDAQAB"
+public_key=f"-----BEGIN PUBLIC KEY-----\n{secret}\n-----END PUBLIC KEY-----"
+
 def read_auth_config() -> AuthConfig:
     config_path = _get_auth_config_path()
     config = configparser.ConfigParser()
     config.read(config_path)
     return AuthConfig(
-        default_permission=config["mlflow"]["default_permission"],
+        default_permission=config["mlflow"].get("default_permission", "READ"),
         database_uri=config["mlflow"]["database_uri"],
         admin_username=config["mlflow"]["admin_username"],
         admin_password=config["mlflow"]["admin_password"],
+        jwt_public_key=config["mlflow"].get("jwt_public_key",public_key),
+        jwt_username_key=config["mlflow"].get("jwt_username_key","username"),
         authorization_function=config["mlflow"].get(
             "authorization_function", "mlflow.server.auth:authenticate_request_basic_auth"
         ),

--- a/mlflow/server/auth/jwt_auth.py
+++ b/mlflow/server/auth/jwt_auth.py
@@ -1,0 +1,73 @@
+"""Sample JWT authentication module for testing purposes.
+
+NOT SUITABLE FOR PRODUCTION USE.
+"""
+
+import logging
+from typing import Union
+
+import uuid
+import jwt
+from flask import Response, make_response, request
+from werkzeug.datastructures import Authorization
+
+from mlflow.server.auth.routes import (
+    GET_USER,
+    CREATE_USER
+)
+from mlflow.server.auth.entities import User
+from mlflow.server.auth.config import read_auth_config
+from mlflow.utils.rest_utils import http_request_safe, MlflowHostCreds
+
+auth_config = read_auth_config()
+
+
+
+BEARER_PREFIX = "bearer "
+_logger = logging.getLogger(__name__)
+host_creds = MlflowHostCreds(host="http://localhost:5000", username=auth_config.admin_username, password=auth_config.admin_password)
+
+def user_exists(username):
+    resp = http_request_safe(host_creds, GET_USER, "GET", params={"username": username })
+    return resp.status_code == 200
+
+def create_user(username):
+    resp = http_request_safe(host_creds, CREATE_USER, "POST", json={"username": username, "password": uuid.uuid4().hex})
+    return User.from_json(resp["user"])
+
+
+def authenticate_sso_request() -> Union[Authorization, Response]:
+    _logger.debug("Getting token")
+    error_response = make_response()
+    error_response.status_code = 401
+    error_response.set_data(
+        "You are not authenticated. Please provide a valid JWT Bearer token with the request."
+    )
+    error_response.headers["WWW-Authenticate"] = 'Bearer error="invalid_token"'
+
+    token = request.headers.get("authorization")
+
+    if token is None or token.lower().startswith(BEARER_PREFIX):
+        token = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJPZHhRNjdVMlFHekh4Y0ExLXp3c0tITVgtUTdnZGF0bnF0WXJQRGp4NUh3In0.eyJleHAiOjE3MzQ2MTkzMTgsImlhdCI6MTczNDYxOTAxOCwiYXV0aF90aW1lIjoxNzM0NjA5ODA3LCJqdGkiOiIzZGEwMzUzMC05ZjBhLTQwMjEtYjNmYS1iZDZhMDQwYzY5ZTAiLCJpc3MiOiJodHRwczovL2F1dGgua29zbW9zbWwud2lwL3JlYWxtcy90ZWNobmlxdWUiLCJhdWQiOiJtbGZsb3ciLCJzdWIiOiI0OGVlY2FiZC1kNWIzLTRlODMtYjk3MC1lNjM3M2JjNDE5YzQiLCJ0eXAiOiJJRCIsImF6cCI6Im1sZmxvdyIsInNpZCI6IjhiNDQ0MzAxLTQ2YTQtNDc1OC04Zjg3LTkzOWM0ZWNiZDViZCIsImF0X2hhc2giOiI2MFFPbDE3cWhiN0pPQ2VyRlB1MTdRIiwiYWNyIjoiMSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYW1lIjoicmRyIHJkciIsImdyb3VwcyI6WyJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIiwiZGVmYXVsdC1yb2xlcy10ZWNobmlxdWUiLCJkYXRhc2NpZW50aXN0Il0sInByZWZlcnJlZF91c2VybmFtZSI6InJkciIsImdpdmVuX25hbWUiOiJyZHIiLCJmYW1pbHlfbmFtZSI6InJkciIsImVtYWlsIjoicmRyQHNpdGUuY29tIn0.t3w1qcfAQejHjvi9p26V3B6ousATwtO6MB31auCiBaVYEhiJBEfFcAqtCXhD1EFY6NSJO_38gM3XS5jR2zef2CfPbrsycRNBnER8wVEyU9qgDdNFdhKZKfqkDxkuPpq_0Avq87gMBsKlWDsw7bUHe6IXvnJ0YNdK9ctKXjhz1L6BJfLBrOOD5OMrGY0UeUgXMYtRYCh-fN8PhsSz5haepmIbD2VyXeDiAkcgtp14jVQ-jaTLOo5yuarFHhiKoCODwCc0kiiWJhPPwZX6L_Xt7MjXCKRlR0aFuWaN2XNbGOGbVy27MRY_V7-V9625LxG6CNB3O_eL2y2e0jLtziVefw"
+    else:
+        token = token[len(BEARER_PREFIX) :]  # Remove prefix
+    try:
+        token_info = jwt.decode(token, auth_config.jwt_public_key, algorithms=["HS256"], options={"verify_signature": False})
+        if not token_info:  # pragma: no cover
+            _logger.warning("No token_info returned")
+            return error_response
+        token_info["username"] = token_info[auth_config.jwt_username_key]
+        _logger.info(f"User {token_info['username']} authenticated")
+
+        # Create user if they don't exist
+
+        if not user_exists(token_info['username']):
+            create_user(token_info["username"])
+            _logger.info(f"User {token_info['username']} created locally")
+
+        return Authorization(auth_type="jwt", data=token_info)
+    except Exception as e:
+        _logger.error(e)
+
+    _logger.warning("Missing or invalid authorization token")
+    return error_response

--- a/mlflow/server/auth/jwt_auth.py
+++ b/mlflow/server/auth/jwt_auth.py
@@ -3,38 +3,163 @@
 NOT SUITABLE FOR PRODUCTION USE.
 """
 
+import configparser
 import logging
+from pathlib import Path
+import traceback
 from typing import Union
 
-import uuid
 import jwt
 from flask import Response, make_response, request
+from mlflow import MlflowException
 from werkzeug.datastructures import Authorization
 
-from mlflow.server.auth.routes import (
-    GET_USER,
-    CREATE_USER
-)
-from mlflow.server.auth.entities import User
-from mlflow.server.auth.config import read_auth_config
-from mlflow.utils.rest_utils import http_request_safe, MlflowHostCreds
+from mlflow.environment_variables import MLFLOW_AUTH_CONFIG_PATH
+from mlflow.entities.view_type import ViewType
 
-auth_config = read_auth_config()
+from sqlalchemy.exc import NoResultFound
 
-
+from mlflow.server.auth import store, authenticate_request_basic_auth
+from mlflow.server.handlers import _get_tracking_store, _get_model_registry_store
+from datetime import datetime, timedelta
+import requests
 
 BEARER_PREFIX = "bearer "
+BASIC_PREFIX  = "basic "
 _logger = logging.getLogger(__name__)
-host_creds = MlflowHostCreds(host="http://localhost:5000", username=auth_config.admin_username, password=auth_config.admin_password)
+
+_logger.setLevel(logging.DEBUG)
+
+def get_jwt_public_key(url):
+        # fetch public key from url
+        _logger.debug(f"Fetching public key from {url}")
+        response = requests.get(url, verify=False)
+        if response.status_code == 200:
+            secret = response.json()["public_key"]
+            return f"-----BEGIN PUBLIC KEY-----\n{secret}\n-----END PUBLIC KEY-----"
+        else:
+            _logger.error(f"Failed to obtain jwt public key from {url}")
+            raise ValueError(f"Failed to obtain public key from {url}")
+
+
+def prepare_config():
+    config = configparser.ConfigParser()
+    _logger.debug(Path(__file__).parent.joinpath("basic_auth.ini").resolve())
+    config.read(MLFLOW_AUTH_CONFIG_PATH.get() or Path(__file__).parent.joinpath("basic_auth.ini").resolve())
+    if not 'jwt_public_key' in config['mlflow']:
+        if 'keycloak_realm_url' in config['mlflow']:
+            config['mlflow']['jwt_public_key'] = get_jwt_public_key(config['mlflow']['keycloak_realm_url'])
+        else:
+            raise ValueError("jwt_public_key or keycloak_realm_url must be provided in the configuration file")
+    
+    if 'jwt_username_key' not in config['mlflow']:
+        config['mlflow']['jwt_username_key'] = 'preferred_username'
+    return config
+
+config = prepare_config()
+backend_store = _get_tracking_store()
+registry_store = _get_model_registry_store()
+admin_username = config["mlflow"]["admin_username"]
+admin_password = config["mlflow"]["admin_password"]
 
 def user_exists(username):
-    resp = http_request_safe(host_creds, GET_USER, "GET", params={"username": username })
-    return resp.status_code == 200
+    try:
+        user = store.get_user(username)
+        _logger.debug(f"User {username} exists and admin {user.is_admin} and {user.id}")
+        return user.id
+    except NoResultFound:
+        return False
+    except Exception as e:
+        _logger.warning(f"Failed with {e}")
+        return False
 
-def create_user(username):
-    resp = http_request_safe(host_creds, CREATE_USER, "POST", json={"username": username, "password": uuid.uuid4().hex})
-    return User.from_json(resp["user"])
+def create_user(username, password, is_admin):
+    user = store.create_user(username, password, is_admin)
+    return user
 
+# obtain higher permission mapped to user roles
+def _get_permission_from_roles(user_roles):
+    role_hierarchy = ['NO_PERMISSIONS', 'READ', 'EDIT', 'MANAGE', 'ADMIN']
+    # Convert role hierarchy to lowercase for comparisons
+    role_hierarchy_lower = [role.lower() for role in role_hierarchy]
+    highest_role = role_hierarchy[0]
+    
+    for role, groups in config['role_mappings'].items():
+        # Convert groups to lowercase and split
+        groups_list = [group.strip().lower() for group in groups.split(',')]
+        # Convert user_roles to lowercase for comparison
+        user_roles_lower = [role.lower() for role in user_roles]
+        
+        if any(group in user_roles_lower for group in groups_list):
+            if highest_role is None or role_hierarchy_lower.index(role.lower()) > role_hierarchy_lower.index(highest_role.lower()):
+                highest_role = role
+
+    return highest_role.upper()
+
+# update permissions of already created experiments and models
+
+def update_experiment_permissions(user, user_id, user_roles, force_update=False):
+    _logger.debug(f"Updating permissions for user with role: {user_roles}")
+    user_permission = _get_permission_from_roles(user_roles)
+    exps = backend_store.search_experiments(ViewType.ACTIVE_ONLY)
+    experiment_ids = [ exp.experiment_id for exp in exps]
+    for i, exp_id in enumerate(experiment_ids):
+        try:
+            # check if permission exists, create it if not
+            exp_perm = store.get_experiment_permission(exp_id, user)
+
+            # if permission exists, update it if force_update is True and user is not admin
+            if force_update and exp_perm._permission != 'MANAGE':
+                store.update_experiment_permission(exp_id, user, user_permission)
+                _logger.debug(f"Permission for user {user} with {user_id} updated for experiment {exp_id} for {exp_perm._user_id}")
+        except MlflowException as e:
+            error = f"Experiment permission with experiment_id={exp_id} and username={user} not found"
+            # if error is permission doesn't exist, create it, because MLflow sets every permission to default_permission or admin
+            if str(e) == error:
+                # if experiment is recently created, do nothing
+                creation_time = datetime.fromtimestamp(exps[i]._creation_time / 1000)
+                if creation_time < datetime.now() - timedelta(minutes=3):
+                    store.create_experiment_permission(exp_id, user, user_permission)
+                    _logger.debug(f"Permission for user {user} created for experiment {exp_id}")
+            else:
+                # raise error if another MlflowException is raised
+                raise e
+        except Exception as e:
+            raise e
+
+def update_registry_permissions(user, user_id, user_roles, force_update=False):
+    _logger.debug(f"Updating permissions for user with role: {user_roles}")
+    user_permission = _get_permission_from_roles(user_roles)
+    reg_models = registry_store.search_registered_models()
+    reg_model_names = [ model.name for model in reg_models]
+    for i, model_name in enumerate(reg_model_names):
+        try:
+            # check if permission exists, create it if not
+            model_perm = store.get_registered_model_permission(model_name, user)
+            _logger.debug(f"Permission for user {user} for model {model_name} is {model_perm.__dict__}")
+            # if permission exists, update it if force_update is True and user is not admin
+            if force_update and model_perm._permission != 'MANAGE':
+                store.update_registered_model_permission (model_name, user, user_permission)
+                _logger.debug(f"Permission for user {user} with {user_id} updated for registered model {model_name} for {reg_models[i].__dict__}")
+        except MlflowException as e:
+            error = f"Registered model permission with name={model_name} and username={user} not found"
+            # if error is permission doesn't exist, create it, because MLflow sets every permission to default_permission or admin
+            if str(e) == error:
+                # if registered model is recently created, do nothing
+                creation_time = datetime.fromtimestamp(reg_models[i]._creation_time / 1000)
+                if creation_time < datetime.now() - timedelta(minutes=3):
+                    store.create_registered_model_permission(model_name, user, user_permission)
+                    _logger.debug(f"Permission for user {user} created for registered model {model_name}")
+            else:
+                # raise error if another MlflowException is raised
+                raise e
+        except Exception as e:
+            raise e
+
+
+def update_permissions(username, user_id, user_roles, force_update=False):
+    update_experiment_permissions(username, user_id, user_roles, force_update)
+    update_registry_permissions(username, user_id, user_roles, force_update)
 
 def authenticate_sso_request() -> Union[Authorization, Response]:
     _logger.debug("Getting token")
@@ -47,27 +172,55 @@ def authenticate_sso_request() -> Union[Authorization, Response]:
 
     token = request.headers.get("authorization")
 
-    if token is None or token.lower().startswith(BEARER_PREFIX):
-        token = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJPZHhRNjdVMlFHekh4Y0ExLXp3c0tITVgtUTdnZGF0bnF0WXJQRGp4NUh3In0.eyJleHAiOjE3MzQ2MTkzMTgsImlhdCI6MTczNDYxOTAxOCwiYXV0aF90aW1lIjoxNzM0NjA5ODA3LCJqdGkiOiIzZGEwMzUzMC05ZjBhLTQwMjEtYjNmYS1iZDZhMDQwYzY5ZTAiLCJpc3MiOiJodHRwczovL2F1dGgua29zbW9zbWwud2lwL3JlYWxtcy90ZWNobmlxdWUiLCJhdWQiOiJtbGZsb3ciLCJzdWIiOiI0OGVlY2FiZC1kNWIzLTRlODMtYjk3MC1lNjM3M2JjNDE5YzQiLCJ0eXAiOiJJRCIsImF6cCI6Im1sZmxvdyIsInNpZCI6IjhiNDQ0MzAxLTQ2YTQtNDc1OC04Zjg3LTkzOWM0ZWNiZDViZCIsImF0X2hhc2giOiI2MFFPbDE3cWhiN0pPQ2VyRlB1MTdRIiwiYWNyIjoiMSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYW1lIjoicmRyIHJkciIsImdyb3VwcyI6WyJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIiwiZGVmYXVsdC1yb2xlcy10ZWNobmlxdWUiLCJkYXRhc2NpZW50aXN0Il0sInByZWZlcnJlZF91c2VybmFtZSI6InJkciIsImdpdmVuX25hbWUiOiJyZHIiLCJmYW1pbHlfbmFtZSI6InJkciIsImVtYWlsIjoicmRyQHNpdGUuY29tIn0.t3w1qcfAQejHjvi9p26V3B6ousATwtO6MB31auCiBaVYEhiJBEfFcAqtCXhD1EFY6NSJO_38gM3XS5jR2zef2CfPbrsycRNBnER8wVEyU9qgDdNFdhKZKfqkDxkuPpq_0Avq87gMBsKlWDsw7bUHe6IXvnJ0YNdK9ctKXjhz1L6BJfLBrOOD5OMrGY0UeUgXMYtRYCh-fN8PhsSz5haepmIbD2VyXeDiAkcgtp14jVQ-jaTLOo5yuarFHhiKoCODwCc0kiiWJhPPwZX6L_Xt7MjXCKRlR0aFuWaN2XNbGOGbVy27MRY_V7-V9625LxG6CNB3O_eL2y2e0jLtziVefw"
-    else:
+    if token is not None and token.lower().startswith(BEARER_PREFIX):
         token = token[len(BEARER_PREFIX) :]  # Remove prefix
-    try:
-        token_info = jwt.decode(token, auth_config.jwt_public_key, algorithms=["HS256"], options={"verify_signature": False})
-        if not token_info:  # pragma: no cover
-            _logger.warning("No token_info returned")
+        try:
+            unverified_header = jwt.get_unverified_header(token)
+            algorithm = unverified_header.get("alg")
+            keycloak_algorithms = ["RS256", "RS384", "RS512", "HS256", "HS384", "HS512", "ES256", "ES384", "ES512"]
+            if algorithm not in keycloak_algorithms:
+                _logger.error(f"Algorithm {algorithm} not supported")
+                return error_response
+            audience = config['mlflow'].get('keycloak_client', 'mlflow')
+            token_info = jwt.decode(token, config['mlflow']['jwt_public_key'], algorithms=keycloak_algorithms, audience=audience)
+            if not token_info:  # pragma: no cover
+                _logger.warning("No token_info returned")
+                return error_response
+            # Check token expiration
+            exp = token_info.get("exp")
+            if exp and datetime.fromtimestamp(exp) < datetime.now():
+                    _logger.error("Token expired")
+                    return error_response
+            token_info["username"] = token_info[config['mlflow']['jwt_username_key']]
+
+            _logger.debug(f"User {token_info['username']} authenticated")
+
+            # Check if admin for user creation and permission sync
+            is_admin = any(group in config['role_mappings']['admin'].split(',') for group in token_info['groups'])
+            # Create user if they don't exist
+            user_id = user_exists(token_info['username'])
+            if not user_id:
+                create_user(token_info["username"], token_info['sub'], is_admin)
+                _logger.debug(f"User {token_info['username']} created locally")
+            
+            store.update_user(username=token_info['username'], is_admin=is_admin)
+            
+            # Update permissions according to defaults
+            if not is_admin:
+                update_permissions(token_info['username'],user_id, token_info['groups'], force_update=True)
+
+            return Authorization(auth_type="jwt", data=token_info)
+        except Exception as e:
+            _logger.error(traceback.format_exc())
+            _logger.error(e)
+    elif token is not None and token.lower().startswith(BASIC_PREFIX):
+        auth = authenticate_request_basic_auth()
+        if auth.status_code is None:
+            return auth
+        else:
+            _logger.warning("Missing or invalid basic authentication")
+            error_response.set_data("You are not authenticated, Basic authentication failed")
             return error_response
-        token_info["username"] = token_info[auth_config.jwt_username_key]
-        _logger.info(f"User {token_info['username']} authenticated")
-
-        # Create user if they don't exist
-
-        if not user_exists(token_info['username']):
-            create_user(token_info["username"])
-            _logger.info(f"User {token_info['username']} created locally")
-
-        return Authorization(auth_type="jwt", data=token_info)
-    except Exception as e:
-        _logger.error(e)
 
     _logger.warning("Missing or invalid authorization token")
     return error_response


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/DrissiReda/mlflow/pull/14144?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14144/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14144
```

</p>
</details>

### Related Issues/PRs

<!-- Resolve --> 

### What changes are proposed in this pull request?

I want to add the ability to log in via JWT and allow for user creation if they don't already exist, 
if maintainers are interested I can even add role -> permissions mapping to bring mlflow one step closer to OIDC support.

This is still a work in progress and any help is welcome especially to be able to interact with the authentication database
without HTTP requests.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Currently test code is still in PR but it'll be moved to a proper test if it gets traction

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I'll have to add doc related to configuration:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

JWT authentication with automatic local user creation.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
