### PR TITLE
Implement tool standard for crewai

### DIFF
--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -21,10 +21,7 @@ def patched_class_call(original, self, *args, **kwargs):
     if config.log_traces:
         fullname = f"{self.__class__.__name__}.{original.__name__}"
         span_type = _get_span_type(self)
-        with mlflow.start_span(
-            name=fullname,
-            span_type=span_type,
-        ) as span:
+        with mlflow.start_span(name=fullname, span_type=span_type) as span:
             inputs = _construct_full_inputs(original, self, *args, **kwargs)
             span.set_inputs(inputs)
             _set_span_attributes(span=span, instance=self)

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -6,6 +6,7 @@ import warnings
 from packaging.version import Version
 
 import mlflow
+from mlflow.crewai.chat import set_span_chat_attributes
 from mlflow.entities import SpanType
 from mlflow.entities.span import LiveSpan
 from mlflow.tracing.utils import TraceJSONEncoder
@@ -19,14 +20,20 @@ def patched_class_call(original, self, *args, **kwargs):
 
     if config.log_traces:
         fullname = f"{self.__class__.__name__}.{original.__name__}"
+        span_type = _get_span_type(self)
         with mlflow.start_span(
             name=fullname,
-            span_type=_get_span_type(self),
+            span_type=span_type,
         ) as span:
             inputs = _construct_full_inputs(original, self, *args, **kwargs)
             span.set_inputs(inputs)
             _set_span_attributes(span=span, instance=self)
             result = original(self, *args, **kwargs)
+
+            if span_type == SpanType.LLM:
+                set_span_chat_attributes(
+                    span=span, messages=inputs.get("messages", []), output=result
+                )
             # Need to convert the response of generate_content for better visualization
             outputs = result.__dict__ if hasattr(result, "__dict__") else result
             span.set_outputs(outputs)

--- a/mlflow/crewai/chat.py
+++ b/mlflow/crewai/chat.py
@@ -1,0 +1,29 @@
+import logging
+from typing import Any
+
+from mlflow.entities.span import LiveSpan
+from mlflow.exceptions import MlflowException
+from mlflow.tracing import set_span_chat_messages
+
+_logger = logging.getLogger(__name__)
+
+
+def set_span_chat_attributes(span: LiveSpan, messages: list[dict[str, Any]], output: Any):
+    """
+    This method logs chat messages to a span. Since the CrewAI library includes tool definition
+    in the text content, mlflow.chat.tools attribute is not recorded.
+
+    Args:
+        span: A span object to record the chat messages.
+        messages: Input messages for the LLM call.
+        output: Text response from LLM.
+    """
+    output_message = {"role": "assistant", "content": str(output)}
+
+    try:
+        set_span_chat_messages(span, [*messages, output_message])
+    except MlflowException:
+        _logger.debug(
+            "Failed to set chat messages on span",
+            exc_info=True,
+        )

--- a/mlflow/crewai/chat.py
+++ b/mlflow/crewai/chat.py
@@ -10,13 +10,13 @@ _logger = logging.getLogger(__name__)
 
 def set_span_chat_attributes(span: LiveSpan, messages: list[dict[str, Any]], output: Any):
     """
-    This method logs chat messages to a span. Since the CrewAI library includes tool definition
-    in the text content, mlflow.chat.tools attribute is not recorded.
+    This method logs chat messages to a span when LLM class is called. Since the CrewAI library
+    includes tool definition in the text content, mlflow.chat.tools attribute is not recorded.
 
     Args:
         span: A span object to record the chat messages.
         messages: Input messages for the LLM call.
-        output: Text response from LLM.
+        output: Response from LLM. Though the signature is str, tool response might be returned.
     """
     output_message = {"role": "assistant", "content": str(output)}
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -843,7 +843,7 @@ crewai:
       pip install git+https://github.com/crewAIInc/crewAI
   autologging:
     minimum: "0.80.0"
-    maximum: "0.86.0"
+    maximum: "0.95.0"
     python:
       ">= 0.80.0": "3.10"
     requirements:

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -326,7 +326,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.80.0",
-            "maximum": "0.86.0"
+            "maximum": "0.95.0"
         }
     },
     "sentence_transformers": {

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -4,6 +4,7 @@ import crewai
 import pytest
 from crewai import Agent, Crew, Task
 from crewai.flow.flow import Flow, start
+from crewai.tools import BaseTool
 from packaging.version import Version
 
 import mlflow
@@ -12,48 +13,61 @@ from mlflow.entities.span import SpanType
 from tests.tracing.helper import get_traces
 
 # This is a special word for CrewAI to complete the agent execution: https://github.com/crewAIInc/crewAI/blob/c6a6c918e0eba167be1fb82831c73dd664c641e3/src/crewai/agents/parser.py#L7
-FINAL_ANSWER_ACTION = "Final Answer:"
+_FINAL_ANSWER_KEYWORD = "Final Answer:"
 
-SIMPLE_CHAT_COMPLETION = {
-    "id": "chatcmpl-123",
-    "object": "chat.completion",
-    "created": 1677652288,
-    "model": "gpt-4o",
-    "system_fingerprint": "fp_44709d6fcb",
-    "choices": [
-        {
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": f"{FINAL_ANSWER_ACTION} What about Tokyo?",
+_LLM_ANSWER = "What about Tokyo?"
+
+
+def create_sample_llm_response(content):
+    return {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "gpt-4o",
+        "system_fingerprint": "fp_44709d6fcb",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                },
+                "logprobs": None,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 9,
+            "completion_tokens": 12,
+            "total_tokens": 21,
+            "completion_tokens_details": {
+                "reasoning_tokens": 0,
+                "accepted_prediction_tokens": 0,
+                "rejected_prediction_tokens": 0,
             },
-            "logprobs": None,
-            "finish_reason": "stop",
-        }
-    ],
-    "usage": {
-        "prompt_tokens": 9,
-        "completion_tokens": 12,
-        "total_tokens": 21,
-        "completion_tokens_details": {
-            "reasoning_tokens": 0,
-            "accepted_prediction_tokens": 0,
-            "rejected_prediction_tokens": 0,
         },
-    },
-}
+    }
 
-EMBEDDING = {
+
+_SIMPLE_CHAT_COMPLETION = create_sample_llm_response(f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}")
+
+# Special keywords for tool calling in crewai
+_TOOL_CHAT_COMPLETION = create_sample_llm_response("""
+                    Action: TestTool
+                    Action Input: {"argument": "a"}
+                """)
+
+_EMBEDDING = {
     "object": "list",
     "data": [{"object": "embedding", "embedding": [0, 0, 0], "index": 0}],
     "model": "text-embedding-ada-002",
     "usage": {"prompt_tokens": 8, "total_tokens": 8},
 }
 
-CREW_OUTPUT = {
+_CREW_OUTPUT = {
     "json_dict": None,
     "pydantic": None,
-    "raw": "What about Tokyo?",
+    "raw": _LLM_ANSWER,
     "tasks_output": [
         {
             "agent": "City Selection Expert",
@@ -63,7 +77,7 @@ CREW_OUTPUT = {
             "json_dict": None,
             "pydantic": None,
             "output_format": "raw",
-            "raw": "What about Tokyo?",
+            "raw": _LLM_ANSWER,
             "summary": "Analyze and select the best city for the trip...",
         }
     ],
@@ -76,41 +90,81 @@ CREW_OUTPUT = {
     },
 }
 
+_AGENT_1_GOAL = "Select the best city based on weather, season, and prices"
+_AGENT_1_BACKSTORY = "An expert in analyzing travel data to pick ideal destinations"
+
 
 @pytest.fixture
 def simple_agent_1():
     return Agent(
         role="City Selection Expert",
-        goal="Select the best city based on weather, season, and prices",
-        backstory="An expert in analyzing travel data to pick ideal destinations",
+        goal=_AGENT_1_GOAL,
+        backstory=_AGENT_1_BACKSTORY,
         tools=[],
     )
+
+
+_AGENT_2_GOAL = "Provide the BEST insights about the selected city"
 
 
 @pytest.fixture
 def simple_agent_2():
     return Agent(
         role="Local Expert at this city",
-        goal="Provide the BEST insights about the selected city",
+        goal=_AGENT_2_GOAL,
         backstory="""A knowledgeable local guide with extensive information
         about the city, it's attractions and customs""",
         tools=[],
     )
 
 
+class SampleTool(BaseTool):
+    name: str = "TestTool"
+    description: str = "test tool"
+
+    def _run(self, argument: str) -> str:
+        return "Tool Answer"
+
+
+@pytest.fixture
+def tool_agent_1():
+    return Agent(
+        role="City Selection Expert",
+        goal=_AGENT_1_GOAL,
+        backstory=_AGENT_1_BACKSTORY,
+        tools=[SampleTool()],
+    )
+
+
+_TASK_1_DESCRIPTION = "Analyze and select the best city for the trip"
+_TASK_1_OUTPUT = "Detailed report on the chosen city"
+
+
 @pytest.fixture
 def task_1(simple_agent_1):
     return Task(
-        description=("Analyze and select the best city for the trip"),
+        description=(_TASK_1_DESCRIPTION),
         agent=simple_agent_1,
-        expected_output="Detailed report on the chosen city",
+        expected_output=_TASK_1_OUTPUT,
     )
+
+
+@pytest.fixture
+def task_1_with_tool(tool_agent_1):
+    return Task(
+        description=(_TASK_1_DESCRIPTION),
+        agent=tool_agent_1,
+        expected_output=_TASK_1_OUTPUT,
+    )
+
+
+_TASK_2_DESCRIPTION = "Compile an in-depth guide"
 
 
 @pytest.fixture
 def task_2(simple_agent_2):
     return Task(
-        description=("Compile an in-depth guide"),
+        description=(_TASK_2_DESCRIPTION),
         agent=simple_agent_2,
         expected_output="Comprehensive city guide",
     )
@@ -118,7 +172,7 @@ def task_2(simple_agent_2):
 
 def global_autolog():
     # Libraries used within tests or crewai library
-    mlflow.autolog(exclude_flavors=["openai", "litellm"])
+    mlflow.autolog(exclude_flavors=["openai", "litellm", "langchain"])
     mlflow.utils.import_hooks.notify_module_loaded(crewai)
 
 
@@ -146,7 +200,7 @@ def test_kickoff_enable_disable_autolog(simple_agent_1, task_1, autolog):
         ],
         tasks=[task_1],
     )
-    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
+    with patch("litellm.completion", return_value=_SIMPLE_CHAT_COMPLETION):
         autolog()
         crew.kickoff()
 
@@ -160,7 +214,7 @@ def test_kickoff_enable_disable_autolog(simple_agent_1, task_1, autolog):
     assert span_0.span_type == SpanType.CHAIN
     assert span_0.parent_id is None
     assert span_0.inputs == {}
-    assert span_0.outputs == CREW_OUTPUT
+    assert span_0.outputs == _CREW_OUTPUT
     # Task
     span_1 = traces[0].data.spans[1]
     assert span_1.name == "Task.execute_sync"
@@ -178,7 +232,7 @@ def test_kickoff_enable_disable_autolog(simple_agent_1, task_1, autolog):
         "name": None,
         "output_format": "raw",
         "pydantic": None,
-        "raw": "What about Tokyo?",
+        "raw": _LLM_ANSWER,
         "summary": "Analyze and select the best city for the trip...",
     }
     # Agent
@@ -190,14 +244,22 @@ def test_kickoff_enable_disable_autolog(simple_agent_1, task_1, autolog):
         "context": "",
         "tools": [],
     }
-    assert span_2.outputs == "What about Tokyo?"
+    assert span_2.outputs == _LLM_ANSWER
     # LLM
     span_3 = traces[0].data.spans[3]
     assert span_3.name == "LLM.call"
     assert span_3.span_type == SpanType.LLM
     assert span_3.parent_id is span_2.span_id
     assert span_3.inputs["messages"] is not None
-    assert span_3.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    assert span_3.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
+    chat_attributes = span_3.get_attribute("mlflow.chat.messages")
+    assert len(chat_attributes) == 3
+    assert chat_attributes[0]["role"] == "system"
+    assert _AGENT_1_GOAL in chat_attributes[0]["content"]
+    assert chat_attributes[1]["role"] == "user"
+    assert _TASK_1_DESCRIPTION in chat_attributes[1]["content"]
+    assert chat_attributes[2]["role"] == "assistant"
+    assert _LLM_ANSWER in chat_attributes[2]["content"]
 
     # Create Long Term Memory
     span_4 = traces[0].data.spans[4]
@@ -206,14 +268,14 @@ def test_kickoff_enable_disable_autolog(simple_agent_1, task_1, autolog):
     assert span_4.parent_id is span_2.span_id
     assert span_4.inputs == {
         "output": {
-            "output": "What about Tokyo?",
-            "text": "Final Answer: What about Tokyo?",
+            "output": _LLM_ANSWER,
+            "text": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
             "thought": "",
         }
     }
     assert span_4.outputs is None
 
-    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
+    with patch("litellm.completion", return_value=_SIMPLE_CHAT_COMPLETION):
         mlflow.crewai.autolog(disable=True)
         crew.kickoff()
 
@@ -273,6 +335,102 @@ def test_kickoff_failure(simple_agent_1, task_1, autolog):
     assert span_3.status.status_code == "ERROR"
 
 
+def test_kickoff_tool_calling(tool_agent_1, task_1_with_tool, autolog):
+    crew = Crew(
+        agents=[
+            tool_agent_1,
+        ],
+        tasks=[task_1_with_tool],
+    )
+    with patch("litellm.completion", side_effect=[_TOOL_CHAT_COMPLETION, _SIMPLE_CHAT_COMPLETION]):
+        autolog()
+        crew.kickoff()
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert len(traces[0].data.spans) == 6
+    # Crew
+    span_0 = traces[0].data.spans[0]
+    assert span_0.name == "Crew.kickoff"
+    assert span_0.span_type == SpanType.CHAIN
+    assert span_0.parent_id is None
+    assert span_0.inputs == {}
+    assert span_0.outputs == _CREW_OUTPUT
+    # Task
+    span_1 = traces[0].data.spans[1]
+    assert span_1.name == "Task.execute_sync"
+    assert span_1.span_type == SpanType.CHAIN
+    assert span_1.parent_id is span_0.span_id
+    assert len(span_1.inputs["tools"]) == 1
+    assert span_1.inputs["tools"][0]["name"] == "TestTool"
+    assert span_1.outputs == {
+        "agent": "City Selection Expert",
+        "description": "Analyze and select the best city for the trip",
+        "expected_output": "Detailed report on the chosen city",
+        "json_dict": None,
+        "name": None,
+        "output_format": "raw",
+        "pydantic": None,
+        "raw": _LLM_ANSWER,
+        "summary": "Analyze and select the best city for the trip...",
+    }
+    # Agent
+    span_2 = traces[0].data.spans[2]
+    assert span_2.name == "Agent.execute_task"
+    assert span_2.span_type == SpanType.AGENT
+    assert span_2.parent_id is span_1.span_id
+    assert len(span_2.inputs["tools"]) == 1
+    assert span_2.inputs["tools"][0]["name"] == "TestTool"
+    assert span_2.outputs == _LLM_ANSWER
+    # LLM - tool calling
+    span_3 = traces[0].data.spans[3]
+    assert span_3.name == "LLM.call_1"
+    assert span_3.span_type == SpanType.LLM
+    assert span_3.parent_id is span_2.span_id
+    assert span_3.inputs["messages"] is not None
+    assert "Action: TestTool" in span_3.outputs
+    chat_attributes = span_3.get_attribute("mlflow.chat.messages")
+    assert len(chat_attributes) == 3
+    assert chat_attributes[0]["role"] == "system"
+    assert _AGENT_1_GOAL in chat_attributes[0]["content"]
+    assert chat_attributes[1]["role"] == "user"
+    assert _TASK_1_DESCRIPTION in chat_attributes[1]["content"]
+    assert chat_attributes[2]["role"] == "assistant"
+    assert "Action: TestTool" in chat_attributes[2]["content"]
+    # LLM - return answer
+    span_4 = traces[0].data.spans[4]
+    assert span_4.name == "LLM.call_2"
+    assert span_4.span_type == SpanType.LLM
+    assert span_4.parent_id is span_2.span_id
+    assert span_4.inputs["messages"] is not None
+    assert span_4.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
+    chat_attributes = span_4.get_attribute("mlflow.chat.messages")
+    assert len(chat_attributes) == 4
+    assert chat_attributes[0]["role"] == "system"
+    assert _AGENT_1_GOAL in chat_attributes[0]["content"]
+    assert chat_attributes[1]["role"] == "user"
+    assert _TASK_1_DESCRIPTION in chat_attributes[1]["content"]
+    assert chat_attributes[2]["role"] == "assistant"
+    assert "Tool Answer" in chat_attributes[2]["content"]
+    assert chat_attributes[3]["role"] == "assistant"
+    assert _LLM_ANSWER in chat_attributes[3]["content"]
+
+    # Create Long Term Memory
+    span_5 = traces[0].data.spans[5]
+    assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_5.span_type == SpanType.RETRIEVER
+    assert span_5.parent_id is span_2.span_id
+    assert span_5.inputs == {
+        "output": {
+            "output": _LLM_ANSWER,
+            "text": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
+            "thought": "",
+        }
+    }
+    assert span_5.outputs is None
+
+
 def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     crew = Crew(
         agents=[
@@ -281,7 +439,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
         ],
         tasks=[task_1, task_2],
     )
-    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
+    with patch("litellm.completion", return_value=_SIMPLE_CHAT_COMPLETION):
         autolog()
         crew.kickoff()
 
@@ -298,7 +456,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     assert span_0.outputs == {
         "json_dict": None,
         "pydantic": None,
-        "raw": "What about Tokyo?",
+        "raw": _LLM_ANSWER,
         "tasks_output": [
             {
                 "agent": "City Selection Expert",
@@ -308,7 +466,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
                 "json_dict": None,
                 "pydantic": None,
                 "output_format": "raw",
-                "raw": "What about Tokyo?",
+                "raw": _LLM_ANSWER,
                 "summary": "Analyze and select the best city for the trip...",
             },
             {
@@ -319,7 +477,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
                 "name": None,
                 "output_format": "raw",
                 "pydantic": None,
-                "raw": "What about Tokyo?",
+                "raw": _LLM_ANSWER,
                 "summary": "Compile an in-depth guide...",
             },
         ],
@@ -348,7 +506,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
         "name": None,
         "output_format": "raw",
         "pydantic": None,
-        "raw": "What about Tokyo?",
+        "raw": _LLM_ANSWER,
         "summary": "Analyze and select the best city for the trip...",
     }
     # Agent
@@ -360,14 +518,22 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
         "context": "",
         "tools": [],
     }
-    assert span_2.outputs == "What about Tokyo?"
+    assert span_2.outputs == _LLM_ANSWER
     # LLM
     span_3 = traces[0].data.spans[3]
     assert span_3.name == "LLM.call_1"
     assert span_3.span_type == SpanType.LLM
     assert span_3.parent_id is span_2.span_id
     assert span_3.inputs["messages"] is not None
-    assert span_3.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    assert span_3.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
+    chat_attributes = span_3.get_attribute("mlflow.chat.messages")
+    assert len(chat_attributes) == 3
+    assert chat_attributes[0]["role"] == "system"
+    assert _AGENT_1_GOAL in chat_attributes[0]["content"]
+    assert chat_attributes[1]["role"] == "user"
+    assert _TASK_1_DESCRIPTION in chat_attributes[1]["content"]
+    assert chat_attributes[2]["role"] == "assistant"
+    assert _LLM_ANSWER in chat_attributes[2]["content"]
 
     # Create Long Term Memory
     span_4 = traces[0].data.spans[4]
@@ -376,8 +542,8 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     assert span_4.parent_id is span_2.span_id
     assert span_4.inputs == {
         "output": {
-            "output": "What about Tokyo?",
-            "text": "Final Answer: What about Tokyo?",
+            "output": _LLM_ANSWER,
+            "text": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
             "thought": "",
         }
     }
@@ -389,7 +555,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     assert span_5.span_type == SpanType.CHAIN
     assert span_5.parent_id is span_0.span_id
     assert span_5.inputs == {
-        "context": "What about Tokyo?",
+        "context": _LLM_ANSWER,
         "tools": [],
     }
     assert span_5.outputs == {
@@ -400,7 +566,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
         "name": None,
         "output_format": "raw",
         "pydantic": None,
-        "raw": "What about Tokyo?",
+        "raw": _LLM_ANSWER,
         "summary": "Compile an in-depth guide...",
     }
     # Agent
@@ -409,17 +575,25 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     assert span_6.span_type == SpanType.AGENT
     assert span_6.parent_id is span_5.span_id
     assert span_6.inputs == {
-        "context": "What about Tokyo?",
+        "context": _LLM_ANSWER,
         "tools": [],
     }
-    assert span_6.outputs == "What about Tokyo?"
+    assert span_6.outputs == _LLM_ANSWER
     # LLM
     span_7 = traces[0].data.spans[7]
     assert span_7.name == "LLM.call_2"
     assert span_7.span_type == SpanType.LLM
     assert span_7.parent_id is span_6.span_id
     assert span_7.inputs["messages"] is not None
-    assert span_7.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    assert span_7.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
+    chat_attributes = span_7.get_attribute("mlflow.chat.messages")
+    assert len(chat_attributes) == 3
+    assert chat_attributes[0]["role"] == "system"
+    assert _AGENT_2_GOAL in chat_attributes[0]["content"]
+    assert chat_attributes[1]["role"] == "user"
+    assert _TASK_2_DESCRIPTION in chat_attributes[1]["content"]
+    assert chat_attributes[2]["role"] == "assistant"
+    assert _LLM_ANSWER in chat_attributes[2]["content"]
     # Create Long Term Memory
     span_8 = traces[0].data.spans[8]
     assert span_8.name == "CrewAgentExecutor._create_long_term_memory_2"
@@ -427,8 +601,8 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     assert span_8.parent_id is span_6.span_id
     assert span_8.inputs == {
         "output": {
-            "output": "What about Tokyo?",
-            "text": "Final Answer: What about Tokyo?",
+            "output": _LLM_ANSWER,
+            "text": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
             "thought": "",
         }
     }
@@ -448,9 +622,9 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
         tasks=[task_1],
         memory=True,
     )
-    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
+    with patch("litellm.completion", return_value=_SIMPLE_CHAT_COMPLETION):
         with patch("openai.OpenAI") as client:
-            client().embeddings.create.return_value = EMBEDDING
+            client().embeddings.create.return_value = _EMBEDDING
             autolog()
             crew.kickoff()
 
@@ -464,7 +638,7 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
     assert span_0.span_type == SpanType.CHAIN
     assert span_0.parent_id is None
     assert span_0.inputs == {}
-    assert span_0.outputs == CREW_OUTPUT
+    assert span_0.outputs == _CREW_OUTPUT
     # Task
     span_1 = traces[0].data.spans[1]
     assert span_1.name == "Task.execute_sync"
@@ -482,7 +656,7 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
         "name": None,
         "output_format": "raw",
         "pydantic": None,
-        "raw": "What about Tokyo?",
+        "raw": _LLM_ANSWER,
         "summary": "Analyze and select the best city for the trip...",
     }
     # Agent
@@ -494,7 +668,7 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
         "context": "",
         "tools": [],
     }
-    assert span_2.outputs == "What about Tokyo?"
+    assert span_2.outputs == _LLM_ANSWER
 
     # LongTermMemory
     span_3 = traces[0].data.spans[3]
@@ -531,7 +705,15 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
     assert span_6.span_type == SpanType.LLM
     assert span_6.parent_id is span_2.span_id
     assert span_6.inputs["messages"] is not None
-    assert span_6.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    assert span_6.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
+    chat_attributes = span_6.get_attribute("mlflow.chat.messages")
+    assert len(chat_attributes) == 3
+    assert chat_attributes[0]["role"] == "system"
+    assert _AGENT_1_GOAL in chat_attributes[0]["content"]
+    assert chat_attributes[1]["role"] == "user"
+    assert _TASK_1_DESCRIPTION in chat_attributes[1]["content"]
+    assert chat_attributes[2]["role"] == "assistant"
+    assert _LLM_ANSWER in chat_attributes[2]["content"]
 
     # ShortTermMemory.save
     span_7 = traces[0].data.spans[7]
@@ -543,7 +725,7 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
         "metadata": {
             "observation": "Analyze and select the best city for the trip",
         },
-        "value": "Final Answer: What about Tokyo?",
+        "value": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
     }
     assert span_7.outputs is None
 
@@ -554,8 +736,8 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
     assert span_8.parent_id is span_2.span_id
     assert span_8.inputs == {
         "output": {
-            "output": "What about Tokyo?",
-            "text": "Final Answer: What about Tokyo?",
+            "output": _LLM_ANSWER,
+            "text": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
             "thought": "",
         }
     }
@@ -580,7 +762,7 @@ def test_knowledge(simple_agent_1, task_1, monkeypatch, autolog):
         tasks=[task_1],
         knowledge={"sources": [string_source], "metadata": {"preference": "personal"}},
     )
-    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
+    with patch("litellm.completion", return_value=_SIMPLE_CHAT_COMPLETION):
         autolog()
         crew.kickoff()
 
@@ -594,7 +776,7 @@ def test_knowledge(simple_agent_1, task_1, monkeypatch, autolog):
     assert span_0.span_type == SpanType.CHAIN
     assert span_0.parent_id is None
     assert span_0.inputs == {}
-    assert span_0.outputs == CREW_OUTPUT
+    assert span_0.outputs == _CREW_OUTPUT
     # Task
     span_1 = traces[0].data.spans[1]
     assert span_1.name == "Task.execute_sync"
@@ -612,7 +794,7 @@ def test_knowledge(simple_agent_1, task_1, monkeypatch, autolog):
         "name": None,
         "output_format": "raw",
         "pydantic": None,
-        "raw": "What about Tokyo?",
+        "raw": _LLM_ANSWER,
         "summary": "Analyze and select the best city for the trip...",
     }
     # Agent
@@ -624,7 +806,7 @@ def test_knowledge(simple_agent_1, task_1, monkeypatch, autolog):
         "context": "",
         "tools": [],
     }
-    assert span_2.outputs == "What about Tokyo?"
+    assert span_2.outputs == _LLM_ANSWER
 
     # Knowledge
     span_3 = traces[0].data.spans[3]
@@ -640,7 +822,15 @@ def test_knowledge(simple_agent_1, task_1, monkeypatch, autolog):
     assert span_4.span_type == SpanType.LLM
     assert span_4.parent_id is span_2.span_id
     assert span_4.inputs["messages"] is not None
-    assert span_4.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    assert span_4.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
+    chat_attributes = span_4.get_attribute("mlflow.chat.messages")
+    assert len(chat_attributes) == 3
+    assert chat_attributes[0]["role"] == "system"
+    assert _AGENT_1_GOAL in chat_attributes[0]["content"]
+    assert chat_attributes[1]["role"] == "user"
+    assert _TASK_1_DESCRIPTION in chat_attributes[1]["content"]
+    assert chat_attributes[2]["role"] == "assistant"
+    assert _LLM_ANSWER in chat_attributes[2]["content"]
 
     # Create Long Term Memory
     span_5 = traces[0].data.spans[5]
@@ -649,8 +839,8 @@ def test_knowledge(simple_agent_1, task_1, monkeypatch, autolog):
     assert span_5.parent_id is span_2.span_id
     assert span_5.inputs == {
         "output": {
-            "output": "What about Tokyo?",
-            "text": "Final Answer: What about Tokyo?",
+            "output": _LLM_ANSWER,
+            "text": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
             "thought": "",
         }
     }
@@ -664,7 +854,7 @@ def test_kickoff_for_each(simple_agent_1, task_1, autolog):
         ],
         tasks=[task_1],
     )
-    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
+    with patch("litellm.completion", return_value=_SIMPLE_CHAT_COMPLETION):
         autolog()
         crew.kickoff_for_each([{}])
 
@@ -678,7 +868,7 @@ def test_kickoff_for_each(simple_agent_1, task_1, autolog):
     assert span_0.span_type == SpanType.CHAIN
     assert span_0.parent_id is None
     assert span_0.inputs == {"inputs": [{}]}
-    assert span_0.outputs == [CREW_OUTPUT]
+    assert span_0.outputs == [_CREW_OUTPUT]
     # Crew
     span_1 = traces[0].data.spans[1]
     assert span_1.name == "Crew.kickoff"
@@ -687,7 +877,7 @@ def test_kickoff_for_each(simple_agent_1, task_1, autolog):
     assert span_1.inputs == {
         "inputs": {},
     }
-    assert span_1.outputs == CREW_OUTPUT
+    assert span_1.outputs == _CREW_OUTPUT
     # Task
     span_2 = traces[0].data.spans[2]
     assert span_2.name == "Task.execute_sync"
@@ -705,7 +895,7 @@ def test_kickoff_for_each(simple_agent_1, task_1, autolog):
         "name": None,
         "output_format": "raw",
         "pydantic": None,
-        "raw": "What about Tokyo?",
+        "raw": _LLM_ANSWER,
         "summary": "Analyze and select the best city for the trip...",
     }
     # Agent
@@ -717,14 +907,14 @@ def test_kickoff_for_each(simple_agent_1, task_1, autolog):
         "context": "",
         "tools": [],
     }
-    assert span_3.outputs == "What about Tokyo?"
+    assert span_3.outputs == _LLM_ANSWER
     # LLM
     span_4 = traces[0].data.spans[4]
     assert span_4.name == "LLM.call"
     assert span_4.span_type == SpanType.LLM
     assert span_4.parent_id is span_3.span_id
     assert span_4.inputs["messages"] is not None
-    assert span_4.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    assert span_4.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
     # Create Long Term Memory
     span_5 = traces[0].data.spans[5]
     assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
@@ -732,8 +922,8 @@ def test_kickoff_for_each(simple_agent_1, task_1, autolog):
     assert span_5.parent_id is span_3.span_id
     assert span_5.inputs == {
         "output": {
-            "output": "What about Tokyo?",
-            "text": "Final Answer: What about Tokyo?",
+            "output": _LLM_ANSWER,
+            "text": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
             "thought": "",
         }
     }
@@ -755,7 +945,7 @@ def test_flow(simple_agent_1, task_1, autolog):
 
     flow = TestFlow()
 
-    with patch("litellm.completion", return_value=SIMPLE_CHAT_COMPLETION):
+    with patch("litellm.completion", return_value=_SIMPLE_CHAT_COMPLETION):
         autolog()
         flow.kickoff()
 
@@ -769,14 +959,14 @@ def test_flow(simple_agent_1, task_1, autolog):
     assert span_0.span_type == SpanType.CHAIN
     assert span_0.parent_id is None
     assert span_0.inputs == {}
-    assert span_0.outputs == CREW_OUTPUT
+    assert span_0.outputs == _CREW_OUTPUT
     # Crew
     span_1 = traces[0].data.spans[1]
     assert span_1.name == "Crew.kickoff"
     assert span_1.span_type == SpanType.CHAIN
     assert span_1.parent_id == span_0.span_id
     assert span_1.inputs == {}
-    assert span_1.outputs == CREW_OUTPUT
+    assert span_1.outputs == _CREW_OUTPUT
     # Task
     span_2 = traces[0].data.spans[2]
     assert span_2.name == "Task.execute_sync"
@@ -794,7 +984,7 @@ def test_flow(simple_agent_1, task_1, autolog):
         "name": None,
         "output_format": "raw",
         "pydantic": None,
-        "raw": "What about Tokyo?",
+        "raw": _LLM_ANSWER,
         "summary": "Analyze and select the best city for the trip...",
     }
     # Agent
@@ -806,14 +996,22 @@ def test_flow(simple_agent_1, task_1, autolog):
         "context": "",
         "tools": [],
     }
-    assert span_3.outputs == "What about Tokyo?"
+    assert span_3.outputs == _LLM_ANSWER
     # LLM
     span_4 = traces[0].data.spans[4]
     assert span_4.name == "LLM.call"
     assert span_4.span_type == SpanType.LLM
     assert span_4.parent_id is span_3.span_id
     assert span_4.inputs["messages"] is not None
-    assert span_4.outputs == f"{FINAL_ANSWER_ACTION} What about Tokyo?"
+    assert span_4.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
+    chat_attributes = span_4.get_attribute("mlflow.chat.messages")
+    assert len(chat_attributes) == 3
+    assert chat_attributes[0]["role"] == "system"
+    assert _AGENT_1_GOAL in chat_attributes[0]["content"]
+    assert chat_attributes[1]["role"] == "user"
+    assert _TASK_1_DESCRIPTION in chat_attributes[1]["content"]
+    assert chat_attributes[2]["role"] == "assistant"
+    assert _LLM_ANSWER in chat_attributes[2]["content"]
     # Create Long Term Memory
     span_5 = traces[0].data.spans[5]
     assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
@@ -821,8 +1019,8 @@ def test_flow(simple_agent_1, task_1, autolog):
     assert span_5.parent_id is span_3.span_id
     assert span_5.inputs == {
         "output": {
-            "output": "What about Tokyo?",
-            "text": "Final Answer: What about Tokyo?",
+            "output": _LLM_ANSWER,
+            "text": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
             "thought": "",
         }
     }


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR implements https://github.com/mlflow/mlflow/pull/14140 for CrewAI.

Updating CrewAI auto-tracing to record the `mlflow.chat.message` span attribute;  records input and output messages in the OpenAI message format.
`mlflow.chat.tools` attribute is not recorded because crewai library includes tool definition in the text content rather than tool parameter.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="998" alt="image" src="https://github.com/user-attachments/assets/b9309792-f6f3-48db-aabd-908980620790" />

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
