### PR TITLE
Log file name in `model_code_path`

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -354,7 +354,7 @@ def save_model(
         code=code_dir_subpath,
         predict_stream_fn="predict_stream",
         streamable=streamable,
-        model_code_path=model_code_path,
+        model_code_path=os.path.basename(model_code_path),
         model_config=model_config,
         **model_data_kwargs,
     )

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -354,7 +354,7 @@ def save_model(
         code=code_dir_subpath,
         predict_stream_fn="predict_stream",
         streamable=streamable,
-        model_code_path=os.path.basename(model_code_path),
+        model_code_path=model_code_path and os.path.basename(model_code_path),
         model_config=model_config,
         **model_data_kwargs,
     )

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -265,7 +265,7 @@ def save_model(
         conda_env=_CONDA_ENV_FILE_NAME,
         python_env=_PYTHON_ENV_FILE_NAME,
         code=code_dir_subpath,
-        model_code_path=model_code_path,
+        model_code_path=os.path.basename(model_code_path),
         model_config=model_config,
     )
     mlflow_model.add_flavor(

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -265,7 +265,7 @@ def save_model(
         conda_env=_CONDA_ENV_FILE_NAME,
         python_env=_PYTHON_ENV_FILE_NAME,
         code=code_dir_subpath,
-        model_code_path=os.path.basename(model_code_path),
+        model_code_path=model_code_path and os.path.basename(model_code_path),
         model_config=model_config,
     )
     mlflow_model.add_flavor(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -673,7 +673,7 @@ def add_to_model(
     if model_config:
         params[MODEL_CONFIG] = model_config
     if model_code_path:
-        params[MODEL_CODE_PATH] = os.path.basename(model_code_path)
+        params[MODEL_CODE_PATH] = model_code_path
     return model.add_flavor(FLAVOR_NAME, **params)
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -673,7 +673,7 @@ def add_to_model(
     if model_config:
         params[MODEL_CONFIG] = model_config
     if model_code_path:
-        params[MODEL_CODE_PATH] = model_code_path
+        params[MODEL_CODE_PATH] = os.path.basename(model_code_path)
     return model.add_flavor(FLAVOR_NAME, **params)
 
 

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -579,7 +579,7 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
         python_env=_PYTHON_ENV_FILE_NAME,
         model_config=model_config,
         streamable=streamable,
-        model_code_path=model_code_path,
+        model_code_path=os.path.basename(model_code_path),
         **custom_model_config_kwargs,
     )
     if size := get_total_file_size(path):

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -579,7 +579,7 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
         python_env=_PYTHON_ENV_FILE_NAME,
         model_config=model_config,
         streamable=streamable,
-        model_code_path=os.path.basename(model_code_path),
+        model_code_path=model_code_path and os.path.basename(model_code_path),
         **custom_model_config_kwargs,
     )
     if size := get_total_file_size(path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14264?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14264/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14264
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for the following scenario where windows is used to log a model, and the model is loaded on Databrciks (linux):

1. Log a model on Windows machine to Databricks using a token. `MLmodel` would look like this:

```yml
artifact_path: model
flavors:
  ...
  python_function:
    env:
      conda: conda.yaml
      virtualenv: python_env.yaml
    loader_module: mlflow.langchain
    model_code_path: C:\foo\bar\model.py
...
```

2. Load the model on Databricks notebook.

The following line constructs the path to load the model from, but `os.path.basename` returns `C:\foo\bar\model.py` on Linux, not `model.py`, resulting in `No such file or directory`:

https://github.com/mlflow/mlflow/blob/1b7ecdb246ee4065019b43d3c21acd28cc7197e7/mlflow/langchain/__init__.py#L864-L867

This PR fixes this issue by logging the file name, not the file path. `MLmodel` should look like this:

```yml
artifact_path: model
flavors:
  ...
  python_function:
    env:
      conda: conda.yaml
      virtualenv: python_env.yaml
    loader_module: mlflow.langchain
    model_code_path: model.py  👈
...
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
