### PR TITLE
Special type hint support

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -583,7 +583,7 @@ class Model:
         return self.signature._is_signature_from_type_hint if self.signature is not None else False
 
     def _is_type_hint_from_example(self):
-        return self.signature._type_hint_from_example if self.signature is not None else False
+        return self.signature._is_type_hint_from_example if self.signature is not None else False
 
     def get_model_info(self) -> ModelInfo:
         """
@@ -634,7 +634,7 @@ class Model:
         if self.signature is not None:
             res["signature"] = self.signature.to_dict()
             res["is_signature_from_type_hint"] = self.signature._is_signature_from_type_hint
-            res["type_hint_from_example"] = self.signature._type_hint_from_example
+            res["type_hint_from_example"] = self.signature._is_type_hint_from_example
         if self.saved_input_example_info is not None:
             res["saved_input_example_info"] = self.saved_input_example_info
         if self.mlflow_version is None and _MLFLOW_VERSION_KEY in res:
@@ -733,7 +733,7 @@ class Model:
                     "is_signature_from_type_hint"
                 )
             if "type_hint_from_example" in model_dict:
-                signature._type_hint_from_example = model_dict.pop("type_hint_from_example")
+                signature._is_type_hint_from_example = model_dict.pop("type_hint_from_example")
             model_dict["signature"] = signature
 
         if "model_uuid" not in model_dict:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -403,14 +403,16 @@ class Model:
 
         return _load_serving_input_example(self, path)
 
-    def load_input_example(self, path: str) -> Optional[str]:
+    def load_input_example(self, path: Optional[str] = None) -> Optional[str]:
         """
         Load the input example saved along a model. Returns None if there is no example metadata
         (i.e. the model was saved without example). Raises FileNotFoundError if there is model
         metadata but the example file is missing.
 
         Args:
-            path: Path to the model directory.
+            path: Model or run URI, or path to the `model` directory.
+                e.g. models://<model_name>/<model_version>, runs:/<run_id>/<artifact_path>
+                or /path/to/model
 
         Returns:
             Input example (NumPy ndarray, SciPy csc_matrix, SciPy csr_matrix,
@@ -420,6 +422,9 @@ class Model:
         # Just-in-time import to only load example-parsing libraries (e.g. numpy, pandas, etc.) if
         # example is requested.
         from mlflow.models.utils import _read_example
+
+        if path is None:
+            path = f"runs:/{self.run_id}/{self.artifact_path}"
 
         return _read_example(self, path)
 
@@ -577,6 +582,9 @@ class Model:
     def _is_signature_from_type_hint(self):
         return self.signature._is_signature_from_type_hint if self.signature is not None else False
 
+    def _is_type_hint_from_example(self):
+        return self.signature._type_hint_from_example if self.signature is not None else False
+
     def get_model_info(self) -> ModelInfo:
         """
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
@@ -626,6 +634,7 @@ class Model:
         if self.signature is not None:
             res["signature"] = self.signature.to_dict()
             res["is_signature_from_type_hint"] = self.signature._is_signature_from_type_hint
+            res["type_hint_from_example"] = self.signature._type_hint_from_example
         if self.saved_input_example_info is not None:
             res["saved_input_example_info"] = self.saved_input_example_info
         if self.mlflow_version is None and _MLFLOW_VERSION_KEY in res:
@@ -723,6 +732,8 @@ class Model:
                 signature._is_signature_from_type_hint = model_dict.pop(
                     "is_signature_from_type_hint"
                 )
+            if "type_hint_from_example" in model_dict:
+                signature._type_hint_from_example = model_dict.pop("type_hint_from_example")
             model_dict["signature"] = signature
 
         if "model_uuid" not in model_dict:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -426,7 +426,7 @@ class Model:
         if path is None:
             path = f"runs:/{self.run_id}/{self.artifact_path}"
 
-        return _read_example(self, path)
+        return _read_example(self, str(path))
 
     def load_input_example_params(self, path: str):
         """

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -100,7 +100,7 @@ class ModelSignature:
             self.outputs = outputs
         self.params = params
         self.__is_signature_from_type_hint = False
-        self.__type_hint_from_example = False
+        self.__is_type_hint_from_example = False
 
     @property
     def _is_signature_from_type_hint(self):
@@ -111,12 +111,12 @@ class ModelSignature:
         self.__is_signature_from_type_hint = value
 
     @property
-    def _type_hint_from_example(self):
-        return self.__type_hint_from_example
+    def _is_type_hint_from_example(self):
+        return self.__is_type_hint_from_example
 
-    @_type_hint_from_example.setter
-    def _type_hint_from_example(self, value):
-        self.__type_hint_from_example = value
+    @_is_type_hint_from_example.setter
+    def _is_type_hint_from_example(self, value):
+        self.__is_type_hint_from_example = value
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -100,6 +100,7 @@ class ModelSignature:
             self.outputs = outputs
         self.params = params
         self.__is_signature_from_type_hint = False
+        self.__type_hint_from_example = False
 
     @property
     def _is_signature_from_type_hint(self):
@@ -108,6 +109,14 @@ class ModelSignature:
     @_is_signature_from_type_hint.setter
     def _is_signature_from_type_hint(self, value):
         self.__is_signature_from_type_hint = value
+
+    @property
+    def _type_hint_from_example(self):
+        return self.__type_hint_from_example
+
+    @_type_hint_from_example.setter
+    def _type_hint_from_example(self, value):
+        self.__type_hint_from_example = value
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -583,6 +583,10 @@ _CHAT_PARAMS_WARNING_MESSAGE = (
     "Default values for temperature, n and stream in ChatParams will be removed in the "
     "next release. Specify them in the input example explicitly if needed."
 )
+_TYPE_FROM_EXAMPLE_ERROR_MESSAGE = (
+    "Input example must be provided when using TypeFromExample as type hint. "
+    "Fix this by passing `input_example` when logging your model."
+)
 
 
 class EnvType:
@@ -3019,7 +3023,7 @@ def save_model(
             type_hints = python_model.predict_type_hints
             type_hint_from_example = _is_type_hint_from_example(type_hints.input)
             if type_hint_from_example:
-                infer_signature_from_type_hints = False
+                should_infer_signature_from_type_hints = False
             else:
                 should_infer_signature_from_type_hints = (
                     not _signature_cannot_be_inferred_from_type_hint(type_hints.input)
@@ -3054,8 +3058,8 @@ def save_model(
                 else:
                     if type_hint_from_example:
                         _logger.warning(
-                            "Input example must be provided when using TypeFromExample as "
-                            "type hint."
+                            _TYPE_FROM_EXAMPLE_ERROR_MESSAGE,
+                            extra={"color": "red"},
                         )
                     # if signature is inferred from type hints, warnings are emitted
                     # in _infer_signature_from_type_hints
@@ -3085,8 +3089,8 @@ def save_model(
             if saved_example is None:
                 _logger.warning(
                     # TODO: add link to documentation
-                    "Input example must be provided when using TypeFromExample as type hint. "
-                    "Fix this by passing `input_example` when logging your model."
+                    _TYPE_FROM_EXAMPLE_ERROR_MESSAGE,
+                    extra={"color": "red"},
                 )
             else:
                 # TODO: validate input example against signature

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3084,7 +3084,9 @@ def save_model(
         if type_hint_from_example:
             if saved_example is None:
                 _logger.warning(
-                    "Input example must be provided when using TypeFromExample as type hint."
+                    # TODO: add link to documentation
+                    "Input example must be provided when using TypeFromExample as type hint. "
+                    "Fix this by passing `input_example` when logging your model."
                 )
             else:
                 # TODO: validate input example against signature
@@ -3144,11 +3146,12 @@ def save_model(
 
 def update_signature_for_type_hint_from_example(input_example: Any, signature: ModelSignature):
     if _is_example_valid_for_type_from_example(input_example):
-        signature._type_hint_from_example = True
+        signature._is_type_hint_from_example = True
     else:
         _logger.warning(
-            "Input example must be one of pandas.DataFrame, "
-            "pandas.Series or list when using TypeFromExample as type hint."
+            # TODO: add link to documentation
+            "Input example must be one of pandas.DataFrame, pandas.Series "
+            f"or list when using TypeFromExample as type hint, got {type(input_example)}. "
         )
 
 

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -11,6 +11,7 @@ from mlflow.models.signature import (
 from mlflow.types.type_hints import (
     _convert_data_to_type_hint,
     _infer_schema_from_list_type_hint,
+    _is_type_hint_from_example,
     _signature_cannot_be_inferred_from_type_hint,
     _validate_example_against_type_hint,
 )
@@ -102,7 +103,9 @@ def _get_func_info_if_type_hint_supported(func) -> Optional[FuncInfo]:
     type_hint = _extract_type_hints(func, input_arg_index=input_arg_index).input
     input_param_name = param_names[input_arg_index]
     if type_hint is not None:
-        if _signature_cannot_be_inferred_from_type_hint(type_hint):
+        if _signature_cannot_be_inferred_from_type_hint(type_hint) or _is_type_hint_from_example(
+            type_hint
+        ):
             return
         try:
             _infer_schema_from_list_type_hint(type_hint)

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -145,7 +145,8 @@ def _convert_dataframe_to_example_format(data: Any, input_example: Any) -> Any:
                 _logger.warning("Cannot convert DataFrame to a single dictionary.")
                 return data
         if isinstance(input_example, list):
-            if len(data.columns) == 1:
+            # list[scalar]
+            if len(data.columns) == 1 and all(np.isscalar(x) for x in input_example):
                 return data.iloc[:, 0].tolist()
             else:
                 # Note: this doesn't work well if dictionaries in the list

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -149,8 +149,10 @@ def _convert_dataframe_to_example_format(data: Any, input_example: Any) -> Any:
             if len(data.columns) == 1 and all(np.isscalar(x) for x in input_example):
                 return data.iloc[:, 0].tolist()
             else:
-                # Note: this doesn't work well if dictionaries in the list
-                # have different keys
+                # NB: there are some cases that this doesn't work well, but it's the best we can do
+                # e.g. list of dictionaries with different keys
+                # [{"a": 1}, {"b": 2}] -> pd.DataFrame(...) during schema enforcement
+                # here -> [{'a': 1.0, 'b': nan}, {'a': nan, 'b': 2.0}]
                 return data.to_dict(orient="records")
 
     return data

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -2,7 +2,7 @@ import base64
 import logging
 from datetime import datetime
 from functools import lru_cache
-from typing import Any, NamedTuple, Optional, Union, get_args, get_origin
+from typing import Any, NamedTuple, Optional, TypeVar, Union, get_args, get_origin
 
 import pydantic
 import pydantic.fields
@@ -36,6 +36,9 @@ try:
 except ImportError:
     pass
 
+# special type hint that can be used to convert data to
+# the input example type after data validation
+TypeFromExample = TypeVar("TypeFromExample")
 
 # numpy types are not supported
 TYPE_HINTS_TO_DATATYPE_MAPPING = {
@@ -104,6 +107,52 @@ class InvalidTypeHintException(MlflowException):
 
 def _signature_cannot_be_inferred_from_type_hint(type_hint: type[Any]) -> bool:
     return type_hint in type_hints_no_signature_inference()
+
+
+def _is_type_hint_from_example(type_hint: type[Any]) -> bool:
+    return type_hint == TypeFromExample
+
+
+def _is_example_valid_for_type_from_example(example: Any) -> bool:
+    allowed_types = (list,)
+    try:
+        import pandas as pd
+
+        allowed_types += (pd.DataFrame, pd.Series)
+    except ImportError:
+        pass
+    return isinstance(example, allowed_types)
+
+
+def _convert_dataframe_to_example_format(data: Any, input_example: Any) -> Any:
+    import numpy as np
+    import pandas as pd
+
+    if isinstance(data, pd.DataFrame):
+        if isinstance(input_example, pd.DataFrame):
+            return data
+        if isinstance(input_example, pd.Series):
+            data = data.iloc[:, 0]
+            data.name = input_example.name
+            return data
+        if np.isscalar(input_example):
+            return data.iloc[0, 0]
+        if isinstance(input_example, dict):
+            if len(data) == 1:
+                return data.to_dict(orient="records")[0]
+            else:
+                # This case shouldn't happen
+                _logger.warning("Cannot convert DataFrame to a single dictionary.")
+                return data
+        if isinstance(input_example, list):
+            if len(data.columns) == 1:
+                return data.iloc[:, 0].tolist()
+            else:
+                # Note: this doesn't work well if dictionaries in the list
+                # have different keys
+                return data.to_dict(orient="records")
+
+    return data
 
 
 def _infer_colspec_type_from_type_hint(type_hint: type[Any]) -> ColSpecType:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -14,6 +14,7 @@ from packaging.version import Version
 from scipy.sparse import csc_matrix
 
 import mlflow
+from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature, infer_signature, set_model, validate_schema
 from mlflow.models.model import METADATA_FILES, SET_MODEL_ERROR
 from mlflow.models.resources import DatabricksServingEndpoint, DatabricksVectorSearchIndex
@@ -428,12 +429,12 @@ def test_model_load_input_example_failures():
         loaded_example = loaded_model.load_input_example(local_path)
         assert loaded_example is not None
 
-        with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        with pytest.raises(MlflowException, match="No such file or directory"):
             loaded_model.load_input_example(os.path.join(local_path, "folder_which_does_not_exist"))
 
         path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
         os.remove(path)
-        with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        with pytest.raises(MlflowException, match="No such file or directory"):
             loaded_model.load_input_example(local_path)
 
 

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -17,7 +17,7 @@ from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 from mlflow.pyfunc.utils import pyfunc
 from mlflow.pyfunc.utils.environment import _simulate_serving_environment
 from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
-from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER
+from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER, TypeFromExample
 from mlflow.utils.env_manager import VIRTUALENV
 
 from tests.helper_functions import pyfunc_serve_and_score_model
@@ -819,3 +819,45 @@ def test_warning_message_when_logging_model():
             f"Type hint {model.predict_type_hints} cannot be used to infer model signature and "
             "input example is not provided, model signature cannot be inferred."
         ) in mock_warning.call_args[0][0]
+
+
+def assert_equal(data1, data2):
+    if isinstance(data1, pd.DataFrame):
+        pd.testing.assert_frame_equal(data1, data2)
+    elif isinstance(data1, pd.Series):
+        pd.testing.assert_series_equal(data1, data2)
+    else:
+        assert data1 == data2
+
+
+@pytest.mark.parametrize(
+    "input_example",
+    [
+        # list[scalar]
+        ["x", "y", "z"],
+        [1, 2, 3],
+        [1.0, 2.0, 3.0],
+        [True, False, True],
+        [b"Hello", b"World"],
+        # list[dict]
+        [{"a": 1, "b": 2}],
+        [{"role": "user", "content": "hello"}, {"role": "admin", "content": "hi"}],
+        # pd DataFrame
+        pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}),
+    ],
+)
+def test_type_hint_from_example(input_example):
+    class Model(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input: TypeFromExample):
+            return model_input
+
+    model = Model()
+    assert_equal(model.predict(input_example), input_example)
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "model", python_model=model, input_example=input_example
+        )
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    result = pyfunc_model.predict(input_example)
+    assert_equal(result, input_example)

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -840,6 +840,7 @@ def assert_equal(data1, data2):
         [1.0, 2.0, 3.0],
         [True, False, True],
         # list[dict]
+        [{"x": True}],
         [{"a": 1, "b": 2}],
         [{"role": "user", "content": "hello"}, {"role": "admin", "content": "hi"}],
         # pd DataFrame


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14182?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14182/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14182
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Special type hint support: 1DD https://docs.google.com/document/d/1EWE7WmHmJi-aYkH7ZFz7-OX6tkeGe2pn4R9MG_h9G4Q/edit?usp=sharing

The use case is: when the user only provides an input example when logging a pyfunc model, they can use `TypeFromExample` as a special type hint. Model signature will still be inferred from the input example, and schema enforcement will be done, but we will convert the pandas.DF back to logged input example format before passing it to predict function. 
Since `predict` function should work on batch inputs, the supported input example must be one of: pd.DF, pd.Series, list.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
