### PR TITLE
Add tool attributes for gemini flavor

### DIFF
--- a/mlflow/gemini/autolog.py
+++ b/mlflow/gemini/autolog.py
@@ -31,11 +31,12 @@ def patched_class_call(original, self, *args, **kwargs):
         ) as span:
             inputs = _construct_full_inputs(original, self, *args, **kwargs)
             span.set_inputs(inputs)
+            if isinstance(self, genai.GenerativeModel):
+                _log_tool_definition(self, span)
 
             result = original(self, *args, **kwargs)
 
             if isinstance(result, genai.types.GenerateContentResponse):
-                _log_tool_definition(self, span)
                 try:
                     content = inputs.get("contents", []) or inputs.get("content", [])
                     messages = parse_gemini_content_to_mlflow_chat_messages(content)

--- a/mlflow/gemini/autolog.py
+++ b/mlflow/gemini/autolog.py
@@ -1,9 +1,111 @@
 import inspect
+import logging
 
 import mlflow
 import mlflow.gemini
 from mlflow.entities import SpanType
+from mlflow.gemini.chat import (
+    convert_gemini_func_to_mlflow_chat_tool,
+    parse_gemini_content_to_mlflow_chat_messages,
+)
+from mlflow.tracing.utils import set_span_chat_messages, set_span_chat_tools
+from mlflow.types.chat import ChatMessage
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
+
+_logger = logging.getLogger(__name__)
+
+
+def patched_class_call(original, self, *args, **kwargs):
+    """
+    This method is used for patching class methods of the google.generativeai module.
+    This patch creates a span and set input and output of the original method to the span.
+    """
+    import google.generativeai as genai
+
+    config = AutoLoggingConfig.init(flavor_name=mlflow.gemini.FLAVOR_NAME)
+
+    if config.log_traces:
+        with mlflow.start_span(
+            name=f"{self.__class__.__name__}.{original.__name__}",
+            span_type=_get_span_type(original.__name__),
+        ) as span:
+            inputs = _construct_full_inputs(original, self, *args, **kwargs)
+            span.set_inputs(inputs)
+
+            result = original(self, *args, **kwargs)
+
+            if isinstance(result, genai.types.GenerateContentResponse):
+                _log_tool_definition(self, span)
+                try:
+                    content = inputs.get("contents", []) or inputs.get("content", [])
+                    messages = parse_gemini_content_to_mlflow_chat_messages(content)
+                    messages += _parse_outputs(result)
+                    if messages:
+                        set_span_chat_messages(span=span, messages=messages)
+                except Exception as e:
+                    _logger.warning(
+                        f"An exception occurred on logging chat attributes for {span}. Error: {e}"
+                    )
+
+            # need to convert the response of generate_content for better visualization
+            outputs = result.to_dict() if hasattr(result, "to_dict") else result
+            span.set_outputs(outputs)
+
+            return result
+
+
+def patched_module_call(original, *args, **kwargs):
+    """
+    This method is used for patching standalone functions of the google.generativeai module.
+    This patch creates a span and set input and output of the original function to the span.
+    """
+    config = AutoLoggingConfig.init(flavor_name=mlflow.gemini.FLAVOR_NAME)
+
+    if config.log_traces:
+        with mlflow.start_span(
+            name=f"{original.__name__}",
+            span_type=_get_span_type(original.__name__),
+        ) as span:
+            inputs = _construct_full_inputs(original, *args, **kwargs)
+            span.set_inputs(inputs)
+            result = original(*args, **kwargs)
+            # need to convert the response of generate_content for better visualization
+            outputs = result.to_dict() if hasattr(result, "to_dict") else result
+            span.set_outputs(outputs)
+
+            return result
+
+
+def _parse_outputs(outputs) -> list[ChatMessage]:
+    """
+    This method extract chat messages from genai.types.generation_types.GenerateContentResponse
+    """
+    # content always exist on output
+    # https://github.com/googleapis/googleapis/blob/9e966149c59f47f6305d66c98e2a9e7d9c26a2eb/google/ai/generativelanguage/v1beta/generative_service.proto#L490
+    return sum(
+        [
+            parse_gemini_content_to_mlflow_chat_messages(candidate.content)
+            for candidate in outputs.candidates
+        ],
+        [],
+    )
+
+
+def _log_tool_definition(model, span):
+    # when tools are not passed or object is ChatSession
+    if not getattr(model, "_tools", None):
+        return
+
+    try:
+        set_span_chat_tools(
+            span,
+            [
+                convert_gemini_func_to_mlflow_chat_tool(func)
+                for func in model._tools.to_proto()[0].function_declarations
+            ],
+        )
+    except Exception as e:
+        _logger.warning(f"Failed to set tool definitions for {span}. Error: {e}")
 
 
 def _get_span_type(task_name: str) -> str:
@@ -16,9 +118,9 @@ def _get_span_type(task_name: str) -> str:
     return span_type_mapping.get(task_name, SpanType.UNKNOWN)
 
 
-def construct_full_inputs(func, *args, **kwargs):
+def _construct_full_inputs(func, *args, **kwargs):
     signature = inspect.signature(func)
-    # this does not create copy. So values should not be mutated directly
+    # this method does not create copy. So values should not be mutated directly
     arguments = signature.bind_partial(*args, **kwargs).arguments
 
     if "self" in arguments:
@@ -28,39 +130,3 @@ def construct_full_inputs(func, *args, **kwargs):
             arguments["model_name"] = self.model_name
 
     return arguments
-
-
-def patched_class_call(original, self, *args, **kwargs):
-    config = AutoLoggingConfig.init(flavor_name=mlflow.gemini.FLAVOR_NAME)
-
-    if config.log_traces:
-        with mlflow.start_span(
-            name=f"{self.__class__.__name__}.{original.__name__}",
-            span_type=_get_span_type(original.__name__),
-        ) as span:
-            inputs = construct_full_inputs(original, self, *args, **kwargs)
-            span.set_inputs(inputs)
-            result = original(self, *args, **kwargs)
-            # need to convert the response of generate_content for better visualization
-            outputs = result.to_dict() if hasattr(result, "to_dict") else result
-            span.set_outputs(outputs)
-
-            return result
-
-
-def patched_module_call(original, *args, **kwargs):
-    config = AutoLoggingConfig.init(flavor_name=mlflow.gemini.FLAVOR_NAME)
-
-    if config.log_traces:
-        with mlflow.start_span(
-            name=f"{original.__name__}",
-            span_type=_get_span_type(original.__name__),
-        ) as span:
-            inputs = construct_full_inputs(original, *args, **kwargs)
-            span.set_inputs(inputs)
-            result = original(*args, **kwargs)
-            # need to convert the response of generate_content for better visualization
-            outputs = result.to_dict() if hasattr(result, "to_dict") else result
-            span.set_outputs(outputs)
-
-            return result

--- a/mlflow/gemini/autolog.py
+++ b/mlflow/gemini/autolog.py
@@ -93,7 +93,7 @@ def _parse_outputs(outputs) -> list[ChatMessage]:
 
 
 def _log_tool_definition(model, span):
-    # when tools are not passed or object is ChatSession
+    # when tools are not passed
     if not getattr(model, "_tools", None):
         return
 

--- a/mlflow/gemini/chat.py
+++ b/mlflow/gemini/chat.py
@@ -1,0 +1,188 @@
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from mlflow.types.chat import (
+    ChatMessage,
+    ChatTool,
+    Function,
+    FunctionParams,
+    FunctionToolDefinition,
+    ParamProperty,
+    TextContentPart,
+    ToolCall,
+)
+
+if TYPE_CHECKING:
+    import google.generativeai as genai
+
+_logger = logging.getLogger(__name__)
+
+
+def convert_gemini_param_property_to_mlflow_param_property(param_property) -> ParamProperty:
+    """
+    Convert Gemini parameter property definition into MLflow's standard format (OpenAI compatible).
+    Ref: https://ai.google.dev/gemini-api/docs/function-calling
+
+    Args:
+        param_property: A genai.protos.Schema object representing a parameter property.
+
+    Returns:
+        ParamProperty: MLflow's standard param property object.
+    """
+    return ParamProperty(
+        description=param_property.description,
+        enum=param_property.enum,
+        type=param_property.type.name.lower(),
+    )
+
+
+def convert_gemini_function_param_to_mlflow_function_param(
+    function_params: "genai.protos.Schema",
+) -> FunctionParams:
+    """
+    Convert Gemini function parameter definition into MLflow's standard format (OpenAI compatible).
+    Ref: https://ai.google.dev/gemini-api/docs/function-calling
+
+    Args:
+        function_params: A genai.protos.Schema object representing function parameters.
+
+    Returns:
+        FunctionParams: MLflow's standard function parameter object.
+    """
+    return FunctionParams(
+        properties={
+            k: convert_gemini_param_property_to_mlflow_param_property(v)
+            for k, v in function_params.properties.items()
+        },
+        required=function_params.required,
+    )
+
+
+def convert_gemini_func_to_mlflow_chat_tool(
+    function_def: "genai.protos.FunctionDeclaration",
+) -> ChatTool:
+    """
+    Convert Gemini function definition into MLflow's standard format (OpenAI compatible).
+    Ref: https://ai.google.dev/gemini-api/docs/function-calling
+
+    Args:
+        function_def: A genai.protos.FunctionDeclaration object representing a function definition.
+
+    Returns:
+        ChatTool: MLflow's standard tool definition object.
+    """
+    return ChatTool(
+        type="function",
+        function=FunctionToolDefinition(
+            name=function_def.name,
+            description=function_def.description,
+            parameters=convert_gemini_function_param_to_mlflow_function_param(
+                function_def.parameters
+            ),
+        ),
+    )
+
+
+def convert_gemini_func_call_to_mlflow_tool_call(
+    func_call: "genai.protos.FunctionCall",
+) -> ToolCall:
+    """
+    Convert Gemini function call into MLflow's standard format (OpenAI compatible).
+    Ref: https://ai.google.dev/gemini-api/docs/function-calling
+
+    Args:
+        func_call: A genai.protos.FunctionCall object representing a single func call.
+
+    Returns:
+        ToolCall: MLflow's standard tool call object.
+    """
+    # original args object is not json serializable
+    args = func_call.args or {}
+
+    return ToolCall(
+        # Gemini does not have func call id
+        id=func_call.name,
+        type="function",
+        function=Function(name=func_call.name, arguments=json.dumps(dict(args))),
+    )
+
+
+def parse_gemini_content_to_mlflow_chat_messages(
+    content: "genai.content_types.ContentsType",
+) -> list[ChatMessage]:
+    """
+    Convert a gemini content to chat messages.
+
+    Args:
+        content: A genai.content_types.ContentsType object representing the model content.
+
+    Returns:
+        list[ChatMessage]: A list of MLflow's standard chat messages.
+    """
+    if isinstance(content, str):
+        # Assume str content is used only for user input
+        return [
+            ChatMessage(
+                role="user",
+                content=content,
+            )
+        ]
+    elif isinstance(content, list):
+        # either list of user inputs or multi-turn conversation
+        if not content:
+            return []
+        # when chat history is passed, parse content recursively
+        if hasattr(content[0], "parts"):
+            return sum(
+                [
+                    parse_gemini_content_to_mlflow_chat_messages(content_block)
+                    for content_block in content
+                ],
+                [],
+            )
+
+        # when multiple contents are passed by user
+        content_parts = []
+        for content_block in content:
+            if isinstance(content_block, str):
+                content_parts.append(TextContentPart(text=content_block, type="text"))
+            else:
+                # TODO: support more content types (e.g. PIL image)
+                _logger.debug(
+                    f"Received an unsupported content block type: {content_block.__class__}"
+                )
+        return [
+            ChatMessage(
+                role="user",
+                content=content_parts,
+            )
+        ]
+    elif hasattr(content, "parts"):
+        # eigher protos.Content or ContentDict
+
+        # This could be unset for single turn conversation even if this is content proto
+        # https://github.com/googleapis/googleapis/blob/9e966149c59f47f6305d66c98e2a9e7d9c26a2eb/google/ai/generativelanguage/v1beta/content.proto#L64
+        role = getattr(content, "role", "model") or "model"
+        tool_calls = []
+        chat_content = None
+        for part in content.parts:
+            if function_call := getattr(part, "function_call", None):
+                tool_calls.append(convert_gemini_func_call_to_mlflow_tool_call(function_call))
+            elif text := getattr(part, "text", None):
+                chat_content = text
+            elif isinstance(part, str):
+                chat_content = part
+
+        chat_message = ChatMessage(
+            role=role,
+            content=chat_content,
+        )
+
+        if tool_calls:
+            chat_message.tool_calls = tool_calls
+
+        return [chat_message]
+    else:
+        _logger.debug(f"Received an unsupported content type: {content.__class__}")
+        return []

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -54,7 +54,7 @@ _DUMMY_EMBEDDING_RESPONSE = {"embedding": [1, 2, 3]}
 
 _CHAT_MESSAGES = [
     {"role": "user", "content": "test content"},
-    {"role": "model", "content": "test answer"},
+    {"role": "assistant", "content": [{"type": "text", "text": "test answer"}]},
 ]
 
 
@@ -196,7 +196,7 @@ def test_chat_session_tool_calling_autolog():
             "role": "user",
         },
         {
-            "role": "model",
+            "role": "assistant",
             "content": None,
             "tool_calls": [
                 {

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -8,39 +8,62 @@ from mlflow.entities.span import SpanType
 
 from tests.tracing.helper import get_traces
 
-CANDIDATES = [{"content": {"parts": [{"text": "test answer"}], "role": "model"}}]
+_CONTENT = {"parts": [{"text": "test answer"}], "role": "model"}
 
-USER_METADATA = {
+_USER_METADATA = {
     "prompt_token_count": 6,
     "candidates_token_count": 6,
     "total_token_count": 6,
     "cached_content_token_count": 0,
 }
 
-DUMMY_GENERATE_CONTENT_RESPONSE = {
-    "candidates": CANDIDATES,
-    "usage_metadata": USER_METADATA,
-}
 
-DUMMY_COUNT_TOKENS_RESPONSE = {"total_count": 10}
+def _generate_content_response(content):
+    return {
+        "candidates": [
+            {
+                "content": content,
+                "avg_logprobs": 0.0,
+                "finish_reason": 0,
+                "grounding_attributions": [],
+                "safety_ratings": [],
+                "token_count": 0,
+            }
+        ],
+        "usage_metadata": _USER_METADATA,
+    }
 
-DUMMY_EMBEDDING_RESPONSE = {"embedding": [1, 2, 3]}
+
+_GENERATE_CONTENT_RESPONSE = _generate_content_response(_CONTENT)
+
+_DUMMY_GENERATE_CONTENT_RESPONSE = genai.types.GenerateContentResponse.from_response(
+    genai.protos.GenerateContentResponse(_GENERATE_CONTENT_RESPONSE)
+)
+
+_DUMMY_COUNT_TOKENS_RESPONSE = {"total_count": 10}
+
+_DUMMY_EMBEDDING_RESPONSE = {"embedding": [1, 2, 3]}
+
+_CHAT_MESSAGES = [
+    {"role": "user", "content": "test content"},
+    {"role": "model", "content": "test answer"},
+]
 
 
 def generate_content(self, contents):
-    return DUMMY_GENERATE_CONTENT_RESPONSE
+    return _DUMMY_GENERATE_CONTENT_RESPONSE
 
 
 def send_message(self, content):
-    return DUMMY_GENERATE_CONTENT_RESPONSE
+    return _DUMMY_GENERATE_CONTENT_RESPONSE
 
 
 def count_tokens(self, contents):
-    return DUMMY_COUNT_TOKENS_RESPONSE
+    return _DUMMY_COUNT_TOKENS_RESPONSE
 
 
 def embed_content(model, content):
-    return DUMMY_EMBEDDING_RESPONSE
+    return _DUMMY_EMBEDDING_RESPONSE
 
 
 def test_generate_content_enable_disable_autolog():
@@ -57,7 +80,8 @@ def test_generate_content_enable_disable_autolog():
         assert span.name == "GenerativeModel.generate_content"
         assert span.span_type == SpanType.LLM
         assert span.inputs == {"contents": "test content", "model_name": "models/gemini-1.5-flash"}
-        assert span.outputs == DUMMY_GENERATE_CONTENT_RESPONSE
+        assert span.outputs == _GENERATE_CONTENT_RESPONSE
+        assert span.get_attribute("mlflow.chat.messages") == _CHAT_MESSAGES
 
         mlflow.gemini.autolog(disable=True)
         model = genai.GenerativeModel("gemini-1.5-flash")
@@ -103,7 +127,8 @@ def test_chat_session_autolog():
         assert span.name == "ChatSession.send_message"
         assert span.span_type == SpanType.CHAT_MODEL
         assert span.inputs == {"content": "test content"}
-        assert span.outputs == DUMMY_GENERATE_CONTENT_RESPONSE
+        assert span.outputs == _GENERATE_CONTENT_RESPONSE
+        assert span.get_attribute("mlflow.chat.messages") == _CHAT_MESSAGES
 
         mlflow.gemini.autolog(disable=True)
         model = genai.GenerativeModel("gemini-1.5-flash")
@@ -113,6 +138,96 @@ def test_chat_session_autolog():
         # No new trace should be created
         traces = get_traces()
         assert len(traces) == 1
+
+
+def test_chat_session_tool_calling_autolog():
+    def multiply(a: float, b: float):
+        """returns a * b."""
+        return a * b
+
+    tool_attribute = [
+        {
+            "type": "function",
+            "function": {
+                "name": "multiply",
+                "description": "returns a * b.",
+                "parameters": {
+                    "properties": {
+                        "a": {"type": "number", "description": "", "enum": [], "items": None},
+                        "b": {"type": "number", "description": "", "enum": [], "items": None},
+                    },
+                    "type": "object",
+                    "required": ["a", "b"],
+                    "additionalProperties": None,
+                },
+                "strict": None,
+            },
+        },
+    ]
+
+    tool_call_content = {
+        "parts": [
+            {
+                "function_call": {
+                    "name": "multiply",
+                    "args": {
+                        "a": 57.0,
+                        "b": 44.0,
+                    },
+                }
+            }
+        ],
+        "role": "model",
+    }
+
+    raw_response = _generate_content_response(tool_call_content)
+    response = genai.types.GenerateContentResponse.from_response(
+        genai.protos.GenerateContentResponse(raw_response)
+    )
+
+    chat_messages = [
+        {
+            "content": "I have 57 cats, each owns 44 mittens, how many mittens is that in total?",
+            "role": "user",
+        },
+        {
+            "role": "model",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "multiply",
+                    "type": "function",
+                    "function": {"name": "multiply", "arguments": '{"a": 57.0, "b": 44.0}'},
+                }
+            ],
+        },
+    ]
+
+    def generate_content(self, content):
+        return response
+
+    with patch("google.generativeai.GenerativeModel.generate_content", new=generate_content):
+        mlflow.gemini.autolog()
+        model = genai.GenerativeModel("gemini-1.5-flash", tools=[multiply])
+        model.generate_content(
+            "I have 57 cats, each owns 44 mittens, how many mittens is that in total?"
+        )
+
+        traces = get_traces()
+        assert len(traces) == 1
+        assert traces[0].info.status == "OK"
+        assert len(traces[0].data.spans) == 1
+        span = traces[0].data.spans[0]
+        assert span.name == "GenerativeModel.generate_content"
+        assert span.span_type == SpanType.LLM
+        assert span.inputs == {
+            "content": "I have 57 cats, each owns 44 mittens, how many mittens is that in total?",
+            "model_name": "models/gemini-1.5-flash",
+        }
+        assert span.get_attribute("mlflow.chat.tools") == tool_attribute
+        assert span.get_attribute("mlflow.chat.messages") == chat_messages
+
+        mlflow.gemini.autolog(disable=True)
 
 
 def test_count_tokens_autolog():
@@ -129,7 +244,7 @@ def test_count_tokens_autolog():
         assert span.name == "GenerativeModel.count_tokens"
         assert span.span_type == SpanType.LLM
         assert span.inputs == {"contents": "test content", "model_name": "models/gemini-1.5-flash"}
-        assert span.outputs == DUMMY_COUNT_TOKENS_RESPONSE
+        assert span.outputs == _DUMMY_COUNT_TOKENS_RESPONSE
 
         mlflow.gemini.autolog(disable=True)
         model = genai.GenerativeModel("gemini-1.5-flash")
@@ -153,7 +268,7 @@ def test_embed_content_autolog():
         assert span.name == "embed_content"
         assert span.span_type == SpanType.EMBEDDING
         assert span.inputs == {"content": "Hello World", "model": "models/text-embedding-004"}
-        assert span.outputs == DUMMY_EMBEDDING_RESPONSE
+        assert span.outputs == _DUMMY_EMBEDDING_RESPONSE
 
         mlflow.gemini.autolog(disable=True)
         genai.embed_content(model="models/text-embedding-004", content="Hello World")


### PR DESCRIPTION
### Related Issues/PRs
N/A

### What changes are proposed in this pull request?

This PR implements https://github.com/mlflow/mlflow/pull/14140 for Gemini.

Basically updating Gemini auto-tracing to record the following two span attributes:

- mlflow.chat.message - records input and output messages in the OpenAI message format.
- mlflow.chat.tools - records the tool definition passed within the input request, in the OpenAI's tool format.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```python
import google.generativeai as genai
import mlflow

mlflow.gemini.autolog()
def multiply(a: float, b: float):
    """returns a * b."""
    return a * b

model = genai.GenerativeModel(
    model_name="gemini-1.5-flash", tools=[multiply]
)

chat = model.start_chat(enable_automatic_function_calling=True)
response = chat.send_message(
    "I have 57 cats, each owns 44 mittens, how many mittens is that in total?"
)
response.text
```
<img width="722" alt="image" src="https://github.com/user-attachments/assets/2c40b30d-a7c8-4c40-9fea-72fece0ff7b4" />

<img width="623" alt="image" src="https://github.com/user-attachments/assets/081117c0-b122-4231-8b64-a67213bcb2e0" />


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
