### PR TITLE
Support no op type hints

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -30,7 +30,7 @@ from mlflow.types.type_hints import (
     InvalidTypeHintException,
     _get_example_validation_result,
     _infer_schema_from_type_hint,
-    _type_hint_needs_signature,
+    _signature_cannot_be_inferred_from_type_hint,
 )
 from mlflow.types.utils import _infer_param_schema, _infer_schema
 from mlflow.utils.uri import append_to_uri_path
@@ -376,7 +376,7 @@ def _should_infer_signature_from_type_hints(type_hints: _TypeHints):
     if type_hints.input is None:
         return False
 
-    if _type_hint_needs_signature(type_hints.input):
+    if _signature_cannot_be_inferred_from_type_hint(type_hints.input):
         return False
 
     return True
@@ -412,8 +412,8 @@ def _infer_signature_from_type_hints(
             output_schema = _infer_schema_from_type_hint(type_hints.output)
             is_output_type_hint_valid = True
         except InvalidTypeHintException as e:
-            warnings.warn(
-                f"Invalid output type hint, setting output schema to AnyType. Error: {e}",
+            _logger.info(
+                f"Unsupported output type hint, setting output schema to AnyType. {e}",
                 stacklevel=2,
             )
             output_schema = default_output_schema

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -406,6 +406,7 @@ def _infer_signature_from_type_hints(
 
     default_output_schema = Schema([ColSpec(type=AnyType())])
     is_output_type_hint_valid = False
+    output_schema = None
     if type_hints.output:
         try:
             output_schema = _infer_schema_from_type_hint(type_hints.output)

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -417,6 +417,8 @@ def _infer_signature_from_type_hints(
                 stacklevel=2,
             )
             output_schema = default_output_schema
+    else:
+        output_schema = default_output_schema
     params_schema = _infer_param_schema(params) if params else None
 
     if input_example is not None:

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -47,7 +47,7 @@ TYPE_HINTS_TO_DATATYPE_MAPPING = {
 
 
 @lru_cache(maxsize=1)
-def type_hints_needing_signature():
+def type_hints_no_signature_inference():
     """
     This function returns a tuple of types that can be used
     as type hints, but no schema can be inferred from them.
@@ -98,8 +98,8 @@ class InvalidTypeHintException(MlflowException):
         )
 
 
-def _type_hint_needs_signature(type_hint: type[Any]) -> bool:
-    return type_hint in type_hints_needing_signature()
+def _signature_cannot_be_inferred_from_type_hint(type_hint: type[Any]) -> bool:
+    return type_hint in type_hints_no_signature_inference()
 
 
 def _infer_colspec_type_from_type_hint(type_hint: type[Any]) -> ColSpecType:

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -266,7 +266,9 @@ def test_pyfunc_model_infer_signature_from_type_hints_errors():
                 "test_model", python_model=Model(), input_example=pd.DataFrame()
             )
         assert "cannot be used to infer model signature." in mock_warning.call_args[0][0]
-        assert "Failed to infer model signature from input example" in mock_warning.call_args[0][0]
+        assert (
+            "Inferring model signature from input example failure" in mock_warning.call_args[0][0]
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -374,7 +374,7 @@ def test_functional_python_model_only_input_type_hints():
             "model", python_model=python_model, input_example=["a"]
         )
     assert model_info.signature.inputs == Schema([ColSpec(type=Array(DataType.string))])
-    assert model_info.signature.outputs is None
+    assert model_info.signature.outputs == Schema([ColSpec(AnyType())])
 
 
 def test_functional_python_model_only_output_type_hints():

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -197,8 +197,22 @@ def test_pyfunc_model_with_no_op_type_hint_pass_signature_works():
         model_info = mlflow.pyfunc.log_model(
             "test_model",
             python_model=predict,
-            input_example=pd.DataFrame({"a": [1]}),
+            input_example=input_example,
             signature=signature,
+        )
+    assert model_info.signature.inputs == Schema([ColSpec(type=DataType.long, name="a")])
+    pyfunc = mlflow.pyfunc.load_model(model_info.model_uri)
+    pd.testing.assert_frame_equal(pyfunc.predict(input_example), input_example)
+
+    class Model(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input: pd.DataFrame, params=None) -> pd.DataFrame:
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "test_model",
+            python_model=Model(),
+            input_example=input_example,
         )
     assert model_info.signature.inputs == Schema([ColSpec(type=DataType.long, name="a")])
     pyfunc = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -232,20 +246,6 @@ def test_pyfunc_model_infer_signature_from_type_hints_errors():
         )
         assert model_info.signature.inputs == Schema([ColSpec(type=DataType.long)])
         assert model_info.signature.outputs == Schema([ColSpec(AnyType())])
-
-    def predict(model_input: pd.DataFrame) -> pd.DataFrame:
-        return model_input
-
-    with mlflow.start_run():
-        with mock.patch("mlflow.models.signature._logger.warning") as mock_warning:
-            model_info = mlflow.pyfunc.log_model(
-                "test_model", python_model=predict, input_example=pd.DataFrame()
-            )
-        assert (
-            f"Type hint {pd.DataFrame} can not be used to infer model signature"
-            in mock_warning.call_args[0][0]
-        )
-        assert model_info.signature is None
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -247,6 +247,27 @@ def test_pyfunc_model_infer_signature_from_type_hints_errors():
         assert model_info.signature.inputs == Schema([ColSpec(type=DataType.long)])
         assert model_info.signature.outputs == Schema([ColSpec(AnyType())])
 
+    class Model(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input: pd.DataFrame, params=None) -> pd.DataFrame:
+            return model_input
+
+    with mlflow.start_run():
+        with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
+            mlflow.pyfunc.log_model("test_model", python_model=Model())
+        assert "cannot be used to infer model signature." in mock_warning.call_args[0][0]
+        assert (
+            "Input example is not provided, model signature cannot be inferred."
+            in mock_warning.call_args[0][0]
+        )
+
+    with mlflow.start_run():
+        with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
+            mlflow.pyfunc.log_model(
+                "test_model", python_model=Model(), input_example=pd.DataFrame()
+            )
+        assert "cannot be used to infer model signature." in mock_warning.call_args[0][0]
+        assert "Failed to infer model signature from input example" in mock_warning.call_args[0][0]
+
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
 def test_pyfunc_model_infer_signature_from_type_hints_for_python_3_10():

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -16,7 +16,7 @@ from mlflow.types.type_hints import (
     InvalidTypeHintException,
     _convert_data_to_type_hint,
     _infer_schema_from_type_hint,
-    _type_hint_needs_signature,
+    _signature_cannot_be_inferred_from_type_hint,
     _validate_example_against_type_hint,
 )
 
@@ -169,7 +169,7 @@ def test_infer_schema_from_python_type_hints(type_hint, expected_schema):
     ],
 )
 def test_type_hints_needs_signature(type_hint):
-    assert _type_hint_needs_signature(type_hint) is True
+    assert _signature_cannot_be_inferred_from_type_hint(type_hint) is True
 
 
 def test_infer_schema_from_type_hints_errors():

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -16,6 +16,7 @@ from mlflow.types.type_hints import (
     InvalidTypeHintException,
     _convert_data_to_type_hint,
     _infer_schema_from_type_hint,
+    _type_hint_needs_signature,
     _validate_example_against_type_hint,
 )
 
@@ -167,8 +168,8 @@ def test_infer_schema_from_python_type_hints(type_hint, expected_schema):
         csr_matrix,
     ],
 )
-def test_infer_schema_from_no_op_type_hints(type_hint):
-    assert _infer_schema_from_type_hint(type_hint) is None
+def test_type_hints_needs_signature(type_hint):
+    assert _type_hint_needs_signature(type_hint) is True
 
 
 def test_infer_schema_from_type_hints_errors():

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -349,20 +349,6 @@ def test_python_type_hints_validation(type_hint, example):
     assert _validate_example_against_type_hint(example=example, type_hint=type_hint) == example
 
 
-@pytest.mark.parametrize(
-    ("type_hint", "example"),
-    [
-        (pd.DataFrame, pd.DataFrame({"a": ["a", "b"]})),
-        (pd.Series, pd.Series([1, 2])),
-        (np.ndarray, np.array([1, 2])),
-        (csc_matrix, csc_matrix((3, 4))),
-        (csr_matrix, csr_matrix((3, 4))),
-    ],
-)
-def test_validate_example_for_no_op_type_hints(type_hint, example):
-    _validate_example_against_type_hint(example=example, type_hint=type_hint)
-
-
 def test_type_hints_validation_errors():
     with pytest.raises(
         MlflowException, match=r"Input example is not valid for Pydantic model `CustomModel`"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14156?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14156/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14156
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As discussed in decision 6, we should support some no-op type hints. They cannot be used to infer signature, but we should also allow users use them.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
