### PR TITLE
Spark_udf support for model with type hints

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -413,7 +413,6 @@ import uuid
 import warnings
 from contextlib import contextmanager
 from copy import deepcopy
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterator, Optional, Tuple, Union
 from urllib.parse import urlparse
@@ -1578,7 +1577,6 @@ def _convert_array_values(values, result_type):
     )
 
 
-@lru_cache
 def _get_spark_primitive_types():
     from pyspark.sql import types
 
@@ -1592,7 +1590,6 @@ def _get_spark_primitive_types():
     )
 
 
-@lru_cache
 def _get_spark_primitive_type_to_np_type():
     from pyspark.sql import types
 
@@ -1606,7 +1603,6 @@ def _get_spark_primitive_type_to_np_type():
     }
 
 
-@lru_cache
 def _get_spark_primitive_type_to_python_type():
     from pyspark.sql import types
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -420,6 +420,7 @@ from urllib.parse import urlparse
 
 import numpy as np
 import pandas
+import pydantic
 import yaml
 from packaging.version import Version
 
@@ -569,6 +570,7 @@ from mlflow.utils.model_utils import (
     _validate_pyfunc_model_config,
 )
 from mlflow.utils.nfs_on_spark import get_nfs_cache_root_dir
+from mlflow.utils.pydantic_utils import model_dump_compat
 from mlflow.utils.requirements_utils import (
     _parse_requirements,
     warn_dependency_requirement_mismatches,
@@ -1440,9 +1442,9 @@ _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP = 200
 
 
 def _convert_spec_type_to_spark_type(spec_type):
-    from pyspark.sql.types import ArrayType, StructField, StructType
+    from pyspark.sql.types import ArrayType, MapType, StringType, StructField, StructType
 
-    from mlflow.types.schema import Array, DataType, Object
+    from mlflow.types.schema import Array, DataType, Map, Object
 
     if isinstance(spec_type, DataType):
         return spec_type.to_spark()
@@ -1463,6 +1465,14 @@ def _convert_spec_type_to_spark_type(spec_type):
                 for property in spec_type.properties
             ]
         )
+
+    # Map only supports string as key
+    if isinstance(spec_type, Map):
+        return MapType(
+            keyType=StringType(), valueType=_convert_spec_type_to_spark_type(spec_type.value_type)
+        )
+
+    raise MlflowException(f"Failed to convert schema type `{spec_type}` to spark type.")
 
 
 def _cast_output_spec_to_spark_type(spec):
@@ -1596,63 +1606,37 @@ def _get_spark_primitive_type_to_np_type():
     }
 
 
-def _check_udf_return_struct_type(struct_type):
-    from pyspark.sql.types import ArrayType, StructType
+@lru_cache
+def _get_spark_primitive_type_to_python_type():
+    from pyspark.sql import types
 
-    primitive_types = _get_spark_primitive_types()
-
-    for field in struct_type.fields:
-        field_type = field.dataType
-        if isinstance(field_type, primitive_types):
-            continue
-
-        if isinstance(field_type, ArrayType) and _check_udf_return_array_type(
-            field_type, allow_struct=True
-        ):
-            continue
-
-        if isinstance(field_type, StructType) and _check_udf_return_struct_type(field_type):
-            continue
-
-        return False
-
-    return True
-
-
-def _check_udf_return_array_type(array_type, allow_struct):
-    from pyspark.sql.types import ArrayType, StructType
-
-    elem_type = array_type.elementType
-    primitive_types = _get_spark_primitive_types()
-
-    if isinstance(elem_type, primitive_types):
-        return True
-
-    if isinstance(elem_type, ArrayType):
-        return _check_udf_return_array_type(elem_type, allow_struct)
-
-    if isinstance(elem_type, StructType):
-        if allow_struct:
-            # Array of struct values.
-            return _check_udf_return_struct_type(elem_type)
-
-        return False
-
-    return False
+    return {
+        types.IntegerType: int,
+        types.LongType: int,
+        types.FloatType: float,
+        types.DoubleType: float,
+        types.BooleanType: bool,
+        types.StringType: str,
+    }
 
 
 def _check_udf_return_type(data_type):
-    from pyspark.sql.types import ArrayType, StructType
+    from pyspark.sql.types import ArrayType, MapType, StringType, StructType
 
     primitive_types = _get_spark_primitive_types()
     if isinstance(data_type, primitive_types):
         return True
 
     if isinstance(data_type, ArrayType):
-        return _check_udf_return_array_type(data_type, allow_struct=True)
+        return _check_udf_return_type(data_type.elementType)
 
     if isinstance(data_type, StructType):
-        return _check_udf_return_struct_type(data_type)
+        return all(_check_udf_return_type(field.dataType) for field in data_type.fields)
+
+    if isinstance(data_type, MapType):
+        return isinstance(data_type.keyType, StringType) and _check_udf_return_type(
+            data_type.valueType
+        )
 
     return False
 
@@ -1665,7 +1649,7 @@ def _convert_struct_values(
     Convert spark StructType values to spark dataframe column values.
     """
 
-    from pyspark.sql.types import ArrayType, StructType
+    from pyspark.sql.types import ArrayType, MapType, StructType
 
     if not isinstance(result_type, StructType):
         raise MlflowException.invalid_parameter_value(
@@ -1687,7 +1671,10 @@ def _convert_struct_values(
         if type(field_type) in spark_primitive_type_to_np_type:
             np_type = spark_primitive_type_to_np_type[type(field_type)]
             if is_pandas_df:
-                field_values = field_values.astype(np_type)
+                # it's possible that field_values contain only Nones
+                # in this case, we don't need to cast the type
+                if not all(_is_none_or_nan(field_value) for field_value in field_values):
+                    field_values = field_values.astype(np_type)
             else:
                 field_values = (
                     None
@@ -1711,6 +1698,22 @@ def _convert_struct_values(
                 )
             else:
                 field_values = _convert_struct_values(field_values, field_type)
+        elif isinstance(field_type, MapType):
+            if is_pandas_df:
+                field_values = pandas.Series(
+                    [
+                        {
+                            key: _convert_value_based_on_spark_type(value, field_type.valueType)
+                            for key, value in field_value.items()
+                        }
+                        for field_value in field_values
+                    ]
+                ).astype(object)
+            else:
+                field_values = {
+                    key: _convert_value_based_on_spark_type(value, field_type.valueType)
+                    for key, value in field_values.items()
+                }
         else:
             raise MlflowException.invalid_parameter_value(
                 f"Unsupported field type {field_type.simpleString()} in struct type.",
@@ -1720,6 +1723,32 @@ def _convert_struct_values(
     if is_pandas_df:
         return pandas.DataFrame(result_dict)
     return result_dict
+
+
+def _convert_value_based_on_spark_type(value, spark_type):
+    """
+    Convert value to python types based on the given spark type.
+    """
+
+    from pyspark.sql.types import ArrayType, MapType, StructType
+
+    spark_primitive_type_to_python_type = _get_spark_primitive_type_to_python_type()
+
+    if type(spark_type) in spark_primitive_type_to_python_type:
+        python_type = spark_primitive_type_to_python_type[type(spark_type)]
+        return None if _is_none_or_nan(value) else python_type(value)
+    if isinstance(spark_type, StructType):
+        return _convert_struct_values(value, spark_type)
+    if isinstance(spark_type, ArrayType):
+        return [_convert_value_based_on_spark_type(v, spark_type.elementType) for v in value]
+    if isinstance(spark_type, MapType):
+        return {
+            key: _convert_value_based_on_spark_type(value[key], spark_type.valueType)
+            for key in value
+        }
+    raise MlflowException.invalid_parameter_value(
+        f"Unsupported type {spark_type} for value {value}"
+    )
 
 
 # This location is used to prebuild python environment in Databricks runtime.
@@ -1933,6 +1962,18 @@ def build_model_env(model_uri, save_path):
             os.remove(tmp_archive_path)
 
 
+def _convert_data_to_spark_compat(data):
+    if isinstance(data, list):
+        return [_convert_data_to_spark_compat(d) for d in data]
+    if isinstance(data, dict):
+        return {k: _convert_data_to_spark_compat(v) for k, v in data.items()}
+    if isinstance(data, np.ndarray):
+        return data.tolist()
+    if isinstance(data, pydantic.BaseModel):
+        return model_dump_compat(data)
+    return data
+
+
 def spark_udf(
     spark,
     model_uri,
@@ -2103,6 +2144,7 @@ def spark_udf(
         FloatType,
         IntegerType,
         LongType,
+        MapType,
         StringType,
     )
     from pyspark.sql.types import StructType as SparkStructType
@@ -2318,24 +2360,25 @@ def spark_udf(
         if isinstance(result_type, str):
             result_type = _parse_spark_datatype(result_type)
 
-    if not _check_udf_return_type(result_type):
-        raise MlflowException.invalid_parameter_value(
-            f"""Invalid 'spark_udf' result type: {result_type}.
+        # if result type is inferred by MLflow, we don't need to check it
+        if not _check_udf_return_type(result_type):
+            raise MlflowException.invalid_parameter_value(
+                f"""Invalid 'spark_udf' result type: {result_type}.
 It must be one of the following types:
 Primitive types:
- - int
- - long
- - float
- - double
- - string
- - boolean
+- int
+- long
+- float
+- double
+- string
+- boolean
 Compound types:
- - ND array of primitives / structs.
- - struct<field: primitive | array<primitive> | array<array<primitive>>, ...>:
-   A struct with primitive, ND array<primitive/structs>,
-   e.g., struct<a:int, b:array<int>>.
+- ND array of primitives / structs.
+- struct<field: primitive | array<primitive> | array<array<primitive>>, ...>:
+A struct with primitive, ND array<primitive/structs>,
+e.g., struct<a:int, b:array<int>>.
 """
-        )
+            )
     params = _validate_params(params, model_metadata)
 
     def _predict_row_batch(predict_fn, args):
@@ -2371,6 +2414,7 @@ Compound types:
             )
 
         result = predict_fn(pdf, params)
+        result = _convert_data_to_spark_compat(result)
 
         if isinstance(result, dict):
             result = {k: list(v) for k, v in result.items()}
@@ -2380,7 +2424,13 @@ Compound types:
             return pandas.Series(result_values)
 
         if not isinstance(result, pandas.DataFrame):
-            result = pandas.DataFrame([result]) if np.isscalar(result) else pandas.DataFrame(result)
+            if isinstance(result_type, MapType):
+                # list of dicts should be converted into a single column
+                result = pandas.DataFrame([result])
+            else:
+                result = (
+                    pandas.DataFrame([result]) if np.isscalar(result) else pandas.DataFrame(result)
+                )
 
         if isinstance(result_type, SparkStructType):
             return _convert_struct_values(result, result_type)

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -735,8 +735,10 @@ class _PythonModelPyfuncWrapper:
                     len(self.signature.inputs) == 1
                     and next(iter(self.signature.inputs)).name is None
                 ):
-                    first_string_column = _get_first_string_column(model_input)
-                    return model_input[[first_string_column]].to_dict(orient="records")
+                    if first_string_column := _get_first_string_column(model_input):
+                        return model_input[[first_string_column]].to_dict(orient="records")
+                    if len(model_input.columns) == 1:
+                        return model_input.to_dict("list")[0]
                 return model_input.to_dict(orient="records")
             elif isinstance(hints.input, type) and (
                 issubclass(hints.input, ChatCompletionRequest)

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -606,7 +606,8 @@ def _convert_data_to_type_hint(data: Any, type_hint: type[Any]) -> Any:
                 result = data.to_dict(orient="records")
         else:
             if len(data.columns) != 1:
-                # TODO: remove the warning and raise Exception once the bug [ML-48554] is fixed
+                # TODO: remove the warning and raise Exception once the bug about evaluate
+                # DF containing multiple columns is fixed
                 _logger.warning(
                     "`predict` function with list[...] type hints of non-dictionary collection "
                     "type only supports pandas DataFrame with a single column. But got "

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -6,7 +6,6 @@ from typing import Any, NamedTuple, Optional, TypeVar, Union, get_args, get_orig
 
 import pydantic
 import pydantic.fields
-from packaging.version import Version
 
 from mlflow.environment_variables import _MLFLOW_IS_IN_SERVING_ENVIRONMENT
 from mlflow.exceptions import MlflowException
@@ -22,10 +21,10 @@ from mlflow.types.schema import (
     Property,
     Schema,
 )
+from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER, model_dump_compat
 from mlflow.utils.warnings_utils import color_warning
 
-PYDANTIC_V1_OR_OLDER = Version(pydantic.VERSION).major <= 1
-FIELD_TYPE = pydantic.fields.ModelField if PYDANTIC_V1_OR_OLDER else pydantic.fields.FieldInfo
+FIELD_TYPE = pydantic.fields.FieldInfo if IS_PYDANTIC_V2_OR_NEWER else pydantic.fields.ModelField
 _logger = logging.getLogger(__name__)
 NONE_TYPE = type(None)
 UNION_TYPES = (Union,)
@@ -66,6 +65,15 @@ SUPPORTED_TYPE_HINT_MSG = (
     f"{list(TYPE_HINTS_TO_DATATYPE_MAPPING.keys())}, pydantic BaseModel subclasses, "
     "lists and dictionaries of primitive types, or typing.Any."
 )
+
+
+def _try_import_numpy():
+    try:
+        import numpy
+
+        return numpy
+    except ImportError:
+        return
 
 
 @lru_cache(maxsize=1)
@@ -317,24 +325,24 @@ def _is_pydantic_type_hint(type_hint: type[Any]) -> bool:
 def model_fields(
     model: pydantic.BaseModel,
 ) -> dict[str, type[FIELD_TYPE]]:
-    if PYDANTIC_V1_OR_OLDER:
-        return model.__fields__
-    return model.model_fields
+    if IS_PYDANTIC_V2_OR_NEWER:
+        return model.model_fields
+    return model.__fields__
 
 
 def model_validate(model: pydantic.BaseModel, values: Any) -> None:
-    if PYDANTIC_V1_OR_OLDER:
-        model.validate(values)
-    else:
+    if IS_PYDANTIC_V2_OR_NEWER:
         # use strict mode to avoid any data conversion here
         # e.g. "123" will not be converted to 123 if the type is int
         model.model_validate(values, strict=True)
+    else:
+        model.validate(values)
 
 
 def field_required(field: type[FIELD_TYPE]) -> bool:
-    if PYDANTIC_V1_OR_OLDER:
-        return field.required
-    return field.is_required()
+    if IS_PYDANTIC_V2_OR_NEWER:
+        return field.is_required()
+    return field.required
 
 
 def _get_element_type_of_list_type_hint(type_hint: type[list[Any]]) -> Any:
@@ -409,7 +417,7 @@ def _validate_data_against_type_hint(data: Any, type_hint: type[Any]) -> Any:
     if _is_pydantic_type_hint(type_hint):
         # if data is a pydantic model instance, convert it to a dictionary for validation
         if isinstance(data, pydantic.BaseModel):
-            data_dict = data.dict() if PYDANTIC_V1_OR_OLDER else data.model_dump()
+            data_dict = model_dump_compat(data)
         elif isinstance(data, dict):
             data_dict = data
         else:
@@ -569,28 +577,63 @@ def _get_origin_type(type_hint: type[Any]) -> Any:
 def _convert_data_to_type_hint(data: Any, type_hint: type[Any]) -> Any:
     """
     Convert data to the expected format based on the type hint.
-    This function should only used in limited situations such as mlflow.evaluate.
+    This function is used in data validation of @pyfunc to support compatibility with
+    functions such as mlflow.evaluate and spark_udf since they accept pandas DF as input.
+    NB: the input pandas DataFrame must contain a single column with the same type as the type hint.
     Supported conversions:
         - pandas DataFrame with a single column + list[...] type hint -> list
+        - pandas DataFrame with multiple columns + list[dict[...]] type hint -> list[dict[...]]
     """
     import pandas as pd
 
+    result = data
     if isinstance(data, pd.DataFrame) and type_hint != pd.DataFrame:
         origin_type = _get_origin_type(type_hint)
-        if type_hint == Any or origin_type == Any:
-            return data
-        if len(data.columns) != 1:
-            # TODO: remove the warning and raise Exception once the bug [ML-48554] is fixed
-            _logger.warning(
-                "`predict` function with type hints only supports pandas DataFrame "
-                f"with a single column. But got {len(data.columns)} columns. "
-                "The data will be converted to a list of the first column."
-            )
         if origin_type is not list:
             raise MlflowException(
                 "Only `list[...]` or `Any` type hint supports pandas DataFrame input "
                 f"with a single column. But got {_type_hint_repr(type_hint)}."
             )
-        return data.iloc[:, 0].tolist()
+        element_type = _get_element_type_of_list_type_hint(type_hint)
+        if element_type is dict or _is_pydantic_type_hint(element_type):
+            result = data.to_dict(orient="records")
+        else:
+            if len(data.columns) == 1:
+                result = data.iloc[:, 0].tolist()
+            else:
+                # TODO: remove the warning and raise Exception once the bug [ML-48554] is fixed
+                _logger.warning(
+                    "`predict` function with list[...] type hints of non-dictionary collection "
+                    "type only supports pandas DataFrame with a single column. But got "
+                    f"{len(data.columns)} columns. The data will be converted to a list "
+                    "of the first column."
+                )
+        # only sanitize the data when it's converted from pandas DataFrame
+        # since spark_udf implicitly converts lists into numpy arrays
+        return _sanitize_data(result)
 
+    return data
+
+
+def _sanitize_data(data: Any) -> Any:
+    """
+    Sanitize the data by converting any numpy lists to Python lists.
+    This is needed because spark_udf (pandas_udf) implicitly converts lists into numpy arrays.
+
+    For example, below udf demonstrates the behavior:
+        df = spark.createDataFrame(pd.DataFrame({"input": [["a", "b"], ["c", "d"]]}))
+        @pandas_udf(ArrayType(StringType()))
+        def my_udf(input_series: pd.Series) -> pd.Series:
+            print(type(input_series.iloc[0]))
+        df.withColumn("output", my_udf("input")).show()
+    """
+    if np := _try_import_numpy():
+        if isinstance(data, np.ndarray):
+            data = data.tolist()
+        if isinstance(data, list):
+            data = [_sanitize_data(elem) for elem in data]
+        if isinstance(data, dict):
+            data = {key: _sanitize_data(value) for key, value in data.items()}
+        if isinstance(data, float) and np.isnan(data):
+            data = None
     return data

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -339,7 +339,6 @@ def test_spark_udf(spark, type_hint, result_type, input_example):
     else:
         schema = StructType([StructField("input", result_type)])
         df = spark.createDataFrame(pd.DataFrame({"input": input_example}), schema=schema)
-    df.show()
     df = df.withColumn("response", udf("input"))
     pdf = df.toPandas()
     assert [

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -9,6 +9,16 @@ import pandas as pd
 import pydantic
 import pytest
 from packaging.version import Version
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    ArrayType,
+    IntegerType,
+    MapType,
+    Row,
+    StringType,
+    StructField,
+    StructType,
+)
 
 import mlflow
 from mlflow.environment_variables import _MLFLOW_IS_IN_SERVING_ENVIRONMENT
@@ -19,10 +29,17 @@ from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 from mlflow.pyfunc.utils import pyfunc
 from mlflow.pyfunc.utils.environment import _simulate_serving_environment
 from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
-from mlflow.types.type_hints import PYDANTIC_V1_OR_OLDER, TypeFromExample
+from mlflow.types.type_hints import TypeFromExample
 from mlflow.utils.env_manager import VIRTUALENV
+from mlflow.utils.pydantic_utils import model_dump_compat
 
 from tests.helper_functions import pyfunc_serve_and_score_model
+
+
+@pytest.fixture(scope="module")
+def spark():
+    with SparkSession.builder.master("local[*]").getOrCreate() as s:
+        yield s
 
 
 class CustomExample(pydantic.BaseModel):
@@ -217,7 +234,7 @@ def test_pyfunc_model_infer_signature_from_type_hints(
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     result = pyfunc_model.predict(input_example)
     if isinstance(result[0], pydantic.BaseModel):
-        result = [r.dict() if PYDANTIC_V1_OR_OLDER else r.model_dump() for r in result]
+        result = [model_dump_compat(r) for r in result]
     assert result == input_example
 
     # test serving
@@ -229,6 +246,105 @@ def test_pyfunc_model_infer_signature_from_type_hints(
         extra_args=["--env-manager", "local"],
     )
     assert scoring_response.status_code == 200
+
+
+class CustomExample3(pydantic.BaseModel):
+    custom_field: dict[str, list[str]]
+    messages: list[Message]
+    optional_int: Optional[int] = None
+
+
+@pytest.mark.parametrize(
+    ("type_hint", "result_type", "input_example"),
+    [
+        # scalars
+        # bytes and datetime are not supported in spark_udf
+        (list[int], None, [1, 2, 3]),
+        (list[str], None, ["a", "b", "c"]),
+        (list[bool], None, [True, False, True]),
+        (list[float], None, [1.23, 2.34, 3.45]),
+        # lists
+        (list[list[str]], ArrayType(StringType()), [["a", "b"], ["c", "d"]]),
+        # dictionaries
+        (
+            list[dict[str, str]],
+            MapType(StringType(), StringType()),
+            [{"a": "b"}, {"c": "d"}],
+        ),
+        (
+            list[dict[str, list[str]]],
+            MapType(StringType(), ArrayType(StringType())),
+            [{"a": ["b"]}, {"c": ["d"]}],
+        ),
+        # Union type is not supported because fields in the same column of spark DataFrame
+        # must be of same type
+        # Any type is not supported yet
+        # (list[Any], Schema([ColSpec(type=AnyType())]), ["a", "b", "c"]),
+        # Pydantic Models
+        (
+            list[CustomExample3],
+            StructType(
+                [
+                    StructField("custom_field", MapType(StringType(), ArrayType(StringType()))),
+                    StructField(
+                        "messages",
+                        ArrayType(
+                            StructType(
+                                [
+                                    StructField("role", StringType(), False),
+                                    StructField("content", StringType(), False),
+                                ]
+                            )
+                        ),
+                    ),
+                    StructField("optional_int", IntegerType()),
+                ]
+            ),
+            [
+                {
+                    "custom_field": {"a": ["a", "b", "c"]},
+                    "messages": [
+                        {"role": "admin", "content": "hello"},
+                        {"role": "user", "content": "hi"},
+                    ],
+                    "optional_int": 123,
+                },
+                {
+                    "custom_field": {"a": ["a", "b", "c"]},
+                    "messages": [
+                        {"role": "admin", "content": "hello"},
+                    ],
+                    "optional_int": None,
+                },
+            ],
+        ),
+    ],
+)
+def test_spark_udf(spark, type_hint, result_type, input_example):
+    class Model(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input: type_hint) -> type_hint:
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "model", python_model=Model(), input_example=input_example
+        )
+
+    # test spark_udf
+    udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, result_type=result_type)
+    # the spark dataframe must put the input data in a single column
+    if result_type is None:
+        # rely on spark to auto-infer schema
+        df = spark.createDataFrame(pd.DataFrame({"input": input_example}))
+    else:
+        schema = StructType([StructField("input", result_type)])
+        df = spark.createDataFrame(pd.DataFrame({"input": input_example}), schema=schema)
+    df.show()
+    df = df.withColumn("response", udf("input"))
+    pdf = df.toPandas()
+    assert [
+        x.asDict(recursive=True) if isinstance(x, Row) else x for x in pdf["response"].tolist()
+    ] == input_example
 
 
 def test_pyfunc_model_with_no_op_type_hint_pass_signature_works():

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -13,7 +13,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.models.utils import _enforce_schema
 from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
 from mlflow.types.type_hints import (
-    PYDANTIC_V1_OR_OLDER,
     InvalidTypeHintException,
     UnsupportedTypeHintException,
     _convert_data_to_type_hint,
@@ -24,6 +23,7 @@ from mlflow.types.type_hints import (
     _validate_data_against_type_hint,
 )
 from mlflow.types.utils import _infer_schema
+from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER
 
 
 class CustomModel(pydantic.BaseModel):
@@ -191,7 +191,7 @@ def test_infer_schema_from_type_hints_errors():
     class InvalidModel(pydantic.BaseModel):
         bool_field: Optional[bool]
 
-    if not PYDANTIC_V1_OR_OLDER:
+    if IS_PYDANTIC_V2_OR_NEWER:
         message = (
             r"Optional field `bool_field` in Pydantic model `InvalidModel` "
             r"doesn't have a default value. Please set default value to None for this field."

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -435,13 +435,10 @@ def test_type_hint_for_python_3_10():
         ({"a": 1, "b": 2}, dict[str, int], {"a": 1, "b": 2}),
         (1, Optional[int], 1),
         (None, Optional[int], None),
-        (pd.DataFrame([["a", "b"]]), Any, pd.DataFrame([["a", "b"]])),
         (pd.DataFrame({"a": ["a", "b"]}), list[str], ["a", "b"]),
         (pd.DataFrame({"a": [{"x": "x"}]}), list[dict[str, str]], [{"x": "x"}]),
         # This is a temp workaround for evaluate
         (pd.DataFrame({"a": ["x", "y"], "b": ["c", "d"]}), list[str], ["x", "y"]),
-        (["x", "y"], Any, ["x", "y"]),
-        ([1, "a", None], Optional[Any], [1, "a", None]),
     ],
 )
 def test_maybe_convert_data_for_type_hint(data, type_hint, expected_data):
@@ -462,7 +459,7 @@ def test_maybe_convert_data_for_type_hint_errors():
 
     with pytest.raises(
         MlflowException,
-        match=r"Only `list\[...\]` or `Any` type hint supports pandas DataFrame input",
+        match=r"Only `list\[...\]` type hint supports pandas DataFrame input",
     ):
         _convert_data_to_type_hint(pd.DataFrame([["a", "b"]]), str)
 

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -459,7 +459,7 @@ def test_maybe_convert_data_for_type_hint_errors():
 
     with pytest.raises(
         MlflowException,
-        match=r"Only `list\[...\]` type hint supports pandas DataFrame input",
+        match=r"Only `list\[\.\.\.\]` type hint supports pandas DataFrame input",
     ):
         _convert_data_to_type_hint(pd.DataFrame([["a", "b"]]), str)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14265?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14265/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14265
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As title: make PythonModel with type hints work in spark_udf
Critical changes:
1. Allow MapType in spark_udf
2. pandas_udf might implicitly convert lists into numpy arrays, so we need to convert it back before validating data against type hint
3. Refactor a bit by reusing pydantic_utils

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
