### PR TITLE
Fix Registering Model within log_model() for MLflow 3.0

### DIFF
--- a/examples/mlflow-3/register_model.py
+++ b/examples/mlflow-3/register_model.py
@@ -21,7 +21,11 @@ print(m.tags)
 # Register model in log_model() directly
 with mlflow.start_run():
     model_1 = LinearRegression().fit([[1], [2]], [3, 4])
-    model_info_1 = mlflow.sklearn.log_model(model_1, "model1", registered_model_name="model1")
+    model_info_1 = mlflow.sklearn.log_model(model_1, "model_1", registered_model_name="model_1")
+
 m = mlflow.get_logged_model(model_info_1.model_id)
 assert len(json.loads(m.tags["mlflow.modelVersions"])) == 1
 print(m.tags)
+
+client = mlflow.MlflowClient()
+m = client.get_model_version("model_1", 1)

--- a/examples/mlflow-3/register_model.py
+++ b/examples/mlflow-3/register_model.py
@@ -17,3 +17,11 @@ mlflow.register_model(model_info.model_uri, name="hello")
 m = mlflow.get_logged_model(model_info.model_id)
 assert len(json.loads(m.tags["mlflow.modelVersions"])) == 2
 print(m.tags)
+
+# Register model in log_model() directly
+with mlflow.start_run():
+    model_1 = LinearRegression().fit([[1], [2]], [3, 4])
+    model_info_1 = mlflow.sklearn.log_model(model_1, "model1", registered_model_name="model1")
+m = mlflow.get_logged_model(model_info_1.model_id)
+assert len(json.loads(m.tags["mlflow.modelVersions"])) == 1
+print(m.tags)

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1036,16 +1036,16 @@ class Model:
             #     _logger.warning(_LOG_MODEL_METADATA_WARNING_TEMPLATE, mlflow.get_artifact_uri())
             #     _logger.debug("", exc_info=True)
 
-        if registered_model_name is not None:
-            registered_model = mlflow.tracking._model_registry.fluent._register_model(
-                f"models:/{model.model_id}",
-                registered_model_name,
-                await_registration_for=await_registration_for,
-                local_model_path=local_path,
-            )
-        model_info = mlflow_model.get_model_info(model)
-        if registered_model is not None:
-            model_info.registered_model_version = registered_model.version
+            if registered_model_name is not None:
+                registered_model = mlflow.tracking._model_registry.fluent._register_model(
+                    f"models:/{model.model_id}",
+                    registered_model_name,
+                    await_registration_for=await_registration_for,
+                    local_model_path=local_path,
+                )
+            model_info = mlflow_model.get_model_info(model)
+            if registered_model is not None:
+                model_info.registered_model_version = registered_model.version
 
         return model_info
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/raymondzhou-db/mlflow/pull/14246?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14246/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14246
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix a bug related to registering a model within log_model() when `registered_model_name` param is passed. The code block to register the model got moved to outside of the scope of the `TempDir`, causing the call to fail with an error like
```
MlflowException: Could not find an "MLmodel" configuration file at "/local_disk0/user_tmp_data/spark-63dafbaf-3ff4-49fc-8ff4-2a/tmpo3bzj4od/model"
```

This update is also consistent with how the function looks on [master](https://github.com/mlflow/mlflow/blob/master/mlflow/models/model.py#L789-L919) (non-MLflow 3)

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

Extend `examples/register_model.py` unit test. Manually tested this change
<img width="1374" alt="image" src="https://github.com/user-attachments/assets/bad0405f-dfe2-4040-aead-099a695da21a" />
<img width="964" alt="image" src="https://github.com/user-attachments/assets/54b5b840-2395-4c93-94c6-1c06c58809e4" />
 

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
