### PR TITLE
Implement chat message attribute logic for LangChain

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -430,7 +430,7 @@ nitpick_ignore = [
     ("py:class", "remove"),
     # sphinx can't resolve TYPE_CHECKING imports
     ("py:class", "LiveSpan"),
-    ("py:class", "RequestMessage"),
+    ("py:class", "ChatMessage"),
     ("py:class", "ChatTool"),
 ]
 

--- a/docs/source/llms/tracing/tracing-schema.rst
+++ b/docs/source/llms/tracing/tracing-schema.rst
@@ -359,7 +359,7 @@ custom attributes for standardized chat messages and tool defintions:
         conversation with the chat model. It enables rich conversation rendering in the UI,
         and will also be used in MLflow evaluation in the future. 
         
-        The type must be ``List[`` :py:class:`RequestMessage <mlflow.types.chat.RequestMessage>` ``]``
+        The type must be ``List[`` :py:class:`ChatMessage <mlflow.types.chat.ChatMessage>` ``]``
       - This attribute can be conveniently set using the :py:func:`mlflow.tracing.set_span_chat_messages` function. This function
         will throw a validation error if the data does not conform to the spec.
     
@@ -368,7 +368,7 @@ custom attributes for standardized chat messages and tool defintions:
         context, this would be equivalent to the `tools <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools>`_ 
         param in the Chat Completions API.
 
-        The type must be ``List[`` :py:class:`RequestMessage <mlflow.types.chat.ChatTool>` ``]``
+        The type must be ``List[`` :py:class:`ChatTool <mlflow.types.chat.ChatTool>` ``]``
       - This attribute can be conveniently set using the :py:func:`mlflow.tracing.set_span_chat_tools` function. This function
         will throw a validation error if the data does not conform to the spec.
 

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -1,13 +1,47 @@
+"""
+This module defines the schemas for the MLflow AI Gateway's chat endpoint.
+
+The schemas must be compatible with OpenAI's Chat Completion API.
+https://platform.openai.com/docs/api-reference/chat
+
+NB: These Pydantic models just alias the models defined in mlflow.types.chat to avoid code
+    duplication, but with the addition of RequestModel and ResponseModel base classes.
+"""
+
+from typing import Literal, Optional
+
+from pydantic import Field
+
 from mlflow.gateway.base_models import RequestModel, ResponseModel
 from mlflow.types.chat import (
+    ChatChoice,
+    ChatChoiceDelta,
+    ChatChunkChoice,
     ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
+    ChatMessage,
+    FunctionToolDefinition,
 )
-
-# Alias ChatMessage from mlflow.types.chat to RequestMessage for backwards compatibility
-from mlflow.types.chat import ChatMessage as RequestMessage  # noqa: F401
+from mlflow.types.chat import ChatCompletionRequest as _Function
+from mlflow.types.chat import ChatCompletionResponse as _ToolCall
+from mlflow.types.chat import ChatUsage as _ChatUsage
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
+
+
+class RequestMessage(ChatMessage, RequestModel):
+    pass
+
+
+class UnityCatalogFunctionToolDefinition(RequestModel):
+    name: str
+
+
+class ChatToolWithUC(RequestModel):
+    type: Literal["function", "uc_function"]
+    function: Optional[FunctionToolDefinition] = None
+    uc_function: Optional[UnityCatalogFunctionToolDefinition] = None
+
 
 _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
     "messages": [
@@ -22,7 +56,12 @@ _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
 }
 
 
+# NB: RequestPayload is mostly OpenAI's ChatCompletion API spec, except for the `tools` field.
+#     The field accepts a tool with a special type 'uc_function' for Unity Catalog integration.
+#     https://mlflow.org/docs/latest/llms/deployments/uc_integration.html
 class RequestPayload(ChatCompletionRequest, RequestModel):
+    tools: Optional[list[ChatToolWithUC]] = None
+
     class Config:
         if IS_PYDANTIC_V2_OR_NEWER:
             json_schema_extra = _REQUEST_PAYLOAD_EXTRA_SCHEMA
@@ -48,12 +87,47 @@ _RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 }
 
 
+class Function(_Function, ResponseModel):
+    pass
+
+
+class ToolCall(_ToolCall, ResponseModel):
+    pass
+
+
+class ResponseMessage(ChatMessage, ResponseModel):
+    # Override the `tool_call_id` field to be excluded from the response.
+    # This is a band-aid solution to avoid exposing the tool_call_id in the response,
+    # while we use the same ChatMessage model for both request and response.
+    tool_call_id: Optional[str] = Field(None, exclude=True)
+
+
+class Choice(ChatChoice, ResponseModel):
+    # Override the `message` field to use the ResponseMessage model.
+    message: ResponseMessage
+
+
+class ChatUsage(_ChatUsage, ResponseModel):
+    pass
+
+
 class ResponsePayload(ChatCompletionResponse, ResponseModel):
+    # Override the `choices` field to use the Choice model
+    choices: list[Choice]
+
     class Config:
         if IS_PYDANTIC_V2_OR_NEWER:
             json_schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
         else:
             schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
+
+
+class StreamDelta(ChatChoiceDelta, ResponseModel):
+    pass
+
+
+class StreamChoice(ChatChunkChoice, ResponseModel):
+    pass
 
 
 _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -39,7 +39,7 @@ class UnityCatalogFunctionToolDefinition(RequestModel):
 class ChatToolWithUC(RequestModel):
     """
     A tool definition for the chat endpoint with Unity Catalog integration.
-    The Gateway request accepts a tool with a special type 'uc_function' for Unity Catalog integration.
+    The Gateway request accepts a special tool type 'uc_function' for Unity Catalog integration.
     https://mlflow.org/docs/latest/llms/deployments/uc_integration.html
     """
 

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -4,6 +4,9 @@ from mlflow.types.chat import (
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
+
+# Alias ChatMessage from mlflow.types.chat to RequestMessage for backwards compatibility
+from mlflow.types.chat import ChatMessage as RequestMessage  # noqa: F401
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
 _REQUEST_PAYLOAD_EXTRA_SCHEMA = {

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -1,20 +1,10 @@
-from typing import Optional
-
-from pydantic import Field
-
 from mlflow.gateway.base_models import RequestModel, ResponseModel
-from mlflow.types.chat import ChatTools, ContentType, RequestMessage, ToolCall
+from mlflow.types.chat import (
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+)
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
-
-
-class BaseRequestPayload(ChatTools, RequestModel):
-    temperature: float = Field(0.0, ge=0, le=2)
-    n: int = Field(1, ge=1)
-    stop: Optional[list[str]] = Field(None, min_items=1)
-    max_tokens: Optional[int] = Field(None, ge=1)
-    stream: Optional[bool] = None
-    model: Optional[str] = None
-
 
 _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
     "messages": [
@@ -29,34 +19,12 @@ _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
 }
 
 
-class RequestPayload(BaseRequestPayload):
-    messages: list[RequestMessage] = Field(..., min_items=1)
-
+class RequestPayload(ChatCompletionRequest, RequestModel):
     class Config:
         if IS_PYDANTIC_V2_OR_NEWER:
             json_schema_extra = _REQUEST_PAYLOAD_EXTRA_SCHEMA
         else:
             schema_extra = _REQUEST_PAYLOAD_EXTRA_SCHEMA
-
-
-class ResponseMessage(ResponseModel):
-    role: str
-    content: Optional[ContentType] = None
-    tool_calls: Optional[list[ToolCall]] = None
-    tool_call_id: Optional[str] = None
-    refusal: Optional[str] = None
-
-
-class Choice(ResponseModel):
-    index: int
-    message: ResponseMessage
-    finish_reason: Optional[str] = None
-
-
-class ChatUsage(ResponseModel):
-    prompt_tokens: Optional[int] = None
-    completion_tokens: Optional[int] = None
-    total_tokens: Optional[int] = None
 
 
 _RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
@@ -77,30 +45,12 @@ _RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 }
 
 
-class ResponsePayload(ResponseModel):
-    id: Optional[str] = None
-    object: str = "chat.completion"
-    created: int
-    model: str
-    choices: list[Choice]
-    usage: ChatUsage
-
+class ResponsePayload(ChatCompletionResponse, ResponseModel):
     class Config:
         if IS_PYDANTIC_V2_OR_NEWER:
             json_schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
         else:
             schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
-
-
-class StreamDelta(ResponseModel):
-    role: Optional[str] = None
-    content: Optional[str] = None
-
-
-class StreamChoice(ResponseModel):
-    index: int
-    finish_reason: Optional[str] = None
-    delta: StreamDelta
 
 
 _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
@@ -120,13 +70,7 @@ _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 }
 
 
-class StreamResponsePayload(ResponseModel):
-    id: Optional[str] = None
-    object: str = "chat.completion.chunk"
-    created: int
-    model: str
-    choices: list[StreamChoice]
-
+class StreamResponsePayload(ChatCompletionChunk, ResponseModel):
     class Config:
         if IS_PYDANTIC_V2_OR_NEWER:
             json_schema_extra = _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -43,6 +43,7 @@ class ResponseMessage(ResponseModel):
     role: str
     content: Optional[ContentType] = None
     tool_calls: Optional[list[ToolCall]] = None
+    tool_call_id: Optional[str] = None
     refusal: Optional[str] = None
 
 

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -14,9 +14,11 @@ from pydantic import Field
 
 from mlflow.gateway.base_models import RequestModel, ResponseModel
 
-# Import marked with noqa is for aliasing the models from mlflow.types.chat
+# Import marked with noqa is for backward compatibility
 from mlflow.types.chat import (
     ChatChoice,
+    ChatChoiceDelta,
+    ChatChunkChoice,
     ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -26,10 +28,12 @@ from mlflow.types.chat import (
     FunctionToolDefinition,
     ToolCall,  # noqa F401
 )
-from mlflow.types.chat import ChatChoiceDelta as StreamDelta  # noqa F401
-from mlflow.types.chat import ChatChunkChoice as StreamChoice  # noqa F401
-from mlflow.types.chat import ChatMessage as RequestMessage
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
+
+# NB: `import x as y` does not work and will cause a Pydantic error.
+StreamDelta = ChatChoiceDelta
+StreamChoice = ChatChunkChoice
+RequestMessage = ChatMessage
 
 
 class UnityCatalogFunctionToolDefinition(RequestModel):

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -24,8 +24,8 @@ from mlflow.types.chat import (
     FunctionToolDefinition,
 )
 from mlflow.types.chat import ChatCompletionRequest as _Function
-from mlflow.types.chat import ChatCompletionResponse as _ToolCall
 from mlflow.types.chat import ChatUsage as _ChatUsage
+from mlflow.types.chat import ToolCall as _ToolCall
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
 

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -66,7 +66,7 @@ _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
 
 
 class RequestPayload(ChatCompletionRequest, RequestModel):
-    messages: list[RequestMessage]
+    messages: list[RequestMessage] = Field(..., min_items=1)
     tools: Optional[list[ChatToolWithUC]] = None
 
     class Config:

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from mlflow.gateway.base_models import ResponseModel
+from mlflow.gateway.base_models import RequestModel, ResponseModel
 from mlflow.types.chat import BaseRequestPayload
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
@@ -15,7 +15,7 @@ _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
 }
 
 
-class RequestPayload(BaseRequestPayload):
+class RequestPayload(BaseRequestPayload, RequestModel):
     prompt: str
     model: Optional[str] = None
 

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from mlflow.gateway.base_models import ResponseModel
-from mlflow.gateway.schemas.chat import BaseRequestPayload
+from mlflow.types.chat import BaseRequestPayload
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
 _REQUEST_PAYLOAD_EXTRA_SCHEMA = {

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -64,8 +64,7 @@ def convert_lc_message_to_chat_message(lc_message: Union[BaseMessage]) -> ChatMe
         return ChatMessage(role="system", content=lc_message.content)
     else:
         raise MlflowException.invalid_parameter_value(
-            f"Unexpected message type: {type(lc_message)}. "
-            "Expected an AIMessage, a HumanMessage, or a SystemMessage object."
+            f"Unexpected message type. Expected a BaseMessage subclass, but got: {type(lc_message)}"
         )
 
 
@@ -90,6 +89,10 @@ def _chat_model_to_langchain_message(message: ChatMessage) -> BaseMessage:
 
 
 def _get_tool_calls_from_ai_message(message: AIMessage) -> list[dict]:
+    # AIMessage does not have tool_calls field in LangChain < 0.1.0.
+    if not hasattr(message, "tool_calls"):
+        return []
+
     tool_calls = [
         {
             "type": "function",

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -20,12 +20,14 @@ from mlflow.environment_variables import MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCH
 from mlflow.exceptions import MlflowException
 from mlflow.types.chat import (
     ChatChoice,
+    ChatChoiceDelta,
+    ChatChunkChoice,
+    ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChatMessage,
     ChatUsage,
 )
-from mlflow.types.llm import ChatChoiceDelta, ChatChunkChoice, ChatCompletionChunk
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
 _logger = logging.getLogger(__name__)

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -3,6 +3,7 @@ import logging
 import time
 from typing import Any, Union
 
+import pydantic
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -334,7 +335,7 @@ def transform_request_json_for_chat_if_necessary(request_json, lc_model):
     if should_convert:
         try:
             return _convert_chat_request(request_json), True
-        except MlflowException:
+        except pydantic.ValidationError:
             _logger.debug(
                 "Failed to convert the request JSON to LangChain's Message format. "
                 "The request will be passed to the LangChain model as-is. ",

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -3,7 +3,6 @@ import logging
 import time
 from typing import Any, Union
 
-import pydantic
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -335,7 +334,7 @@ def transform_request_json_for_chat_if_necessary(request_json, lc_model):
     if should_convert:
         try:
             return _convert_chat_request(request_json), True
-        except pydantic.ValidationError:
+        except MlflowException:
             _logger.debug(
                 "Failed to convert the request JSON to LangChain's Message format. "
                 "The request will be passed to the LangChain model as-is. ",

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -23,7 +23,7 @@ SPANS_COLUMN_NAME = "spans"
 
 if TYPE_CHECKING:
     from mlflow.entities import LiveSpan
-    from mlflow.types.chat import ChatTool, RequestMessage
+    from mlflow.types.chat import ChatMessage, ChatTools
 
 
 def capture_function_input_args(func, args, kwargs) -> dict[str, Any]:
@@ -238,7 +238,7 @@ def generate_request_id() -> str:
 
 def set_span_chat_messages(
     span: LiveSpan,
-    messages: list[RequestMessage],
+    messages: list[ChatMessage],
 ):
     """
     Set the `mlflow.chat.messages` attribute on the specified span. This
@@ -270,15 +270,15 @@ def set_span_chat_messages(
 
         f()
     """
-    from mlflow.types.chat import RequestMessage
+    from mlflow.types.chat import ChatMessage
 
     for message in messages:
-        RequestMessage.validate_compat(message)
+        ChatMessage.validate_compat(message)
 
     span.set_attribute(SpanAttributeKey.CHAT_MESSAGES, messages)
 
 
-def set_span_chat_tools(span: LiveSpan, tools: list[ChatTool]):
+def set_span_chat_tools(span: LiveSpan, tools: list[ChatTools]):
     """
     Set the `mlflow.chat.tools` attribute on the specified span. This
     attribute is used in the UI, and also by downstream applications that

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -23,7 +23,7 @@ SPANS_COLUMN_NAME = "spans"
 
 if TYPE_CHECKING:
     from mlflow.entities import LiveSpan
-    from mlflow.types.chat import ChatMessage, ChatTools
+    from mlflow.types.chat import ChatMessage, ChatTool
 
 
 def capture_function_input_args(func, args, kwargs) -> dict[str, Any]:
@@ -278,7 +278,7 @@ def set_span_chat_messages(
     span.set_attribute(SpanAttributeKey.CHAT_MESSAGES, messages)
 
 
-def set_span_chat_tools(span: LiveSpan, tools: list[ChatTools]):
+def set_span_chat_tools(span: LiveSpan, tools: list[ChatTool]):
     """
     Set the `mlflow.chat.tools` attribute on the specified span. This
     attribute is used in the UI, and also by downstream applications that

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -326,7 +326,14 @@ def set_span_chat_tools(span: LiveSpan, tools: list[ChatTool]):
 
         f()
     """
-    from mlflow.types.chat import ChatTools
+    from mlflow.types.chat import ChatTool
 
-    ChatTools.validate_compat({"tools": tools})
+    if not isinstance(tools, list):
+        raise MlflowTracingException(
+            f"Invalid tools type {type(tools)}. Expected a list of ChatTool.",
+            error_code=BAD_REQUEST,
+        )
+    for tool in tools:
+        ChatTool.validate_compat(tool)
+
     span.set_attribute(SpanAttributeKey.CHAT_TOOLS, tools)

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -97,7 +97,7 @@ class ChatMessage(BaseModel):
 
 
 class ParamType(BaseModel):
-    type: Literal["string", "number", "integer", "object", "array", "boolean", "null"]
+    type: Optional[Literal["string", "number", "integer", "object", "array", "boolean", "null"]] = None
 
 
 class ParamProperty(ParamType):

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -123,7 +123,7 @@ class ChatTools(BaseModel):
     tools: Optional[list[ChatTool]] = Field(None, min_items=1)
 
 
-class ChatCompletionRequest(ChatTool, BaseModel):
+class ChatCompletionRequest(ChatTools, BaseModel):
     messages: list[ChatMessage] = Field(..., min_items=1)
     temperature: float = Field(0.0, ge=0, le=2)
     n: int = Field(1, ge=1)

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -127,10 +127,6 @@ class ChatTool(BaseModel):
     function: Optional[FunctionToolDefinition] = None
 
 
-class ChatTools(BaseModel):
-    tools: Optional[list[ChatTool]] = Field(None, min_items=1)
-
-
 class BaseRequestPayload(BaseModel):
     """Common parameters used for chat completions and completion endpoints."""
 
@@ -142,7 +138,7 @@ class BaseRequestPayload(BaseModel):
     model: Optional[str] = None
 
 
-class ChatCompletionRequest(ChatTools, BaseRequestPayload):
+class ChatCompletionRequest(BaseRequestPayload):
     """
     A request to the chat completion API.
 
@@ -151,6 +147,7 @@ class ChatCompletionRequest(ChatTools, BaseRequestPayload):
     """
 
     messages: list[ChatMessage] = Field(..., min_items=1)
+    tools: Optional[list[ChatTool]] = Field(None, min_items=1)
 
 
 class ChatCompletionResponse(BaseModel):

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -3,22 +3,18 @@ from __future__ import annotations
 from typing import Annotated, Any, Literal, Optional, Union
 
 from pydantic import BaseModel as _BaseModel
-from pydantic import Field, ValidationError
+from pydantic import Field
 
-from mlflow.exceptions import MlflowException
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
 
 class BaseModel(_BaseModel):
     @classmethod
     def validate_compat(cls, obj: Any):
-        try:
-            if IS_PYDANTIC_V2_OR_NEWER:
-                return cls.model_validate(obj)
-            else:
-                return cls.parse_obj(obj)
-        except ValidationError as e:
-            raise MlflowException.invalid_parameter_value(e) from e
+        if IS_PYDANTIC_V2_OR_NEWER:
+            return cls.model_validate(obj)
+        else:
+            return cls.parse_obj(obj)
 
 
 class TextContentPart(BaseModel):

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -67,7 +67,7 @@ class ToolCall(BaseModel):
     function: Function
 
 
-class RequestMessage(BaseModel):
+class ChatMessage(BaseModel):
     """
     A chat request. ``content`` can be a string, or an array of content parts.
 
@@ -121,3 +121,53 @@ class ChatTool(BaseModel):
 
 class ChatTools(BaseModel):
     tools: Optional[list[ChatTool]] = Field(None, min_items=1)
+
+
+class ChatCompletionRequest(ChatTool, BaseModel):
+    messages: list[ChatMessage] = Field(..., min_items=1)
+    temperature: float = Field(0.0, ge=0, le=2)
+    n: int = Field(1, ge=1)
+    stop: Optional[list[str]] = Field(None, min_items=1)
+    max_tokens: Optional[int] = Field(None, ge=1)
+    stream: Optional[bool] = None
+    model: Optional[str] = None
+
+
+class ChatChoice(BaseModel):
+    index: int
+    message: ChatMessage
+    finish_reason: Optional[str] = None
+
+
+class ChatUsage(BaseModel):
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+
+
+class ChatCompletionResponse(BaseModel):
+    id: Optional[str] = None
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: list[ChatChoice]
+    usage: ChatUsage
+
+
+class ChatChoiceDelta(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class ChatChunkChoice(BaseModel):
+    index: int
+    finish_reason: Optional[str] = None
+    delta: ChatChoiceDelta
+
+
+class ChatCompletionChunk(BaseModel):
+    id: Optional[str] = None
+    object: str = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: list[ChatChunkChoice]

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -97,7 +97,9 @@ class ChatMessage(BaseModel):
 
 
 class ParamType(BaseModel):
-    type: Optional[Literal["string", "number", "integer", "object", "array", "boolean", "null"]] = None
+    type: Optional[Literal["string", "number", "integer", "object", "array", "boolean", "null"]] = (
+        None
+    )
 
 
 class ParamProperty(ParamType):

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -92,8 +92,8 @@ class ChatMessage(BaseModel):
     #   system/user/assistant/tool, etc), and create a factory function to allow users
     #   to create them without worrying about the details.
     tool_calls: Optional[list[ToolCall]] = Field(None, min_items=1)
-    refusal: Optional[str] = Field(None)
-    tool_call_id: Optional[str] = Field(None)
+    refusal: Optional[str] = None
+    tool_call_id: Optional[str] = None
 
 
 class ParamType(BaseModel):

--- a/tests/langchain/test_chat_utils.py
+++ b/tests/langchain/test_chat_utils.py
@@ -9,7 +9,6 @@ from langchain_core.messages import (
     AIMessageChunk,
     HumanMessage,
     SystemMessage,
-    ToolCall,
     ToolMessage,
 )
 from packaging.version import Version
@@ -54,6 +53,8 @@ def test_convert_lc_message_to_chat_message(message, expected):
     reason="AIMessage does not have tool_calls attribute",
 )
 def test_convert_lc_message_to_chat_message_too_calls():
+    from langchain_core.messages import ToolCall
+
     message = AIMessage(
         content="", tool_calls=[ToolCall(name="tool_name", args={"arg1": "val1"}, id="123")]
     )

--- a/tests/langchain/test_chat_utils.py
+++ b/tests/langchain/test_chat_utils.py
@@ -1,15 +1,74 @@
 from unittest.mock import MagicMock, patch
 
+import langchain
+import pytest
 from langchain.agents import AgentExecutor
-from langchain.chat_models.base import SimpleChatModel
-from langchain.schema import AIMessage, HumanMessage, SystemMessage
-from langchain_core.messages.ai import AIMessageChunk
+from langchain_core.language_models.chat_models import SimpleChatModel
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    HumanMessage,
+    SystemMessage,
+    ToolCall,
+    ToolMessage,
+)
+from packaging.version import Version
 
 from mlflow.langchain.utils.chat import (
+    convert_lc_message_to_chat_message,
     transform_request_json_for_chat_if_necessary,
     try_transform_response_iter_to_chat_format,
     try_transform_response_to_chat_format,
 )
+from mlflow.types.chat import ChatMessage, Function
+from mlflow.types.chat import ToolCall as _ToolCall
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            AIMessage(content="foo", id="123"),
+            ChatMessage(role="assistant", content="foo", id="123"),
+        ),
+        (
+            ToolMessage(content="foo", tool_call_id="123"),
+            ChatMessage(role="tool", content="foo", tool_call_id="123"),
+        ),
+        (
+            SystemMessage(content="foo"),
+            ChatMessage(role="system", content="foo"),
+        ),
+        (
+            HumanMessage(content="foo"),
+            ChatMessage(role="user", content="foo"),
+        ),
+    ],
+)
+def test_convert_lc_message_to_chat_message(message, expected):
+    assert convert_lc_message_to_chat_message(message) == expected
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.1.0"),
+    reason="AIMessage does not have tool_calls attribute",
+)
+def test_convert_lc_message_to_chat_message_too_calls():
+    message = AIMessage(
+        content="", tool_calls=[ToolCall(name="tool_name", args={"arg1": "val1"}, id="123")]
+    )
+
+    assert convert_lc_message_to_chat_message(message) == ChatMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            _ToolCall(
+                id="123",
+                type="function",
+                function=Function(name="tool_name", arguments='{"arg1": "val1"}'),
+            )
+        ],
+    )
 
 
 def test_transform_response_to_chat_format_no_conversion():

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -294,16 +294,10 @@ def test_llmchain_autolog(async_logging_enabled):
             {
                 "role": "user",
                 "content": "What is MLflow?",
-                "tool_calls": None,
-                "tool_call_id": None,
-                "refusal": None,
             },
             {
                 "role": "assistant",
                 "content": "What is MLflow?",
-                "tool_calls": None,
-                "tool_call_id": None,
-                "refusal": None,
             },
         ]
 
@@ -414,16 +408,10 @@ def test_chat_model_autolog():
         {
             "role": "system",
             "content": "You are a helpful assistant.",
-            "tool_calls": None,
-            "tool_call_id": None,
-            "refusal": None,
         },
         {
             "role": "user",
             "content": "What is the weather in San Francisco?",
-            "tool_calls": None,
-            "tool_call_id": None,
-            "refusal": None,
         },
         {
             "role": "assistant",
@@ -438,22 +426,15 @@ def test_chat_model_autolog():
                     "type": "function",
                 }
             ],
-            "tool_call_id": None,
-            "refusal": None,
         },
         {
             "role": "tool",
             "content": "Weather in San Francisco is 70F.",
-            "tool_calls": None,
             "tool_call_id": "123",
-            "refusal": None,
         },
         {
             "role": "assistant",
             "content": response.content,
-            "tool_calls": None,
-            "tool_call_id": None,
-            "refusal": None,
         },
     ]
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -388,7 +388,7 @@ def test_chat_model_autolog():
         SystemMessage(content="You are a helpful assistant."),
         HumanMessage(content="What is the weather in San Francisco?"),
         AIMessage(
-            content="",
+            content="foo",
             tool_calls=[{"name": "GetWeather", "args": {"location": "San Francisco"}, "id": "123"}],
         ),
         ToolMessage(content="Weather in San Francisco is 70F.", tool_call_id="123"),
@@ -427,7 +427,7 @@ def test_chat_model_autolog():
         },
         {
             "role": "assistant",
-            "content": None,
+            "content": "foo",
             "tool_calls": [
                 {
                     "function": {

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -398,7 +398,10 @@ def test_chat_model_autolog():
     span = traces[0].data.spans[0]
     assert span.name == "ChatOpenAI"
     assert span.span_type == "CHAT_MODEL"
-    assert span.inputs == [[msg.model_dump() for msg in messages]]
+    if Version(langchain.__version__) >= Version("0.2.0"):
+        assert span.inputs == [[msg.model_dump() for msg in messages]]
+    else:
+        assert span.inputs == [[msg.dict() for msg in messages]]
     assert span.outputs["generations"][0][0]["message"]["content"] == response.content
     assert span.get_attribute("invocation_params")["model"] == "gpt-4o-mini"
     assert span.get_attribute("invocation_params")["temperature"] == 0.9

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -377,6 +377,10 @@ def test_loaded_llmchain_autolog():
         assert signature == infer_signature(question, [TEST_CONTENT])
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.1.0"),
+    reason="Callback does not pass all messages in older versions",
+)
 def test_chat_model_autolog():
     mlflow.langchain.autolog()
     model = ChatOpenAI(model="gpt-4o-mini", temperature=0.9)
@@ -398,7 +402,8 @@ def test_chat_model_autolog():
     span = traces[0].data.spans[0]
     assert span.name == "ChatOpenAI"
     assert span.span_type == "CHAT_MODEL"
-    if Version(langchain.__version__) >= Version("0.2.0"):
+    # LangChain uses pydantic V1 until LangChain v0.3.0
+    if Version(langchain.__version__) >= Version("0.3.0"):
         assert span.inputs == [[msg.model_dump() for msg in messages]]
     else:
         assert span.inputs == [[msg.dict() for msg in messages]]

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -378,7 +378,7 @@ def test_loaded_llmchain_autolog():
 
 
 @pytest.mark.skipif(
-    Version(langchain.__version__) < Version("0.1.0"),
+    Version(langchain.__version__) < Version("0.2.0"),
     reason="Callback does not pass all messages in older versions",
 )
 def test_chat_model_autolog():
@@ -386,7 +386,7 @@ def test_chat_model_autolog():
     model = ChatOpenAI(model="gpt-4o-mini", temperature=0.9)
     messages = [
         SystemMessage(content="You are a helpful assistant."),
-        HumanMessage(content="What is MLflow?"),
+        HumanMessage(content="What is the weather in San Francisco?"),
         AIMessage(
             content="",
             tool_calls=[{"name": "GetWeather", "args": {"location": "San Francisco"}, "id": "123"}],
@@ -420,7 +420,7 @@ def test_chat_model_autolog():
         },
         {
             "role": "user",
-            "content": "What is MLflow?",
+            "content": "What is the weather in San Francisco?",
             "tool_calls": None,
             "tool_call_id": None,
             "refusal": None,

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -37,6 +37,8 @@ try:
     from langchain_huggingface import HuggingFacePipeline
 except ImportError:
     from langchain_community.llms import HuggingFacePipeline
+from unittest.mock import ANY
+
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.chat_models.base import SimpleChatModel
 from langchain.llms.base import LLM
@@ -905,7 +907,7 @@ def test_log_and_load_retriever_chain(tmp_path):
     ]
     # "id" field was added to Document model in langchain 0.2.7
     if Version(langchain.__version__) >= Version("0.2.7"):
-        expected_result = [{**d, "id": None} for d in expected_result]
+        expected_result = [{**d, "id": ANY} for d in expected_result]
     assert result == [expected_result]
 
     # Serve the retriever
@@ -1275,11 +1277,17 @@ def test_predict_with_callbacks_supports_chat_response_conversion(fake_chat_mode
         "id": None,
         "object": "chat.completion",
         "created": 1677858242,
-        "model": None,
+        "model": "",
         "choices": [
             {
                 "index": 0,
-                "message": {"role": "assistant", "content": "Databricks"},
+                "message": {
+                    "role": "assistant",
+                    "content": "Databricks",
+                    "refusal": None,
+                    "tool_call_id": None,
+                    "tool_calls": None,
+                },
                 "finish_reason": None,
             }
         ],
@@ -1372,6 +1380,9 @@ def test_simple_chat_model_inference():
             "ai: What would you like to ask?\n"
             "human: Who owns MLflow?"
         ),
+        "refusal": None,
+        "tool_call_id": None,
+        "tool_calls": None,
     }
     response1 = loaded_model.predict([input_example])
     assert len(response1) == 1
@@ -2152,13 +2163,16 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
         "id": None,
         "object": "chat.completion",
         "created": 1677858242,
-        "model": None,
+        "model": "",
         "choices": [
             {
                 "index": 0,
                 "message": {
                     "role": "assistant",
                     "content": content,
+                    "refusal": None,
+                    "tool_call_id": None,
+                    "tool_calls": None,
                 },
                 "finish_reason": None,
             }
@@ -2226,13 +2240,16 @@ def test_predict_with_builtin_pyfunc_chat_conversion_for_aimessage_response():
                 "id": None,
                 "object": "chat.completion",
                 "created": 1677858242,
-                "model": None,
+                "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
                             "content": "You own MLflow",
+                            "refusal": None,
+                            "tool_call_id": None,
+                            "tool_calls": None,
                         },
                         "finish_reason": None,
                     }
@@ -2281,18 +2298,18 @@ def test_pyfunc_builtin_chat_request_conversion_fails_gracefully():
     ]
     assert pyfunc_loaded_model.predict(
         {
-            "messages": [{"role": "user", "content": "blah"}, {"role": "blah"}],
+            "messages": [{"role": "user", "content": "blah"}, {}],
         }
     ) == [
         {"role": "user", "content": "blah"},
-        {"role": "blah"},
+        {},
     ]
     assert pyfunc_loaded_model.predict(
         {
-            "messages": [{"role": "role", "content": "content", "extra": "extra"}],
+            "messages": [{"role": "user", "content": 123}],
         }
     ) == [
-        {"role": "role", "content": "content", "extra": "extra"},
+        {"role": "user", "content": 123},
     ]
 
     # Verify behavior for batches of message histories
@@ -2930,7 +2947,7 @@ def test_simple_chat_model_stream_inference(fake_chat_stream_model, provide_sign
                     "id": None,
                     "object": "chat.completion.chunk",
                     "created": 1677858242,
-                    "model": None,
+                    "model": "",
                     "choices": [
                         {
                             "index": 0,
@@ -2943,7 +2960,7 @@ def test_simple_chat_model_stream_inference(fake_chat_stream_model, provide_sign
                     "id": None,
                     "object": "chat.completion.chunk",
                     "created": 1677858242,
-                    "model": None,
+                    "model": "",
                     "choices": [
                         {
                             "index": 0,
@@ -2956,7 +2973,7 @@ def test_simple_chat_model_stream_inference(fake_chat_stream_model, provide_sign
                     "id": None,
                     "object": "chat.completion.chunk",
                     "created": 1677858242,
-                    "model": None,
+                    "model": "",
                     "choices": [
                         {
                             "index": 0,
@@ -3147,11 +3164,17 @@ def test_save_model_as_code_correct_streamable(chain_model_signature, chain_path
             "id": None,
             "object": "chat.completion",
             "created": 1677858242,
-            "model": None,
+            "model": "",
             "choices": [
                 {
                     "index": 0,
-                    "message": {"role": "assistant", "content": "Databricks"},
+                    "message": {
+                        "role": "assistant",
+                        "content": "Databricks",
+                        "refusal": None,
+                        "tool_call_id": None,
+                        "tool_calls": None,
+                    },
                     "finish_reason": None,
                 }
             ],

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2343,12 +2343,15 @@ def test_pyfunc_builtin_chat_request_conversion_fails_gracefully():
                 "messages": [{"role": "user", "content": "content"}],
             },
             {
-                "messages": [{"role": "user", "content": "content"}, {"role": "user"}],
+                "messages": [
+                    {"role": "user", "content": "content"},
+                    {"role": "user", "content": 123},
+                ],
             },
         ]
     ) == [
         [{"role": "user", "content": "content"}],
-        [{"role": "user", "content": "content"}, {"role": "user"}],
+        [{"role": "user", "content": "content"}, {"role": "user", "content": 123}],
     ]
 
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1284,9 +1284,6 @@ def test_predict_with_callbacks_supports_chat_response_conversion(fake_chat_mode
                 "message": {
                     "role": "assistant",
                     "content": "Databricks",
-                    "refusal": None,
-                    "tool_call_id": None,
-                    "tool_calls": None,
                 },
                 "finish_reason": None,
             }
@@ -1380,9 +1377,6 @@ def test_simple_chat_model_inference():
             "ai: What would you like to ask?\n"
             "human: Who owns MLflow?"
         ),
-        "refusal": None,
-        "tool_call_id": None,
-        "tool_calls": None,
     }
     response1 = loaded_model.predict([input_example])
     assert len(response1) == 1
@@ -2170,9 +2164,6 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
                 "message": {
                     "role": "assistant",
                     "content": content,
-                    "refusal": None,
-                    "tool_call_id": None,
-                    "tool_calls": None,
                 },
                 "finish_reason": None,
             }
@@ -2247,9 +2238,6 @@ def test_predict_with_builtin_pyfunc_chat_conversion_for_aimessage_response():
                         "message": {
                             "role": "assistant",
                             "content": "You own MLflow",
-                            "refusal": None,
-                            "tool_call_id": None,
-                            "tool_calls": None,
                         },
                         "finish_reason": None,
                     }
@@ -3174,9 +3162,6 @@ def test_save_model_as_code_correct_streamable(chain_model_signature, chain_path
                     "message": {
                         "role": "assistant",
                         "content": "Databricks",
-                        "refusal": None,
-                        "tool_call_id": None,
-                        "tool_calls": None,
                     },
                     "finish_reason": None,
                 }

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -121,16 +121,10 @@ def test_llm_success():
         {
             "role": "user",
             "content": "test prompt",
-            "tool_calls": None,
-            "tool_call_id": None,
-            "refusal": None,
         },
         {
             "role": "assistant",
             "content": "generated text",
-            "tool_calls": None,
-            "tool_call_id": None,
-            "refusal": None,
         },
     ]
 
@@ -164,9 +158,6 @@ def test_llm_error():
         {
             "role": "user",
             "content": "test prompt",
-            "tool_calls": None,
-            "tool_call_id": None,
-            "refusal": None,
         },
     ]
 
@@ -347,16 +338,10 @@ def test_multiple_components():
             {
                 "role": "user",
                 "content": f"test prompt {i}",
-                "tool_calls": None,
-                "tool_call_id": None,
-                "refusal": None,
             },
             {
                 "role": "assistant",
                 "content": f"generated text {i}",
-                "tool_calls": None,
-                "tool_call_id": None,
-                "refusal": None,
             },
         ]
 

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -116,7 +116,7 @@ def test_set_chat_messages_validation():
         set_span_chat_messages(span, messages)
         return None
 
-    with pytest.raises(MlflowException, match="validation error for RequestMessage"):
+    with pytest.raises(MlflowException, match="validation error for ChatMessage"):
         dummy_call(messages)
 
 

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -1,9 +1,10 @@
 import pytest
+from pydantic import ValidationError
 
 import mlflow
 from mlflow.entities import LiveSpan
 from mlflow.entities.span import SpanType
-from mlflow.exceptions import MlflowException, MlflowTracingException
+from mlflow.exceptions import MlflowTracingException
 from mlflow.tracing import set_span_chat_messages, set_span_chat_tools
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.utils import (
@@ -116,7 +117,7 @@ def test_set_chat_messages_validation():
         set_span_chat_messages(span, messages)
         return None
 
-    with pytest.raises(MlflowException, match="validation error for ChatMessage"):
+    with pytest.raises(ValidationError, match="validation error for ChatMessage"):
         dummy_call(messages)
 
 
@@ -136,5 +137,5 @@ def test_set_chat_tools_validation():
         set_span_chat_tools(span, tools)
         return None
 
-    with pytest.raises(MlflowException, match="validation error for ChatTool"):
+    with pytest.raises(ValidationError, match="validation error for ChatTool"):
         dummy_call(tools)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14152?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14152/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14152
```

</p>
</details>

### What changes are proposed in this pull request?

Support span standardization for chat messages in LagnChain tracing, similarly to what we did for OpenAI: https://github.com/mlflow/mlflow/pull/14140

The core change of this PR is the conversion from the LangChain's message models such as `AIMessage`, `HumanMessage`, into the standard OpenAI format. We actually have this logic in the code base, which is the chat conversion for pyfunc [here](https://github.com/mlflow/mlflow/blob/master/mlflow/langchain/utils/chat.py). However, this logic has its own Pydantic models now and also doesn't handle all message types such as `ToolMessage`.

Therefore, this PR does
1. Update the pyfunc chat conversion logic to use the new Pydantic models in `mlflow.types.chat`.
2. Update the LangChain Tracer to set the `mlflow.chat.messages` attribute, re-using the same conversion logic.

Note: a follow-up PR will be filed for setting the `mlflow.chat.tools` as well.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

ChatOpenAI:

![Screenshot 2024-12-23 at 17 48 35](https://github.com/user-attachments/assets/81679e19-966c-4934-8d4f-fa5ee7574d14)


ChatDatabricks:

![Screenshot 2024-12-23 at 17 51 36](https://github.com/user-attachments/assets/c8c9c5f7-dafd-46c5-a4de-6367e56636aa)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
