### PR TITLE
add azure-cli as a valid auth_type for databricks authentication

### DIFF
--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -468,10 +468,15 @@ class DatabricksConfig:
         return self.auth_type == "databricks-cli"
 
     @property
+    def is_azure_cli_auth_type(self):
+        return self.auth_type == "azure-cli"
+
+    @property
     def is_valid(self):
         return (
             self.is_valid_with_token
             or self.is_valid_with_password
             or self.is_valid_with_client_id_secret
             or self.is_databricks_cli_auth_type
+            or self.is_azure_cli_auth_type
         )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Lodewic/mlflow/pull/14158?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14158/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14158
```

</p>
</details>

### Related Issues/PRs

Resolves #14157

### What changes are proposed in this pull request?

Recognize `auth_type="azure-cli"` as a valid authentication type when authenticating databricks.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual 

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Manual testing

Set .databricksfg with auth_type="azure-cli".
```
# ~/.databricksfg
[dev]
host       = https://adb-********.azuredatabricks.net/
auth_type  = azure-cli
```

This would raise an error in the current mlflow version. This PR makes this runnable.
```python
from mlflow.utils import databricks_utils

host_creds = databricks_utils.get_databricks_host_creds(server_uri="databricks://dev")
host_creds.__dict__
>>> {'host': 'https://adb-********.azuredatabricks.net/',
 'username': None,
 'password': None,
 'token': None,
 'aws_sigv4': False,
 'auth': None,
 'ignore_tls_verification': None,
 'client_cert_path': None,
 'server_cert_path': None,
 'use_databricks_sdk': True,
 'databricks_auth_profile': 'dev',
 'client_id': None,
 'client_secret': None,
 'use_secret_scope_token': False}
```

See if we can indeed start a run and log a param.

```python
import mlflow

mlflow.set_tracking_uri('databricks://dev')
mlflow.set_experiment("mlflow-feature-test")
with mlflow.start_run() as run:
    mlflow.log_param("great", "success!")
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

When using databricks authentication profiles, you are now able to use profiles with `auth_type="azure-cli"`. For example,
when setting your tracking uri to `databricks://{profile}`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
