### PR TITLE
Warn if no type hints provided for PythonModel

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3034,10 +3034,10 @@ def save_model(
                 signature_from_type_hints = _infer_signature_from_type_hints(
                     func=python_model, type_hints=type_hints, input_example=input_example
                 )
-            _pyfunc_decorator_used = getattr(python_model, "_is_pyfunc", False)
+            pyfunc_decorator_used = getattr(python_model, "_is_pyfunc", False)
             # only show the warning here if @pyfunc is not applied on the function
             # since @pyfunc will trigger the warning instead
-            if type_hints.input is None and not _pyfunc_decorator_used:
+            if type_hints.input is None and not pyfunc_decorator_used:
                 # TODO: add link to documentation
                 color_warning(
                     "Add type hints to the `predict` method to enable "

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3041,7 +3041,7 @@ def save_model(
                 # TODO: add link to documentation
                 color_warning(
                     "Add type hints to the `predict` method to enable "
-                    "data validation and automatic signature inference. ",
+                    "data validation and automatic signature inference.",
                     stacklevel=1,
                     color="yellow",
                 )

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -130,6 +130,14 @@ def _get_func_info_if_type_hint_supported(func) -> Optional[FuncInfo]:
             )
         else:
             return FuncInfo(input_type_hint=type_hint, input_param_name=input_param_name)
+    else:
+        # TODO: add link to documentation
+        color_warning(
+            "Add type hints to the `predict` method to enable data validation "
+            "and automatic signature inference during model logging.",
+            stacklevel=1,
+            color="yellow",
+        )
 
 
 def _model_input_index_in_function_signature(func):

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -910,12 +910,22 @@ def test_invalid_type_hint_raise_exception():
 
 
 def test_python_model_without_type_hint_warning():
-    class PythonModelWithoutTypeHint(mlflow.pyfunc.PythonModel):
-        def predict(self, model_input, params=None):
+    msg = r"Add type hints to the `predict` method"
+    with pytest.warns(UserWarning, match=msg):
+
+        class PythonModelWithoutTypeHint(mlflow.pyfunc.PythonModel):
+            def predict(self, model_input, params=None):
+                return model_input
+
+    with pytest.warns(UserWarning, match=msg):
+
+        @pyfunc
+        def predict(model_input):
             return model_input
 
+    def predict(model_input):
+        return model_input
+
     with mlflow.start_run():
-        with pytest.warns(
-            UserWarning, match=r"Add type hints to the `predict` method of the PythonModel"
-        ):
-            mlflow.pyfunc.log_model("model", python_model=PythonModelWithoutTypeHint())
+        with pytest.warns(UserWarning, match=msg):
+            mlflow.pyfunc.log_model("model", python_model=predict, input_example="abc")

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -907,3 +907,15 @@ def test_invalid_type_hint_raise_exception():
         @pyfunc
         def predict(model_input: list[Message]):
             return model_input
+
+
+def test_python_model_without_type_hint_warning():
+    class PythonModelWithoutTypeHint(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input, params=None):
+            return model_input
+
+    with mlflow.start_run():
+        with pytest.warns(
+            UserWarning, match=r"Add type hints to the `predict` method of the PythonModel"
+        ):
+            mlflow.pyfunc.log_model("model", python_model=PythonModelWithoutTypeHint())


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14235?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14235/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14235
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We print a warning if no type hint is used in PythonModel to suggest users adding type hints.
This by default is triggered by @pyfunc decorator and it's automatically applied for PythonModel. While if @pyfunc not applied, we should print a warning during model logging for callables as well.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
