### PR TITLE
Apply timeout override to within-request local scoring server for Spark UDF inference

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -3841,6 +3841,13 @@ This information is moved to `MLflow Deployment <deployment/index.html>`_ page.
 Export a ``python_function`` model as an Apache Spark UDF
 ---------------------------------------------------------
 
+.. note:: 
+    If you are using a model that has a very long running inference latency (i.e., a 
+    `transformers` model) that could take longer than the default timeout of 60 seconds, 
+    you can utilize the `extra_env` argument when defining the `spark_udf` instance for your 
+    MLflow model, specifying an override to the environment variable `MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT`.
+    For further guidance, please see :py:func:`mlflow.pyfunc.spark_udf`.
+
 You can output a ``python_function`` model as an Apache Spark UDF, which can be uploaded to a
 Spark cluster and used to score the model.
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2021,6 +2021,8 @@ def spark_udf(
         params: Additional parameters to pass to the model for inference.
 
         extra_env: Extra environment variables to pass to the UDF executors.
+            For overrides that need to propagate to the Spark workers (i.e.,
+            overriding the scoring server timeout via `MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT`).
 
         prebuilt_env_uri: The path of the prebuilt env archive file created by
             `mlflow.pyfunc.build_model_env` API.

--- a/mlflow/pyfunc/scoring_server/client.py
+++ b/mlflow/pyfunc/scoring_server/client.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 import requests
 
 from mlflow.deployments import PredictionsResponse
+from mlflow.environment_variables import MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT
 from mlflow.exceptions import MlflowException
 from mlflow.pyfunc import scoring_server
 from mlflow.utils.proto_json_utils import dump_input_data
@@ -140,6 +141,6 @@ class StdinScoringServerClient(BaseScoringServerClient):
                         return resp
             except Exception as e:
                 _logger.debug("Exception while waiting for scoring to complete: %s", e)
-            if time.time() - begin_time > 60:
+            if time.time() - begin_time > MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get():
                 raise MlflowException("Scoring timeout")
             time.sleep(1)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1703,5 +1703,5 @@ def test_spark_udf_model_server_timeout(spark, monkeypatch):
     # Raised from mlflow.pyfunc.scoring_server.client.StdinScoringServerClient,
     # but handled as a PythonException from a subprocess failure for a timeout exception.
     # Broad exception catching here due to PySpark / DBConnect stacktrace handling.
-    with pytest.raises(Exception, match="Scoring timeout"):
+    with pytest.raises(Exception, match="An exception was thrown from the Python worker"):
         spark_df.withColumn("res", udf("input_col")).select("res").toPandas()

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1662,8 +1662,6 @@ def test_spark_udf_model_server_timeout(spark, monkeypatch):
 
     class TestModel(PythonModel):
         def predict(self, context, model_input, params=None):
-            import time
-
             time.sleep(2)
             return pd.DataFrame({k: [v] * len(model_input) for k, v in params.items()})
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/14202?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14202/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14202
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Replaces the default 60s timeout for the per-prediction request within the local scoring server used by SparkUDF's when not running in `local` mode. The environment variable for this timeout exists, but it exclusively used for the serving local endpoint to be available, which is not intended by this environment variable flag. 
This PR allows for this to mutable, enabling batch predictions in Spark that require long within-model-request inference (such as batch usage of transformers models within a UDF).

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
