### PR TITLE
Add support for invokers rights in Databricks Resources

### DIFF
--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -1,7 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 
 import yaml
 
@@ -77,6 +77,24 @@ class DatabricksResource(Resource, ABC):
     def target_uri(self) -> str:
         return "databricks"
 
+    @property
+    def type(self) -> ResourceType:
+        raise NotImplementedError("Subclasses must implement the 'type' property.")
+
+    def __init__(self, name: str, on_behalf_of_user: Optional[bool] = None):
+        self.name = name
+        self.on_behalf_of_user = on_behalf_of_user
+
+    def to_dict(self):
+        result = {self.type.value: [{"name": self.name}]}
+        if self.on_behalf_of_user is not None:
+            result[self.type.value][0]["on_behalf_of_user"] = self.on_behalf_of_user
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str]):
+        return cls(data["name"], data.get("on_behalf_of_user"))
+
 
 class DatabricksUCConnection(DatabricksResource):
     """
@@ -85,21 +103,16 @@ class DatabricksUCConnection(DatabricksResource):
     Args:
         connection_name (str): The name of the databricks UC connection
         used to create the tool which was used to build the model.
+        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
+        is used on behalf of a user.
     """
 
     @property
     def type(self) -> ResourceType:
         return ResourceType.UC_CONNECTION
 
-    def __init__(self, connection_name: str):
-        self.connection_name = connection_name
-
-    def to_dict(self):
-        return {self.type.value: [{"name": self.connection_name}]}
-
-    @classmethod
-    def from_dict(cls, data: dict[str, str]):
-        return cls(connection_name=data["name"])
+    def __init__(self, connection_name: str, on_behalf_of_user: Optional[bool] = None):
+        super().__init__(connection_name, on_behalf_of_user)
 
 
 class DatabricksServingEndpoint(DatabricksResource):
@@ -108,21 +121,16 @@ class DatabricksServingEndpoint(DatabricksResource):
 
     Args:
         endpoint_name (str): The name of all the databricks endpoints used by the model.
+        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
+        is used on behalf of a user.
     """
 
     @property
     def type(self) -> ResourceType:
         return ResourceType.SERVING_ENDPOINT
 
-    def __init__(self, endpoint_name: str):
-        self.endpoint_name = endpoint_name
-
-    def to_dict(self):
-        return {self.type.value: [{"name": self.endpoint_name}]}
-
-    @classmethod
-    def from_dict(cls, data: dict[str, str]):
-        return cls(endpoint_name=data["name"])
+    def __init__(self, endpoint_name: str, on_behalf_of_user: Optional[bool] = None):
+        super().__init__(endpoint_name, on_behalf_of_user)
 
 
 class DatabricksVectorSearchIndex(DatabricksResource):
@@ -132,21 +140,16 @@ class DatabricksVectorSearchIndex(DatabricksResource):
     Args:
         index_name (str): The name of all the databricks vector search index names
         used by the model.
+        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
+        is used on behalf of a user.
     """
 
     @property
     def type(self) -> ResourceType:
         return ResourceType.VECTOR_SEARCH_INDEX
 
-    def __init__(self, index_name: str):
-        self.index_name = index_name
-
-    def to_dict(self):
-        return {self.type.value: [{"name": self.index_name}]}
-
-    @classmethod
-    def from_dict(cls, data: dict[str, str]):
-        return cls(index_name=data["name"])
+    def __init__(self, index_name: str, on_behalf_of_user: Optional[bool] = None):
+        super().__init__(index_name, on_behalf_of_user)
 
 
 class DatabricksSQLWarehouse(DatabricksResource):
@@ -155,21 +158,16 @@ class DatabricksSQLWarehouse(DatabricksResource):
 
     Args:
         warehouse_id (str): The id of the sql warehouse used by the model
+        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
+        is used on behalf of a user.
     """
 
     @property
     def type(self) -> ResourceType:
         return ResourceType.SQL_WAREHOUSE
 
-    def __init__(self, warehouse_id: str):
-        self.warehouse_id = warehouse_id
-
-    def to_dict(self):
-        return {self.type.value: [{"name": self.warehouse_id}]}
-
-    @classmethod
-    def from_dict(cls, data: dict[str, str]):
-        return cls(warehouse_id=data["name"])
+    def __init__(self, warehouse_id: str, on_behalf_of_user: Optional[bool] = None):
+        super().__init__(warehouse_id, on_behalf_of_user)
 
 
 class DatabricksFunction(DatabricksResource):
@@ -178,21 +176,16 @@ class DatabricksFunction(DatabricksResource):
 
     Args:
         function_name (str): The name of the function used by the model
+        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
+        is used on behalf of a user.
     """
 
     @property
     def type(self) -> ResourceType:
         return ResourceType.FUNCTION
 
-    def __init__(self, function_name: str):
-        self.function_name = function_name
-
-    def to_dict(self):
-        return {self.type.value: [{"name": self.function_name}]}
-
-    @classmethod
-    def from_dict(cls, data: dict[str, str]):
-        return cls(function_name=data["name"])
+    def __init__(self, function_name: str, on_behalf_of_user: Optional[bool] = None):
+        super().__init__(function_name, on_behalf_of_user)
 
 
 class DatabricksGenieSpace(DatabricksResource):
@@ -201,21 +194,16 @@ class DatabricksGenieSpace(DatabricksResource):
 
     Args:
         genie_space_id (str): The genie space id
+        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
+        is used on behalf of a user.
     """
 
     @property
     def type(self) -> ResourceType:
         return ResourceType.GENIE_SPACE
 
-    def __init__(self, genie_space_id: str):
-        self.genie_space_id = genie_space_id
-
-    def to_dict(self):
-        return {self.type.value: [{"name": self.genie_space_id}]}
-
-    @classmethod
-    def from_dict(cls, data: dict[str, str]):
-        return cls(genie_space_id=data["name"])
+    def __init__(self, genie_space_id: str, on_behalf_of_user: Optional[bool] = None):
+        super().__init__(genie_space_id, on_behalf_of_user)
 
 
 class DatabricksTable(DatabricksResource):
@@ -226,21 +214,16 @@ class DatabricksTable(DatabricksResource):
 
      Args:
          table_name (str): The name of the table used by the model
+         on_behalf_of_user (Optional[bool]): Flag indicating if the resource
+         is used on behalf of a user.
     """
 
     @property
     def type(self) -> ResourceType:
         return ResourceType.TABLE
 
-    def __init__(self, table_name: str):
-        self.table_name = table_name
-
-    def to_dict(self):
-        return {self.type.value: [{"name": self.table_name}]}
-
-    @classmethod
-    def from_dict(cls, data: dict[str, str]):
-        return cls(table_name=data["name"])
+    def __init__(self, table_name: str, on_behalf_of_user: Optional[bool] = None):
+        super().__init__(table_name, on_behalf_of_user)
 
 
 def _get_resource_class_by_type(target_uri: str, resource_type: ResourceType):

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -105,7 +105,7 @@ class DatabricksUCConnection(DatabricksResource):
         used to create the tool which was used to build the model.
         on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
         with the permission of the invoker of the model in the serving endpoint. If set to
-        None or False, the resources is accesssed with definers rights
+        None or False, the resources is accesssed with the permissions of the creator
     """
 
     @property
@@ -124,7 +124,7 @@ class DatabricksServingEndpoint(DatabricksResource):
         endpoint_name (str): The name of all the databricks endpoints used by the model.
         on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
         with the permission of the invoker of the model in the serving endpoint. If set to
-        None or False, the resources is accesssed with definers rights
+        None or False, the resources is accesssed with the permissions of the creator
     """
 
     @property
@@ -144,7 +144,7 @@ class DatabricksVectorSearchIndex(DatabricksResource):
         used by the model
         on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
         with the permission of the invoker of the model in the serving endpoint. If set to
-        None or False, the resources is accesssed with definers rights
+        None or False, the resources is accesssed with the permissions of the creator
     """
 
     @property
@@ -163,7 +163,7 @@ class DatabricksSQLWarehouse(DatabricksResource):
         warehouse_id (str): The id of the sql warehouse used by the model
         on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
         with the permission of the invoker of the model in the serving endpoint. If set to
-        None or False, the resources is accesssed with definers rights
+        None or False, the resources is accesssed with the permissions of the creator
     """
 
     @property
@@ -182,7 +182,7 @@ class DatabricksFunction(DatabricksResource):
         function_name (str): The name of the function used by the model
         on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
         with the permission of the invoker of the model in the serving endpoint. If set to
-        None or False, the resources is accesssed with definers rights
+        None or False, the resources is accesssed with the permissions of the creator
     """
 
     @property
@@ -201,7 +201,7 @@ class DatabricksGenieSpace(DatabricksResource):
         genie_space_id (str): The genie space id
         on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
         with the permission of the invoker of the model in the serving endpoint. If set to
-        None or False, the resources is accesssed with definers rights
+        None or False, the resources is accesssed with the permissions of the creator
     """
 
     @property
@@ -222,7 +222,7 @@ class DatabricksTable(DatabricksResource):
          table_name (str): The name of the table used by the model
          on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
         with the permission of the invoker of the model in the serving endpoint. If set to
-        None or False, the resources is accesssed with definers rights
+        None or False, the resources is accesssed with the permissions of the creator
     """
 
     @property

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -103,8 +103,9 @@ class DatabricksUCConnection(DatabricksResource):
     Args:
         connection_name (str): The name of the databricks UC connection
         used to create the tool which was used to build the model.
-        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
-        is used on behalf of a user.
+        on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
+        with the permission of the invoker of the model in the serving endpoint. If set to
+        None or False, the resources is accesssed with definers rights
     """
 
     @property
@@ -121,8 +122,9 @@ class DatabricksServingEndpoint(DatabricksResource):
 
     Args:
         endpoint_name (str): The name of all the databricks endpoints used by the model.
-        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
-        is used on behalf of a user.
+        on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
+        with the permission of the invoker of the model in the serving endpoint. If set to
+        None or False, the resources is accesssed with definers rights
     """
 
     @property
@@ -138,10 +140,11 @@ class DatabricksVectorSearchIndex(DatabricksResource):
     Define Databricks vector search index name resource to serve a model.
 
     Args:
-        index_name (str): The name of all the databricks vector search index names
-        used by the model.
-        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
-        is used on behalf of a user.
+        index_name (str): The name of the databricks vector search index
+        used by the model
+        on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
+        with the permission of the invoker of the model in the serving endpoint. If set to
+        None or False, the resources is accesssed with definers rights
     """
 
     @property
@@ -158,8 +161,9 @@ class DatabricksSQLWarehouse(DatabricksResource):
 
     Args:
         warehouse_id (str): The id of the sql warehouse used by the model
-        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
-        is used on behalf of a user.
+        on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
+        with the permission of the invoker of the model in the serving endpoint. If set to
+        None or False, the resources is accesssed with definers rights
     """
 
     @property
@@ -176,8 +180,9 @@ class DatabricksFunction(DatabricksResource):
 
     Args:
         function_name (str): The name of the function used by the model
-        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
-        is used on behalf of a user.
+        on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
+        with the permission of the invoker of the model in the serving endpoint. If set to
+        None or False, the resources is accesssed with definers rights
     """
 
     @property
@@ -194,8 +199,9 @@ class DatabricksGenieSpace(DatabricksResource):
 
     Args:
         genie_space_id (str): The genie space id
-        on_behalf_of_user (Optional[bool]): Flag indicating if the resource
-        is used on behalf of a user.
+        on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
+        with the permission of the invoker of the model in the serving endpoint. If set to
+        None or False, the resources is accesssed with definers rights
     """
 
     @property
@@ -214,8 +220,9 @@ class DatabricksTable(DatabricksResource):
 
      Args:
          table_name (str): The name of the table used by the model
-         on_behalf_of_user (Optional[bool]): Flag indicating if the resource
-         is used on behalf of a user.
+         on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
+        with the permission of the invoker of the model in the serving endpoint. If set to
+        None or False, the resources is accesssed with definers rights
     """
 
     @property

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -256,6 +256,8 @@ def _fetch_langchain_dependency_from_model_resources(databricks_dependencies, ke
     dependencies = databricks_dependencies.get(key, [])
     deps = []
     for dependency in dependencies:
+        if dependency.get("on_behalf_of_user", False):
+            continue
         deps.append({"type": resource_type, "name": dependency["name"]})
     return deps
 

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -256,7 +256,7 @@ def _fetch_langchain_dependency_from_model_resources(databricks_dependencies, ke
     dependencies = databricks_dependencies.get(key, [])
     deps = []
     for dependency in dependencies:
-        deps.append({"type": resource_type, **dependency})
+        deps.append({"type": resource_type, "name": dependency["name"]})
     return deps
 
 

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -15,48 +15,74 @@ from mlflow.models.resources import (
 
 @pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
 def test_serving_endpoint(on_behalf_of_user):
-    endpoint = DatabricksServingEndpoint(endpoint_name="llm_server", on_behalf_of_user=on_behalf_of_user)
-    expected = {"serving_endpoint": [{"name": "llm_server"}]} if on_behalf_of_user is None else {"serving_endpoint": [{"name": "llm_server", "on_behalf_of_user": on_behalf_of_user}]}
+    endpoint = DatabricksServingEndpoint(
+        endpoint_name="llm_server", on_behalf_of_user=on_behalf_of_user
+    )
+    expected = (
+        {"serving_endpoint": [{"name": "llm_server"}]}
+        if on_behalf_of_user is None
+        else {"serving_endpoint": [{"name": "llm_server", "on_behalf_of_user": on_behalf_of_user}]}
+    )
     assert endpoint.to_dict() == expected
     assert _ResourceBuilder.from_resources([endpoint]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
+
 @pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
 def test_index_name(on_behalf_of_user):
     index = DatabricksVectorSearchIndex(index_name="index1", on_behalf_of_user=on_behalf_of_user)
-    expected = {"vector_search_index": [{"name": "index1"}]} if on_behalf_of_user is None else {"vector_search_index": [{"name": "index1", "on_behalf_of_user": on_behalf_of_user}]}
+    expected = (
+        {"vector_search_index": [{"name": "index1"}]}
+        if on_behalf_of_user is None
+        else {"vector_search_index": [{"name": "index1", "on_behalf_of_user": on_behalf_of_user}]}
+    )
     assert index.to_dict() == expected
     assert _ResourceBuilder.from_resources([index]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
+
 @pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
 def test_sql_warehouse(on_behalf_of_user):
     sql_warehouse = DatabricksSQLWarehouse(warehouse_id="id1", on_behalf_of_user=on_behalf_of_user)
-    expected = {"sql_warehouse": [{"name": "id1"}]} if on_behalf_of_user is None else {"sql_warehouse": [{"name": "id1", "on_behalf_of_user": on_behalf_of_user}]}
+    expected = (
+        {"sql_warehouse": [{"name": "id1"}]}
+        if on_behalf_of_user is None
+        else {"sql_warehouse": [{"name": "id1", "on_behalf_of_user": on_behalf_of_user}]}
+    )
     assert sql_warehouse.to_dict() == expected
     assert _ResourceBuilder.from_resources([sql_warehouse]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
+
 @pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
 def test_uc_function(on_behalf_of_user):
     uc_function = DatabricksFunction(function_name="function", on_behalf_of_user=on_behalf_of_user)
-    expected = {"function": [{"name": "function"}]} if on_behalf_of_user is None else {"function": [{"name": "function", "on_behalf_of_user": on_behalf_of_user}]}
+    expected = (
+        {"function": [{"name": "function"}]}
+        if on_behalf_of_user is None
+        else {"function": [{"name": "function", "on_behalf_of_user": on_behalf_of_user}]}
+    )
     assert uc_function.to_dict() == expected
     assert _ResourceBuilder.from_resources([uc_function]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
+
 @pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
 def test_genie_space(on_behalf_of_user):
     genie_space = DatabricksGenieSpace(genie_space_id="id1", on_behalf_of_user=on_behalf_of_user)
-    expected = {"genie_space": [{"name": "id1"}]} if on_behalf_of_user is None else {"genie_space": [{"name": "id1", "on_behalf_of_user": on_behalf_of_user}]}
+    expected = (
+        {"genie_space": [{"name": "id1"}]}
+        if on_behalf_of_user is None
+        else {"genie_space": [{"name": "id1", "on_behalf_of_user": on_behalf_of_user}]}
+    )
 
     assert genie_space.to_dict() == expected
     assert _ResourceBuilder.from_resources([genie_space]) == {
@@ -64,20 +90,34 @@ def test_genie_space(on_behalf_of_user):
         "databricks": expected,
     }
 
+
 @pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
 def test_uc_connection(on_behalf_of_user):
-    uc_function = DatabricksUCConnection(connection_name="slack_connection", on_behalf_of_user=on_behalf_of_user)
-    expected = {"uc_connection": [{"name": "slack_connection"}]} if on_behalf_of_user is None else {"uc_connection": [{"name": "slack_connection", "on_behalf_of_user": on_behalf_of_user}]}
+    uc_function = DatabricksUCConnection(
+        connection_name="slack_connection", on_behalf_of_user=on_behalf_of_user
+    )
+    expected = (
+        {"uc_connection": [{"name": "slack_connection"}]}
+        if on_behalf_of_user is None
+        else {
+            "uc_connection": [{"name": "slack_connection", "on_behalf_of_user": on_behalf_of_user}]
+        }
+    )
     assert uc_function.to_dict() == expected
     assert _ResourceBuilder.from_resources([uc_function]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
+
 @pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
 def test_table(on_behalf_of_user):
     table = DatabricksTable(table_name="tableName", on_behalf_of_user=on_behalf_of_user)
-    expected = {"table": [{"name": "tableName"}]} if on_behalf_of_user is None else {"table": [{"name": "tableName", "on_behalf_of_user": on_behalf_of_user}]} 
+    expected = (
+        {"table": [{"name": "tableName"}]}
+        if on_behalf_of_user is None
+        else {"table": [{"name": "tableName", "on_behalf_of_user": on_behalf_of_user}]}
+    )
 
     assert table.to_dict() == expected
     assert _ResourceBuilder.from_resources([table]) == {

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -13,81 +13,50 @@ from mlflow.models.resources import (
 )
 
 
-def test_serving_endpoint():
-    endpoint = DatabricksServingEndpoint(endpoint_name="llm_server")
-    expected = {"serving_endpoint": [{"name": "llm_server"}]}
+@pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
+def test_serving_endpoint(on_behalf_of_user):
+    endpoint = DatabricksServingEndpoint(endpoint_name="llm_server", on_behalf_of_user=on_behalf_of_user)
+    expected = {"serving_endpoint": [{"name": "llm_server"}]} if on_behalf_of_user is None else {"serving_endpoint": [{"name": "llm_server", "on_behalf_of_user": on_behalf_of_user}]}
     assert endpoint.to_dict() == expected
     assert _ResourceBuilder.from_resources([endpoint]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
-    endpoint = DatabricksServingEndpoint(endpoint_name="llm_server", on_behalf_of_user=False)
-    expected = {"serving_endpoint": [{"name": "llm_server", "on_behalf_of_user": False}]}
-    assert endpoint.to_dict() == expected
-    assert _ResourceBuilder.from_resources([endpoint]) == {
-        "api_version": DEFAULT_API_VERSION,
-        "databricks": expected,
-    }
-
-
-def test_index_name():
-    index = DatabricksVectorSearchIndex(index_name="index1")
-    expected = {"vector_search_index": [{"name": "index1"}]}
+@pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
+def test_index_name(on_behalf_of_user):
+    index = DatabricksVectorSearchIndex(index_name="index1", on_behalf_of_user=on_behalf_of_user)
+    expected = {"vector_search_index": [{"name": "index1"}]} if on_behalf_of_user is None else {"vector_search_index": [{"name": "index1", "on_behalf_of_user": on_behalf_of_user}]}
     assert index.to_dict() == expected
     assert _ResourceBuilder.from_resources([index]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
-    index = DatabricksVectorSearchIndex(index_name="index1", on_behalf_of_user=True)
-    expected = {"vector_search_index": [{"name": "index1", "on_behalf_of_user": True}]}
-    assert index.to_dict() == expected
-    assert _ResourceBuilder.from_resources([index]) == {
-        "api_version": DEFAULT_API_VERSION,
-        "databricks": expected,
-    }
-
-
-def test_sql_warehouse():
-    sql_warehouse = DatabricksSQLWarehouse(warehouse_id="id1")
-    expected = {"sql_warehouse": [{"name": "id1"}]}
+@pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
+def test_sql_warehouse(on_behalf_of_user):
+    sql_warehouse = DatabricksSQLWarehouse(warehouse_id="id1", on_behalf_of_user=on_behalf_of_user)
+    expected = {"sql_warehouse": [{"name": "id1"}]} if on_behalf_of_user is None else {"sql_warehouse": [{"name": "id1", "on_behalf_of_user": on_behalf_of_user}]}
     assert sql_warehouse.to_dict() == expected
     assert _ResourceBuilder.from_resources([sql_warehouse]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
-    sql_warehouse = DatabricksSQLWarehouse(warehouse_id="id1", on_behalf_of_user=True)
-    expected = {"sql_warehouse": [{"name": "id1", "on_behalf_of_user": True}]}
-    assert sql_warehouse.to_dict() == expected
-    assert _ResourceBuilder.from_resources([sql_warehouse]) == {
-        "api_version": DEFAULT_API_VERSION,
-        "databricks": expected,
-    }
-
-
-def test_uc_function():
-    uc_function = DatabricksFunction(function_name="function")
-    expected = {"function": [{"name": "function"}]}
+@pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
+def test_uc_function(on_behalf_of_user):
+    uc_function = DatabricksFunction(function_name="function", on_behalf_of_user=on_behalf_of_user)
+    expected = {"function": [{"name": "function"}]} if on_behalf_of_user is None else {"function": [{"name": "function", "on_behalf_of_user": on_behalf_of_user}]}
     assert uc_function.to_dict() == expected
     assert _ResourceBuilder.from_resources([uc_function]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
-    uc_function = DatabricksFunction(function_name="function", on_behalf_of_user=True)
-    expected = {"function": [{"name": "function", "on_behalf_of_user": True}]}
-    assert uc_function.to_dict() == expected
-    assert _ResourceBuilder.from_resources([uc_function]) == {
-        "api_version": DEFAULT_API_VERSION,
-        "databricks": expected,
-    }
-
-
-def test_genie_space():
-    genie_space = DatabricksGenieSpace(genie_space_id="id1")
-    expected = {"genie_space": [{"name": "id1"}]}
+@pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
+def test_genie_space(on_behalf_of_user):
+    genie_space = DatabricksGenieSpace(genie_space_id="id1", on_behalf_of_user=on_behalf_of_user)
+    expected = {"genie_space": [{"name": "id1"}]} if on_behalf_of_user is None else {"genie_space": [{"name": "id1", "on_behalf_of_user": on_behalf_of_user}]}
 
     assert genie_space.to_dict() == expected
     assert _ResourceBuilder.from_resources([genie_space]) == {
@@ -95,50 +64,23 @@ def test_genie_space():
         "databricks": expected,
     }
 
-    genie_space = DatabricksGenieSpace(genie_space_id="id1", on_behalf_of_user=True)
-    expected = {"genie_space": [{"name": "id1", "on_behalf_of_user": True}]}
-
-    assert genie_space.to_dict() == expected
-    assert _ResourceBuilder.from_resources([genie_space]) == {
-        "api_version": DEFAULT_API_VERSION,
-        "databricks": expected,
-    }
-
-
-def test_uc_connection():
-    uc_function = DatabricksUCConnection(connection_name="slack_connection")
-    expected = {"uc_connection": [{"name": "slack_connection"}]}
+@pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
+def test_uc_connection(on_behalf_of_user):
+    uc_function = DatabricksUCConnection(connection_name="slack_connection", on_behalf_of_user=on_behalf_of_user)
+    expected = {"uc_connection": [{"name": "slack_connection"}]} if on_behalf_of_user is None else {"uc_connection": [{"name": "slack_connection", "on_behalf_of_user": on_behalf_of_user}]}
     assert uc_function.to_dict() == expected
     assert _ResourceBuilder.from_resources([uc_function]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }
 
-    uc_function = DatabricksUCConnection(
-        connection_name="slack_connection", on_behalf_of_user=False
-    )
-    expected = {"uc_connection": [{"name": "slack_connection", "on_behalf_of_user": False}]}
-    assert uc_function.to_dict() == expected
-    assert _ResourceBuilder.from_resources([uc_function]) == {
-        "api_version": DEFAULT_API_VERSION,
-        "databricks": expected,
-    }
-
-
-def test_table():
-    table = DatabricksTable(table_name="tableName")
-    expected = {"table": [{"name": "tableName"}]}
+@pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
+def test_table(on_behalf_of_user):
+    table = DatabricksTable(table_name="tableName", on_behalf_of_user=on_behalf_of_user)
+    expected = {"table": [{"name": "tableName"}]} if on_behalf_of_user is None else {"table": [{"name": "tableName", "on_behalf_of_user": on_behalf_of_user}]} 
 
     assert table.to_dict() == expected
     assert _ResourceBuilder.from_resources([table]) == {
-        "api_version": DEFAULT_API_VERSION,
-        "databricks": expected,
-    }
-
-    uc_function = DatabricksUCConnection(connection_name="slack_connection", on_behalf_of_user=True)
-    expected = {"uc_connection": [{"name": "slack_connection", "on_behalf_of_user": True}]}
-    assert uc_function.to_dict() == expected
-    assert _ResourceBuilder.from_resources([uc_function]) == {
         "api_version": DEFAULT_API_VERSION,
         "databricks": expected,
     }

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1669,6 +1669,222 @@ def test_model_save_load_with_resources(tmp_path):
     assert reloaded_model.resources == expected_resources
 
 
+def test_model_save_load_with_invokers_resources(tmp_path):
+    pyfunc_model_path = os.path.join(tmp_path, "pyfunc_model")
+    pyfunc_model_path_2 = os.path.join(tmp_path, "pyfunc_model_2")
+
+    expected_resources = {
+        "api_version": "1",
+        "databricks": {
+            "serving_endpoint": [
+                {"name": "databricks-mixtral-8x7b-instruct", "on_behalf_of_user": True},
+                {"name": "databricks-bge-large-en"},
+                {"name": "azure-eastus-model-serving-2_vs_endpoint"},
+            ],
+            "vector_search_index": [
+                {"name": "rag.studio_bugbash.databricks_docs_index", "on_behalf_of_user": True}
+            ],
+            "sql_warehouse": [{"name": "testid"}],
+            "function": [
+                {"name": "rag.studio.test_function_a", "on_behalf_of_user": True},
+                {"name": "rag.studio.test_function_b"},
+            ],
+            "genie_space": [
+                {"name": "genie_space_id_1", "on_behalf_of_user": True},
+                {"name": "genie_space_id_2"},
+            ],
+            "uc_connection": [{"name": "test_connection_1"}, {"name": "test_connection_2"}],
+            "table": [
+                {"name": "rag.studio.table_a", "on_behalf_of_user": True},
+                {"name": "rag.studio.table_b"},
+            ],
+        },
+    }
+    mlflow.pyfunc.save_model(
+        path=pyfunc_model_path,
+        conda_env=_conda_env(),
+        python_model=mlflow.pyfunc.model.PythonModel(),
+        resources=[
+            DatabricksServingEndpoint(
+                endpoint_name="databricks-mixtral-8x7b-instruct", on_behalf_of_user=True
+            ),
+            DatabricksServingEndpoint(endpoint_name="databricks-bge-large-en"),
+            DatabricksServingEndpoint(endpoint_name="azure-eastus-model-serving-2_vs_endpoint"),
+            DatabricksVectorSearchIndex(
+                index_name="rag.studio_bugbash.databricks_docs_index", on_behalf_of_user=True
+            ),
+            DatabricksSQLWarehouse(warehouse_id="testid"),
+            DatabricksFunction(function_name="rag.studio.test_function_a", on_behalf_of_user=True),
+            DatabricksFunction(function_name="rag.studio.test_function_b"),
+            DatabricksGenieSpace(genie_space_id="genie_space_id_1", on_behalf_of_user=True),
+            DatabricksGenieSpace(genie_space_id="genie_space_id_2"),
+            DatabricksUCConnection(connection_name="test_connection_1"),
+            DatabricksUCConnection(connection_name="test_connection_2"),
+            DatabricksTable(table_name="rag.studio.table_a", on_behalf_of_user=True),
+            DatabricksTable(table_name="rag.studio.table_b"),
+        ],
+    )
+
+    reloaded_model = Model.load(pyfunc_model_path)
+    assert reloaded_model.resources == expected_resources
+
+    yaml_file = tmp_path.joinpath("resources.yaml")
+    with open(yaml_file, "w") as f:
+        f.write(
+            """
+            api_version: "1"
+            databricks:
+                vector_search_index:
+                - name: rag.studio_bugbash.databricks_docs_index
+                  on_behalf_of_user: True
+                serving_endpoint:
+                - name: databricks-mixtral-8x7b-instruct
+                  on_behalf_of_user: True
+                - name: databricks-bge-large-en
+                - name: azure-eastus-model-serving-2_vs_endpoint
+                sql_warehouse:
+                - name: testid
+                function:
+                - name: rag.studio.test_function_a
+                  on_behalf_of_user: True
+                - name: rag.studio.test_function_b
+                genie_space:
+                - name: genie_space_id_1
+                  on_behalf_of_user: True
+                - name: genie_space_id_2
+                uc_connection:
+                - name: test_connection_1
+                - name: test_connection_2
+                table:
+                - name: rag.studio.table_a
+                  on_behalf_of_user: True
+                - name: rag.studio.table_b
+            """
+        )
+
+    mlflow.pyfunc.save_model(
+        path=pyfunc_model_path_2,
+        conda_env=_conda_env(),
+        python_model=mlflow.pyfunc.model.PythonModel(),
+        resources=yaml_file,
+    )
+
+    reloaded_model = Model.load(pyfunc_model_path_2)
+    assert reloaded_model.resources == expected_resources
+
+
+def test_model_log_with_invokers_resources(tmp_path):
+    pyfunc_artifact_path = "pyfunc_model"
+
+    expected_resources = {
+        "api_version": "1",
+        "databricks": {
+            "serving_endpoint": [
+                {"name": "databricks-mixtral-8x7b-instruct"},
+                {"name": "databricks-bge-large-en", "on_behalf_of_user": True},
+                {"name": "azure-eastus-model-serving-2_vs_endpoint"},
+            ],
+            "vector_search_index": [
+                {"name": "rag.studio_bugbash.databricks_docs_index", "on_behalf_of_user": True}
+            ],
+            "sql_warehouse": [{"name": "testid", "on_behalf_of_user": True}],
+            "function": [
+                {"name": "rag.studio.test_function_a"},
+                {"name": "rag.studio.test_function_b", "on_behalf_of_user": True},
+            ],
+            "genie_space": [
+                {"name": "genie_space_id_1"},
+                {"name": "genie_space_id_2", "on_behalf_of_user": True},
+            ],
+            "uc_connection": [
+                {"name": "test_connection_1"},
+                {"name": "test_connection_2", "on_behalf_of_user": True},
+            ],
+            "table": [
+                {"name": "rag.studio.table_a"},
+                {"name": "rag.studio.table_b", "on_behalf_of_user": True},
+            ],
+        },
+    }
+    with mlflow.start_run() as run:
+        mlflow.pyfunc.log_model(
+            pyfunc_artifact_path,
+            python_model=mlflow.pyfunc.model.PythonModel(),
+            resources=[
+                DatabricksServingEndpoint(endpoint_name="databricks-mixtral-8x7b-instruct"),
+                DatabricksServingEndpoint(
+                    endpoint_name="databricks-bge-large-en", on_behalf_of_user=True
+                ),
+                DatabricksServingEndpoint(endpoint_name="azure-eastus-model-serving-2_vs_endpoint"),
+                DatabricksVectorSearchIndex(
+                    index_name="rag.studio_bugbash.databricks_docs_index", on_behalf_of_user=True
+                ),
+                DatabricksSQLWarehouse(warehouse_id="testid", on_behalf_of_user=True),
+                DatabricksFunction(function_name="rag.studio.test_function_a"),
+                DatabricksFunction(
+                    function_name="rag.studio.test_function_b", on_behalf_of_user=True
+                ),
+                DatabricksGenieSpace(genie_space_id="genie_space_id_1"),
+                DatabricksGenieSpace(genie_space_id="genie_space_id_2", on_behalf_of_user=True),
+                DatabricksUCConnection(connection_name="test_connection_1"),
+                DatabricksUCConnection(connection_name="test_connection_2", on_behalf_of_user=True),
+                DatabricksTable(table_name="rag.studio.table_a"),
+                DatabricksTable(table_name="rag.studio.table_b", on_behalf_of_user=True),
+            ],
+        )
+    pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
+    pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
+    reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
+    assert reloaded_model.resources == expected_resources
+
+    yaml_file = tmp_path.joinpath("resources.yaml")
+    with open(yaml_file, "w") as f:
+        f.write(
+            """
+            api_version: "1"
+            databricks:
+                vector_search_index:
+                - name: rag.studio_bugbash.databricks_docs_index
+                  on_behalf_of_user: True
+                serving_endpoint:
+                - name: databricks-mixtral-8x7b-instruct
+                - name: databricks-bge-large-en
+                  on_behalf_of_user: True
+                - name: azure-eastus-model-serving-2_vs_endpoint
+                sql_warehouse:
+                - name: testid
+                  on_behalf_of_user: True
+                function:
+                - name: rag.studio.test_function_a
+                - name: rag.studio.test_function_b
+                  on_behalf_of_user: True
+                genie_space:
+                - name: genie_space_id_1
+                - name: genie_space_id_2
+                  on_behalf_of_user: True
+                uc_connection:
+                - name: test_connection_1
+                - name: test_connection_2
+                  on_behalf_of_user: True
+                table:
+                - name: "rag.studio.table_a"
+                - name: "rag.studio.table_b"
+                  on_behalf_of_user: True
+            """
+        )
+
+    with mlflow.start_run() as run:
+        mlflow.pyfunc.log_model(
+            pyfunc_artifact_path,
+            python_model=mlflow.pyfunc.model.PythonModel(),
+            resources=yaml_file,
+        )
+    pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
+    pyfunc_model_path = _download_artifact_from_uri(pyfunc_model_uri)
+    reloaded_model = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
+    assert reloaded_model.resources == expected_resources
+
+
 def test_model_log_with_resources(tmp_path):
     pyfunc_artifact_path = "pyfunc_model"
 

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -244,12 +244,12 @@ def langchain_local_model_dir_with_resources(tmp_path):
                 ],
                 "vector_search_index": [{"name": "index1"}, {"name": "index2"}],
                 "function": [
-                    {"name": "test.schema.test_function"},
+                    {"name": "test.schema.test_function", "on_behalf_of_user": True},
                     {"name": "test.schema.test_function_2"},
                 ],
                 "uc_connection": [{"name": "test_connection"}],
                 "table": [
-                    {"name": "test.schema.test_table"},
+                    {"name": "test.schema.test_table", "on_behalf_of_user": True},
                     {"name": "test.schema.test_table_2"},
                 ],
             }

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -244,10 +244,61 @@ def langchain_local_model_dir_with_resources(tmp_path):
                 ],
                 "vector_search_index": [{"name": "index1"}, {"name": "index2"}],
                 "function": [
-                    {"name": "test.schema.test_function", "on_behalf_of_user": True},
+                    {"name": "test.schema.test_function"},
                     {"name": "test.schema.test_function_2"},
                 ],
                 "uc_connection": [{"name": "test_connection"}],
+                "table": [
+                    {"name": "test.schema.test_table"},
+                    {"name": "test.schema.test_table_2"},
+                ],
+            }
+        },
+    }
+    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+
+    model_version_dependencies = [
+        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index1"},
+        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index2"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "embedding_endpoint"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "llm_endpoint"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "chat_endpoint"},
+        {"type": "DATABRICKS_UC_FUNCTION", "name": "test.schema.test_function"},
+        {"type": "DATABRICKS_UC_FUNCTION", "name": "test.schema.test_function_2"},
+        {"type": "DATABRICKS_UC_CONNECTION", "name": "test_connection"},
+        {"type": "DATABRICKS_TABLE", "name": "test.schema.test_table"},
+        {"type": "DATABRICKS_TABLE", "name": "test.schema.test_table_2"},
+    ]
+
+    return (tmp_path, model_version_dependencies)
+
+
+@pytest.fixture
+def langchain_local_model_dir_with_invoker_resources(tmp_path):
+    fake_signature = ModelSignature(
+        inputs=Schema([ColSpec(DataType.string)]), outputs=Schema([ColSpec(DataType.string)])
+    )
+    fake_mlmodel_contents = {
+        "artifact_path": "some-artifact-path",
+        "run_id": "abc123",
+        "signature": fake_signature.to_dict(),
+        "resources": {
+            "databricks": {
+                "serving_endpoint": [
+                    {"name": "embedding_endpoint"},
+                    {"name": "llm_endpoint"},
+                    {"name": "chat_endpoint"},
+                ],
+                "vector_search_index": [
+                    {"name": "index1", "on_behalf_of_user": False},
+                    {"name": "index2"},
+                ],
+                "function": [
+                    {"name": "test.schema.test_function", "on_behalf_of_user": True},
+                    {"name": "test.schema.test_function_2"},
+                ],
+                "uc_connection": [{"name": "test_connection", "on_behalf_of_user": False}],
                 "table": [
                     {"name": "test.schema.test_table", "on_behalf_of_user": True},
                     {"name": "test.schema.test_table_2"},
@@ -257,7 +308,19 @@ def langchain_local_model_dir_with_resources(tmp_path):
     }
     with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
         yaml.dump(fake_mlmodel_contents, handle)
-    return tmp_path
+
+    model_version_dependencies = [
+        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index1"},
+        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index2"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "embedding_endpoint"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "llm_endpoint"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "chat_endpoint"},
+        {"type": "DATABRICKS_UC_FUNCTION", "name": "test.schema.test_function_2"},
+        {"type": "DATABRICKS_UC_CONNECTION", "name": "test_connection"},
+        {"type": "DATABRICKS_TABLE", "name": "test.schema.test_table_2"},
+    ]
+
+    return (tmp_path, model_version_dependencies)
 
 
 @pytest.fixture
@@ -345,6 +408,8 @@ def test_create_model_version_with_langchain_dependencies(store, langchain_local
 
 
 def test_create_model_version_with_resources(store, langchain_local_model_dir_with_resources):
+    source, model_version_dependencies = langchain_local_model_dir_with_resources
+    source = str(source)
     access_key_id = "fake-key"
     secret_access_key = "secret-key"
     session_token = "session-token"
@@ -356,24 +421,75 @@ def test_create_model_version_with_resources(store, langchain_local_model_dir_wi
         )
     )
     storage_location = "s3://blah"
-    source = str(langchain_local_model_dir_with_resources)
     model_name = "model_1"
     version = "1"
     tags = [
         ModelVersionTag(key="key", value="value"),
         ModelVersionTag(key="anotherKey", value="some other value"),
     ]
-    model_version_dependencies = [
-        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index1"},
-        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index2"},
-        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "embedding_endpoint"},
-        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "llm_endpoint"},
-        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "chat_endpoint"},
-        {"type": "DATABRICKS_UC_FUNCTION", "name": "test.schema.test_function"},
-        {"type": "DATABRICKS_UC_FUNCTION", "name": "test.schema.test_function_2"},
-        {"type": "DATABRICKS_UC_CONNECTION", "name": "test_connection"},
-        {"type": "DATABRICKS_TABLE", "name": "test.schema.test_table"},
-        {"type": "DATABRICKS_TABLE", "name": "test.schema.test_table_2"},
+
+    mock_artifact_repo = mock.MagicMock(autospec=OptimizedS3ArtifactRepository)
+    with (
+        mock.patch(
+            "mlflow.utils.rest_utils.http_request",
+            side_effect=get_request_mock(
+                name=model_name,
+                version=version,
+                temp_credentials=aws_temp_creds,
+                storage_location=storage_location,
+                source=source,
+                tags=tags,
+                model_version_dependencies=model_version_dependencies,
+            ),
+        ) as request_mock,
+        mock.patch(
+            "mlflow.store.artifact.optimized_s3_artifact_repo.OptimizedS3ArtifactRepository",
+            return_value=mock_artifact_repo,
+        ) as optimized_s3_artifact_repo_class_mock,
+        mock.patch.dict("sys.modules", {"boto3": {}}),
+    ):
+        store.create_model_version(name=model_name, source=source, tags=tags)
+        # Verify that s3 artifact repo mock was called with expected args
+        optimized_s3_artifact_repo_class_mock.assert_called_once_with(
+            artifact_uri=storage_location,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+            credential_refresh_def=ANY,
+            s3_upload_extra_args={},
+        )
+        mock_artifact_repo.log_artifacts.assert_called_once_with(local_dir=ANY, artifact_path="")
+        _assert_create_model_version_endpoints_called(
+            request_mock=request_mock,
+            name=model_name,
+            source=source,
+            version=version,
+            tags=tags,
+            model_version_dependencies=model_version_dependencies,
+        )
+
+
+def test_create_model_version_with_invoker_resources(
+    store, langchain_local_model_dir_with_invoker_resources
+):
+    source, model_version_dependencies = langchain_local_model_dir_with_invoker_resources
+    source = str(source)
+    access_key_id = "fake-key"
+    secret_access_key = "secret-key"
+    session_token = "session-token"
+    aws_temp_creds = TemporaryCredentials(
+        aws_temp_credentials=AwsCredentials(
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+        )
+    )
+    storage_location = "s3://blah"
+    model_name = "model_1"
+    version = "1"
+    tags = [
+        ModelVersionTag(key="key", value="value"),
+        ModelVersionTag(key="anotherKey", value="some other value"),
     ]
 
     mock_artifact_repo = mock.MagicMock(autospec=OptimizedS3ArtifactRepository)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aravind-segu/mlflow/pull/14212?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14212/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14212
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This pull request introduces a new `on_behalf_of_user` parameter when defining resources when logging a mlflow model. When set to true, this information will be used to generate the correct downscoped token for a user request to an Agent Endpoint.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Adds support for invokers rights in databricks resources by allowing users to specify whether a specific resource will be accessed on behalf of users. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
