### PR TITLE
Fix OpenAI autolog

### DIFF
--- a/mlflow/openai/_openai_autolog.py
+++ b/mlflow/openai/_openai_autolog.py
@@ -17,6 +17,7 @@ from mlflow.ml_package_versions import _ML_PACKAGE_VERSIONS
 from mlflow.openai.utils.chat_schema import set_span_chat_attributes
 from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracing.trace_manager import InMemoryTraceManager
+from mlflow.tracing.utils import TraceJSONEncoder, start_client_span_or_trace
 from mlflow.tracking.context import registry as context_registry
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.autologging_utils import disable_autologging, get_autologging_config
@@ -70,14 +71,6 @@ def _set_api_key_env_var(client):
         os.environ["OPENAI_API_KEY"] = original
     else:
         os.environ.pop("OPENAI_API_KEY")
-
-
-class _OpenAIJsonEncoder(json.JSONEncoder):
-    def default(self, o):
-        try:
-            return super().default(o)
-        except TypeError:
-            return str(o)
 
 
 def _get_span_type(task) -> str:
@@ -152,22 +145,13 @@ def patched_call(original, self, *args, **kwargs):
         attributes = {k: v for k, v in kwargs.items() if k != "messages"}
 
         # If there is an active span, create a child span under it, otherwise create a new trace
-        if active_span := mlflow.get_current_active_span():
-            span = mlflow_client.start_span(
-                name=self.__class__.__name__,
-                request_id=active_span.request_id,
-                parent_id=active_span.span_id,
-                span_type=_get_span_type(self.__class__),
-                inputs=kwargs,
-                attributes=attributes,
-            )
-        else:
-            span = mlflow_client.start_trace(
-                name=self.__class__.__name__,
-                span_type=_get_span_type(self.__class__),
-                inputs=kwargs,
-                attributes=attributes,
-            )
+        span = start_client_span_or_trace(
+            mlflow_client,
+            name=self.__class__.__name__,
+            span_type=_get_span_type(self.__class__),
+            inputs=kwargs,
+            attributes=attributes,
+        )
 
         request_id = span.request_id
         # Associate run ID to the trace manually, because if a new run is created by
@@ -185,7 +169,7 @@ def patched_call(original, self, *args, **kwargs):
         if config.log_traces and request_id:
             try:
                 span.add_event(SpanEvent.from_exception(e))
-                mlflow_client.end_trace(request_id=request_id, status=SpanStatusCode.ERROR)
+                mlflow_client.end_span(request_id, span.span_id, status=SpanStatusCode.ERROR)
             except Exception as inner_e:
                 _logger.warning(f"Encountered unexpected error when ending trace: {inner_e}")
         raise e
@@ -196,29 +180,34 @@ def patched_call(original, self, *args, **kwargs):
         # If the output is a stream, we add a hook to store the intermediate chunks
         # and then log the outputs as a single artifact when the stream ends
         def _stream_output_logging_hook(stream: Iterator) -> Iterator:
-            chunks = []
             output = []
-            for chunk in stream:
+            for i, chunk in enumerate(stream):
                 # `chunk.choices` can be empty: https://github.com/mlflow/mlflow/issues/13361
                 if isinstance(chunk, Completion) and chunk.choices:
                     output.append(chunk.choices[0].text or "")
                 elif isinstance(chunk, ChatCompletionChunk) and chunk.choices:
                     output.append(chunk.choices[0].delta.content or "")
-                chunks.append(chunk)
+
+                # Record the raw chunks as events
+                span.add_event(
+                    SpanEvent(
+                        name=f"chunk_{i}",
+                        # NB: OTel event attribute only accepts dictionary with primitive types
+                        # (or list or them), not nested dict.
+                        # TODO: Define a consistent format for stream chunk across all providers
+                        attributes={
+                            chunk.__class__.__name__: json.dumps(chunk, cls=TraceJSONEncoder)
+                        },
+                    )
+                )
+
                 yield chunk
 
             try:
-                chunk_dicts = [chunk.to_dict() for chunk in chunks]
                 if config.log_traces and request_id:
                     outputs = "".join(output)
-
                     set_span_chat_attributes(span, kwargs, outputs)
-
-                    mlflow_client.end_trace(
-                        request_id=request_id,
-                        attributes={"events": chunk_dicts},
-                        outputs=outputs,
-                    )
+                    mlflow_client.end_span(request_id, span.span_id, outputs=outputs)
             except Exception as e:
                 _logger.warning(f"Encountered unexpected error during openai autologging: {e}")
 
@@ -227,12 +216,7 @@ def patched_call(original, self, *args, **kwargs):
         if config.log_traces and request_id:
             try:
                 set_span_chat_attributes(span, kwargs, result)
-                if span.parent_id is None:
-                    mlflow_client.end_trace(request_id=request_id, outputs=result)
-                else:
-                    mlflow_client.end_span(
-                        request_id=request_id, span_id=span.span_id, outputs=result
-                    )
+                mlflow_client.end_span(request_id, span.span_id, outputs=result)
             except Exception as e:
                 _logger.warning(f"Encountered unexpected error when ending trace: {e}")
 

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -381,7 +381,7 @@ def start_client_span_or_trace(
         return client.start_span(
             name=name,
             request_id=parent_span.request_id,
-            span_id=parent_span.span_id,
+            parent_id=parent_span.span_id,
             span_type=span_type,
             inputs=inputs,
             attributes=attributes,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14276?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14276/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14276
```

</p>
</details>

### What changes are proposed in this pull request?

1. Replace incorrect `end_trace` call to `end_span` when an exception happens. Calling `end_trace` will end the entire trace including parent spans, but we only want to end the OAI span here.
2. Store chunks to events instead of span attributes. This is the standard way to store stream events in a span in MLflow. We should add a document to describe those rules.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
