### PR TITLE
Improve type hints error messages

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -28,7 +28,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_
 from mlflow.types.schema import AnyType, ColSpec, ParamSchema, Schema, convert_dataclass_to_schema
 from mlflow.types.type_hints import (
     InvalidTypeHintException,
-    _get_example_validation_result,
+    _get_data_validation_result,
     _infer_schema_from_list_type_hint,
     _infer_schema_from_type_hint,
     _is_list_type_hint,
@@ -440,8 +440,8 @@ def _infer_signature_from_type_hints(
         # only validate input example here if pyfunc decorator is not used
         # because when the decorator is used, the input is validated in the predict function
         if not _pyfunc_decorator_used and (
-            msg := _get_example_validation_result(
-                example=input_example, type_hint=type_hints.input
+            msg := _get_data_validation_result(
+                data=input_example, type_hint=type_hints.input
             ).error_message
         ):
             _logger.warning(
@@ -470,8 +470,8 @@ def _infer_signature_from_type_hints(
                 )
             else:
                 if is_output_type_hint_valid and (
-                    msg := _get_example_validation_result(
-                        example=output_example, type_hint=type_hints.output
+                    msg := _get_data_validation_result(
+                        data=output_example, type_hint=type_hints.output
                     ).error_message
                 ):
                     _logger.warning(

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 from functools import lru_cache, wraps
 from typing import Any, NamedTuple, Optional
 
@@ -13,9 +12,10 @@ from mlflow.types.type_hints import (
     _infer_schema_from_list_type_hint,
     _is_type_hint_from_example,
     _signature_cannot_be_inferred_from_type_hint,
-    _validate_example_against_type_hint,
+    _validate_data_against_type_hint,
 )
 from mlflow.utils.annotations import filter_user_warnings_once
+from mlflow.utils.warnings_utils import color_warning
 
 _INVALID_SIGNATURE_ERROR_MSG = (
     "Model's `{func_name}` method contains invalid parameters: {invalid_params}. "
@@ -110,12 +110,15 @@ def _get_func_info_if_type_hint_supported(func) -> Optional[FuncInfo]:
         try:
             _infer_schema_from_list_type_hint(type_hint)
         except Exception as e:
-            warnings.warn(
-                "Type hint used in the model's predict function is not supported "
-                f"for MLflow's schema validation. {e}. "
-                "To enable validation for the input data, specify the input example "
-                "or model signature when logging the model.",
+            color_warning(
+                message="Type hint used in the model's predict function is not supported "
+                f"for MLflow's schema validation. {e} "
+                "Remove the type hint to disable this warning. "
+                "To enable validation for the input data, specify input example "
+                "or model signature when logging the model. ",
+                category=UserWarning,
                 stacklevel=3,
+                color="red",
             )
         else:
             return FuncInfo(input_type_hint=type_hint, input_param_name=input_param_name)
@@ -143,7 +146,7 @@ def _validate_model_input(
         input_pos = model_input_index_in_sig
     if input_pos is not None:
         data = _convert_data_to_type_hint(model_input, type_hint)
-        data = _validate_example_against_type_hint(data, type_hint)
+        data = _validate_data_against_type_hint(data, type_hint)
         if input_pos == "kwargs":
             kwargs[model_input_param_name] = data
         else:

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from functools import lru_cache, wraps
 from typing import Any, NamedTuple, Optional
 

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -39,6 +39,13 @@ except ImportError:
 # special type hint that can be used to convert data to
 # the input example type after data validation
 TypeFromExample = TypeVar("TypeFromExample")
+OPTIONAL_INPUT_MSG = (
+    "Input cannot be optional type. Fix this by removing the "
+    "Optional wrapper from the type hint. To use optional fields, "
+    "use a Pydantic-based type hint definition. See "
+    "https://docs.pydantic.dev/latest/api/base_model/ for pydantic "
+    "BaseModel examples."
+)
 
 # numpy types are not supported
 TYPE_HINTS_TO_DATATYPE_MAPPING = {
@@ -96,9 +103,10 @@ class ColSpecType(NamedTuple):
 class InvalidTypeHintException(MlflowException):
     def __init__(self, *, message=None, type_hint=None, extra_msg=""):
         if message is None:
+            # TODO: add link to documentation for full list of supported type hints
             message = (
-                f"Unsupported type hint `{type_hint}`{extra_msg}. Supported type hints must be "
-                "list[...] where element types are: "
+                f"Unsupported type hint `{_type_hint_repr(type_hint)}`{extra_msg}. "
+                "Supported type hints must be list[...] where element types are: "
                 f"{list(TYPE_HINTS_TO_DATATYPE_MAPPING.keys())}, pydantic BaseModel subclasses, "
                 "lists and dictionaries of primitive types, or typing.Any."
             )
@@ -182,21 +190,24 @@ def _infer_colspec_type_from_type_hint(type_hint: type[Any]) -> ColSpecType:
             if len(args) == 2:
                 if args[0] != str:
                     raise MlflowException.invalid_parameter_value(
-                        f"Dictionary key type must be str, got {args[0]} in type hint {type_hint}"
+                        f"Dictionary key type must be str, got {args[0]} in type hint "
+                        f"{_type_hint_repr(type_hint)}"
                     )
                 return ColSpecType(
                     dtype=Map(_infer_colspec_type_from_type_hint(type_hint=args[1]).dtype),
                     required=True,
                 )
             raise MlflowException.invalid_parameter_value(
-                f"Dictionary type hint must contain two element types, got {type_hint}"
+                "Dictionary type hint must contain two element types, got "
+                f"{_type_hint_repr(type_hint)}"
             )
         if origin_type in UNION_TYPES:
             if NONE_TYPE in args:
                 # This case shouldn't happen, but added for completeness
                 if len(args) < 2:
                     raise MlflowException.invalid_parameter_value(
-                        f"Union type hint must contain at least one non-None type, got {type_hint}"
+                        f"Union type hint must contain at least one non-None type, "
+                        f"got {_type_hint_repr(type_hint)}"
                     )
                 # Optional type
                 elif len(args) == 2:
@@ -314,21 +325,26 @@ def _get_element_type_of_list_type_hint(type_hint: type[list[Any]]) -> Any:
     Get the element type of list[...] type hint
     """
     args = get_args(type_hint)
+    # Optional[list[...]]
+    if type(None) in args:
+        raise MlflowException.invalid_parameter_value(OPTIONAL_INPUT_MSG)
     # a valid list[...] type hint must only contain one argument
     if len(args) == 0:
         raise MlflowException.invalid_parameter_value(
-            f"List type hint must contain the element type, got {type_hint}"
+            f"Type hint `{_type_hint_repr(type_hint)}` doesn't contain element type, fix it "
+            "by adding an element type, e.g. `list[str]` instead of `list`."
         )
     if len(args) > 1:
         raise MlflowException.invalid_parameter_value(
-            f"List type hint must contain only one element type, got {type_hint}"
+            f"Type hint `{_type_hint_repr(type_hint)}` contains {len(args)} element types, "
+            "only one element type is allowed."
         )
     return args[0]
 
 
 def _is_list_type_hint(type_hint: type[Any]) -> bool:
     origin_type = _get_origin_type(type_hint)
-    return origin_type is list
+    return type_hint == list or origin_type is list
 
 
 def _infer_schema_from_list_type_hint(type_hint: type[list[Any]]) -> Schema:
@@ -342,7 +358,9 @@ def _infer_schema_from_list_type_hint(type_hint: type[list[Any]]) -> Schema:
     """
     if not _is_list_type_hint(type_hint):
         raise InvalidTypeHintException(
-            message=f"Type hint for model input must be `list[...]`, got {type_hint}",
+            message="Type hint for model input must be `list[...]`, because "
+            "MLflow pyfunc model's `predict` function is expected to work for "
+            "batch data. Fix this by wrapping your type hint with list[...].",
         )
     internal_type = _get_element_type_of_list_type_hint(type_hint)
     return _infer_schema_from_type_hint(internal_type)
@@ -352,73 +370,66 @@ def _infer_schema_from_type_hint(type_hint: type[Any]) -> Schema:
     col_spec_type = _infer_colspec_type_from_type_hint(type_hint)
     # Creating Schema with unnamed optional inputs is not supported
     if col_spec_type.required is False:
-        raise InvalidTypeHintException(
-            message=(
-                "To define Optional inputs, use a Pydantic-based type hint definition. See "
-                "https://docs.pydantic.dev/latest/api/base_model/ for pydantic BaseModel examples."
-            )
-        )
+        raise InvalidTypeHintException(message=OPTIONAL_INPUT_MSG)
     return Schema([ColSpec(type=col_spec_type.dtype, required=col_spec_type.required)])
 
 
-def _validate_example_against_type_hint(example: Any, type_hint: type[Any]) -> Any:
+def _validate_data_against_type_hint(data: Any, type_hint: type[Any]) -> Any:
     """
-    Validate the example against provided type hint.
+    Validate the data against provided type hint.
     The allowed conversions are:
-        dictionary example with Pydantic model type hint -> Pydantic model instance
+        dictionary data with Pydantic model type hint -> Pydantic model instance
 
     Args:
-        example: The example to validate
+        data: The data to validate
         type_hint: The type hint to validate against
     """
     if _is_pydantic_type_hint(type_hint):
-        # if example is a pydantic model instance, convert it to a dictionary for validation
-        if isinstance(example, pydantic.BaseModel):
-            example_dict = example.dict() if PYDANTIC_V1_OR_OLDER else example.model_dump()
-        elif isinstance(example, dict):
-            example_dict = example
+        # if data is a pydantic model instance, convert it to a dictionary for validation
+        if isinstance(data, pydantic.BaseModel):
+            data_dict = data.dict() if PYDANTIC_V1_OR_OLDER else data.model_dump()
+        elif isinstance(data, dict):
+            data_dict = data
         else:
             raise MlflowException.invalid_parameter_value(
                 "Expecting example to be a dictionary or pydantic model instance for "
-                f"Pydantic type hint, got {type(example)}"
+                f"Pydantic type hint, got {type(data)}"
             )
         try:
-            model_validate(type_hint, example_dict)
+            model_validate(type_hint, data_dict)
         except pydantic.ValidationError as e:
             raise MlflowException.invalid_parameter_value(
-                message=f"Input example is not valid for Pydantic model `{type_hint.__name__}`",
+                message=f"Data doesn't match type hint, error: {e}",
             ) from e
         else:
-            return type_hint(**example_dict) if isinstance(example, dict) else example
+            return type_hint(**data_dict) if isinstance(data, dict) else data
     elif type_hint == Any:
-        return example
+        return data
     elif type_hint in TYPE_HINTS_TO_DATATYPE_MAPPING:
         if _MLFLOW_IS_IN_SERVING_ENVIRONMENT.get():
-            example = _parse_data_for_datatype_hint(data=example, type_hint=type_hint)
-        if isinstance(example, type_hint):
-            return example
+            data = _parse_data_for_datatype_hint(data=data, type_hint=type_hint)
+        if isinstance(data, type_hint):
+            return data
         raise MlflowException.invalid_parameter_value(
-            f"Expected type {type_hint}, but got {type(example).__name__}"
+            f"Expected type {_type_hint_repr(type_hint)}, but got {type(data).__name__}"
         )
     elif origin_type := get_origin(type_hint):
         args = get_args(type_hint)
         if origin_type is list:
-            return _validate_list_elements(element_type=args[0], example=example)
+            return _validate_list_elements(element_type=args[0], data=data)
         elif origin_type is dict:
-            return _validate_dict_elements(element_type=args[1], example=example)
+            return _validate_dict_elements(element_type=args[1], data=data)
         elif origin_type in UNION_TYPES:
             # Optional type
             if NONE_TYPE in args:
-                if example is None:
-                    return example
+                if data is None:
+                    return data
                 if len(args) == 2:
                     effective_type = next((arg for arg in args if arg is not NONE_TYPE), None)
-                    return _validate_example_against_type_hint(
-                        example=example, type_hint=effective_type
-                    )
+                    return _validate_data_against_type_hint(data=data, type_hint=effective_type)
             # Union type with all valid types is matched as AnyType
             # no validation needed for AnyType
-            return example
+            return data
     _invalid_type_hint_error(type_hint)
 
 
@@ -448,50 +459,68 @@ class ValidationResult(NamedTuple):
     error_message: Optional[str] = None
 
 
-def _get_example_validation_result(example: Any, type_hint: type[Any]) -> ValidationResult:
+def _get_data_validation_result(data: Any, type_hint: type[Any]) -> ValidationResult:
     try:
-        value = _validate_example_against_type_hint(example=example, type_hint=type_hint)
+        value = _validate_data_against_type_hint(data=data, type_hint=type_hint)
         return ValidationResult(value=value)
     except MlflowException as e:
         return ValidationResult(error_message=e.message)
 
 
-def _validate_list_elements(element_type: type[Any], example: Any) -> list[Any]:
-    if not isinstance(example, list):
+def _type_hint_repr(type_hint: type[Any]) -> str:
+    return (
+        type_hint.__name__
+        if _is_pydantic_type_hint(type_hint) or type(type_hint) == type
+        else str(type_hint)
+    )
+
+
+def _validate_list_elements(element_type: type[Any], data: Any) -> list[Any]:
+    if not isinstance(data, list):
         raise MlflowException.invalid_parameter_value(
-            f"Expected list, but got {type(example).__name__}"
+            f"Expected list, but got {type(data).__name__}"
         )
-    invalid_elems = {}
+    invalid_elems = []
     result = []
-    for elem in example:
-        validation_result = _get_example_validation_result(example=elem, type_hint=element_type)
+    for elem in data:
+        validation_result = _get_data_validation_result(data=elem, type_hint=element_type)
         if validation_result.error_message:
-            invalid_elems[str(elem)] = validation_result.error_message
+            invalid_elems.append((str(elem), validation_result.error_message))
         else:
             result.append(validation_result.value)
     if invalid_elems:
-        raise MlflowException.invalid_parameter_value(f"Invalid elements in list: {invalid_elems}")
+        invalid_elems_msg = (
+            f"{invalid_elems[:5]} ... (truncated)" if len(invalid_elems) > 5 else invalid_elems
+        )
+        raise MlflowException.invalid_parameter_value(
+            f"Failed to validate data against type hint `list[{_type_hint_repr(element_type)}]`, "
+            f"invalid elements: {invalid_elems_msg}"
+        )
     return result
 
 
-def _validate_dict_elements(element_type: type[Any], example: Any) -> dict[str, Any]:
-    if not isinstance(example, dict):
+def _validate_dict_elements(element_type: type[Any], data: Any) -> dict[str, Any]:
+    if not isinstance(data, dict):
         raise MlflowException.invalid_parameter_value(
-            f"Expected dict, but got {type(example).__name__}"
+            f"Expected dict, but got {type(data).__name__}"
         )
     invalid_elems = {}
     result = {}
-    for key, value in example.items():
+    for key, value in data.items():
         if not isinstance(key, str):
             invalid_elems[str(key)] = f"Key must be a string, got {type(key).__name__}"
             continue
-        validation_result = _get_example_validation_result(example=value, type_hint=element_type)
+        validation_result = _get_data_validation_result(data=value, type_hint=element_type)
         if validation_result.error_message:
             invalid_elems[key] = validation_result.error_message
         else:
             result[key] = validation_result.value
     if invalid_elems:
-        raise MlflowException.invalid_parameter_value(f"Invalid elements in dict: {invalid_elems}")
+        raise MlflowException.invalid_parameter_value(
+            f"Failed to validate data against type hint "
+            f"`dict[str, {_type_hint_repr(element_type)}]`, "
+            f"invalid elements: {invalid_elems}"
+        )
     return result
 
 
@@ -536,7 +565,7 @@ def _convert_data_to_type_hint(data: Any, type_hint: type[Any]) -> Any:
         if origin_type is not list:
             raise MlflowException(
                 "Only `list[...]` or `Any` type hint supports pandas DataFrame input "
-                f"with a single column. But got {type_hint}."
+                f"with a single column. But got {_type_hint_repr(type_hint)}."
             )
         return data.iloc[:, 0].tolist()
 

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -40,6 +40,7 @@ except ImportError:
 # special type hint that can be used to convert data to
 # the input example type after data validation
 TypeFromExample = TypeVar("TypeFromExample")
+# TODO: add link to mlflow documentation to include examples
 OPTIONAL_INPUT_MSG = (
     "Input cannot be Optional type. Fix this by removing the "
     "Optional wrapper from the type hint. To use optional fields, "
@@ -367,8 +368,8 @@ def _infer_schema_from_list_type_hint(type_hint: type[list[Any]]) -> Schema:
     """
     if not _is_list_type_hint(type_hint):
         raise InvalidTypeHintException(
-            message="Type hints must be wrapped in list[...] to support "
-            "multiple-record batch inference. Specify your type hint as "
+            message="Type hints must be wrapped in list[...] because MLflow assumes the "
+            "predict method to take multiple input instances. Specify your type hint as "
             f"`list[{_type_hint_repr(type_hint)}]` for a valid signature."
         )
     internal_type = _get_element_type_of_list_type_hint(type_hint)

--- a/mlflow/utils/warnings_utils.py
+++ b/mlflow/utils/warnings_utils.py
@@ -1,30 +1,22 @@
 import warnings
 
 # ANSI escape code
+ANSI_BASE = "\033["
 COLORS = {
-    "black": 30,
-    "red": 31,
-    "green": 32,
-    "yellow": 33,
-    "blue": 34,
-    "purple": 35,
-    "cyan": 36,
-    "white": 37,
-    "light_black": 90,
-    "light_red": 91,
-    "light_green": 92,
-    "light_yellow": 93,
-    "light_blue": 94,
-    "light_purple": 95,
-    "light_cyan": 96,
-    "light_white": 97,
+    "default_bold": f"{ANSI_BASE}1m",
+    "red": f"{ANSI_BASE}31m",
+    "red_bold": f"{ANSI_BASE}1;31m",
+    "yellow": f"{ANSI_BASE}33m",
+    "yellow_bold": f"{ANSI_BASE}1;33m",
+    "blue": f"{ANSI_BASE}34m",
+    "blue_bold": f"{ANSI_BASE}1;34m",
 }
+RESET = "\033[0m"
 
 
-def color_warning(message: str, category: type[Warning], stacklevel: int, color: str):
-    RESET = "\033[0m"
+def color_warning(message: str, stacklevel: int, color: str, category: type[Warning] = UserWarning):
     if color in COLORS:
-        message = f"\033[{COLORS[color]}m{message}{RESET}"
+        message = f"{COLORS[color]}{message}{RESET}"
 
     warnings.warn(
         message=message,

--- a/mlflow/utils/warnings_utils.py
+++ b/mlflow/utils/warnings_utils.py
@@ -1,0 +1,33 @@
+import warnings
+
+# ANSI escape code
+COLORS = {
+    "black": 30,
+    "red": 31,
+    "green": 32,
+    "yellow": 33,
+    "blue": 34,
+    "purple": 35,
+    "cyan": 36,
+    "white": 37,
+    "light_black": 90,
+    "light_red": 91,
+    "light_green": 92,
+    "light_yellow": 93,
+    "light_blue": 94,
+    "light_purple": 95,
+    "light_cyan": 96,
+    "light_white": 97,
+}
+
+
+def color_warning(message: str, category: type[Warning], stacklevel: int, color: str):
+    RESET = "\033[0m"
+    if color in COLORS:
+        message = f"\033[{COLORS[color]}m{message}{RESET}"
+
+    warnings.warn(
+        message=message,
+        category=category,
+        stacklevel=stacklevel + 1,
+    )

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -179,10 +179,12 @@ def test_type_hints_needs_signature(type_hint):
 
 
 def test_infer_schema_from_type_hints_errors():
-    with pytest.raises(MlflowException, match=r"Type hint for model input must be `list\[...\]`"):
+    with pytest.raises(MlflowException, match=r"Type hints must be wrapped in list\[...\]"):
         _infer_schema_from_list_type_hint(str)
 
-    with pytest.raises(MlflowException, match=r"Type hint `list` doesn't contain element type"):
+    with pytest.raises(
+        MlflowException, match=r"Type hint `list` doesn't contain a collection element type"
+    ):
         _infer_schema_from_list_type_hint(list)
 
     class InvalidModel(pydantic.BaseModel):
@@ -202,8 +204,8 @@ def test_infer_schema_from_type_hints_errors():
         with pytest.raises(MlflowException, match=message):
             _infer_schema_from_list_type_hint(list[list[InvalidModel]])
 
-    message = r"Input cannot be optional type"
-    with pytest.raises(MlflowException, match=r"Input cannot be optional type"):
+    message = r"Input cannot be Optional type"
+    with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(Optional[list[str]])
 
     with pytest.raises(MlflowException, match=message):
@@ -212,7 +214,9 @@ def test_infer_schema_from_type_hints_errors():
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[Union[str, int, type(None)]])
 
-    with pytest.raises(MlflowException, match=r"only one element type is allowed."):
+    with pytest.raises(
+        MlflowException, match=r"Collections must have only a single type definition"
+    ):
         _infer_schema_from_list_type_hint(list[str, int])
 
     with pytest.raises(MlflowException, match=r"Dictionary key type must be str"):

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -20,7 +20,7 @@ from mlflow.types.type_hints import (
     _infer_schema_from_list_type_hint,
     _is_example_valid_for_type_from_example,
     _signature_cannot_be_inferred_from_type_hint,
-    _validate_example_against_type_hint,
+    _validate_data_against_type_hint,
 )
 from mlflow.types.utils import _infer_schema
 
@@ -179,11 +179,10 @@ def test_type_hints_needs_signature(type_hint):
 
 
 def test_infer_schema_from_type_hints_errors():
-    message = r"Type hint for model input must be `list\[...\]`"
-    with pytest.raises(MlflowException, match=message):
+    with pytest.raises(MlflowException, match=r"Type hint for model input must be `list\[...\]`"):
         _infer_schema_from_list_type_hint(str)
 
-    with pytest.raises(MlflowException, match=message):
+    with pytest.raises(MlflowException, match=r"Type hint `list` doesn't contain element type"):
         _infer_schema_from_list_type_hint(list)
 
     class InvalidModel(pydantic.BaseModel):
@@ -203,14 +202,17 @@ def test_infer_schema_from_type_hints_errors():
         with pytest.raises(MlflowException, match=message):
             _infer_schema_from_list_type_hint(list[list[InvalidModel]])
 
-    message = r"To define Optional inputs, use a Pydantic-based type hint definition"
+    message = r"Input cannot be optional type"
+    with pytest.raises(MlflowException, match=r"Input cannot be optional type"):
+        _infer_schema_from_list_type_hint(Optional[list[str]])
+
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[Optional[str]])
 
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[Union[str, int, type(None)]])
 
-    with pytest.raises(MlflowException, match=r"List type hint must contain only one element type"):
+    with pytest.raises(MlflowException, match=r"only one element type is allowed."):
         _infer_schema_from_list_type_hint(list[str, int])
 
     with pytest.raises(MlflowException, match=r"Dictionary key type must be str"):
@@ -321,18 +323,15 @@ def test_infer_schema_from_type_hints_errors():
 )
 def test_pydantic_model_validation(type_hint, example):
     if isinstance(example, dict):
-        assert _validate_example_against_type_hint(
-            example=example, type_hint=type_hint
-        ) == type_hint(**example)
+        assert _validate_data_against_type_hint(data=example, type_hint=type_hint) == type_hint(
+            **example
+        )
     elif isinstance(example, list):
-        assert _validate_example_against_type_hint(example=example, type_hint=type_hint) == [
+        assert _validate_data_against_type_hint(data=example, type_hint=type_hint) == [
             get_args(type_hint)[0](**item) for item in example
         ]
     else:
-        assert (
-            _validate_example_against_type_hint(example=example.dict(), type_hint=type_hint)
-            == example
-        )
+        assert _validate_data_against_type_hint(data=example.dict(), type_hint=type_hint) == example
 
 
 @pytest.mark.parametrize(
@@ -358,51 +357,48 @@ def test_pydantic_model_validation(type_hint, example):
     ],
 )
 def test_python_type_hints_validation(type_hint, example):
-    assert _validate_example_against_type_hint(example=example, type_hint=type_hint) == example
+    assert _validate_data_against_type_hint(data=example, type_hint=type_hint) == example
 
 
 def test_type_hints_validation_errors():
-    with pytest.raises(
-        MlflowException, match=r"Input example is not valid for Pydantic model `CustomModel`"
-    ):
-        _validate_example_against_type_hint({"long_field": 1, "str_field": "a"}, CustomModel)
+    with pytest.raises(MlflowException, match=r"Data doesn't match type hint"):
+        _validate_data_against_type_hint({"long_field": 1, "str_field": "a"}, CustomModel)
 
-    with pytest.raises(MlflowException, match=r"Expected type <class 'int'>, but got str"):
-        _validate_example_against_type_hint("a", int)
+    with pytest.raises(MlflowException, match=r"Expected type int, but got str"):
+        _validate_data_against_type_hint("a", int)
 
     with pytest.raises(MlflowException, match=r"Expected list, but got str"):
-        _validate_example_against_type_hint("a", list[str])
+        _validate_data_against_type_hint("a", list[str])
 
     with pytest.raises(
         MlflowException,
-        match=r'Invalid elements in list: {\'1\': "Expected type <class \'str\'>, but got int"}',
+        match=r"Failed to validate data against type hint `list\[str\]`",
     ):
-        _validate_example_against_type_hint(["a", 1], list[str])
+        _validate_data_against_type_hint(["a", 1], list[str])
 
     with pytest.raises(
         MlflowException,
         match=r"Expected dict, but got list",
     ):
-        _validate_example_against_type_hint(["a", 1], dict[str, int])
+        _validate_data_against_type_hint(["a", 1], dict[str, int])
 
     with pytest.raises(
         MlflowException,
-        match=r"Invalid elements in dict: {'1': 'Key must be a string, got int', "
-        r"'a': 'Expected list, but got int'}",
+        match=r"Failed to validate data against type hint `dict\[str, list\[str\]\]`",
     ):
-        _validate_example_against_type_hint({1: ["a", "b"], "a": 1}, dict[str, list[str]])
+        _validate_data_against_type_hint({1: ["a", "b"], "a": 1}, dict[str, list[str]])
 
     with pytest.raises(
         MlflowException,
-        match=r"Expected type <class 'int'>, but got str",
+        match=r"Expected type int, but got str",
     ):
-        _validate_example_against_type_hint("a", Optional[int])
+        _validate_data_against_type_hint("a", Optional[int])
 
     with pytest.raises(
         InvalidTypeHintException,
-        match=r"Unsupported type hint `<class 'list'>`, it must include a valid element type.",
+        match=r"Unsupported type hint `list`, it must include a valid element type.",
     ):
-        _validate_example_against_type_hint(["a"], list)
+        _validate_data_against_type_hint(["a"], list)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14218?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14218/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14218
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
1. Rename function _get_example_validation_result to _get_data_validation_result (and some similar ones)
2. Update error messages to include type hint and original error during validation
3. Make warning message for data validation `red`
4. some other nit fixes found during bug bash

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
