### PR TITLE
Raise exception if pydantic object is used in infer_signature

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -257,7 +257,9 @@ def infer_signature(
                 schemas[key] = (
                     convert_dataclass_to_schema(data) if is_dataclass(data) else _infer_schema(data)
                 )
-            except Exception:
+            except Exception as e:
+                if isinstance(e, MlflowException) and "Pydantic objects" in e.message:
+                    raise
                 extra_msg = (
                     ("Note that MLflow doesn't validate data types during inference for AnyType. ")
                     if key == "inputs"

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -33,7 +33,11 @@ from mlflow.types.type_hints import (
     _infer_schema_from_type_hint,
     _is_list_type_hint,
 )
-from mlflow.types.utils import _infer_param_schema, _infer_schema
+from mlflow.types.utils import (
+    InvalidDataForSignatureInferenceError,
+    _infer_param_schema,
+    _infer_schema,
+)
 from mlflow.utils.annotations import filter_user_warnings_once
 from mlflow.utils.uri import append_to_uri_path
 
@@ -258,7 +262,7 @@ def infer_signature(
                     convert_dataclass_to_schema(data) if is_dataclass(data) else _infer_schema(data)
                 )
             except Exception as e:
-                if isinstance(e, MlflowException) and "Pydantic objects" in e.message:
+                if isinstance(e, InvalidDataForSignatureInferenceError):
                     raise
                 extra_msg = (
                     ("Note that MLflow doesn't validate data types during inference for AnyType. ")

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -261,9 +261,9 @@ def infer_signature(
                 schemas[key] = (
                     convert_dataclass_to_schema(data) if is_dataclass(data) else _infer_schema(data)
                 )
-            except Exception as e:
-                if isinstance(e, InvalidDataForSignatureInferenceError):
-                    raise
+            except InvalidDataForSignatureInferenceError:
+                raise
+            except Exception:
                 extra_msg = (
                     ("Note that MLflow doesn't validate data types during inference for AnyType. ")
                     if key == "inputs"

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pydantic
 
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.types import DataType
 from mlflow.types.schema import (
     HAS_PYSPARK,
@@ -114,6 +115,11 @@ def _infer_colspec_type(data: Any) -> Union[DataType, Array, Object, AnyType]:
     return dtype
 
 
+class InvalidDataForSignatureInferenceError(MlflowException):
+    def __init__(self, message):
+        super().__init__(message=message, error_code=INVALID_PARAMETER_VALUE)
+
+
 def _infer_datatype(data: Any) -> Optional[Union[DataType, Array, Object, AnyType]]:
     """
     Infer the datatype of input data.
@@ -133,10 +139,10 @@ def _infer_datatype(data: Any) -> Optional[Union[DataType, Array, Object, AnyTyp
     """
     if isinstance(data, pydantic.BaseModel):
         # TODO: add link to documentation
-        raise MlflowException.invalid_parameter_value(
-            "Pydantic objects are not supported for model signature inference. "
-            "To use Pydantic objects, define your PythonModel's `predict` method "
-            "with a Pydantic type hint, and model signature will be automatically "
+        raise InvalidDataForSignatureInferenceError(
+            message="MLflow does not support inferring model signature from input example "
+            "with Pydantic objects. To use Pydantic objects, define your PythonModel's "
+            "`predict` method with a Pydantic type hint, and model signature will be automatically "
             "inferred when logging the model. e.g. "
             "`def predict(self, model_input: list[PydanticType])`"
         )

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+import pydantic
 
 from mlflow.exceptions import MlflowException
 from mlflow.types import DataType
@@ -130,6 +131,15 @@ def _infer_datatype(data: Any) -> Optional[Union[DataType, Array, Object, AnyTyp
         While empty lists are inferred as AnyType instead of None after the support of AnyType.
         e.g. [] -> AnyType, [[], []] -> Array(Any)
     """
+    if isinstance(data, pydantic.BaseModel):
+        # TODO: add link to documentation
+        raise MlflowException.invalid_parameter_value(
+            "Pydantic objects are not supported for model signature inference. "
+            "To use Pydantic objects, define your PythonModel's `predict` method "
+            "with a Pydantic type hint, and model signature will be automatically "
+            "inferred when logging the model. e.g. "
+            "`def predict(self, model_input: list[PydanticType])`"
+        )
 
     if _is_none_or_nan(data) or (isinstance(data, (list, dict)) and not data):
         return AnyType()

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+import pydantic
 import pyspark
 import pytest
 from sklearn.ensemble import RandomForestRegressor
@@ -374,3 +375,15 @@ def test_infer_signature_with_optional_and_child_dataclass():
     assert any(
         schema for schema in inferred_signature.inputs.to_dict() if schema["name"] == "messages"
     )
+
+
+def test_infer_signature_for_pydantic_objects_error():
+    class Message(pydantic.BaseModel):
+        content: str
+        role: str
+
+    m = Message(content="test", role="user")
+    with pytest.raises(
+        MlflowException, match=r"Pydantic objects are not supported for model signature inference."
+    ):
+        infer_signature([m])

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -23,6 +23,7 @@ from mlflow.types.schema import (
     TensorSpec,
     convert_dataclass_to_schema,
 )
+from mlflow.types.utils import InvalidDataForSignatureInferenceError
 
 
 def test_model_signature_with_colspec():
@@ -384,6 +385,8 @@ def test_infer_signature_for_pydantic_objects_error():
 
     m = Message(content="test", role="user")
     with pytest.raises(
-        MlflowException, match=r"Pydantic objects are not supported for model signature inference."
+        InvalidDataForSignatureInferenceError,
+        match=r"MLflow does not support inferring model signature from "
+        r"input example with Pydantic objects",
     ):
         infer_signature([m])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14228?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14228/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14228
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
When pydantic objects are used in `infer_signature`, instead of silent warning we should raise an exception and guide users how to use pydantic type hints correctly in PythonModel.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
