### PR TITLE
Add model_version to gemini tests

### DIFF
--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -40,6 +40,7 @@ def _generate_content_response(content):
     return {
         "candidates": [_get_candidate(content)],
         "usage_metadata": _USER_METADATA,
+        "model_version": "gemini-1.5-flash-002",
     }
 
 

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -37,11 +37,15 @@ def _get_candidate(content):
 
 
 def _generate_content_response(content):
-    return {
+    res = {
         "candidates": [_get_candidate(content)],
         "usage_metadata": _USER_METADATA,
-        "model_version": "gemini-1.5-flash-002",
     }
+
+    if hasattr(genai.types.GenerateContentResponse, "model_version"):
+        res["model_version"] = "gemini-1.5-flash-002"
+
+    return res
 
 
 _GENERATE_CONTENT_RESPONSE = _generate_content_response(_CONTENT)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14272?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14272/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14272
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://github.com/mlflow-automation/mlflow/actions/runs/12853921016/job/35841241089:

```
    def test_generate_content_enable_disable_autolog():
        with patch("google.generativeai.GenerativeModel.generate_content", new=generate_content):
            mlflow.gemini.autolog()
            model = genai.GenerativeModel("gemini-1.5-flash")
            model.generate_content("test content")
    
            traces = get_traces()
            assert len(traces) == 1
            assert traces[0].info.status == "OK"
            assert len(traces[0].data.spans) == 1
            span = traces[0].data.spans[0]
            assert span.name == "GenerativeModel.generate_content"
            assert span.span_type == SpanType.LLM
            assert span.inputs == {"contents": "test content", "model_name": "models/gemini-1.5-flash"}
>           assert span.outputs == _GENERATE_CONTENT_RESPONSE
E           AssertionError: assert {'candidates'...en_count': 6}} == {'candidates'...en_count': 6}}
E             
E             Omitting 2 identical items, use -vv to show
E             Left contains 1 more item:
E             {'model_version': ''}
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
