### PR TITLE
Limit model input typehint to list for predict

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -405,7 +405,7 @@ def _infer_signature_from_type_hints(
     try:
         input_schema = _infer_schema_from_list_type_hint(type_hints.input)
     except InvalidTypeHintException as e:
-        warnings.warn(e.message, stacklevel=3)
+        warnings.warn(f"Failed to infer signature from type hint: {e.message}", stacklevel=3)
         return None
 
     # only warn if the pyfunc decorator is not used and schema can

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -29,7 +29,9 @@ from mlflow.types.schema import AnyType, ColSpec, ParamSchema, Schema, convert_d
 from mlflow.types.type_hints import (
     InvalidTypeHintException,
     _get_example_validation_result,
+    _infer_schema_from_list_type_hint,
     _infer_schema_from_type_hint,
+    _is_list_type_hint,
     _signature_cannot_be_inferred_from_type_hint,
 )
 from mlflow.types.utils import _infer_param_schema, _infer_schema
@@ -401,7 +403,7 @@ def _infer_signature_from_type_hints(
         input_example, params = input_example
 
     try:
-        input_schema = _infer_schema_from_type_hint(type_hints.input)
+        input_schema = _infer_schema_from_list_type_hint(type_hints.input)
     except InvalidTypeHintException as e:
         warnings.warn(e.message, stacklevel=3)
         return None
@@ -422,7 +424,14 @@ def _infer_signature_from_type_hints(
     output_schema = None
     if type_hints.output:
         try:
-            output_schema = _infer_schema_from_type_hint(type_hints.output)
+            # output type hint doesn't need to be a list
+            # but if it's a list, we infer the schema from the list type hint
+            # to be consistent with input schema inference
+            output_schema = (
+                _infer_schema_from_list_type_hint(type_hints.output)
+                if _is_list_type_hint(type_hints.output)
+                else _infer_schema_from_type_hint(type_hints.output)
+            )
             is_output_type_hint_valid = True
         except InvalidTypeHintException as e:
             _logger.info(

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -9,7 +9,7 @@ from mlflow.models.signature import (
 )
 from mlflow.types.type_hints import (
     _convert_data_to_type_hint,
-    _infer_schema_from_type_hint,
+    _infer_schema_from_list_type_hint,
     _signature_cannot_be_inferred_from_type_hint,
     _validate_example_against_type_hint,
 )
@@ -69,7 +69,7 @@ def _get_type_hint_if_supported(func) -> Optional[type[Any]]:
         if _signature_cannot_be_inferred_from_type_hint(type_hint):
             return
         try:
-            _infer_schema_from_type_hint(type_hint)
+            _infer_schema_from_list_type_hint(type_hint)
         except Exception as e:
             warnings.warn(
                 "Type hint used in the model's predict function is not supported "

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -265,12 +265,11 @@ def _get_element_type_of_list_type_hint(type_hint: type[list[Any]]) -> Any:
         raise MlflowException.invalid_parameter_value(
             f"List type hint must contain the element type, got {type_hint}"
         )
-    elif len(args) > 1:
+    if len(args) > 1:
         raise MlflowException.invalid_parameter_value(
             f"List type hint must contain only one element type, got {type_hint}"
         )
-    else:
-        return args[0]
+    return args[0]
 
 
 def _is_list_type_hint(type_hint: type[Any]) -> bool:

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -289,7 +289,7 @@ def _infer_schema_from_list_type_hint(type_hint: type[list[Any]]) -> Schema:
     """
     if not _is_list_type_hint(type_hint):
         raise InvalidTypeHintException(
-            message=f"Type hint must be list[...] with a valid element type, got {type_hint}",
+            message=f"Type hint for model input must be `list[...]`, got {type_hint}",
         )
     internal_type = _get_element_type_of_list_type_hint(type_hint)
     return _infer_schema_from_type_hint(internal_type)

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -289,7 +289,6 @@ def _infer_schema_from_list_type_hint(type_hint: type[list[Any]]) -> Schema:
     """
     if not _is_list_type_hint(type_hint):
         raise InvalidTypeHintException(
-            type_hint=type_hint,
             message=f"Type hint must be list[...] with a valid internal type, got {type_hint}",
         )
     internal_type = _get_internal_type_of_list_type_hint(type_hint)
@@ -303,8 +302,9 @@ def _infer_schema_from_type_hint(type_hint: type[Any]) -> Schema:
     col_spec_type = _infer_colspec_type_from_type_hint(type_hint)
     # Creating Schema with unnamed optional inputs is not supported
     if col_spec_type.required is False:
-        raise MlflowException.invalid_parameter_value(
-            "If you would like to use Optional types, use a Pydantic-based type hint definition."
+        raise InvalidTypeHintException(
+            message="If you would like to use Optional types, "
+            "use a Pydantic-based type hint definition."
         )
     return Schema([ColSpec(type=col_spec_type.dtype, required=col_spec_type.required)])
 

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -9,10 +9,12 @@ from functools import partial
 from json import JSONEncoder
 from typing import Any, Optional
 
+import pydantic
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.json_format import MessageToJson, ParseDict
 
 from mlflow.exceptions import MlflowException
+from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
 _PROTOBUF_INT64_FIELDS = [
     FieldDescriptor.TYPE_INT64,
@@ -187,6 +189,8 @@ class NumpyEncoder(JSONEncoder):
             return np.datetime_as_string(o), True
         if isinstance(o, (pd.Timestamp, datetime.date, datetime.datetime, datetime.time)):
             return o.isoformat(), True
+        if isinstance(o, pydantic.BaseModel):
+            return o.model_dump() if IS_PYDANTIC_V2_OR_NEWER else o.dict(), True
         return o, False
 
     def default(self, o):

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -525,20 +525,20 @@ def test_save_load_input_example_with_pydantic_model(tmp_path):
         content: str
 
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, context, model_input: Message, params=None):
+        def predict(self, context, model_input: list[Message], params=None):
             return model_input
 
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(
             "test_model",
             python_model=MyModel(),
-            input_example=Message(role="user", content="Hello!"),
+            input_example=[Message(role="user", content="Hello!")],
         )
     local_path = _download_artifact_from_uri(model_info.model_uri, output_path=tmp_path)
     loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
     assert loaded_model.saved_input_example_info["type"] == "json_object"
     loaded_example = loaded_model.load_input_example(local_path)
-    assert loaded_example == {"role": "user", "content": "Hello!"}
+    assert loaded_example == [{"role": "user", "content": "Hello!"}]
 
 
 def test_model_saved_by_save_model_can_be_loaded(tmp_path, sklearn_knn_model):

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -15,7 +15,7 @@ from mlflow.types.type_hints import (
     PYDANTIC_V1_OR_OLDER,
     InvalidTypeHintException,
     _convert_data_to_type_hint,
-    _infer_schema_from_type_hint,
+    _infer_schema_from_list_type_hint,
     _signature_cannot_be_inferred_from_type_hint,
     _validate_example_against_type_hint,
 )
@@ -47,7 +47,7 @@ class CustomModel2(pydantic.BaseModel):
     ("type_hint", "expected_schema"),
     [
         (
-            CustomModel,
+            list[CustomModel],
             Schema(
                 [
                     ColSpec(
@@ -70,7 +70,7 @@ class CustomModel2(pydantic.BaseModel):
             ),
         ),
         (
-            list[CustomModel],
+            list[list[CustomModel]],
             Schema(
                 [
                     ColSpec(
@@ -95,7 +95,7 @@ class CustomModel2(pydantic.BaseModel):
             ),
         ),
         (
-            CustomModel2,
+            list[CustomModel2],
             Schema(
                 [
                     ColSpec(
@@ -123,7 +123,7 @@ class CustomModel2(pydantic.BaseModel):
     ],
 )
 def test_infer_schema_from_pydantic_model(type_hint, expected_schema):
-    schema = _infer_schema_from_type_hint(type_hint)
+    schema = _infer_schema_from_list_type_hint(type_hint)
     assert schema == expected_schema
 
 
@@ -131,30 +131,32 @@ def test_infer_schema_from_pydantic_model(type_hint, expected_schema):
     ("type_hint", "expected_schema"),
     [
         # scalars
-        (int, Schema([ColSpec(type=DataType.long)])),
-        (str, Schema([ColSpec(type=DataType.string)])),
-        (bool, Schema([ColSpec(type=DataType.boolean)])),
-        (float, Schema([ColSpec(type=DataType.double)])),
-        (bytes, Schema([ColSpec(type=DataType.binary)])),
-        (datetime.datetime, Schema([ColSpec(type=DataType.datetime)])),
+        (list[int], Schema([ColSpec(type=DataType.long)])),
+        (list[str], Schema([ColSpec(type=DataType.string)])),
+        (list[bool], Schema([ColSpec(type=DataType.boolean)])),
+        (list[float], Schema([ColSpec(type=DataType.double)])),
+        (list[bytes], Schema([ColSpec(type=DataType.binary)])),
+        (list[datetime.datetime], Schema([ColSpec(type=DataType.datetime)])),
         # lists
-        (list[str], Schema([ColSpec(type=Array(DataType.string))])),
-        (List[str], Schema([ColSpec(type=Array(DataType.string))])),  # noqa: UP006
-        (list[list[str]], Schema([ColSpec(type=Array(Array(DataType.string)))])),
-        (List[List[str]], Schema([ColSpec(type=Array(Array(DataType.string)))])),  # noqa: UP006
+        (list[list[str]], Schema([ColSpec(type=Array(DataType.string))])),
+        (List[List[str]], Schema([ColSpec(type=Array(DataType.string))])),  # noqa: UP006
+        (list[list[list[str]]], Schema([ColSpec(type=Array(Array(DataType.string)))])),
+        (List[List[List[str]]], Schema([ColSpec(type=Array(Array(DataType.string)))])),  # noqa: UP006
         # dictionaries
-        (dict[str, int], Schema([ColSpec(type=Map(DataType.long))])),
-        (Dict[str, int], Schema([ColSpec(type=Map(DataType.long))])),  # noqa: UP006
-        (dict[str, list[str]], Schema([ColSpec(type=Map(Array(DataType.string)))])),
-        (Dict[str, List[str]], Schema([ColSpec(type=Map(Array(DataType.string)))])),  # noqa: UP006
+        (list[dict[str, str]], Schema([ColSpec(type=Map(DataType.string))])),
+        (list[dict[str, int]], Schema([ColSpec(type=Map(DataType.long))])),
+        (list[Dict[str, int]], Schema([ColSpec(type=Map(DataType.long))])),  # noqa: UP006
+        (list[dict[str, list[str]]], Schema([ColSpec(type=Map(Array(DataType.string)))])),
+        (list[Dict[str, List[str]]], Schema([ColSpec(type=Map(Array(DataType.string)))])),  # noqa: UP006
         # Union
-        (Union[int, str], Schema([ColSpec(type=AnyType())])),
+        (list[Union[int, str]], Schema([ColSpec(type=AnyType())])),
         # Any
-        (list[Any], Schema([ColSpec(type=Array(AnyType()))])),
+        (list[Any], Schema([ColSpec(type=AnyType())])),
+        (list[list[Any]], Schema([ColSpec(type=Array(AnyType()))])),
     ],
 )
 def test_infer_schema_from_python_type_hints(type_hint, expected_schema):
-    schema = _infer_schema_from_type_hint(type_hint)
+    schema = _infer_schema_from_list_type_hint(type_hint)
     assert schema == expected_schema
 
 
@@ -173,6 +175,13 @@ def test_type_hints_needs_signature(type_hint):
 
 
 def test_infer_schema_from_type_hints_errors():
+    message = r"Type hint must be list\[...\] with a valid internal type"
+    with pytest.raises(MlflowException, match=message):
+        _infer_schema_from_list_type_hint(str)
+
+    with pytest.raises(MlflowException, match=message):
+        _infer_schema_from_list_type_hint(list)
+
     class InvalidModel(pydantic.BaseModel):
         bool_field: Optional[bool]
 
@@ -185,46 +194,46 @@ def test_infer_schema_from_type_hints_errors():
             MlflowException,
             match=message,
         ):
-            _infer_schema_from_type_hint(InvalidModel)
+            _infer_schema_from_list_type_hint(list[InvalidModel])
 
         with pytest.raises(MlflowException, match=message):
-            _infer_schema_from_type_hint(list[InvalidModel])
+            _infer_schema_from_list_type_hint(list[list[InvalidModel]])
 
     message = r"If you would like to use Optional types, use a Pydantic-based type hint definition."
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_type_hint(Optional[str])
+        _infer_schema_from_list_type_hint(list[Optional[str]])
 
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_type_hint(Union[str, int, type(None)])
+        _infer_schema_from_list_type_hint(list[Union[str, int, type(None)]])
 
     with pytest.raises(
         MlflowException, match=r"List type hint must contain only one internal type"
     ):
-        _infer_schema_from_type_hint(list[str, int])
+        _infer_schema_from_list_type_hint(list[str, int])
 
     with pytest.raises(MlflowException, match=r"Dictionary key type must be str"):
-        _infer_schema_from_type_hint(dict[int, int])
+        _infer_schema_from_list_type_hint(list[dict[int, int]])
 
     with pytest.raises(
         MlflowException, match=r"Dictionary type hint must contain two internal types"
     ):
-        _infer_schema_from_type_hint(dict[int])
+        _infer_schema_from_list_type_hint(list[dict[int]])
 
     message = r"it must include a valid internal type"
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_type_hint(Union)
+        _infer_schema_from_list_type_hint(list[Union])
 
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_type_hint(Optional)
+        _infer_schema_from_list_type_hint(list[Optional])
 
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_type_hint(list)
+        _infer_schema_from_list_type_hint(list[list])
 
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_type_hint(dict)
+        _infer_schema_from_list_type_hint(list[dict])
 
     with pytest.raises(InvalidTypeHintException, match=r"Unsupported type hint"):
-        _infer_schema_from_type_hint(object)
+        _infer_schema_from_list_type_hint(list[object])
 
 
 @pytest.mark.parametrize(
@@ -396,8 +405,12 @@ def test_type_hints_validation_errors():
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
 def test_type_hint_for_python_3_10():
-    assert _infer_schema_from_type_hint(bool | int | str) == Schema([ColSpec(type=AnyType())])
-    assert _infer_schema_from_type_hint(list[int | str]) == Schema([ColSpec(type=Array(AnyType()))])
+    assert _infer_schema_from_list_type_hint(list[bool | int | str]) == Schema(
+        [ColSpec(type=AnyType())]
+    )
+    assert _infer_schema_from_list_type_hint(list[list[int | str]]) == Schema(
+        [ColSpec(type=Array(AnyType()))]
+    )
 
     class ToolDef(pydantic.BaseModel):
         type: str
@@ -406,7 +419,7 @@ def test_type_hint_for_python_3_10():
     class Tool(pydantic.BaseModel):
         tool_choice: str | ToolDef
 
-    assert _infer_schema_from_type_hint(Tool) == Schema(
+    assert _infer_schema_from_list_type_hint(list[Tool]) == Schema(
         [ColSpec(type=Object([Property(name="tool_choice", dtype=AnyType())]))]
     )
 

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -175,7 +175,7 @@ def test_type_hints_needs_signature(type_hint):
 
 
 def test_infer_schema_from_type_hints_errors():
-    message = r"Type hint must be list\[...\] with a valid element type"
+    message = r"Type hint for model input must be `list\[...\]`"
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(str)
 

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -175,7 +175,7 @@ def test_type_hints_needs_signature(type_hint):
 
 
 def test_infer_schema_from_type_hints_errors():
-    message = r"Type hint must be list\[...\] with a valid internal type"
+    message = r"Type hint must be list\[...\] with a valid element type"
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(str)
 
@@ -199,27 +199,25 @@ def test_infer_schema_from_type_hints_errors():
         with pytest.raises(MlflowException, match=message):
             _infer_schema_from_list_type_hint(list[list[InvalidModel]])
 
-    message = r"If you would like to use Optional types, use a Pydantic-based type hint definition."
+    message = r"To define Optional inputs, use a Pydantic-based type hint definition"
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[Optional[str]])
 
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[Union[str, int, type(None)]])
 
-    with pytest.raises(
-        MlflowException, match=r"List type hint must contain only one internal type"
-    ):
+    with pytest.raises(MlflowException, match=r"List type hint must contain only one element type"):
         _infer_schema_from_list_type_hint(list[str, int])
 
     with pytest.raises(MlflowException, match=r"Dictionary key type must be str"):
         _infer_schema_from_list_type_hint(list[dict[int, int]])
 
     with pytest.raises(
-        MlflowException, match=r"Dictionary type hint must contain two internal types"
+        MlflowException, match=r"Dictionary type hint must contain two element types"
     ):
         _infer_schema_from_list_type_hint(list[dict[int]])
 
-    message = r"it must include a valid internal type"
+    message = r"it must include a valid element type"
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[Union])
 
@@ -398,7 +396,7 @@ def test_type_hints_validation_errors():
 
     with pytest.raises(
         InvalidTypeHintException,
-        match=r"Unsupported type hint `<class 'list'>`, it must include a valid internal type.",
+        match=r"Unsupported type hint `<class 'list'>`, it must include a valid element type.",
     ):
         _validate_example_against_type_hint(["a"], list)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14171?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14171/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14171
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As offline discussion on decision 5, we should make sure pyfunc model's predict always works on batch inputs. The easiest way is to limit type hint usage for model input to always be list[...]. Output type hint doesn't need to be limited though.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
