### PR TITLE
Show eval template when the input is a vanilla string

### DIFF
--- a/mlflow/models/display_utils.py
+++ b/mlflow/models/display_utils.py
@@ -6,7 +6,16 @@ from mlflow.types import schema
 from mlflow.utils import databricks_utils
 
 
+def _is_input_string(inputs: schema.Schema) -> bool:
+    return (
+        not inputs.has_input_names()
+        and len(inputs.input_types()) == 1
+        and inputs.input_types()[0] == schema.DataType.string
+    )
+
 def _is_input_agent_compatible(inputs: schema.Schema) -> bool:
+    if _is_input_string(inputs):
+        return True
     if not inputs.has_input_names():
         return False
     messages = inputs.input_dict().get("messages")

--- a/mlflow/models/display_utils.py
+++ b/mlflow/models/display_utils.py
@@ -13,6 +13,7 @@ def _is_input_string(inputs: schema.Schema) -> bool:
         and inputs.input_types()[0] == schema.DataType.string
     )
 
+
 def _is_input_agent_compatible(inputs: schema.Schema) -> bool:
     if _is_input_string(inputs):
         return True

--- a/tests/models/test_display_utils.py
+++ b/tests/models/test_display_utils.py
@@ -61,6 +61,9 @@ def test_should_render_eval_template_with_vanilla_string(enable_databricks_env):
     signature = infer_signature(_CHAT_REQUEST, "A vanilla string response")
     assert should_render_agent_eval_template(signature)
 
+def test_should_render_eval_template_with_string_input(enable_databricks_env):
+    signature = infer_signature("A vanilla string input", _STRING_RESPONSE)
+    assert should_render_agent_eval_template(signature)
 
 def test_should_not_render_eval_template_generic_signature(enable_databricks_env):
     signature = infer_signature({"input": "string"}, {"output": "string"})

--- a/tests/models/test_display_utils.py
+++ b/tests/models/test_display_utils.py
@@ -61,9 +61,11 @@ def test_should_render_eval_template_with_vanilla_string(enable_databricks_env):
     signature = infer_signature(_CHAT_REQUEST, "A vanilla string response")
     assert should_render_agent_eval_template(signature)
 
+
 def test_should_render_eval_template_with_string_input(enable_databricks_env):
     signature = infer_signature("A vanilla string input", _STRING_RESPONSE)
     assert should_render_agent_eval_template(signature)
+
 
 def test_should_not_render_eval_template_generic_signature(enable_databricks_env):
     signature = infer_signature({"input": "string"}, {"output": "string"})


### PR DESCRIPTION
### Related Issues/PRs
Continuation of https://github.com/mlflow/mlflow/pull/14084

### What changes are proposed in this pull request?
When the user logs a model that satisfies the Mosaic AI Agent schema, we display a recipe for model evaluation.
This PR relaxes the schema to work with Langchain and OpenAI flavors that take a vanilla string as input.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

https://private-user-images.githubusercontent.com/2294279/395789126-4901413b-de22-4e78-a3d0-1a4327434c17.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzYxOTEzMTksIm5iZiI6MTczNjE5MTAxOSwicGF0aCI6Ii8yMjk0Mjc5LzM5NTc4OTEyNi00OTAxNDEzYi1kZTIyLTRlNzgtYTNkMC0xYTQzMjc0MzRjMTcubXA0P1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDEwNiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTAxMDZUMTkxNjU5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MTNmZGMzYWE4ZDdkN2YwZmEzYjc4ZmUxYzEwZTkzNjk0YzVhM2ZjNmNiYzVmZGIyYjdiZTczMzIzYjI1MWVhNiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.mbvH_uiMwVltjYUN1Gow5spViK7YKEGDN2hmGQIMMdg

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
When the user logs a model that satisfies the Mosaic AI Agent schema, we display a recipe for model evaluation.
This PR relaxes the schema to work with Langchain and OpenAI flavors that take a vanilla string as input.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
