### PR TITLE
Support registering models from `MlflowClient()`

### DIFF
--- a/examples/mlflow-3/register_model.py
+++ b/examples/mlflow-3/register_model.py
@@ -32,6 +32,7 @@ client = mlflow.MlflowClient()
 client.create_registered_model("model_client")
 client.create_model_version("model_client", model_info.model_uri, model_id = model_info.model_id)
 m = client.get_model_version("model_client", 1)
+print(m)
 assert m.model_id == model_info.model_id
 assert m.params == [
     LoggedModelParameter(key="alpha", value="0.5"),

--- a/examples/mlflow-3/register_model.py
+++ b/examples/mlflow-3/register_model.py
@@ -3,7 +3,6 @@ import json
 from sklearn.linear_model import LinearRegression
 
 import mlflow
-from mlflow.entities.logged_model_parameter import LoggedModelParameter
 
 with mlflow.start_run():
     model = LinearRegression().fit([[1], [2]], [3, 4])
@@ -34,7 +33,7 @@ client.create_model_version("model_client", model_info.model_uri, model_id = mod
 m = client.get_model_version("model_client", 1)
 print(m)
 assert m.model_id == model_info.model_id
-assert m.params == [
-    LoggedModelParameter(key="alpha", value="0.5"),
-    LoggedModelParameter(key="l1_ratio", value="0.5"),
-]
+assert m.params == {
+    "alpha": 0.5,
+    "l1_ratio": 0.5,
+}

--- a/examples/mlflow-3/register_model.py
+++ b/examples/mlflow-3/register_model.py
@@ -3,15 +3,25 @@ import json
 from sklearn.linear_model import LinearRegression
 
 import mlflow
+from mlflow.entities.logged_model_parameter import LoggedModelParameter
 
 with mlflow.start_run():
     model = LinearRegression().fit([[1], [2]], [3, 4])
-    model_info = mlflow.sklearn.log_model(model, "model")
+    model_info = mlflow.sklearn.log_model(
+        model, 
+        "model", 
+        params={
+            "alpha": 0.5,
+            "l1_ratio": 0.5,
+        },
+    )
 
 mlflow.register_model(model_info.model_uri, name="model")
 m = mlflow.get_logged_model(model_info.model_id)
 assert len(json.loads(m.tags["mlflow.modelVersions"])) == 1
 print(m.tags)
+assert m.model_id == model_info.model_id
+assert m.params == [LoggedModelParameter(key="alpha", value="0.5"), LoggedModelParameter(key="l1_ratio", value="0.5")]
 
 mlflow.register_model(model_info.model_uri, name="hello")
 m = mlflow.get_logged_model(model_info.model_id)

--- a/examples/mlflow-3/register_model.py
+++ b/examples/mlflow-3/register_model.py
@@ -21,9 +21,19 @@ m = mlflow.get_logged_model(model_info.model_id)
 assert len(json.loads(m.tags["mlflow.modelVersions"])) == 1
 print(m.tags)
 assert m.model_id == model_info.model_id
-assert m.params == [LoggedModelParameter(key="alpha", value="0.5"), LoggedModelParameter(key="l1_ratio", value="0.5")]
 
 mlflow.register_model(model_info.model_uri, name="hello")
 m = mlflow.get_logged_model(model_info.model_id)
 assert len(json.loads(m.tags["mlflow.modelVersions"])) == 2
 print(m.tags)
+
+client = mlflow.MlflowClient()
+
+client.create_registered_model("model_client")
+client.create_model_version("model_client", model_info.model_uri, model_id = model_info.model_id)
+m = client.get_model_version("model_client", 1)
+assert m.model_id == model_info.model_id
+assert m.params == [
+    LoggedModelParameter(key="alpha", value="0.5"),
+    LoggedModelParameter(key="l1_ratio", value="0.5"),
+]

--- a/examples/mlflow-3/register_model.py
+++ b/examples/mlflow-3/register_model.py
@@ -34,6 +34,6 @@ m = client.get_model_version("model_client", 1)
 print(m)
 assert m.model_id == model_info.model_id
 assert m.params == {
-    "alpha": 0.5,
-    "l1_ratio": 0.5,
+    "alpha": '0.5',
+    "l1_ratio": '0.5',
 }

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -236,7 +236,15 @@ class ModelRegistryClient:
             # Fall back to calling create_model_version without
             # local_model_path since old model registry store implementations may not
             # support the local_model_path argument.
-            mv = self.store.create_model_version(name, source, run_id, tags, run_link, description, model_id=model_id)
+            mv = self.store.create_model_version(
+                name,
+                source,
+                run_id,
+                tags,
+                run_link,
+                description,
+                model_id=model_id
+            )
         if await_creation_for and await_creation_for > 0:
             self.store._await_model_version_creation(mv, await_creation_for)
         return mv

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -236,7 +236,7 @@ class ModelRegistryClient:
             # Fall back to calling create_model_version without
             # local_model_path since old model registry store implementations may not
             # support the local_model_path argument.
-            mv = self.store.create_model_version(name, source, run_id, tags, run_link, description)
+            mv = self.store.create_model_version(name, source, run_id, tags, run_link, description, model_id=model_id)
         if await_creation_for and await_creation_for > 0:
             self.store._await_model_version_creation(mv, await_creation_for)
         return mv

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -3728,6 +3728,7 @@ class MlflowClient:
         run_link: Optional[str] = None,
         description: Optional[str] = None,
         await_creation_for: int = DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+        model_id: Optional[str] = None,
     ) -> ModelVersion:
         """
         Create a new model version from given source.
@@ -3746,6 +3747,8 @@ class MlflowClient:
             await_creation_for: Number of seconds to wait for the model version to finish being
                 created and is in ``READY`` status. By default, the function
                 waits for five minutes. Specify 0 or None to skip waiting.
+            model_id: The ID of the model (from an Experiment) that is being promoted to a
+                      registered model version, if applicable.            
 
         Returns:
             Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
@@ -3805,6 +3808,7 @@ class MlflowClient:
             run_link=run_link,
             description=description,
             await_creation_for=await_creation_for,
+            model_id=model_id,
         )
 
     def copy_model_version(self, src_model_uri, dst_name) -> ModelVersion:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -3748,7 +3748,7 @@ class MlflowClient:
                 created and is in ``READY`` status. By default, the function
                 waits for five minutes. Specify 0 or None to skip waiting.
             model_id: The ID of the model (from an Experiment) that is being promoted to a
-                      registered model version, if applicable.            
+                      registered model version, if applicable.
 
         Returns:
             Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by

--- a/mlflow/utils/_unity_catalog_utils.py
+++ b/mlflow/utils/_unity_catalog_utils.py
@@ -75,7 +75,7 @@ def model_version_from_uc_proto(uc_proto: ProtoModelVersion) -> ModelVersion:
         tags=[ModelVersionTag(key=tag.key, value=tag.value) for tag in (uc_proto.tags or [])],
         model_id=uc_proto.model_id,
         params=[
-            ModelParam(key=param.key, value=param.value) for param in (uc_proto.model_params or [])
+            ModelParam(key=param.name, value=param.value) for param in (uc_proto.model_params or [])
         ],
     )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/14245?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14245/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14245
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Title.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Extend `examples/register_model.py` unit test.

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/46059f82-450a-4168-879b-09103b27fa93" />

<img width="1703" alt="image" src="https://github.com/user-attachments/assets/efd71032-25e6-4c40-b85d-af9c5a0d0978" />


Note that `create_model_version` does not return the correct values because of the backend issue with FinalizeModelVersion (being worked on separately). 



### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
