### PR TITLE
Fix infer signature warnings

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -32,7 +32,6 @@ from mlflow.types.type_hints import (
     _infer_schema_from_list_type_hint,
     _infer_schema_from_type_hint,
     _is_list_type_hint,
-    _signature_cannot_be_inferred_from_type_hint,
 )
 from mlflow.types.utils import _infer_param_schema, _infer_schema
 from mlflow.utils.annotations import filter_user_warnings_once
@@ -371,28 +370,12 @@ def _is_context_in_predict_function_signature(*, func=None, parameters=None):
     )
 
 
-def _should_infer_signature_from_type_hints(type_hints: _TypeHints):
-    """
-    Whether model signature should be inferred from type hints.
-    If the input type hint is None or needs a signature, return False.
-    """
-    if type_hints.input is None:
-        return False
-
-    if _signature_cannot_be_inferred_from_type_hint(type_hints.input):
-        return False
-
-    return True
-
-
 @filter_user_warnings_once
 def _infer_signature_from_type_hints(
     func, type_hints: _TypeHints, input_example=None
 ) -> Optional[ModelSignature]:
     """
     Infer the signature from type hints.
-    This function should only be called if _should_infer_signature_from_type_hints
-    is True.
     """
     if type_hints.input is None:
         return None
@@ -402,6 +385,7 @@ def _infer_signature_from_type_hints(
     if _contains_params(input_example):
         input_example, params = input_example
 
+    _logger.info("Inferring model signature from type hints")
     try:
         input_schema = _infer_schema_from_list_type_hint(type_hints.input)
     except InvalidTypeHintException as e:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3016,7 +3016,7 @@ def save_model(
                     if not should_infer_signature_from_type_hints:
                         _logger.warning(
                             "Failed to infer model signature: "
-                            f"Type hint {type_hints} cannot be used to infer model signature, "
+                            f"Type hint {type_hints} cannot be used to infer model signature and "
                             "input example is not provided, model signature cannot be inferred."
                         )
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -424,6 +424,7 @@ import yaml
 from packaging.version import Version
 
 import mlflow
+import mlflow.models.signature
 import mlflow.pyfunc.loaders
 import mlflow.pyfunc.model
 from mlflow.environment_variables import (
@@ -451,7 +452,6 @@ from mlflow.models.signature import (
     _extract_type_hints,
     _infer_signature_from_input_example,
     _infer_signature_from_type_hints,
-    _should_infer_signature_from_type_hints,
 )
 from mlflow.models.utils import (
     PyFuncInput,
@@ -505,6 +505,7 @@ from mlflow.types.llm import (
     ChatMessage,
     ChatParams,
 )
+from mlflow.types.type_hints import _signature_cannot_be_inferred_from_type_hint
 from mlflow.utils import (
     PYTHON_VERSION,
     _is_in_ipython_notebook,
@@ -2977,24 +2978,27 @@ def save_model(
         if callable(python_model):
             # first argument is the model input
             type_hints = _extract_type_hints(python_model, input_arg_index=0)
-            if _should_infer_signature_from_type_hints(type_hints):
+            if not _signature_cannot_be_inferred_from_type_hint(type_hints.input):
                 signature_from_type_hints = _infer_signature_from_type_hints(
                     func=python_model, type_hints=type_hints, input_example=input_example
                 )
         elif isinstance(python_model, PythonModel):
             saved_example = _save_example(mlflow_model, input_example, path, example_no_conversion)
             type_hints = python_model.predict_type_hints
-            infer_signature_from_type_hints = _should_infer_signature_from_type_hints(type_hints)
-            if infer_signature_from_type_hints:
+            should_infer_signature_from_type_hints = (
+                not _signature_cannot_be_inferred_from_type_hint(type_hints.input)
+            )
+            if should_infer_signature_from_type_hints:
                 signature_from_type_hints = _infer_signature_from_type_hints(
                     func=python_model.predict,
-                    type_hints=python_model.predict_type_hints,
+                    type_hints=type_hints,
                     input_example=input_example,
                 )
             # only infer signature based on input example when signature
             # and type hints are not provided
             if signature is None and signature_from_type_hints is None:
                 if saved_example is not None:
+                    _logger.info("Inferring model signature from input example")
                     try:
                         context = PythonModelContext(artifacts, model_config)
                         python_model.load_context(context)
@@ -3003,25 +3007,17 @@ def save_model(
                             _PythonModelPyfuncWrapper(python_model, None, None),
                         )
                     except Exception as e:
-                        if infer_signature_from_type_hints:
-                            _logger.warning(
-                                "Failed to infer model signature from type hints or input example. "
-                                f"Inferring model signature from input example failure: {e}",
-                            )
-                        else:
-                            _logger.warning(
-                                "Failed to infer model signature: "
-                                f"Type hint {type_hints} cannot be used to infer model signature."
-                                f"Inferring model signature from input example failure: {e}"
-                            )
+                        _logger.warning(
+                            f"Failed to infer model signature from input example, error: {e}",
+                        )
                 else:
-                    # if infer_signature_from_type_hints, warnings are emitted
+                    # if signature is inferred from type hints, warnings are emitted
                     # in _infer_signature_from_type_hints
-                    if not infer_signature_from_type_hints:
+                    if not should_infer_signature_from_type_hints:
                         _logger.warning(
                             "Failed to infer model signature: "
-                            f"Type hint {type_hints} cannot be used to infer model signature."
-                            "Input example is not provided, model signature cannot be inferred."
+                            f"Type hint {type_hints} cannot be used to infer model signature, "
+                            "input example is not provided, model signature cannot be inferred."
                         )
 
     if signature_from_type_hints:

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -297,7 +297,7 @@ def test_pyfunc_model_infer_signature_from_type_hints_errors(recwarn):
         with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
             mlflow.pyfunc.log_model("test_model", python_model=Model())
         assert (
-            "cannot be used to infer model signature, input example is not provided, "
+            "cannot be used to infer model signature and input example is not provided, "
             "model signature cannot be inferred."
         ) in mock_warning.call_args[0][0]
 
@@ -816,6 +816,6 @@ def test_warning_message_when_logging_model():
             mlflow.pyfunc.log_model("model", python_model=model)
         assert (
             "Failed to infer model signature: "
-            f"Type hint {model.predict_type_hints} cannot be used to infer model signature, "
+            f"Type hint {model.predict_type_hints} cannot be used to infer model signature and "
             "input example is not provided, model signature cannot be inferred."
         ) in mock_warning.call_args[0][0]

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -296,21 +296,17 @@ def test_pyfunc_model_infer_signature_from_type_hints_errors(recwarn):
     with mlflow.start_run():
         with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
             mlflow.pyfunc.log_model("test_model", python_model=Model())
-        assert "cannot be used to infer model signature." in mock_warning.call_args[0][0]
         assert (
-            "Input example is not provided, model signature cannot be inferred."
-            in mock_warning.call_args[0][0]
-        )
+            "cannot be used to infer model signature, input example is not provided, "
+            "model signature cannot be inferred."
+        ) in mock_warning.call_args[0][0]
 
     with mlflow.start_run():
         with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
             mlflow.pyfunc.log_model(
                 "test_model", python_model=Model(), input_example=pd.DataFrame()
             )
-        assert "cannot be used to infer model signature." in mock_warning.call_args[0][0]
-        assert (
-            "Inferring model signature from input example failure" in mock_warning.call_args[0][0]
-        )
+        assert "Failed to infer model signature from input example" in mock_warning.call_args[0][0]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -786,3 +786,40 @@ def test_model_with_wrong_predict_signature_works():
 
     assert predict(input_example) == expected_response
     assert predict(messages=input_example) == expected_response
+
+
+def test_warning_message_when_logging_model():
+    class TestModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            raise ValueError("test")
+
+    # no type hint + invalid input example
+    with mlflow.start_run():
+        with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
+            mlflow.pyfunc.log_model("model", python_model=TestModel(), input_example="abc")
+        assert "Failed to infer model signature from input example" in mock_warning.call_args[0][0]
+
+    # invalid type hint + invalid input example
+    class TestModel(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input: list[object], params=None) -> str:
+            raise ValueError("test")
+
+    with mlflow.start_run():
+        with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
+            mlflow.pyfunc.log_model("model", python_model=TestModel(), input_example="abc")
+        assert "Failed to infer model signature from input example" in mock_warning.call_args[0][0]
+
+    # type hint that cannot be used to infer model signature + no input example
+    class TestModel(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input: pd.DataFrame, params=None):
+            return model_input
+
+    model = TestModel()
+    with mlflow.start_run():
+        with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
+            mlflow.pyfunc.log_model("model", python_model=model)
+        assert (
+            "Failed to infer model signature: "
+            f"Type hint {model.predict_type_hints} cannot be used to infer model signature, "
+            "input example is not provided, model signature cannot be inferred."
+        ) in mock_warning.call_args[0][0]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14216?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14216/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14216
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Update the warning messages when inferring signature for PythonModel
1. add INFO logs when we try to infer signature from type hints or input example
2. show corresponding warnings instead of mixing them together

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
