### PR TITLE
Fix constraint name for MSSQL in migration 0584bdc529eb

### DIFF
--- a/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
+++ b/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
@@ -29,6 +29,12 @@ def get_datasets_experiment_fk_name():
         autoload_with=conn,
     )
 
+    print(
+        "@@@@ Unable to find the foreign key constraint name from datasets to experiments. "
+        "All foreign key constraints in datasets table: \n"
+        f"{datasets_table.foreign_key_constraints}"
+    )
+
     for constraint in datasets_table.foreign_key_constraints:
         if (constraint.referred_table.name == SqlExperiment.__tablename__ and
             constraint.column_keys[0] == "experiment_id"):
@@ -44,8 +50,6 @@ def get_datasets_experiment_fk_name():
 def upgrade():
     dialect_name = op.get_context().dialect.name
 
-    old_fk_constraint_name = get_datasets_experiment_fk_name()
-
     # standardize the constraint to sqlite naming convention
     new_fk_constraint_name = f"fk_{SqlDataset.__tablename__}_experiment_id_{SqlExperiment.__tablename__}"
 
@@ -59,7 +63,8 @@ def upgrade():
                 "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
             },
         ) as batch_op:
-            batch_op.drop_constraint(old_fk_constraint_name, type_="foreignkey")
+            # in SQLite, constraint.name is None, so we have to hardcode it
+            batch_op.drop_constraint(new_fk_constraint_name, type_="foreignkey")
             # Need to explicitly name the fk constraint with batch alter table
             batch_op.create_foreign_key(
                 new_fk_constraint_name,
@@ -69,6 +74,7 @@ def upgrade():
                 ondelete="CASCADE",
             )
     else:
+        old_fk_constraint_name = get_datasets_experiment_fk_name()
         op.drop_constraint(old_fk_constraint_name, SqlDataset.__tablename__, type_="foreignkey")
         op.create_foreign_key(
             new_fk_constraint_name,

--- a/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
+++ b/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
@@ -29,7 +29,8 @@ def get_datasets_experiment_fk_name():
     )
 
     for constraint in datasets_table.foreign_key_constraints:
-        if constraint.referred_table.name == SqlExperiment.__tablename__:
+        if (constraint.referred_table.name == SqlExperiment.__tablename__ and
+            constraint.column_keys[0] == "experiment_id"):
             return constraint.name
     
     return None

--- a/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
+++ b/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
@@ -8,6 +8,7 @@ Create Date: 2024-11-11 15:27:53.189685
 from alembic import op
 import sqlalchemy as sa
 
+from mlflow.exceptions import MlflowException
 from mlflow.store.tracking.dbmodels.models import SqlDataset, SqlExperiment
 
 
@@ -33,11 +34,17 @@ def get_datasets_experiment_fk_name():
             constraint.column_keys[0] == "experiment_id"):
             return constraint.name
     
-    return None
+    raise MlflowException(
+        "Unable to find the foreign key constraint name from datasets to experiments. "
+        "All foreign key constraints in datasets table: \n"
+        f"{datasets_table.foreign_key_constraints}"
+    )
 
 
 def upgrade():
     dialect_name = op.get_context().dialect.name
+
+    old_fk_constraint_name = get_datasets_experiment_fk_name()
 
     # standardize the constraint to sqlite naming convention
     new_fk_constraint_name = f"fk_{SqlDataset.__tablename__}_experiment_id_{SqlExperiment.__tablename__}"
@@ -52,7 +59,7 @@ def upgrade():
                 "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
             },
         ) as batch_op:
-            batch_op.drop_constraint(new_fk_constraint_name, type_="foreignkey")
+            batch_op.drop_constraint(old_fk_constraint_name, type_="foreignkey")
             # Need to explicitly name the fk constraint with batch alter table
             batch_op.create_foreign_key(
                 new_fk_constraint_name,
@@ -62,17 +69,7 @@ def upgrade():
                 ondelete="CASCADE",
             )
     else:
-        if dialect_name == "postgresql":
-            fk_constraint_name = f"{SqlDataset.__tablename__}_experiment_id_fkey"
-        elif dialect_name == "mysql":
-            fk_constraint_name = f"{SqlDataset.__tablename__}_ibfk_1"
-        elif dialect_name == "mssql":
-            # mssql fk constraint name is nondeterministic.
-            # attempt to find the name by querying the table,
-            # otherwise use the specified name at rev f5a4f2784254
-            fk_constraint_name = get_datasets_experiment_fk_name() or f"FK__{SqlDataset.__tablename__}__experi__6477ECF3"
-
-        op.drop_constraint(fk_constraint_name, SqlDataset.__tablename__, type_="foreignkey")
+        op.drop_constraint(old_fk_constraint_name, SqlDataset.__tablename__, type_="foreignkey")
         op.create_foreign_key(
             new_fk_constraint_name,
             SqlDataset.__tablename__,

--- a/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
+++ b/mlflow/store/db_migrations/versions/0584bdc529eb_add_cascading_deletion_to_datasets_from_experiments.py
@@ -29,12 +29,6 @@ def get_datasets_experiment_fk_name():
         autoload_with=conn,
     )
 
-    print(
-        "@@@@ Unable to find the foreign key constraint name from datasets to experiments. "
-        "All foreign key constraints in datasets table: \n"
-        f"{datasets_table.foreign_key_constraints}"
-    )
-
     for constraint in datasets_table.foreign_key_constraints:
         if (constraint.referred_table.name == SqlExperiment.__tablename__ and
             constraint.column_keys[0] == "experiment_id"):

--- a/tests/db/check_migration.sh
+++ b/tests/db/check_migration.sh
@@ -4,9 +4,9 @@ set -ex
 cd tests/db
 
 # Install the lastest version of mlflow from PyPI
-# pip install mlflow
+pip install mlflow
+python check_migration.py pre-migration
 # Install mlflow from the repository
 pip install -e ../..
-python check_migration.py pre-migration
 mlflow db upgrade $MLFLOW_TRACKING_URI
 python check_migration.py post-migration

--- a/tests/db/check_migration.sh
+++ b/tests/db/check_migration.sh
@@ -4,9 +4,9 @@ set -ex
 cd tests/db
 
 # Install the lastest version of mlflow from PyPI
-pip install mlflow
-python check_migration.py pre-migration
+# pip install mlflow
 # Install mlflow from the repository
 pip install -e ../..
+python check_migration.py pre-migration
 mlflow db upgrade $MLFLOW_TRACKING_URI
 python check_migration.py post-migration


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14146?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14146/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14146
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #13890

### What changes are proposed in this pull request?

It seems that the MSSQL constraint name is nondeterministic (some users' constraint names don't match the db schema in MLflow). Instead of hardcoding, get the column name by querying the foreign key constraint.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
