### PR TITLE
Support type hint in serving

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -389,7 +389,10 @@ def serve_wheel(request, tmp_path_factory):
             os.environ["PIP_EXTRA_INDEX_URL"] = url
             # Set the `UV_INDEX` environment variable to allow fetching the wheel from the
             # url when using `uv` as environment manager
-            os.environ["UV_INDEX"] = f"mlflow={url}"
+            # setuptools also exists in https://download.pytorch.org/whl/cpu, but it might
+            # not include the version we need, and uv by default finds the first index that
+            # has the package, this could cause version not found error
+            os.environ["UV_INDEX"] = f"mlflow={url} setuptools=https://pypi.org/simple"
             yield
         finally:
             prc.terminate()

--- a/conftest.py
+++ b/conftest.py
@@ -389,10 +389,7 @@ def serve_wheel(request, tmp_path_factory):
             os.environ["PIP_EXTRA_INDEX_URL"] = url
             # Set the `UV_INDEX` environment variable to allow fetching the wheel from the
             # url when using `uv` as environment manager
-            # setuptools also exists in https://download.pytorch.org/whl/cpu, but it might
-            # not include the version we need, and uv by default finds the first index that
-            # has the package, this could cause version not found error
-            os.environ["UV_INDEX"] = f"mlflow={url} setuptools=https://pypi.org/simple"
+            os.environ["UV_INDEX"] = f"mlflow={url}"
             yield
         finally:
             prc.terminate()

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -684,4 +684,6 @@ MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN = _BooleanEnvironmentVariable(
 # Specifies whether the current environment is a serving environment.
 # This should only be used internally by MLflow to add some additional logic when running in a
 # serving environment.
-_MLFLOW_IS_SERVING_ENVIRONMENT = _BooleanEnvironmentVariable("_MLFLOW_IS_SERVING_ENVIRONMENT", None)
+_MLFLOW_IS_IN_SERVING_ENVIRONMENT = _BooleanEnvironmentVariable(
+    "_MLFLOW_IS_IN_SERVING_ENVIRONMENT", None
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1,5 +1,8 @@
 """
 This module defines environment variables used in MLflow.
+MLflow's environment variables adhere to the following naming conventions:
+- Public variables: environment variable names begin with `MLFLOW_`
+- Internal-use variables: For variables used only internally, names start with `_MLFLOW_`
 """
 
 import os

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -680,3 +680,8 @@ MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING = _BooleanEnvironmentVariable(
 MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN = _BooleanEnvironmentVariable(
     "MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN", None
 )
+
+# Specifies whether the current environment is a serving environment.
+# This should only be used internally by MLflow to add some additional logic when running in a
+# serving environment.
+_MLFLOW_IS_SERVING_ENVIRONMENT = _BooleanEnvironmentVariable("_MLFLOW_IS_SERVING_ENVIRONMENT", None)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1939,7 +1939,7 @@ def validate_serving_input(model_uri: str, serving_input: Union[str, dict[str, A
         The prediction result from the model.
     """
     from mlflow.pyfunc.scoring_server import _parse_json_data
-    from mlflow.pyfunc.utils.environment import serving_environment
+    from mlflow.pyfunc.utils.environment import _simulate_serving_environment
 
     # sklearn model might not have python_function flavor if it
     # doesn't define a predict function. In such case the model
@@ -1954,7 +1954,7 @@ def validate_serving_input(model_uri: str, serving_input: Union[str, dict[str, A
             pyfunc_model.metadata,
             pyfunc_model.metadata.get_input_schema(),
         )
-        with serving_environment():
+        with _simulate_serving_environment():
             return pyfunc_model.predict(parsed_input.data, params=parsed_input.params)
     finally:
         if output_dir and os.path.exists(output_dir):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1939,6 +1939,7 @@ def validate_serving_input(model_uri: str, serving_input: Union[str, dict[str, A
         The prediction result from the model.
     """
     from mlflow.pyfunc.scoring_server import _parse_json_data
+    from mlflow.pyfunc.utils.environment import serving_environment
 
     # sklearn model might not have python_function flavor if it
     # doesn't define a predict function. In such case the model
@@ -1953,7 +1954,8 @@ def validate_serving_input(model_uri: str, serving_input: Union[str, dict[str, A
             pyfunc_model.metadata,
             pyfunc_model.metadata.get_input_schema(),
         )
-        return pyfunc_model.predict(parsed_input.data, params=parsed_input.params)
+        with serving_environment():
+            return pyfunc_model.predict(parsed_input.data, params=parsed_input.params)
     finally:
         if output_dir and os.path.exists(output_dir):
             shutil.rmtree(output_dir)

--- a/mlflow/pyfunc/utils/environment.py
+++ b/mlflow/pyfunc/utils/environment.py
@@ -1,0 +1,20 @@
+import os
+from contextlib import contextmanager
+
+from mlflow.environment_variables import _MLFLOW_IS_SERVING_ENVIRONMENT
+
+
+@contextmanager
+def serving_environment():
+    """
+    Context manager that sets the `_MLFLOW_IS_SERVING_ENVIRONMENT` environment variable to `True`.
+    """
+    original_value = _MLFLOW_IS_SERVING_ENVIRONMENT.get_raw()
+    try:
+        _MLFLOW_IS_SERVING_ENVIRONMENT.set("true")
+        yield
+    finally:
+        if original_value is not None:
+            os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name] = original_value
+        else:
+            del os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name]

--- a/mlflow/pyfunc/utils/environment.py
+++ b/mlflow/pyfunc/utils/environment.py
@@ -1,20 +1,22 @@
 import os
 from contextlib import contextmanager
 
-from mlflow.environment_variables import _MLFLOW_IS_SERVING_ENVIRONMENT
+from mlflow.environment_variables import _MLFLOW_IS_IN_SERVING_ENVIRONMENT
 
 
 @contextmanager
-def serving_environment():
+def _simulate_serving_environment():
     """
-    Context manager that sets the `_MLFLOW_IS_SERVING_ENVIRONMENT` environment variable to `True`.
+    Some functions (e.g. validate_serving_input) replicate the data transformation logic
+    that happens in the model serving environment to validate data before model deployment.
+    This context manager can be used to simulate the serving environment for such functions.
     """
-    original_value = _MLFLOW_IS_SERVING_ENVIRONMENT.get_raw()
+    original_value = _MLFLOW_IS_IN_SERVING_ENVIRONMENT.get_raw()
     try:
-        _MLFLOW_IS_SERVING_ENVIRONMENT.set("true")
+        _MLFLOW_IS_IN_SERVING_ENVIRONMENT.set("true")
         yield
     finally:
         if original_value is not None:
-            os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name] = original_value
+            os.environ[_MLFLOW_IS_IN_SERVING_ENVIRONMENT.name] = original_value
         else:
-            del os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name]
+            del os.environ[_MLFLOW_IS_IN_SERVING_ENVIRONMENT.name]

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -380,9 +380,10 @@ def _parse_data_for_datatype_hint(data: Any, type_hint: type[Any]) -> Any:
         - string data with bytes type hint -> bytes object
     """
     if type_hint == bytes and isinstance(data, str):
-        # The assumption is that the data is base64 encoded
-        # same as MLflow's NumpyEncoder that's used for saving input example
-        # base64.encodebytes(x).decode("ascii")
+        # The assumption is that the data is base64 encoded, and
+        # scoring server accepts base64 encoded string for bytes fields.
+        # MLflow uses the same method for saving input example
+        # via base64.encodebytes(x).decode("ascii")
         return base64.decodebytes(bytes(data, "utf8"))
     if type_hint == datetime and isinstance(data, str):
         # The assumption is that the data is in ISO format

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -8,7 +8,7 @@ import pydantic
 import pydantic.fields
 from packaging.version import Version
 
-from mlflow.environment_variables import _MLFLOW_IS_SERVING_ENVIRONMENT
+from mlflow.environment_variables import _MLFLOW_IS_IN_SERVING_ENVIRONMENT
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.types.schema import (
@@ -341,7 +341,7 @@ def _validate_example_against_type_hint(example: Any, type_hint: type[Any]) -> A
     elif type_hint == Any:
         return example
     elif type_hint in TYPE_HINTS_TO_DATATYPE_MAPPING:
-        if _MLFLOW_IS_SERVING_ENVIRONMENT.get():
+        if _MLFLOW_IS_IN_SERVING_ENVIRONMENT.get():
             example = _parse_data_for_datatype_hint(data=example, type_hint=type_hint)
         if isinstance(example, type_hint):
             return example

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 from datetime import datetime
 from functools import lru_cache
@@ -7,6 +8,7 @@ import pydantic
 import pydantic.fields
 from packaging.version import Version
 
+from mlflow.environment_variables import _MLFLOW_IS_SERVING_ENVIRONMENT
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.types.schema import (
@@ -339,6 +341,8 @@ def _validate_example_against_type_hint(example: Any, type_hint: type[Any]) -> A
     elif type_hint == Any:
         return example
     elif type_hint in TYPE_HINTS_TO_DATATYPE_MAPPING:
+        if _MLFLOW_IS_SERVING_ENVIRONMENT.get():
+            example = _parse_data_for_datatype_hint(data=example, type_hint=type_hint)
         if isinstance(example, type_hint):
             return example
         raise MlflowException.invalid_parameter_value(
@@ -364,6 +368,26 @@ def _validate_example_against_type_hint(example: Any, type_hint: type[Any]) -> A
             # no validation needed for AnyType
             return example
     _invalid_type_hint_error(type_hint)
+
+
+def _parse_data_for_datatype_hint(data: Any, type_hint: type[Any]) -> Any:
+    """
+    Parse the data based on the type hint.
+    This should only be used in MLflow serving environment to convert
+    json data to the expected format.
+    Allowed conversions:
+        - string data with datetime type hint -> datetime object
+        - string data with bytes type hint -> bytes object
+    """
+    if type_hint == bytes and isinstance(data, str):
+        # The assumption is that the data is base64 encoded
+        # same as MLflow's NumpyEncoder that's used for saving input example
+        # base64.encodebytes(x).decode("ascii")
+        return base64.decodebytes(bytes(data, "utf8"))
+    if type_hint == datetime and isinstance(data, str):
+        # The assumption is that the data is in ISO format
+        return datetime.fromisoformat(data)
+    return data
 
 
 class ValidationResult(NamedTuple):

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -713,7 +713,14 @@ def test_serving_environment(monkeypatch):
     "env_manager",
     [VIRTUALENV, UV],
 )
-def test_predict_model_with_type_hints(env_manager):
+def test_predict_model_with_type_hints(env_manager, monkeypatch):
+    if env_manager == UV:
+        # the test env sets PIP_EXTRA_INDEX_URL to https://download.pytorch.org/whl/cpu
+        # setuptools also exists here, but it might not include the version we need,
+        # and uv by default finds the first index that has the package, this could cause
+        # version not found error
+        monkeypatch.delenv("PIP_EXTRA_INDEX_URL", False)
+
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, model_input: list[str]) -> list[str]:
             return model_input

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -17,7 +17,7 @@ from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 from mlflow.pyfunc.utils import pyfunc
 from mlflow.pyfunc.utils.environment import _simulate_serving_environment
 from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
-from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER, _is_pydantic_type_hint
+from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER
 from mlflow.utils.env_manager import VIRTUALENV
 
 from tests.helper_functions import pyfunc_serve_and_score_model

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -9,13 +9,13 @@ import pydantic
 import pytest
 
 import mlflow
-from mlflow.environment_variables import _MLFLOW_IS_SERVING_ENVIRONMENT
+from mlflow.environment_variables import _MLFLOW_IS_IN_SERVING_ENVIRONMENT
 from mlflow.exceptions import MlflowException
 from mlflow.models import convert_input_example_to_serving_input
 from mlflow.models.signature import _extract_type_hints, infer_signature
 from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 from mlflow.pyfunc.utils import pyfunc
-from mlflow.pyfunc.utils.environment import serving_environment
+from mlflow.pyfunc.utils.environment import _simulate_serving_environment
 from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
 from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER, _is_pydantic_type_hint
 from mlflow.utils.env_manager import UV, VIRTUALENV
@@ -699,14 +699,14 @@ def test_log_model_warn_only_if_model_with_valid_type_hint_not_decorated(recwarn
 
 
 def test_serving_environment(monkeypatch):
-    with serving_environment():
-        assert os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name] == "true"
-    assert os.environ.get(_MLFLOW_IS_SERVING_ENVIRONMENT.name) is None
+    with _simulate_serving_environment():
+        assert os.environ[_MLFLOW_IS_IN_SERVING_ENVIRONMENT.name] == "true"
+    assert os.environ.get(_MLFLOW_IS_IN_SERVING_ENVIRONMENT.name) is None
 
-    monkeypatch.setenv(_MLFLOW_IS_SERVING_ENVIRONMENT.name, "false")
-    with serving_environment():
-        assert os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name] == "true"
-    assert os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name] == "false"
+    monkeypatch.setenv(_MLFLOW_IS_IN_SERVING_ENVIRONMENT.name, "false")
+    with _simulate_serving_environment():
+        assert os.environ[_MLFLOW_IS_IN_SERVING_ENVIRONMENT.name] == "true"
+    assert os.environ[_MLFLOW_IS_IN_SERVING_ENVIRONMENT.name] == "false"
 
 
 @pytest.mark.parametrize(

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -713,14 +713,7 @@ def test_serving_environment(monkeypatch):
     "env_manager",
     [VIRTUALENV, UV],
 )
-def test_predict_model_with_type_hints(env_manager, monkeypatch):
-    if env_manager == UV:
-        # the test env sets PIP_EXTRA_INDEX_URL to https://download.pytorch.org/whl/cpu
-        # setuptools also exists here, but it might not include the version we need,
-        # and uv by default finds the first index that has the package, this could cause
-        # version not found error
-        monkeypatch.delenv("PIP_EXTRA_INDEX_URL", False)
-
+def test_predict_model_with_type_hints(env_manager):
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, model_input: list[str]) -> list[str]:
             return model_input

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import sys
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 from unittest import mock
@@ -8,11 +9,18 @@ import pydantic
 import pytest
 
 import mlflow
+from mlflow.environment_variables import _MLFLOW_IS_SERVING_ENVIRONMENT
 from mlflow.exceptions import MlflowException
+from mlflow.models import convert_input_example_to_serving_input
 from mlflow.models.signature import _extract_type_hints, infer_signature
+from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 from mlflow.pyfunc.utils import pyfunc
+from mlflow.pyfunc.utils.environment import serving_environment
 from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
-from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER
+from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER, _is_pydantic_type_hint
+from mlflow.utils.env_manager import UV, VIRTUALENV
+
+from tests.helper_functions import pyfunc_serve_and_score_model
 
 
 class CustomExample(pydantic.BaseModel):
@@ -20,8 +28,6 @@ class CustomExample(pydantic.BaseModel):
     str_field: str
     bool_field: bool
     double_field: float
-    binary_field: bytes
-    datetime_field: datetime.datetime
     any_field: Any
     optional_str: Optional[str] = None
 
@@ -104,8 +110,6 @@ class CustomExample2(pydantic.BaseModel):
                                 Property(name="str_field", dtype=DataType.string),
                                 Property(name="bool_field", dtype=DataType.boolean),
                                 Property(name="double_field", dtype=DataType.double),
-                                Property(name="binary_field", dtype=DataType.binary),
-                                Property(name="datetime_field", dtype=DataType.datetime),
                                 Property(name="any_field", dtype=AnyType()),
                                 Property(
                                     name="optional_str", dtype=DataType.string, required=False
@@ -115,18 +119,14 @@ class CustomExample2(pydantic.BaseModel):
                     ),
                 ]
             ),
-            [
-                {
-                    "long_field": 123,
-                    "str_field": "abc",
-                    "bool_field": True,
-                    "double_field": 1.23,
-                    "binary_field": b"bytes",
-                    "datetime_field": datetime.datetime.now(),
-                    "any_field": ["any", 123],
-                    "optional_str": "optional",
-                }
-            ],
+            {
+                "long_field": 123,
+                "str_field": "abc",
+                "bool_field": True,
+                "double_field": 1.23,
+                "any_field": ["any", 123],
+                "optional_str": "optional",
+            },
         ),
         (
             list[CustomExample2],
@@ -202,7 +202,12 @@ def test_pyfunc_model_infer_signature_from_type_hints(
     if has_input_example:
         kwargs["input_example"] = input_example
     with mlflow.start_run():
-        model_info = mlflow.pyfunc.log_model("test_model", **kwargs)
+        with mock.patch("mlflow.models.model._logger.warning") as mock_warning:
+            model_info = mlflow.pyfunc.log_model("test_model", **kwargs)
+        assert not any(
+            "Failed to validate serving input example" in call[0][0]
+            for call in mock_warning.call_args_list
+        )
     assert model_info.signature._is_signature_from_type_hint is True
     assert model_info.signature.inputs == expected_schema
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -210,6 +215,16 @@ def test_pyfunc_model_infer_signature_from_type_hints(
     if isinstance(result[0], pydantic.BaseModel):
         result = [r.dict() if PYDANTIC_V1_OR_OLDER else r.model_dump() for r in result]
     assert result == input_example
+
+    # test serving
+    payload = convert_input_example_to_serving_input(input_example)
+    scoring_response = pyfunc_serve_and_score_model(
+        model_uri=model_info.model_uri,
+        data=payload,
+        content_type=CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert scoring_response.status_code == 200
 
 
 def test_pyfunc_model_with_no_op_type_hint_pass_signature_works():
@@ -681,3 +696,36 @@ def test_log_model_warn_only_if_model_with_valid_type_hint_not_decorated(recwarn
             "model", python_model=predict_df, input_example=pd.DataFrame({"a": [1]})
         )
     assert not any("Decorate your function" in str(w.message) for w in recwarn)
+
+
+def test_serving_environment(monkeypatch):
+    with serving_environment():
+        assert os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name] == "true"
+    assert os.environ.get(_MLFLOW_IS_SERVING_ENVIRONMENT.name) is None
+
+    monkeypatch.setenv(_MLFLOW_IS_SERVING_ENVIRONMENT.name, "false")
+    with serving_environment():
+        assert os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name] == "true"
+    assert os.environ[_MLFLOW_IS_SERVING_ENVIRONMENT.name] == "false"
+
+
+@pytest.mark.parametrize(
+    "env_manager",
+    [VIRTUALENV, UV],
+)
+def test_predict_model_with_type_hints(env_manager):
+    class TestModel(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input: list[str]) -> list[str]:
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "model",
+            python_model=TestModel(),
+        )
+
+    mlflow.models.predict(
+        model_uri=model_info.model_uri,
+        input_data=["a", "b", "c"],
+        env_manager=env_manager,
+    )

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -119,14 +119,16 @@ class CustomExample2(pydantic.BaseModel):
                     ),
                 ]
             ),
-            {
-                "long_field": 123,
-                "str_field": "abc",
-                "bool_field": True,
-                "double_field": 1.23,
-                "any_field": ["any", 123],
-                "optional_str": "optional",
-            },
+            [
+                {
+                    "long_field": 123,
+                    "str_field": "abc",
+                    "bool_field": True,
+                    "double_field": 1.23,
+                    "any_field": ["any", 123],
+                    "optional_str": "optional",
+                }
+            ],
         ),
         (
             list[CustomExample2],


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14168?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14168/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14168
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
In this PR:
- If the model signature is inferred from type hint, then during model serving we shouldn't do any data parsing (the old way of parsing could convert input type to numpy type), and the payload key must be `inputs`.
- Add an internal environment variable `_MLFLOW_IS_SERVING_ENVIRONMENT` to determine if the current environment is serving environment
- Update type hint validation logic in `_validate_example_against_type_hint`: if the current environment is serving env, then we allow two types of data conversion: str -> datetime, and str -> bytes under certain assumptions.
- Add context manager `serving_environment` for temporarily set env to serving env: this is useful for some functions like `mlflow.models.predict` and `validate_serving_input` since they're simulating serving environment prediction.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
