### PR TITLE
Fix mistral dev cross verion test

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -856,8 +856,9 @@ mistral:
     install_dev: |
       TMP_DIR=$(mktemp -d)
       git clone --depth 1 https://github.com/mistralai/client-python $TMP_DIR
+      cd $TMP_DIR
       python scripts/prepare-readme.py
-      pip install $TMP_DIR
+      pip install .
       rm -rf $TMP_DIR
   autologging:
     minimum: "1.0.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -860,6 +860,7 @@ mistral:
       # https://github.com/mistralai/client-python/blob/55cd72a8f6300a2ab3838370f7a1cc47d863b31a/pyproject.toml#L6
       touch $TMP_DIR/README-PYPI.md
       pip $TMP_DIR
+      rm -rf $TMP_DIR
   autologging:
     minimum: "1.0.0"
     maximum: "1.2.6"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -859,7 +859,7 @@ mistral:
       # Create a dummy README-PYPI.md file to make `pip install` work
       # https://github.com/mistralai/client-python/blob/55cd72a8f6300a2ab3838370f7a1cc47d863b31a/pyproject.toml#L6
       touch $TMP_DIR/README-PYPI.md
-      pip $TMP_DIR
+      pip install $TMP_DIR
       rm -rf $TMP_DIR
   autologging:
     minimum: "1.0.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -854,7 +854,12 @@ mistral:
     pip_release: "mistralai"
     module_name: "mistralai"
     install_dev: |
-      pip install git+https://github.com/mistralai/client-python
+      TMP_DIR=$(mktemp -d)
+      git clone --depth 1 https://github.com/mistralai/client-python $TMP_DIR
+      # Create a dummy README-PYPI.md file to make `pip install` work
+      # https://github.com/mistralai/client-python/blob/55cd72a8f6300a2ab3838370f7a1cc47d863b31a/pyproject.toml#L6
+      touch $TMP_DIR/README-PYPI.md
+      pip $TMP_DIR
   autologging:
     minimum: "1.0.0"
     maximum: "1.2.6"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -856,9 +856,7 @@ mistral:
     install_dev: |
       TMP_DIR=$(mktemp -d)
       git clone --depth 1 https://github.com/mistralai/client-python $TMP_DIR
-      # Create a dummy README-PYPI.md file to make `pip install` work
-      # https://github.com/mistralai/client-python/blob/55cd72a8f6300a2ab3838370f7a1cc47d863b31a/pyproject.toml#L6
-      touch $TMP_DIR/README-PYPI.md
+      python scripts/prepare-readme.py
       pip install $TMP_DIR
       rm -rf $TMP_DIR
   autologging:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14270?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14270/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14270
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://github.com/mlflow-automation/mlflow/actions/runs/12853921016/job/35841263664:

```
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [29 lines of output]
      Traceback (most recent call last):
        File "/tmp/pip-build-env-epvr9mww/overlay/lib/python3.9/site-packages/poetry/core/masonry/metadata.py", line 63, in from_package
          descriptions.append(readme.read_text(encoding="utf-8"))
        File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/pathlib.py", line 1266, in read_text
          with self.open(mode='r', encoding=encoding, errors=errors) as f:
        File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/pathlib.py", line 1252, in open
          return io.open(self, mode, buffering, encoding, errors, newline,
        File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/pathlib.py", line 1120, in _opener
          return self._accessor.open(self, flags, mode)
      FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-req-build-3jw9rj29/README-PYPI.md'
      
      The above exception was the direct cause of the following exception:
```

Their repo has `README.md`, but not `README-PYPI.md`. This file is automatically generated from `README.md` as a pre-release step. We need to create this file to make pip install work.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
