### PR TITLE
[DOC-FIX #14183] Improve documentation for 'artifact_uri' in 'download_artifacts'

### DIFF
--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -29,12 +29,24 @@ def download_artifacts(
 
     Args:
         artifact_uri: URI pointing to the artifacts. Supported formats include:
-        - ``"runs:/<run_id>/<artifact_path>"``, e.g., ``"runs:/500cf58bee2b40a4a82861cc31a617b1/my_model.pkl"``.
-        - ``"models:/<model_name>/<stage>"``, e.g., ``"models:/my_model/Production"``.
-        - ``"models:/<model_name>/<version>/path/to/model"``, e.g., ``"models:/my_model/2/path/to/model"``.
-        - ``"models:/<model_name>@<alias>/path/to/model"``, e.g., ``"models:/my_model@staging/path/to/model"``.
-        - Cloud storage URIs like ``"s3://<bucket>/<path>"`` or ``"gs://<bucket>/<path>"``.
-        - Tracking server artifact URIs such as ``"http://<host>/mlartifacts"`` or ``"mlflow-artifacts://<host>/mlartifacts"``.
+
+            * ``runs:/<run_id>/<artifact_path>``
+              Example: ``runs:/500cf58bee2b40a4a82861cc31a617b1/my_model.pkl``
+
+            * ``models:/<model_name>/<stage>``
+              Example: ``models:/my_model/Production``
+
+            * ``models:/<model_name>/<version>/path/to/model``
+              Example: ``models:/my_model/2/path/to/model``
+
+            * ``models:/<model_name>@<alias>/path/to/model``
+              Example: ``models:/my_model@staging/path/to/model``
+
+            * Cloud storage URIs: ``s3://<bucket>/<path>`` or ``gs://<bucket>/<path>``
+
+            * Tracking server artifact URIs: ``http://<host>/mlartifacts`` or
+              ``mlflow-artifacts://<host>/mlartifacts``
+
             Exactly one of ``artifact_uri`` or ``run_id`` must be specified.
         run_id: ID of the MLflow Run containing the artifacts. Exactly one of ``run_id`` or
             ``artifact_uri`` must be specified.

--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -28,9 +28,13 @@ def download_artifacts(
     """Download an artifact file or directory to a local directory.
 
     Args:
-        artifact_uri: URI pointing to the artifacts, such as
-            ``"runs:/500cf58bee2b40a4a82861cc31a617b1/my_model.pkl"``,
-            ``"models:/my_model/Production"``, or ``"s3://my_bucket/my/file.txt"``.
+        artifact_uri: URI pointing to the artifacts. Supported formats include:
+        - ``"runs:/<run_id>/<artifact_path>"``, e.g., ``"runs:/500cf58bee2b40a4a82861cc31a617b1/my_model.pkl"``.
+        - ``"models:/<model_name>/<stage>"``, e.g., ``"models:/my_model/Production"``.
+        - ``"models:/<model_name>/<version>/path/to/model"``, e.g., ``"models:/my_model/2/path/to/model"``.
+        - ``"models:/<model_name>@<alias>/path/to/model"``, e.g., ``"models:/my_model@staging/path/to/model"``.
+        - Cloud storage URIs like ``"s3://<bucket>/<path>"`` or ``"gs://<bucket>/<path>"``.
+        - Tracking server artifact URIs such as ``"http://<host>/mlartifacts"`` or ``"mlflow-artifacts://<host>/mlartifacts"``.
             Exactly one of ``artifact_uri`` or ``run_id`` must be specified.
         run_id: ID of the MLflow Run containing the artifacts. Exactly one of ``run_id`` or
             ``artifact_uri`` must be specified.
@@ -106,7 +110,9 @@ def list_artifacts(
 
     if artifact_uri is not None:
         root_uri, artifact_path = _get_root_uri_and_artifact_path(artifact_uri)
-        return get_artifact_repository(artifact_uri=root_uri).list_artifacts(artifact_path)
+        return get_artifact_repository(artifact_uri=root_uri).list_artifacts(
+            artifact_path
+        )
 
     store = _get_store(store_uri=tracking_uri)
     artifact_uri = store.get_run(run_id).info.artifact_uri
@@ -147,7 +153,9 @@ def load_text(artifact_uri: str) -> str:
             try:
                 return str(local_artifact_fd.read())
             except Exception:
-                raise MlflowException("Unable to form a str object from file content", BAD_REQUEST)
+                raise MlflowException(
+                    "Unable to form a str object from file content", BAD_REQUEST
+                )
 
 
 def load_dict(artifact_uri: str) -> dict:
@@ -181,7 +189,9 @@ def load_dict(artifact_uri: str) -> dict:
             try:
                 return json.load(local_artifact_fd)
             except json.JSONDecodeError:
-                raise MlflowException("Unable to form a JSON object from file content", BAD_REQUEST)
+                raise MlflowException(
+                    "Unable to form a JSON object from file content", BAD_REQUEST
+                )
 
 
 def load_image(artifact_uri: str):

--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -122,9 +122,7 @@ def list_artifacts(
 
     if artifact_uri is not None:
         root_uri, artifact_path = _get_root_uri_and_artifact_path(artifact_uri)
-        return get_artifact_repository(artifact_uri=root_uri).list_artifacts(
-            artifact_path
-        )
+        return get_artifact_repository(artifact_uri=root_uri).list_artifacts(artifact_path)
 
     store = _get_store(store_uri=tracking_uri)
     artifact_uri = store.get_run(run_id).info.artifact_uri
@@ -165,9 +163,7 @@ def load_text(artifact_uri: str) -> str:
             try:
                 return str(local_artifact_fd.read())
             except Exception:
-                raise MlflowException(
-                    "Unable to form a str object from file content", BAD_REQUEST
-                )
+                raise MlflowException("Unable to form a str object from file content", BAD_REQUEST)
 
 
 def load_dict(artifact_uri: str) -> dict:
@@ -201,9 +197,7 @@ def load_dict(artifact_uri: str) -> dict:
             try:
                 return json.load(local_artifact_fd)
             except json.JSONDecodeError:
-                raise MlflowException(
-                    "Unable to form a JSON object from file content", BAD_REQUEST
-                )
+                raise MlflowException("Unable to form a JSON object from file content", BAD_REQUEST)
 
 
 def load_image(artifact_uri: str):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/vinayakkgarg/mlflow/pull/14225?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14225/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14225
```

</p>
</details>



### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve  #14183 

### What changes are proposed in this pull request?

- Added detailed examples of supported `artifact_uri` formats, including:
  - Runs-based URIs (e.g., `runs:/<run_id>/<artifact_path>`)
  - Models-based URIs with stages, versions, and aliases
  - Cloud storage URIs (e.g., `s3://`, `gs://`)
  - Tracking server artifact URIs (e.g., `http://<host>/mlartifacts`)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
This update improves the artifact_uri documentation in mlflow.artifacts.download_artifacts, providing detailed examples and clarifying valid formats.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
