### PR TITLE
Implement message and tools standard for Anthropic auto-tracing

### DIFF
--- a/mlflow/anthropic/autolog.py
+++ b/mlflow/anthropic/autolog.py
@@ -1,9 +1,14 @@
 import inspect
+import logging
 
 import mlflow
 import mlflow.anthropic
+from mlflow.anthropic.chat import convert_message_to_mlflow_chat, convert_tool_to_mlflow_chat_tool
 from mlflow.entities import SpanType
+from mlflow.tracing.utils import set_span_chat_messages, set_span_chat_tools
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
+
+_logger = logging.getLogger(__name__)
 
 
 def _get_span_type(task_name: str) -> str:
@@ -36,6 +41,24 @@ def patched_class_call(original, self, *args, **kwargs):
         ) as span:
             inputs = construct_full_inputs(original, self, *args, **kwargs)
             span.set_inputs(inputs)
-            outputs = original(self, *args, **kwargs)
-            span.set_outputs(outputs)
+
+            messages = [convert_message_to_mlflow_chat(msg) for msg in inputs.get("messages", [])]
+            try:
+                outputs = original(self, *args, **kwargs)
+                span.set_outputs(outputs)
+            finally:
+                # Set message attribute once at the end to avoid multiple JSON serialization
+                try:
+                    messages.append(convert_message_to_mlflow_chat(outputs))
+                    set_span_chat_messages(span, messages)
+                except Exception as e:
+                    _logger.debug(f"Failed to set chat messages for {span}. Error: {e}")
+
+                try:
+                    if (tools := inputs.get("tools")) is not None:
+                        tools = [convert_tool_to_mlflow_chat_tool(tool) for tool in tools]
+                        set_span_chat_tools(span, tools)
+                except Exception as e:
+                    _logger.debug(f"Failed to set tools for {span}. Error: {e}")
+
             return outputs

--- a/mlflow/anthropic/autolog.py
+++ b/mlflow/anthropic/autolog.py
@@ -53,6 +53,7 @@ def patched_class_call(original, self, *args, **kwargs):
                     set_span_chat_messages(span, messages)
                 except Exception as e:
                     _logger.debug(f"Failed to set chat messages for {span}. Error: {e}")
+                    raise
 
                 try:
                     if (tools := inputs.get("tools")) is not None:

--- a/mlflow/anthropic/chat.py
+++ b/mlflow/anthropic/chat.py
@@ -1,0 +1,113 @@
+import json
+from typing import Union
+
+from anthropic.types import ContentBlock, Message
+
+from mlflow.exceptions import MlflowException
+from mlflow.types.chat import (
+    ChatMessage,
+    ChatTool,
+    Function,
+    FunctionToolDefinition,
+    ImageContentPart,
+    ImageUrl,
+    TextContentPart,
+    ToolCall,
+)
+
+
+def convert_message_to_mlflow_chat(message: Union[Message, dict]) -> ChatMessage:
+    """
+    Convert Anthropic message object into MLflow's standard format (OpenAI compatible).
+
+    Ref: https://docs.anthropic.com/en/api/messages#body-messages
+
+    Args:
+        message: Anthropic message object or a dictionary representing the message.
+
+    Returns:
+        ChatMessage: MLflow's standard chat message object.
+    """
+    if isinstance(message, dict):
+        content = message.get("content")
+        role = message.get("role")
+    elif isinstance(message, Message):
+        content = message.content
+        role = message.role
+    else:
+        raise MlflowException.invalid_parameter_value(
+            f"Message must be either a dict or a Message object, but got: {type(message)}."
+        )
+
+    if isinstance(content, str):
+        return ChatMessage(role=role, content=content)
+
+    elif isinstance(content, list):
+        contents = []
+        tool_calls = []
+        for content_block in content:
+            if isinstance(content_block, dict):
+                content_block = ContentBlock(**content_block)
+
+            if content_block.type == "text":
+                content = TextContentPart(text=content_block.text, type="text")
+                contents.append(content)
+            elif content_block.type == "image":
+                source = content_block.source
+                content = ImageContentPart(
+                    image_url=ImageUrl(url=f"data:{source.media_type};{source.type},{source.data}"),
+                    type="image_url",
+                )
+                contents.append(content)
+            elif content_block.type == "tool_use":
+                # Anthropic response contains tool calls in the content block
+                # Ref: https://docs.anthropic.com/en/docs/build-with-claude/tool-use#example-api-response-with-a-tool-use-content-block
+                tool_calls.append(
+                    ToolCall(
+                        id=content_block.id,
+                        function=Function(
+                            name=content_block.name, arguments=json.dumps(content_block.input)
+                        ),
+                        type="function",
+                    )
+                )
+            else:
+                raise MlflowException.invalid_parameter_value(
+                    f"Unknown content type: {content_block.type}. Please make sure the message "
+                    "is a valid Anthropic message object. If it is a valid type, contact to the "
+                    "MLflow maintainer via https://github.com/mlflow/mlflow/issues/new/choose for "
+                    "requesting support for a new message type."
+                )
+
+        message = ChatMessage(role=role, content=contents)
+        # Only set tool_calls field when it is present
+        if tool_calls:
+            message.tool_calls = tool_calls
+        return message
+
+    else:
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid content type. Must be either a string or a list, but got: {type(content)}."
+        )
+
+
+def convert_tool_to_mlflow_chat_tool(tool: dict) -> ChatTool:
+    """
+    Convert Anthropic tool definition into MLflow's standard format (OpenAI compatible).
+
+    Ref: https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+
+    Args:
+        tool: A dictionary represents a single tool definition in the input request.
+
+    Returns:
+        ChatTool: MLflow's standard tool definition object.
+    """
+    return ChatTool(
+        type="function",
+        function=FunctionToolDefinition(
+            name=tool.get("name"),
+            description=tool.get("description"),
+            parameters=tool.get("input_schema"),
+        ),
+    )

--- a/mlflow/anthropic/chat.py
+++ b/mlflow/anthropic/chat.py
@@ -1,7 +1,7 @@
 import json
 from typing import Union
 
-from anthropic.types import ContentBlock, Message
+from pydantic import BaseModel
 
 from mlflow.exceptions import MlflowException
 from mlflow.types.chat import (
@@ -14,9 +14,10 @@ from mlflow.types.chat import (
     TextContentPart,
     ToolCall,
 )
+from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
 
-def convert_message_to_mlflow_chat(message: Union[Message, dict]) -> ChatMessage:
+def convert_message_to_mlflow_chat(message: Union[BaseModel, dict]) -> ChatMessage:
     """
     Convert Anthropic message object into MLflow's standard format (OpenAI compatible).
 
@@ -31,7 +32,7 @@ def convert_message_to_mlflow_chat(message: Union[Message, dict]) -> ChatMessage
     if isinstance(message, dict):
         content = message.get("content")
         role = message.get("role")
-    elif isinstance(message, Message):
+    elif isinstance(message, BaseModel):
         content = message.content
         role = message.role
     else:
@@ -45,49 +46,74 @@ def convert_message_to_mlflow_chat(message: Union[Message, dict]) -> ChatMessage
     elif isinstance(content, list):
         contents = []
         tool_calls = []
+        tool_call_id = None
         for content_block in content:
-            if isinstance(content_block, dict):
-                content_block = ContentBlock(**content_block)
+            if isinstance(content_block, BaseModel):
+                if IS_PYDANTIC_V2_OR_NEWER:
+                    content_block = content_block.model_dump()
+                else:
+                    content_block = content_block.dict()
 
-            if content_block.type == "text":
-                content = TextContentPart(text=content_block.text, type="text")
-                contents.append(content)
-            elif content_block.type == "image":
-                source = content_block.source
-                content = ImageContentPart(
-                    image_url=ImageUrl(url=f"data:{source.media_type};{source.type},{source.data}"),
-                    type="image_url",
-                )
-                contents.append(content)
-            elif content_block.type == "tool_use":
+            content_type = content_block.get("type")
+            if content_type == "tool_use":
                 # Anthropic response contains tool calls in the content block
                 # Ref: https://docs.anthropic.com/en/docs/build-with-claude/tool-use#example-api-response-with-a-tool-use-content-block
                 tool_calls.append(
                     ToolCall(
-                        id=content_block.id,
+                        id=content_block["id"],
                         function=Function(
-                            name=content_block.name, arguments=json.dumps(content_block.input)
+                            name=content_block["name"], arguments=json.dumps(content_block["input"])
                         ),
                         type="function",
                     )
                 )
+            elif content_type == "tool_result":
+                # In Anthropic, the result of tool execution is returned as a special content type
+                # "tool_result" with "user" role, which corresponds to the "tool" role in OpenAI.
+                role = "tool"
+                tool_call_id = content_block["tool_use_id"]
+                if result_content := content_block.get("content"):
+                    contents.append(_parse_content(result_content))
+                else:
+                    contents.append(TextContentPart(text="", type="text"))
             else:
-                raise MlflowException.invalid_parameter_value(
-                    f"Unknown content type: {content_block.type}. Please make sure the message "
-                    "is a valid Anthropic message object. If it is a valid type, contact to the "
-                    "MLflow maintainer via https://github.com/mlflow/mlflow/issues/new/choose for "
-                    "requesting support for a new message type."
-                )
+                contents.append(_parse_content(content_block))
 
         message = ChatMessage(role=role, content=contents)
         # Only set tool_calls field when it is present
         if tool_calls:
             message.tool_calls = tool_calls
+        if tool_call_id:
+            message.tool_call_id = tool_call_id
         return message
 
     else:
         raise MlflowException.invalid_parameter_value(
             f"Invalid content type. Must be either a string or a list, but got: {type(content)}."
+        )
+
+
+def _parse_content(content: Union[str, dict]) -> Union[TextContentPart, ImageContentPart]:
+    if isinstance(content, str):
+        return TextContentPart(text=content, type="text")
+
+    content_type = content.get("type")
+    if content_type == "text":
+        return TextContentPart(text=content["text"], type="text")
+    elif content_type == "image":
+        source = content["source"]
+        return ImageContentPart(
+            image_url=ImageUrl(
+                url=f"data:{source['media_type']};{source['type']},{source['data']}"
+            ),
+            type="image_url",
+        )
+    else:
+        raise MlflowException.invalid_parameter_value(
+            f"Unknown content type: {content_type['type']}. Please make sure the message "
+            "is a valid Anthropic message object. If it is a valid type, contact to the "
+            "MLflow maintainer via https://github.com/mlflow/mlflow/issues/new/choose for "
+            "requesting support for a new message type."
         )
 
 

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -101,7 +101,11 @@ class AnthropicAdapter(ProviderAdapter):
             choices=[
                 chat.Choice(
                     index=0,
-                    message=convert_message_to_mlflow_chat(resp),
+                    # TODO: Remove this casting once
+                    # https://github.com/mlflow/mlflow/pull/14160 is merged
+                    message=chat.ResponseMessage(
+                        **convert_message_to_mlflow_chat(resp).model_dump_compat()
+                    ),
                     finish_reason=stop_reason,
                 )
             ],

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -2,7 +2,6 @@ import json
 import time
 from typing import AsyncIterable
 
-from mlflow.anthropic.chat import convert_message_to_mlflow_chat
 from mlflow.gateway.config import AnthropicConfig, RouteConfig
 from mlflow.gateway.constants import (
     MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
@@ -90,6 +89,8 @@ class AnthropicAdapter(ProviderAdapter):
         #   }
         # }
         # ```
+        from mlflow.anthropic.chat import convert_message_to_mlflow_chat
+
         stop_reason = "length" if resp["stop_reason"] == "max_tokens" else "stop"
 
         return chat.ResponsePayload(

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -170,7 +170,10 @@ def _call_llm_provider_api(
             "Failed to score the provided input as the judge LLM did not return "
             "any chat completion results in the response."
         )
-    return chat_response.choices[0].message.content
+    content = chat_response.choices[0].message.content
+
+    # NB: Evaluation only handles text content for now.
+    return content[0].text if isinstance(content, list) else content
 
 
 def _get_provider_instance(provider: str, model: str) -> "BaseProvider":

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -830,6 +830,9 @@ anthropic:
     requirements:
       "< 0.40.0": ["httpx<0.28.0"]
     run: pytest tests/anthropic
+    # Our CI runs tests for every minor version of the library by default, which results in
+    # many test tasks for anthropic. Reducing the number of testing only for every 5 version.
+    test_every_n_versions: 5
 
 crewai:
   package_info:

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -29,7 +29,9 @@ class TextContentPart(BaseModel):
 
 
 class ImageUrl(BaseModel):
-    url: str  # either URL of an image, or bas64 encoded data
+    # URL field can be either URL of an image, or bas64 encoded data.
+    # Ref: https://platform.openai.com/docs/guides/vision?lang=curl#uploading-base64-encoded-images
+    url: str
     detail: Literal["auto", "low", "high"]
 
 
@@ -125,7 +127,11 @@ class FunctionToolDefinition(BaseModel):
 
 
 class ChatTool(BaseModel):
-    """A tool definition passed to the chat completion API."""
+    """
+    A tool definition passed to the chat completion API.
+
+    Ref: https://platform.openai.com/docs/guides/function-calling
+    """
 
     type: Literal["function"]
     function: Optional[FunctionToolDefinition] = None

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -29,8 +29,13 @@ class TextContentPart(BaseModel):
 
 
 class ImageUrl(BaseModel):
-    # URL field can be either URL of an image, or base64 encoded data.
+    """
+    Represents an image URL.
+
+    The `url`` field can be either URL of an image, or base64 encoded data.
     # Ref: https://platform.openai.com/docs/guides/vision?lang=curl#uploading-base64-encoded-images
+    """
+
     url: str
     detail: Literal["auto", "low", "high"]
 

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -29,7 +29,7 @@ class TextContentPart(BaseModel):
 
 
 class ImageUrl(BaseModel):
-    # URL field can be either URL of an image, or bas64 encoded data.
+    # URL field can be either URL of an image, or base64 encoded data.
     # Ref: https://platform.openai.com/docs/guides/vision?lang=curl#uploading-base64-encoded-images
     url: str
     detail: Literal["auto", "low", "high"]

--- a/tests/anthropic/test_anthropic_autolog.py
+++ b/tests/anthropic/test_anthropic_autolog.py
@@ -66,7 +66,12 @@ DUMMY_CREATE_MESSAGE_WITH_TOOLS_RESPONSE = Message(
     stop_reason="end_turn",
     stop_sequence=None,
     type="message",
-    usage=Usage(input_tokens=10, output_tokens=18),
+    usage=Usage(
+        input_tokens=10,
+        output_tokens=18,
+        cache_creation_input_tokens=None,
+        cache_read_input_tokens=None,
+    ),
 )
 
 

--- a/tests/anthropic/test_anthropic_autolog.py
+++ b/tests/anthropic/test_anthropic_autolog.py
@@ -1,10 +1,11 @@
 from unittest.mock import patch
 
 import anthropic
-from anthropic.types import Message, TextBlock, Usage
+from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
 
 import mlflow.anthropic
 from mlflow.entities.span import SpanType
+from mlflow.tracing.constant import SpanAttributeKey
 
 from tests.tracing.helper import get_traces
 
@@ -25,16 +26,55 @@ DUMMY_CREATE_MESSAGE_RESPONSE = Message(
     usage=Usage(input_tokens=10, output_tokens=18),
 )
 
+DUMMY_CREATE_MESSAGE_WITH_TOOLS_REQUEST = {
+    "model": "test_model",
+    "max_tokens": 1024,
+    "tools": [
+        {
+            "name": "get_weather",
+            "description": "Get the current weather in a given location",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g., San Francisco, CA",
+                    },
+                    "unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                        "description": 'The unit of temperature, "celsius" or "fahrenheit"',
+                    },
+                },
+                "required": ["location"],
+            },
+        }
+    ],
+    "messages": [{"role": "user", "content": "What's the weather like in San Francisco?"}],
+}
 
-def create(self, max_tokens, model, messages):
-    return DUMMY_CREATE_MESSAGE_RESPONSE
+DUMMY_CREATE_MESSAGE_WITH_TOOLS_RESPONSE = Message(
+    id="test_id",
+    content=[
+        TextBlock(text="<thinking>I need to use the get_weather</thinking>", type="text"),
+        ToolUseBlock(
+            id="tool_123", name="get_weather", input={"location": "San Francisco"}, type="tool_use"
+        ),
+    ],
+    model="test_model",
+    role="assistant",
+    stop_reason="end_turn",
+    stop_sequence=None,
+    type="message",
+    usage=Usage(input_tokens=10, output_tokens=18),
+)
 
 
-def test_messages_autolog():
-    with patch("anthropic.resources.Messages.create", new=create):
-        mlflow.anthropic.autolog()
-        client = anthropic.Anthropic(api_key="test_key")
-        client.messages.create(**DUMMY_CREATE_MESSAGE_REQUEST)
+@patch("anthropic._base_client.SyncAPIClient.post", return_value=DUMMY_CREATE_MESSAGE_RESPONSE)
+def test_messages_autolog(mock_post):
+    mlflow.anthropic.autolog()
+    client = anthropic.Anthropic(api_key="test_key")
+    client.messages.create(**DUMMY_CREATE_MESSAGE_REQUEST)
 
     traces = get_traces()
     assert len(traces) == 1
@@ -50,11 +90,134 @@ def test_messages_autolog():
     }
     assert span.outputs == DUMMY_CREATE_MESSAGE_RESPONSE.to_dict()
 
-    with patch("anthropic.resources.Messages.create", new=create):
-        mlflow.anthropic.autolog(disable=True)
-        client = anthropic.Anthropic(api_key="test_key")
-        client.messages.create(**DUMMY_CREATE_MESSAGE_REQUEST)
+    assert span.get_attribute(SpanAttributeKey.CHAT_MESSAGES) == [
+        {
+            "role": "user",
+            "content": "test message",
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "test answer",
+                    "type": "text",
+                }
+            ],
+        },
+    ]
+
+    mlflow.anthropic.autolog(disable=True)
+    client = anthropic.Anthropic(api_key="test_key")
+    client.messages.create(**DUMMY_CREATE_MESSAGE_REQUEST)
 
     # No new trace should be created
     traces = get_traces()
     assert len(traces) == 1
+
+
+@patch("anthropic._base_client.SyncAPIClient.post", return_value=DUMMY_CREATE_MESSAGE_RESPONSE)
+def test_messages_autolog_multi_modal(mock_post):
+    mlflow.anthropic.autolog()
+    client = anthropic.Anthropic(api_key="test_key")
+    client.messages.create(**DUMMY_CREATE_MESSAGE_REQUEST)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert len(traces[0].data.spans) == 1
+    span = traces[0].data.spans[0]
+    assert span.name == "Messages.create"
+    assert span.span_type == SpanType.CHAT_MODEL
+    assert span.inputs == DUMMY_CREATE_MESSAGE_REQUEST
+    # Only keep input_tokens / output_tokens fields in usage dict.
+    span.outputs["usage"] = {
+        key: span.outputs["usage"][key] for key in ["input_tokens", "output_tokens"]
+    }
+    assert span.outputs == DUMMY_CREATE_MESSAGE_RESPONSE.to_dict()
+
+    assert span.get_attribute(SpanAttributeKey.CHAT_MESSAGES) == [
+        {
+            "role": "user",
+            "content": "test message",
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "test answer",
+                    "type": "text",
+                }
+            ],
+        },
+    ]
+
+
+@patch(
+    "anthropic._base_client.SyncAPIClient.post",
+    return_value=DUMMY_CREATE_MESSAGE_WITH_TOOLS_RESPONSE,
+)
+def test_messages_autolog_tool_calling(mock_post):
+    mlflow.anthropic.autolog()
+    client = anthropic.Anthropic(api_key="test_key")
+    client.messages.create(**DUMMY_CREATE_MESSAGE_WITH_TOOLS_REQUEST)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert len(traces[0].data.spans) == 1
+    span = traces[0].data.spans[0]
+    assert span.name == "Messages.create"
+    assert span.span_type == SpanType.CHAT_MODEL
+    assert span.inputs == DUMMY_CREATE_MESSAGE_WITH_TOOLS_REQUEST
+    assert span.outputs == DUMMY_CREATE_MESSAGE_WITH_TOOLS_RESPONSE.to_dict()
+
+    assert span.get_attribute(SpanAttributeKey.CHAT_MESSAGES) == [
+        {
+            "role": "user",
+            "content": "What's the weather like in San Francisco?",
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "<thinking>I need to use the get_weather</thinking>",
+                    "type": "text",
+                }
+            ],
+            "tool_calls": [
+                {
+                    "id": "tool_123",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "San Francisco"}',
+                    },
+                }
+            ],
+        },
+    ]
+
+    assert span.get_attribute(SpanAttributeKey.CHAT_TOOLS) == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "properties": {
+                        "location": {
+                            "description": "The city and state, e.g., San Francisco, CA",
+                            "type": "string",
+                        },
+                        "unit": {
+                            "description": 'The unit of temperature, "celsius" or "fahrenheit"',
+                            "enum": ["celsius", "fahrenheit"],
+                            "type": "string",
+                        },
+                    },
+                    "required": ["location"],
+                    "type": "object",
+                },
+            },
+        }
+    ]

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -270,7 +270,7 @@ async def test_chat():
                 {
                     "message": {
                         "role": "assistant",
-                        "content": "Response message",
+                        "content": [{"text": "Response message", "type": "text"}],
                         "tool_calls": None,
                         "refusal": None,
                     },


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14164?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14164/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14164
```

</p>
</details>

### What changes are proposed in this pull request?

Implement https://github.com/mlflow/mlflow/pull/14140 for Anthropic.
 
Basically updating Anthropic auto-tracing to record the following two span attirbutes:
* `mlflow.chat.message` - records input and output messages in the OpenAI message format.
* `mlflow.chat.tools` - records the tool definition passed within the input request, in the OpenAI's tool format.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Normal chat request:
<img width="864" alt="Screenshot 2024-12-25 at 13 49 13" src="https://github.com/user-attachments/assets/f3f8123c-dd2d-442e-bd0d-62287e09f5f6" />


Tool calling:

![Screenshot 2024-12-25 at 13 50 10](https://github.com/user-attachments/assets/7ded44a6-beaa-4532-a027-e35640de76c9)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
