### PR TITLE
Exclude unset fields from AI Gateway response

### DIFF
--- a/mlflow/gateway/app.py
+++ b/mlflow/gateway/app.py
@@ -65,12 +65,14 @@ class GatewayAPI(FastAPI):
                     MLFLOW_DEPLOYMENTS_ENDPOINTS_BASE + route.name + MLFLOW_DEPLOYMENTS_QUERY_SUFFIX
                 ),
                 endpoint=_route_type_to_endpoint(route, limiter, "deployments"),
+                response_model_exclude_unset=True,
                 methods=["POST"],
             )
             self.add_api_route(
                 path=f"{MLFLOW_GATEWAY_ROUTE_BASE}{route.name}{MLFLOW_QUERY_SUFFIX}",
                 endpoint=_route_type_to_endpoint(route, limiter, "gateway"),
                 methods=["POST"],
+                response_model_exclude_unset=True,
                 include_in_schema=False,
             )
             self.dynamic_routes[route.name] = route
@@ -361,7 +363,7 @@ def create_app_from_config(config: GatewayConfig) -> GatewayAPI:
             detail=f"Route {name} not found in the configuration.",
         )
 
-    @app.post("/v1/chat/completions")
+    @app.post("/v1/chat/completions", response_model_exclude_unset=True)
     async def openai_chat_handler(
         request: Request, payload: chat.RequestPayload
     ) -> chat.ResponsePayload:
@@ -379,7 +381,7 @@ def create_app_from_config(config: GatewayConfig) -> GatewayAPI:
         else:
             return await prov.chat(payload)
 
-    @app.post("/v1/completions")
+    @app.post("/v1/completions", response_model_exclude_unset=True)
     async def openai_completions_handler(
         request: Request, payload: completions.RequestPayload
     ) -> completions.ResponsePayload:
@@ -397,7 +399,7 @@ def create_app_from_config(config: GatewayConfig) -> GatewayAPI:
         else:
             return await prov.completions(payload)
 
-    @app.post("/v1/embeddings")
+    @app.post("/v1/embeddings", response_model_exclude_unset=True)
     async def openai_embeddings_handler(
         request: Request, payload: embeddings.RequestPayload
     ) -> embeddings.ResponsePayload:

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -68,6 +68,7 @@ class AI21LabsProvider(BaseProvider):
         # }
         # ```
         return completions.ResponsePayload(
+            id=resp["id"],
             created=int(time.time()),
             object="text_completion",
             model=self.config.model.name,

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -117,6 +117,7 @@ class AnthropicAdapter(ProviderAdapter):
         return chat.StreamResponsePayload(
             id=resp["id"],
             created=int(time.time()),
+            object="chat.completion.chunk",
             model=resp["model"],
             choices=[
                 chat.StreamChoice(
@@ -135,6 +136,7 @@ class AnthropicAdapter(ProviderAdapter):
         stop_reason = "stop" if resp["stop_reason"] == "stop_sequence" else "length"
 
         return completions.ResponsePayload(
+            id=resp["id"],
             created=int(time.time()),
             object="text_completion",
             model=resp["model"],

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -70,6 +70,7 @@ class AWSTitanAdapter(ProviderAdapter):
     @classmethod
     def model_to_completions(cls, resp, config):
         return completions.ResponsePayload(
+            id=str(resp.get("id")),
             created=int(time.time()),
             object="text_completion",
             model=config.model.name,
@@ -113,6 +114,7 @@ class AI21Adapter(ProviderAdapter):
     @classmethod
     def model_to_completions(cls, resp, config):
         return completions.ResponsePayload(
+            id=str(resp.get("id")),
             created=int(time.time()),
             object="text_completion",
             model=config.model.name,

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -33,6 +33,7 @@ class CohereAdapter(ProviderAdapter):
         # }
         # ```
         return completions.ResponsePayload(
+            id=resp["id"],
             created=int(time.time()),
             object="text_completion",
             model=config.model.name,
@@ -87,7 +88,7 @@ class CohereAdapter(ProviderAdapter):
         # ```
         response = resp.get("response")
         return completions.StreamResponsePayload(
-            id=response["id"] if response else None,
+            id=response["id"] if response else "",
             created=int(time.time()),
             model=config.model.name,
             choices=[
@@ -105,6 +106,7 @@ class CohereAdapter(ProviderAdapter):
                 completion_tokens=None,
                 total_tokens=None,
             ),
+            object="text_completion_chunk",
         )
 
     @classmethod
@@ -140,10 +142,7 @@ class CohereAdapter(ProviderAdapter):
         # ```
         return embeddings.ResponsePayload(
             data=[
-                embeddings.EmbeddingObject(
-                    embedding=output,
-                    index=idx,
-                )
+                embeddings.EmbeddingObject(embedding=output, index=idx, object="embedding")
                 for idx, output in enumerate(resp["embeddings"])
             ],
             model=config.model.name,
@@ -151,6 +150,7 @@ class CohereAdapter(ProviderAdapter):
                 prompt_tokens=None,
                 total_tokens=None,
             ),
+            object="list",
         )
 
     @classmethod
@@ -322,6 +322,7 @@ class CohereAdapter(ProviderAdapter):
                 completion_tokens=response["token_count"]["response_tokens"] if response else None,
                 total_tokens=response["token_count"]["total_tokens"] if response else None,
             ),
+            object="chat.completion.chunk",
         )
 
 

--- a/mlflow/gateway/providers/huggingface.py
+++ b/mlflow/gateway/providers/huggingface.py
@@ -97,6 +97,7 @@ class HFTextGenerationInferenceServerProvider(BaseProvider):
         output_tokens = resp["details"]["generated_tokens"]
         input_tokens = len(resp["details"]["prefill"])
         return completions.ResponsePayload(
+            id="",
             created=int(time.time()),
             object="text_completion",
             model=self.config.model.name,

--- a/mlflow/gateway/providers/mistral.py
+++ b/mlflow/gateway/providers/mistral.py
@@ -36,6 +36,7 @@ class MistralAdapter(ProviderAdapter):
         # }
         # ```
         return completions.ResponsePayload(
+            id=resp["id"],
             created=int(time.time()),
             object="text_completion",
             model=config.model.name,
@@ -115,6 +116,7 @@ class MistralAdapter(ProviderAdapter):
                 embeddings.EmbeddingObject(
                     embedding=data["embedding"],
                     index=data["index"],
+                    object="embedding",
                 )
                 for data in resp["data"]
             ],
@@ -123,6 +125,7 @@ class MistralAdapter(ProviderAdapter):
                 prompt_tokens=resp["usage"]["prompt_tokens"],
                 total_tokens=resp["usage"]["total_tokens"],
             ),
+            object="list",
         )
 
     @classmethod

--- a/mlflow/gateway/providers/mlflow.py
+++ b/mlflow/gateway/providers/mlflow.py
@@ -119,6 +119,7 @@ class MlflowModelServingProvider(BaseProvider):
         # {"predictions": ["hello", "hi", "goodbye"]}
 
         return completions.ResponsePayload(
+            id="",
             created=int(time.time()),
             object="text_completion",
             model=self.config.model.name,
@@ -172,6 +173,7 @@ class MlflowModelServingProvider(BaseProvider):
         # {"predictions": ["answer"]}
 
         return chat.ResponsePayload(
+            id="",
             created=int(time.time()),
             model=self.config.model.name,
             choices=[
@@ -189,6 +191,7 @@ class MlflowModelServingProvider(BaseProvider):
                 completion_tokens=None,
                 total_tokens=None,
             ),
+            object="chat.completion",
         )
 
     def _process_embeddings_response_for_mlflow_serving(self, response):
@@ -224,6 +227,7 @@ class MlflowModelServingProvider(BaseProvider):
                 embeddings.EmbeddingObject(
                     embedding=embedding,
                     index=idx,
+                    object="embedding",
                 )
                 for idx, embedding in enumerate(
                     self._process_embeddings_response_for_mlflow_serving(resp)
@@ -234,4 +238,5 @@ class MlflowModelServingProvider(BaseProvider):
                 prompt_tokens=None,
                 total_tokens=None,
             ),
+            object="list",
         )

--- a/mlflow/gateway/providers/mosaicml.py
+++ b/mlflow/gateway/providers/mosaicml.py
@@ -133,6 +133,7 @@ class MosaicMLProvider(BaseProvider):
         # }
         # ```
         return chat.ResponsePayload(
+            id=resp.get("id", ""),
             created=int(time.time()),
             model=self.config.model.name,
             choices=[
@@ -148,6 +149,7 @@ class MosaicMLProvider(BaseProvider):
                 completion_tokens=None,
                 total_tokens=None,
             ),
+            object="chat.completion",
         )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
@@ -199,6 +201,7 @@ class MosaicMLProvider(BaseProvider):
         # }
         # ```
         return completions.ResponsePayload(
+            id=resp.get("id", ""),
             created=int(time.time()),
             object="text_completion",
             model=self.config.model.name,
@@ -260,6 +263,7 @@ class MosaicMLProvider(BaseProvider):
                 embeddings.EmbeddingObject(
                     embedding=output,
                     index=idx,
+                    object="embedding",
                 )
                 for idx, output in enumerate(resp["outputs"])
             ],
@@ -268,6 +272,7 @@ class MosaicMLProvider(BaseProvider):
                 prompt_tokens=None,
                 total_tokens=None,
             ),
+            object="list",
         )
 
 

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -198,6 +198,7 @@ class OpenAIAdapter(ProviderAdapter):
                     finish_reason=c["finish_reason"],
                     delta=completions.StreamDelta(
                         content=c["delta"].get("content"),
+                        role=None,
                     ),
                 )
                 for c in resp["choices"]
@@ -234,6 +235,7 @@ class OpenAIAdapter(ProviderAdapter):
                 embeddings.EmbeddingObject(
                     embedding=d["embedding"],
                     index=idx,
+                    object="embedding",
                 )
                 for idx, d in enumerate(resp["data"])
             ],
@@ -242,6 +244,7 @@ class OpenAIAdapter(ProviderAdapter):
                 prompt_tokens=resp["usage"]["prompt_tokens"],
                 total_tokens=resp["usage"]["total_tokens"],
             ),
+            object="list",
         )
 
 

--- a/mlflow/gateway/providers/palm.py
+++ b/mlflow/gateway/providers/palm.py
@@ -85,6 +85,7 @@ class PaLMProvider(BaseProvider):
         # }
         # ```
         return chat.ResponsePayload(
+            id="",
             created=int(time.time()),
             model=self.config.model.name,
             choices=[
@@ -100,6 +101,7 @@ class PaLMProvider(BaseProvider):
                 completion_tokens=None,
                 total_tokens=None,
             ),
+            object="chat.completion",
         )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
@@ -147,6 +149,7 @@ class PaLMProvider(BaseProvider):
         # }
         # ```
         return completions.ResponsePayload(
+            id="",
             created=int(time.time()),
             object="text_completion",
             model=self.config.model.name,
@@ -206,8 +209,7 @@ class PaLMProvider(BaseProvider):
         return embeddings.ResponsePayload(
             data=[
                 embeddings.EmbeddingObject(
-                    embedding=embedding["value"],
-                    index=idx,
+                    embedding=embedding["value"], index=idx, object="embedding"
                 )
                 for idx, embedding in enumerate(resp["embeddings"])
             ],
@@ -216,4 +218,5 @@ class PaLMProvider(BaseProvider):
                 prompt_tokens=None,
                 total_tokens=None,
             ),
+            object="list",
         )

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -39,13 +39,13 @@ class TogetherAIAdapter(ProviderAdapter):
         return embeddings_schema.ResponsePayload(
             data=[
                 embeddings_schema.EmbeddingObject(
-                    embedding=item["embedding"],
-                    index=item["index"],
+                    embedding=item["embedding"], index=item["index"], object="embedding"
                 )
                 for item in resp["data"]
             ],
             model=config.model.name,
             usage=embeddings_schema.EmbeddingsUsage(prompt_tokens=None, total_tokens=None),
+            object="list",
         )
 
     @classmethod
@@ -85,6 +85,7 @@ class TogetherAIAdapter(ProviderAdapter):
                 completion_tokens=resp["usage"]["completion_tokens"],
                 total_tokens=resp["usage"]["total_tokens"],
             ),
+            object="text_completion",
         )
 
     @classmethod
@@ -127,6 +128,7 @@ class TogetherAIAdapter(ProviderAdapter):
                 )
                 for idx, choice in enumerate(resp.get("choices", []))
             ],
+            object="text_completion_chunk",
             # usage is not included in OpenAI StreamResponsePayload
         )
 

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 
 from mlflow.gateway.base_models import RequestModel, ResponseModel
 from mlflow.types.chat import BaseRequestPayload
@@ -53,7 +53,7 @@ _RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 
 
 class ResponsePayload(ResponseModel):
-    id: Optional[str] = None
+    id: Optional[str]
     object: str = "text_completion"
     created: int
     model: str
@@ -96,8 +96,8 @@ _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 
 
 class StreamResponsePayload(ResponseModel):
-    id: Optional[str] = None
-    object: str = "text_completion_chunk"
+    id: str
+    object: Literal["text_completion_chunk"]
     created: int
     model: str
     choices: list[StreamChoice]

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -53,7 +53,7 @@ _RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 
 
 class ResponsePayload(ResponseModel):
-    id: Optional[str]
+    id: str
     object: str = "text_completion"
     created: int
     model: str

--- a/mlflow/gateway/schemas/embeddings.py
+++ b/mlflow/gateway/schemas/embeddings.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from mlflow.gateway.base_models import RequestModel, ResponseModel
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
@@ -21,7 +21,7 @@ class RequestPayload(RequestModel):
 
 
 class EmbeddingObject(ResponseModel):
-    object: str = "embedding"
+    object: Literal["embedding"]
     embedding: Union[list[float], str]
     index: int
 
@@ -85,7 +85,7 @@ _RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 
 
 class ResponsePayload(ResponseModel):
-    object: str = "list"
+    object: Literal["list"]
     data: list[EmbeddingObject]
     model: str
     usage: EmbeddingsUsage

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -156,8 +156,8 @@ class ChatCompletionResponse(BaseModel):
     https://platform.openai.com/docs/api-reference/chat
     """
 
-    id: Optional[str] = None
-    object: str = "chat.completion"
+    id: str
+    object: Literal["chat.completion"]
     created: int
     model: str
     choices: list[ChatChoice]
@@ -180,7 +180,7 @@ class ChatCompletionChunk(BaseModel):
     """A chunk of a chat completion stream response."""
 
     id: Optional[str] = None
-    object: str = "chat.completion.chunk"
+    object: Literal["chat.completion.chunk"]
     created: int
     model: str
     choices: list[ChatChunkChoice]

--- a/tests/deployments/server/test_server_app.py
+++ b/tests/deployments/server/test_server_app.py
@@ -91,7 +91,6 @@ test_response = {
                 "role": "assistant",
                 "content": "\n\nThis is a test!",
                 "tool_calls": None,
-                "refusal": None,
             },
             "finish_reason": "stop",
             "index": 0,

--- a/tests/gateway/providers/test_ai21labs.py
+++ b/tests/gateway/providers/test_ai21labs.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi.encoders import jsonable_encoder
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import RouteConfig
@@ -11,7 +10,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse
+from tests.gateway.tools import MockAsyncResponse, jsonable_encoder
 
 
 def completions_config():
@@ -101,7 +100,7 @@ async def test_completions():
         }
         response = await provider.completions(completions.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "7921a78e-d905-c9df-27e3-88e4831e3c3b",
             "object": "text_completion",
             "created": 1677858242,
             "model": "j2-ultra",

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
@@ -15,13 +14,14 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.anthropic import AnthropicProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse
+from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, jsonable_encoder
 
 
 def completions_response():
     return {
         "completion": "Here is a basic overview of how a car works:\n\n1. The engine. "
         "The engine is the power source that makes the car move.",
+        "id": "test-123",
         "stop_reason": "max_tokens",
         "model": "claude-instant-1.1",
         "truncated": False,
@@ -48,7 +48,7 @@ def completions_config():
 
 def parsed_completions_response():
     return {
-        "id": None,
+        "id": "test-123",
         "object": "text_completion",
         "created": 1677858242,
         "model": "claude-instant-1.1",
@@ -271,8 +271,6 @@ async def test_chat():
                     "message": {
                         "role": "assistant",
                         "content": "Response message",
-                        "tool_calls": None,
-                        "refusal": None,
                     },
                     "finish_reason": "stop",
                     "index": 0,

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from fastapi.encoders import jsonable_encoder
 
 from mlflow.gateway.config import (
     AmazonBedrockConfig,
@@ -20,6 +19,7 @@ from tests.gateway.providers.test_anthropic import (
     parsed_completions_response as anthropic_parsed_completions_response,
 )
 from tests.gateway.providers.test_cohere import completions_response as cohere_completions_response
+from tests.gateway.tools import jsonable_encoder
 
 
 def ai21_completion_response():
@@ -90,7 +90,7 @@ def ai21_completion_response():
 
 def ai21_parsed_completion_response(mdl):
     return {
-        "id": None,
+        "id": "1234",
         "object": "text_completion",
         "created": 1677858242,
         "model": mdl,
@@ -191,7 +191,7 @@ bedrock_model_provider_fixtures = [
             "inputTextTokenCount": 4,
         },
         "expected": {
-            "id": None,
+            "id": "None",
             "object": "text_completion",
             "created": 1677858242,
             "model": "amazon.titan-tg1-large",

--- a/tests/gateway/providers/test_cohere.py
+++ b/tests/gateway/providers/test_cohere.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
@@ -11,7 +10,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse
+from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, jsonable_encoder
 
 
 def chat_config():
@@ -82,8 +81,6 @@ async def test_chat():
                     "message": {
                         "role": "assistant",
                         "content": "\n\nThis is a test!",
-                        "tool_calls": None,
-                        "refusal": None,
                     },
                     "finish_reason": None,
                     "index": 0,
@@ -292,7 +289,7 @@ async def test_completions():
         }
         response = await provider.completions(completions.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "string",
             "object": "text_completion",
             "created": 1677858242,
             "model": "command",
@@ -375,7 +372,7 @@ async def test_completions_stream():
                     }
                 ],
                 "created": 1677858242,
-                "id": None,
+                "id": "",
                 "model": "command",
                 "object": "text_completion_chunk",
             },
@@ -388,7 +385,7 @@ async def test_completions_stream():
                     }
                 ],
                 "created": 1677858242,
-                "id": None,
+                "id": "",
                 "model": "command",
                 "object": "text_completion_chunk",
             },

--- a/tests/gateway/providers/test_huggingface.py
+++ b/tests/gateway/providers/test_huggingface.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi.encoders import jsonable_encoder
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
@@ -10,7 +9,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.huggingface import HFTextGenerationInferenceServerProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse
+from tests.gateway.tools import MockAsyncResponse, jsonable_encoder
 
 
 def completions_config():
@@ -77,7 +76,7 @@ async def test_completions():
         }
         response = await provider.completions(completions.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "",
             "object": "text_completion",
             "created": 1677858242,
             "model": "hf-tgi",

--- a/tests/gateway/providers/test_mistral.py
+++ b/tests/gateway/providers/test_mistral.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
@@ -12,7 +11,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.mistral import MistralProvider
 from mlflow.gateway.schemas import completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse
+from tests.gateway.tools import MockAsyncResponse, jsonable_encoder
 
 TEST_STRING = "This is a test"
 CONTENT_TYPE = "application/json"
@@ -70,7 +69,7 @@ async def test_completions():
         }
         response = await provider.completions(completions.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "string",
             "object": "text_completion",
             "created": 1677858242,
             "model": "mistral-tiny",

--- a/tests/gateway/providers/test_mlflow.py
+++ b/tests/gateway/providers/test_mlflow.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pydantic
 import pytest
 from aiohttp import ClientTimeout
-from fastapi.encoders import jsonable_encoder
 
 from mlflow.gateway.config import MlflowModelServingConfig, RouteConfig
 from mlflow.gateway.constants import (
@@ -14,7 +13,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse, mock_http_client
+from tests.gateway.tools import MockAsyncResponse, jsonable_encoder, mock_http_client
 
 
 def completions_config():
@@ -51,7 +50,7 @@ async def test_completions():
         }
         response = await provider.completions(completions.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "",
             "object": "text_completion",
             "created": 1677858242,
             "model": "text2text",
@@ -262,7 +261,7 @@ async def test_chat():
         payload = {"messages": [{"role": "user", "content": "Is this a test?"}]}
         response = await provider.chat(chat.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "",
             "created": 1700242674,
             "object": "chat.completion",
             "model": "chat-bot-9000",
@@ -271,8 +270,6 @@ async def test_chat():
                     "message": {
                         "role": "assistant",
                         "content": "It is a test",
-                        "tool_calls": None,
-                        "refusal": None,
                     },
                     "finish_reason": None,
                     "index": 0,

--- a/tests/gateway/providers/test_mosaicml.py
+++ b/tests/gateway/providers/test_mosaicml.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 from aiohttp import ClientTimeout
 from fastapi import HTTPException
-from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow import MlflowException
@@ -14,7 +13,7 @@ from mlflow.gateway.providers.mosaicml import MosaicMLProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 from mlflow.gateway.schemas.chat import RequestMessage
 
-from tests.gateway.tools import MockAsyncResponse
+from tests.gateway.tools import MockAsyncResponse, jsonable_encoder
 
 
 def completions_config():
@@ -55,7 +54,7 @@ async def test_completions():
         }
         response = await provider.completions(completions.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "",
             "object": "text_completion",
             "created": 1677858242,
             "model": "mpt-7b-instruct",
@@ -174,7 +173,7 @@ async def test_chat(payload, expected_llm_input):
         provider = MosaicMLProvider(RouteConfig(**config))
         response = await provider.chat(chat.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "",
             "created": 1700242674,
             "object": "chat.completion",
             "model": "llama2-70b-chat",
@@ -183,8 +182,6 @@ async def test_chat(payload, expected_llm_input):
                     "message": {
                         "role": "assistant",
                         "content": "This is a test",
-                        "tool_calls": None,
-                        "refusal": None,
                     },
                     "finish_reason": None,
                     "index": 0,

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.exceptions import MlflowException
@@ -15,6 +14,7 @@ from mlflow.gateway.schemas import chat, completions, embeddings
 from tests.gateway.tools import (
     MockAsyncResponse,
     MockAsyncStreamingResponse,
+    jsonable_encoder,
     mock_http_client,
 )
 
@@ -80,7 +80,6 @@ async def test_chat():
                         "role": "assistant",
                         "content": "\n\nThis is a test!",
                         "tool_calls": None,
-                        "refusal": None,
                     },
                     "finish_reason": "stop",
                     "index": 0,

--- a/tests/gateway/providers/test_openai_uc_functions.py
+++ b/tests/gateway/providers/test_openai_uc_functions.py
@@ -3,7 +3,6 @@ import json
 from unittest import mock
 
 import pytest
-from fastapi.encoders import jsonable_encoder
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.providers.openai import OpenAIProvider
@@ -13,6 +12,7 @@ from mlflow.gateway.uc_function_utils import uc_type_to_json_schema_type
 from tests.gateway.tools import (
     MockAsyncResponse,
     MockHttpClient,
+    jsonable_encoder,
 )
 
 
@@ -212,7 +212,6 @@ async def test_uc_functions(monkeypatch):
 
 1 + 2 = 3""".lstrip(),
                         "tool_calls": None,
-                        "refusal": None,
                     },
                     "finish_reason": "stop",
                 }
@@ -408,7 +407,6 @@ async def test_uc_functions_user_defined_functions(monkeypatch):
                                 },
                             },
                         ],
-                        "refusal": None,
                     },
                     "finish_reason": None,
                 }

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
@@ -11,7 +10,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.palm import PaLMProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse
+from tests.gateway.tools import MockAsyncResponse, jsonable_encoder
 
 
 def completions_config():
@@ -59,7 +58,7 @@ async def test_completions():
         }
         response = await provider.completions(completions.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "",
             "object": "text_completion",
             "created": 1677858242,
             "model": "text-bison",
@@ -177,7 +176,7 @@ async def test_chat(payload, expected_llm_input):
         provider = PaLMProvider(RouteConfig(**config))
         response = await provider.chat(chat.RequestPayload(**payload))
         assert jsonable_encoder(response) == {
-            "id": None,
+            "id": "",
             "created": 1700242674,
             "object": "chat.completion",
             "model": "chat-bison",
@@ -186,8 +185,6 @@ async def test_chat(payload, expected_llm_input):
                     "message": {
                         "role": "1",
                         "content": "Hi there! How can I help you today?",
-                        "tool_calls": None,
-                        "refusal": None,
                     },
                     "finish_reason": None,
                     "index": 0,

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi.encoders import jsonable_encoder
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
@@ -11,7 +10,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.togetherai import TogetherAIProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse
+from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, jsonable_encoder
 
 
 def completions_config():
@@ -421,8 +420,6 @@ async def test_chat():
                     "message": {
                         "role": "assistant",
                         "content": "Its Artyom!",
-                        "tool_calls": None,
-                        "refusal": None,
                     },
                     "finish_reason": None,
                 }

--- a/tests/gateway/schemas/test_chat.py
+++ b/tests/gateway/schemas/test_chat.py
@@ -105,6 +105,7 @@ def test_chat_request():
 def test_chat_response():
     chat.ResponsePayload(
         **{
+            "id": "some",
             "created": 100,
             "model": "gpt-4",
             "choices": [
@@ -118,6 +119,7 @@ def test_chat_response():
                 "completion_tokens": 1,
                 "total_tokens": 1,
             },
+            "object": "chat.completion",
         }
     )
 

--- a/tests/gateway/schemas/test_completions.py
+++ b/tests/gateway/schemas/test_completions.py
@@ -47,6 +47,7 @@ def test_completions_response():
     )
 
     completions.ResponsePayload(
+        id="some",
         object="text_completion",
         created=int(time.time()),
         model="hf-tgi",

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -16,6 +16,7 @@ import requests
 import transformers
 import uvicorn
 import yaml
+from fastapi.encoders import jsonable_encoder as _jsonable_encoder
 from sentence_transformers import SentenceTransformer
 
 import mlflow
@@ -316,3 +317,12 @@ def start_mlflow_server(port, model_uri):
 def stop_mlflow_server(server_pid):
     process_group = os.getpgid(server_pid.pid)
     os.killpg(process_group, signal.SIGTERM)
+
+
+def jsonable_encoder(response):
+    """
+    A customized JSON encoder that exclude unset fields.
+
+    The Gateway endpoint has the setting `response_model_exclude_unset=True`.
+    """
+    return _jsonable_encoder(response, exclude_unset=True)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14160?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14160/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14160
```

</p>
</details>

### What changes are proposed in this pull request?

Follow-up for https://github.com/mlflow/mlflow/pull/14152

In OpenAI API spec, an input message is defined by multiple different schemas, such as system message, user message, tool message ([ref](https://platform.openai.com/docs/api-reference/chat/create)). Moreover, the message stored in the response has different schema than those input messages.

One natural way to represent define separate sub classes for different types of request and response messages e.g., `ToolMessage` that subclasses a base class like `BaseMessage`. However, such design doesn't work simply in MLflow, for example, how would we infer model signature from a type hint like `input_message: BaseMessage`.

Therefore, our chat spec definition instead has the single `ChatMessage` model, which covers all possible input fields from those different subtypes.

However, one problem is that the model exposes unnecessary fields to users. For example, we use the same `ChatMessage` pydantic model for MLflow Gateway. However, when we define the endpoint's response spec based on the `ChatMessage`, the endpoint will returns extra fields that should only present in the request, such as `tool_call_id=None`. The Gateway endpoint must be OpenAI compatible, so this is not acceptable.

In order to address this, this PR uses the [response_model_exclude_unset](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter) feature in FastAPI. If this flag is set to True, FastAPI will only serialize the fields that are explicitly set when constructing the Pydantic model. The `tool_call_id` field is never set in the response, so users will not see it in the actual response from the gateway endpoint.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
