### PR TITLE
Move predict function definition check to model creation 

### DIFF
--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -76,7 +76,7 @@ def _wrap_predict_with_pyfunc(func, func_info: Optional[FuncInfo]):
 
 def _check_func_signature(func, func_name) -> list[str]:
     parameters = inspect.signature(func).parameters
-    param_names = list(filter(lambda x: x != "self", list(parameters.keys())))
+    param_names = [name for name in parameters.keys() if name != "self"]
     if invalid_params := set(param_names) - {"self", "context", "model_input", "params"}:
         warnings.warn(
             _INVALID_SIGNATURE_ERROR_MSG.format(func_name=func_name, invalid_params=invalid_params),

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -17,7 +17,7 @@ from mlflow.types.type_hints import (
 from mlflow.utils.annotations import filter_user_warnings_once
 
 _INVALID_SIGNATURE_ERROR_MSG = (
-    "The underlying model's `{func_name}` method contains invalid parameters: {invalid_params}. "
+    "Model's `{func_name}` method contains invalid parameters: {invalid_params}. "
     "Only the following parameter names are allowed: context, model_input, and params. "
     "Note that invalid parameters will no longer be permitted in future versions."
 )
@@ -77,7 +77,7 @@ def _wrap_predict_with_pyfunc(func, func_info: Optional[FuncInfo]):
 def _check_func_signature(func, func_name) -> list[str]:
     parameters = inspect.signature(func).parameters
     param_names = list(filter(lambda x: x != "self", list(parameters.keys())))
-    if invalid_params := set(param_names) - {"context", "model_input", "params"}:
+    if invalid_params := set(param_names) - {"self", "context", "model_input", "params"}:
         warnings.warn(
             _INVALID_SIGNATURE_ERROR_MSG.format(func_name=func_name, invalid_params=invalid_params),
             FutureWarning,

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 from functools import lru_cache, wraps
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 from mlflow.exceptions import MlflowException
 from mlflow.models.signature import (
@@ -16,6 +16,17 @@ from mlflow.types.type_hints import (
 )
 from mlflow.utils.annotations import filter_user_warnings_once
 
+_INVALID_SIGNATURE_ERROR_MSG = (
+    "The underlying model's `{func_name}` method contains invalid parameters: {invalid_params}. "
+    "Only the following parameter names are allowed: context, model_input, and params. "
+    "Note that invalid parameters will no longer be permitted in future versions."
+)
+
+
+class FuncInfo(NamedTuple):
+    input_type_hint: Optional[type[Any]]
+    input_param_name: str
+
 
 def pyfunc(func):
     """
@@ -27,24 +38,30 @@ def pyfunc(func):
         of `mlflow.pyfunc.PythonModel`, or a callable that takes a single input.
     """
 
-    type_hint = _get_type_hint_if_supported(func)
-    return _wrap_predict_with_pyfunc(func, type_hint)
+    func_info = _get_func_info_if_type_hint_supported(func)
+    return _wrap_predict_with_pyfunc(func, func_info)
 
 
-def _wrap_predict_with_pyfunc(func, type_hint):
-    if type_hint is not None:
+def _wrap_predict_with_pyfunc(func, func_info: Optional[FuncInfo]):
+    if func_info is not None:
         model_input_index = _model_input_index_in_function_signature(func)
 
         @wraps(func)
         def wrapper(*args, **kwargs):
             try:
-                args, kwargs = _validate_model_input(args, kwargs, model_input_index, type_hint)
+                args, kwargs = _validate_model_input(
+                    args,
+                    kwargs,
+                    model_input_index,
+                    func_info.input_type_hint,
+                    func_info.input_param_name,
+                )
             except Exception as e:
                 if isinstance(e, MlflowException):
                     raise e
                 raise MlflowException(
-                    f"Failed to validate the input data against the type hint `{type_hint}`. "
-                    f"Error: {e}"
+                    "Failed to validate the input data against the type hint "
+                    f"`{func_info.input_type_hint}`. Error: {e}"
                 )
             return func(*args, **kwargs)
     else:
@@ -57,9 +74,21 @@ def _wrap_predict_with_pyfunc(func, type_hint):
     return wrapper
 
 
+def _check_func_signature(func, func_name) -> list[str]:
+    parameters = inspect.signature(func).parameters
+    param_names = list(filter(lambda x: x != "self", list(parameters.keys())))
+    if invalid_params := set(param_names) - {"context", "model_input", "params"}:
+        warnings.warn(
+            _INVALID_SIGNATURE_ERROR_MSG.format(func_name=func_name, invalid_params=invalid_params),
+            FutureWarning,
+            stacklevel=2,
+        )
+    return param_names
+
+
 @lru_cache
 @filter_user_warnings_once
-def _get_type_hint_if_supported(func) -> Optional[type[Any]]:
+def _get_func_info_if_type_hint_supported(func) -> Optional[FuncInfo]:
     """
     Internal method to check if the predict function has type hints and if they are supported
     by MLflow.
@@ -68,12 +97,10 @@ def _get_type_hint_if_supported(func) -> Optional[type[Any]]:
         - predict(self, model_input, params=None)
     For callables, the function must contain only one input argument.
     """
-    # TODO: move function signature validation here
-    # instead of the pyfunc wrapper
-    if _is_context_in_predict_function_signature(func=func):
-        type_hint = _extract_type_hints(func, input_arg_index=1).input
-    else:
-        type_hint = _extract_type_hints(func, input_arg_index=0).input
+    param_names = _check_func_signature(func, "predict")
+    input_arg_index = 1 if _is_context_in_predict_function_signature(func=func) else 0
+    type_hint = _extract_type_hints(func, input_arg_index=input_arg_index).input
+    input_param_name = param_names[input_arg_index]
     if type_hint is not None:
         if _signature_cannot_be_inferred_from_type_hint(type_hint):
             return
@@ -88,7 +115,7 @@ def _get_type_hint_if_supported(func) -> Optional[type[Any]]:
                 stacklevel=3,
             )
         else:
-            return type_hint
+            return FuncInfo(input_type_hint=type_hint, input_param_name=input_param_name)
 
 
 def _model_input_index_in_function_signature(func):
@@ -100,11 +127,13 @@ def _model_input_index_in_function_signature(func):
     return index
 
 
-def _validate_model_input(args, kwargs, model_input_index_in_sig, type_hint):
+def _validate_model_input(
+    args, kwargs, model_input_index_in_sig, type_hint, model_input_param_name
+):
     model_input = None
     input_pos = None
-    if "model_input" in kwargs:
-        model_input = kwargs["model_input"]
+    if model_input_param_name in kwargs:
+        model_input = kwargs[model_input_param_name]
         input_pos = "kwargs"
     elif len(args) >= model_input_index_in_sig + 1:
         model_input = args[model_input_index_in_sig]
@@ -113,7 +142,7 @@ def _validate_model_input(args, kwargs, model_input_index_in_sig, type_hint):
         data = _convert_data_to_type_hint(model_input, type_hint)
         data = _validate_example_against_type_hint(data, type_hint)
         if input_pos == "kwargs":
-            kwargs["model_input"] = data
+            kwargs[model_input_param_name] = data
         else:
             args = args[:input_pos] + (data,) + args[input_pos + 1 :]
     return args, kwargs

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2149,28 +2149,23 @@ def test_callable_python_model_without_context_in_predict():
 
 
 def test_pyfunc_model_with_wrong_predict_signature_warning():
-    class Model(mlflow.pyfunc.PythonModel):
-        def predict(self, ctx, model_input, params=None):
-            return model_input
+    with pytest.warns(
+        FutureWarning,
+        match=r"The underlying model's `predict` method contains invalid parameters: {'messages'}",
+    ):
 
-        def predict_stream(self, _, model_input, params=None):
-            yield model_input
+        class Model(mlflow.pyfunc.PythonModel):
+            def predict(self, context, messages, params=None):
+                return messages
 
-    m = Model()
-    with mlflow.start_run():
-        model_info = mlflow.pyfunc.log_model("model", python_model=m, input_example="abc")
-    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    with mock.patch("mlflow.pyfunc.model.warnings.warn") as warn_mock:
-        pyfunc_model.predict("abc")
-        assert warn_mock.call_count == 1
-        assert (
-            "The underlying model's `predict` method contains invalid parameters: {'ctx'}"
-            in warn_mock.call_args[0][0]
-        )
+    with pytest.warns(
+        FutureWarning,
+        match=r"The underlying model's `predict_stream` method contains invalid parameters: {'_'}",
+    ):
 
-        pyfunc_model.predict_stream("abc")
-        assert warn_mock.call_count == 2
-        assert (
-            "The underlying model's `predict_stream` method contains invalid parameters: {'_'}"
-            in warn_mock.call_args[0][0]
-        )
+        class Model(mlflow.pyfunc.PythonModel):
+            def predict(self, model_input, params=None):
+                return model_input
+
+            def predict_stream(self, _, model_input, params=None):
+                yield model_input

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2151,7 +2151,7 @@ def test_callable_python_model_without_context_in_predict():
 def test_pyfunc_model_with_wrong_predict_signature_warning():
     with pytest.warns(
         FutureWarning,
-        match=r"The underlying model's `predict` method contains invalid parameters: {'messages'}",
+        match=r"Model's `predict` method contains invalid parameters: {'messages'}",
     ):
 
         class Model(mlflow.pyfunc.PythonModel):
@@ -2160,7 +2160,7 @@ def test_pyfunc_model_with_wrong_predict_signature_warning():
 
     with pytest.warns(
         FutureWarning,
-        match=r"The underlying model's `predict_stream` method contains invalid parameters: {'_'}",
+        match=r"Model's `predict_stream` method contains invalid parameters: {'_'}",
     ):
 
         class Model(mlflow.pyfunc.PythonModel):

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -734,7 +734,7 @@ def test_predict_model_with_type_hints():
 
 
 def test_predict_with_wrong_signature_warns():
-    message = r"The underlying model's `predict` method contains invalid parameters"
+    message = r"Model's `predict` method contains invalid parameters"
     with pytest.warns(FutureWarning, match=message):
 
         class ModelWOTypeHint(mlflow.pyfunc.PythonModel):

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -731,3 +731,58 @@ def test_predict_model_with_type_hints():
         # has the package, this could cause version not found error
         env_manager=VIRTUALENV,
     )
+
+
+def test_predict_with_wrong_signature_warns():
+    message = r"The underlying model's `predict` method contains invalid parameters"
+    with pytest.warns(FutureWarning, match=message):
+
+        class ModelWOTypeHint(mlflow.pyfunc.PythonModel):
+            def predict(self, context, messages, params=None):
+                return messages
+
+    with pytest.warns(FutureWarning, match=message):
+
+        class ModelWithTypeHint(mlflow.pyfunc.PythonModel):
+            def predict(self, messages: list[str], params=None) -> list[str]:
+                return messages
+
+    # applying @pyfunc on the callable should trigger the warning
+    with pytest.warns(FutureWarning, match=message):
+
+        @pyfunc
+        def predict(messages: list[str]) -> list[str]:
+            return messages
+
+    with pytest.warns(FutureWarning, match=message):
+
+        @pyfunc
+        def predict(messages):
+            return message
+
+    # no @pyfunc decorator, then logging it should trigger the warning
+    def predict(messages) -> list[str]:
+        return messages
+
+    with mlflow.start_run():
+        with pytest.warns(FutureWarning, match=message):
+            mlflow.pyfunc.log_model("model", python_model=predict, input_example=["a"])
+
+
+def test_model_with_wrong_predict_signature_works():
+    class Model(mlflow.pyfunc.PythonModel):
+        def predict(self, messages: list[Message], params=None) -> list[str]:
+            return [m.content for m in messages]
+
+    model = Model()
+    input_example = [{"role": "admin", "content": "hello"}]
+    expected_response = ["hello"]
+    assert model.predict(input_example) == expected_response
+    assert model.predict(messages=input_example) == expected_response
+
+    @pyfunc
+    def predict(messages: list[Message]) -> list[str]:
+        return [m.content for m in messages]
+
+    assert predict(input_example) == expected_response
+    assert predict(messages=input_example) == expected_response


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14213?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14213/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14213
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
The follow-up for https://github.com/mlflow/mlflow/pull/14130#discussion_r1897784778
This should check if the `predict` function uses the same signature as PythonModel's predict function.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
