### PR TITLE
Update DSPy tracing to handle tool calling

### DIFF
--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -143,38 +143,40 @@ def test_mlflow_callback_exception():
     assert spans[3].status.status_code == "ERROR"
 
 
-@pytest.mark.skipif(
-    # NB: We also need to filter out version < 2.5.17 because installing DSPy
-    # from source will have hard-coded version number 2.5.15.
-    # https://github.com/stanfordnlp/dspy/blob/803dff03c42d2f436aa67398ce5aba17e7b45611/pyproject.toml#L8-L9
-    _DSPY_VERSION >= Version("2.5.19") or _DSPY_VERSION < Version("2.5.17"),
-    reason="dspy.ReAct is broken in >=2.5.19",
-)
 def test_autolog_react():
+    # NB: DSPy's __version__ is not reliable as it is hard-coded in the package.
+    if not hasattr(BaseCallback, "on_tool_start"):
+        pytest.skip("DSPy callback does not handle Tool in versions < 2.5.42")
+
     mlflow.dspy.autolog()
 
     dspy.settings.configure(
         lm=DummyLM(
             [
                 {
-                    "Thought_1": "I need to search for the highest mountain in the world",
-                    "Action_1": "Search['Highest mountain in the world']",
+                    "next_thought": "I need to search for the highest mountain in the world",
+                    "next_tool_name": "search",
+                    "next_tool_args": {"query": "Highest mountain in the world"},
                 },
                 {
-                    "Thought_2": "I found the highest mountain in the world",
-                    "Action_2": "Finish[Mount Everest]",
+                    "next_thought": "I found the highest mountain in the world",
+                    "next_tool_name": "finish",
+                    "next_tool_args": {"answer": "Mount Everest"},
+                },
+                {
+                    "answer": "Mount Everest",
+                    "reasoning": "No more responses",
                 },
             ]
         ),
+        adapter=dspy.ChatAdapter(),
     )
 
-    class BasicQA(dspy.Signature):
-        """Answer questions with short factoid answers."""
+    def search(query: str) -> list[str]:
+        return "Mount Everest"
 
-        question = dspy.InputField()
-        answer = dspy.OutputField(desc="often between 1 and 5 words")
-
-    react = dspy.ReAct(BasicQA, tools=[])
+    tools = [dspy.Tool(search)]
+    react = dspy.ReAct("question -> answer", tools=tools)
     result = react(question="What is the highest mountain in the world?")
     assert result["answer"] == "Mount Everest"
 
@@ -184,18 +186,23 @@ def test_autolog_react():
     assert trace.info.execution_time_ms > 0
 
     spans = trace.data.spans
-    assert len(spans) == 10
+    assert len(spans) == 15
     assert [span.name for span in spans] == [
         "ReAct.forward",
         "Predict.forward_1",
         "ChatAdapter.format_1",
         "DummyLM.__call___1",
         "ChatAdapter.parse_1",
-        "Retrieve.forward",
+        "Tool.search",
         "Predict.forward_2",
         "ChatAdapter.format_2",
         "DummyLM.__call___2",
         "ChatAdapter.parse_2",
+        "ChainOfThought.forward",
+        "Predict.forward_3",
+        "ChatAdapter.format_3",
+        "DummyLM.__call___3",
+        "ChatAdapter.parse_3",
     ]
 
 

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -143,11 +143,11 @@ def test_mlflow_callback_exception():
     assert spans[3].status.status_code == "ERROR"
 
 
+@pytest.mark.skipif(
+    _DSPY_VERSION < Version("2.5.42"),
+    reason="DSPy callback does not handle Tool in versions < 2.5.42",
+)
 def test_autolog_react():
-    # NB: DSPy's __version__ is not reliable as it is hard-coded in the package.
-    if not hasattr(BaseCallback, "on_tool_start"):
-        pytest.skip("DSPy callback does not handle Tool in versions < 2.5.42")
-
     mlflow.dspy.autolog()
 
     dspy.settings.configure(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14196?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14196/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14196
```

</p>
</details>

### What changes are proposed in this pull request?

Tool is supported in DSPy callback since https://github.com/stanfordnlp/dspy/pull/1879. This PR updates our callback to create a span for tool execution.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
