### PR TITLE
Update presigned URL list_artifacts to return an empty list instead of an exception

### DIFF
--- a/mlflow/store/artifact/presigned_url_artifact_repo.py
+++ b/mlflow/store/artifact/presigned_url_artifact_repo.py
@@ -117,7 +117,7 @@ class PresignedUrlArtifactRepository(CloudArtifactRepository):
                 )
             except RestException as e:
                 if e.error_code == ErrorCode.Name(NOT_FOUND):
-                    return infos
+                    return []
                 else:
                     raise e
             for dir_entry in resp.contents:

--- a/mlflow/store/artifact/presigned_url_artifact_repo.py
+++ b/mlflow/store/artifact/presigned_url_artifact_repo.py
@@ -3,6 +3,7 @@ import os
 import posixpath
 
 from mlflow.entities import FileInfo
+from mlflow.exceptions import RestException
 from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialInfo
 from mlflow.protos.databricks_filesystem_service_pb2 import (
     CreateDownloadUrlRequest,
@@ -12,6 +13,7 @@ from mlflow.protos.databricks_filesystem_service_pb2 import (
     FilesystemService,
     ListDirectoryResponse,
 )
+from mlflow.protos.databricks_pb2 import NOT_FOUND, ErrorCode
 from mlflow.store.artifact.artifact_repo import _retry_with_new_creds
 from mlflow.store.artifact.cloud_artifact_repo import CloudArtifactRepository
 from mlflow.utils.file_utils import download_file_using_http_uri
@@ -101,13 +103,23 @@ class PresignedUrlArtifactRepository(CloudArtifactRepository):
             req_body = json.dumps({"page_token": page_token}) if page_token else None
 
             response_proto = ListDirectoryResponse()
-            resp = call_endpoint(
-                host_creds=self.db_creds,
-                endpoint=endpoint,
-                method="GET",
-                json_body=req_body,
-                response_proto=response_proto,
-            )
+
+            # If the path specified is not a directory, we return an empty list instead of raising
+            # an exception. This is due to this method being used in artifact_repo._is_directory
+            # to determine when a filepath is a directory.
+            try:
+                resp = call_endpoint(
+                    host_creds=self.db_creds,
+                    endpoint=endpoint,
+                    method="GET",
+                    json_body=req_body,
+                    response_proto=response_proto,
+                )
+            except RestException as e:
+                if e.error_code == ErrorCode.Name(NOT_FOUND):
+                    return infos
+                else:
+                    raise e
             for dir_entry in resp.contents:
                 rel_path = posixpath.relpath(dir_entry.path, self.artifact_uri)
                 if dir_entry.is_directory:

--- a/tests/store/artifact/test_presigned_url_artifact_repo.py
+++ b/tests/store/artifact/test_presigned_url_artifact_repo.py
@@ -103,7 +103,7 @@ def test_list_artifacts_failure():
     with (
         mock.patch(f"{PRESIGNED_URL_ARTIFACT_REPOSITORY}.call_endpoint", side_effect=exc)
     ):
-        empty_infos = artifact_repo._download_from_cloud(remote_file_path, "local_file")
+        empty_infos = artifact_repo.list_artifacts(remote_file_path)
         assert len(empty_infos) == 0
 
 

--- a/tests/store/artifact/test_presigned_url_artifact_repo.py
+++ b/tests/store/artifact/test_presigned_url_artifact_repo.py
@@ -100,9 +100,7 @@ def test_list_artifacts_failure():
     exc_code = "NOT_FOUND"
     exc_message = "The directory being accessed is not found."
     exc = RestException({"error_code": exc_code, "message": exc_message})
-    with (
-        mock.patch(f"{PRESIGNED_URL_ARTIFACT_REPOSITORY}.call_endpoint", side_effect=exc)
-    ):
+    with mock.patch(f"{PRESIGNED_URL_ARTIFACT_REPOSITORY}.call_endpoint", side_effect=exc):
         empty_infos = artifact_repo.list_artifacts(remote_file_path)
         assert len(empty_infos) == 0
 

--- a/tests/store/artifact/test_presigned_url_artifact_repo.py
+++ b/tests/store/artifact/test_presigned_url_artifact_repo.py
@@ -101,16 +101,13 @@ def test_list_artifacts_failure():
     exc_message = "The directory being accessed is not found."
     exc = RestException({"error_code": exc_code, "message": exc_message})
     with (
-        mock.patch(f"{PRESIGNED_URL_ARTIFACT_REPOSITORY}.call_endpoint", side_effect=exc),
-        pytest.raises(RestException) as exc_info,  # noqa: PT011
+        mock.patch(f"{PRESIGNED_URL_ARTIFACT_REPOSITORY}.call_endpoint", side_effect=exc)
     ):
-        artifact_repo._download_from_cloud(remote_file_path, "local_file")
-
-    assert exc_info.value.error_code == exc_code
-    assert str(exc_info.value) == f"{exc_code}: {exc_message}"
+        empty_infos = artifact_repo._download_from_cloud(remote_file_path, "local_file")
+        assert len(empty_infos) == 0
 
 
-def _make_pesigned_url(remote_path):
+def _make_presigned_url(remote_path):
     return f"presigned_url/{remote_path}"
 
 
@@ -121,7 +118,7 @@ def _make_headers(remote_path):
 def mock_create_download_url(*args, **kwargs):
     remote_path = json.loads(kwargs["json_body"])["path"]
     return CreateDownloadUrlResponse(
-        url=_make_pesigned_url(remote_path),
+        url=_make_presigned_url(remote_path),
         headers=[
             HttpHeader(name=header, value=val) for header, val in _make_headers(remote_path).items()
         ],
@@ -151,7 +148,7 @@ def test_get_read_credentials():
                 response_proto=ANY,
             )
 
-        assert {_make_pesigned_url(f"{MODEL_URI}/{path}") for path in remote_file_paths} == {
+        assert {_make_presigned_url(f"{MODEL_URI}/{path}") for path in remote_file_paths} == {
             cred.signed_uri for cred in creds
         }
         expected_headers = {}
@@ -166,7 +163,7 @@ def test_get_read_credentials():
 def mock_create_upload_url(*args, **kwargs):
     remote_path = json.loads(kwargs["json_body"])["path"]
     return CreateUploadUrlResponse(
-        url=_make_pesigned_url(remote_path),
+        url=_make_presigned_url(remote_path),
         headers=[
             HttpHeader(name=header, value=val) for header, val in _make_headers(remote_path).items()
         ],
@@ -211,7 +208,7 @@ def test_download_from_cloud():
         mock.patch(
             f"{PRESIGNED_URL_ARTIFACT_REPOSITORY}.PresignedUrlArtifactRepository._get_download_presigned_url_and_headers",
             return_value=CreateDownloadUrlResponse(
-                url=_make_pesigned_url(remote_file_path),
+                url=_make_presigned_url(remote_file_path),
                 headers=[
                     HttpHeader(name=k, value=v) for k, v in _make_headers(remote_file_path).items()
                 ],
@@ -226,7 +223,7 @@ def test_download_from_cloud():
 
         mock_request.assert_called_once_with(remote_file_path)
         mock_download.assert_called_once_with(
-            http_uri=_make_pesigned_url(remote_file_path),
+            http_uri=_make_presigned_url(remote_file_path),
             download_path=local_file,
             headers=_make_headers(remote_file_path),
         )
@@ -255,7 +252,7 @@ def test_log_artifact():
     artifact_path = "remote/file/location"
     total_remote_path = f"{artifact_path}/{os.path.basename(local_file)}"
     creds = ArtifactCredentialInfo(
-        signed_uri=_make_pesigned_url(total_remote_path),
+        signed_uri=_make_presigned_url(total_remote_path),
         headers=[
             ArtifactCredentialInfo.HttpHeader(name=k, value=v)
             for k, v in _make_headers(total_remote_path).items()
@@ -297,7 +294,7 @@ def test_upload_to_cloud(tmp_path):
         ) as mock_status,
     ):
         cred_info = ArtifactCredentialInfo(
-            signed_uri=_make_pesigned_url(remote_file_path),
+            signed_uri=_make_presigned_url(remote_file_path),
             headers=[
                 ArtifactCredentialInfo.HttpHeader(name=k, value=v)
                 for k, v in _make_headers(remote_file_path).items()
@@ -306,7 +303,7 @@ def test_upload_to_cloud(tmp_path):
         artifact_repo._upload_to_cloud(cred_info, local_file, "some/irrelevant/path")
         mock_cloud.assert_called_once_with(
             "put",
-            _make_pesigned_url(remote_file_path),
+            _make_presigned_url(remote_file_path),
             data=bytearray(content, "utf-8"),
             headers=_make_headers(remote_file_path),
         )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/arpitjasa-db/mlflow/pull/14203?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14203/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14203
```

</p>
</details>

### Related Issues/PRs

ES-1325017

### What changes are proposed in this pull request?

We update presigned URL `list_artifacts` to return an empty list instead of an exception. This is due to this method being used by `artifact_repo._is_directory` to determine when a file is a directory, and it expects an empty list of artifacts instead of an exception when the filepath is not a directory.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
