### PR TITLE
Fix filename encoding issue in log_image

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -562,15 +562,28 @@ def _send_artifact(artifact_repository, path):
     # Always send artifacts as attachments to prevent the browser from displaying them on our web
     # server's domain, which might enable XSS.
     mime_type = _guess_mime_type(file_path)
-    # We need to explicitly encode a filename in case the filename includes invalid characters
-    filename = os.path.basename(file_path)
+    # Need to escape control characters from the filename
+    filename = _escape_control_characters(os.path.basename(file_path))
     file_sender_response = send_file(
         file_path,
         mimetype=mime_type,
         as_attachment=True,
-        download_name=urllib.parse.quote(filename),
+        download_name=filename,
     )
     return _response_with_file_attachment_headers(file_path, file_sender_response)
+
+
+def _escape_control_characters(text: str) -> str:
+    # Method to escape control characters (e.g. \u0017)
+    def escape_char(c):
+        code_point = ord(c)
+
+        # If it's a control character (ASCII 0-31 or 127), escape it
+        if (0 <= code_point <= 31) or (code_point == 127):
+            return f"%{code_point:02x}"
+        return c
+
+    return "".join(escape_char(c) for c in text)
 
 
 def catch_mlflow_exception(func):

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -562,28 +562,8 @@ def _send_artifact(artifact_repository, path):
     # Always send artifacts as attachments to prevent the browser from displaying them on our web
     # server's domain, which might enable XSS.
     mime_type = _guess_mime_type(file_path)
-    # Need to escape control characters from the filename
-    filename = _escape_control_characters(os.path.basename(file_path))
-    file_sender_response = send_file(
-        file_path,
-        mimetype=mime_type,
-        as_attachment=True,
-        download_name=filename,
-    )
+    file_sender_response = send_file(file_path, mimetype=mime_type, as_attachment=True)
     return _response_with_file_attachment_headers(file_path, file_sender_response)
-
-
-def _escape_control_characters(text: str) -> str:
-    # Method to escape control characters (e.g. \u0017)
-    def escape_char(c):
-        code_point = ord(c)
-
-        # If it's a control character (ASCII 0-31 or 127), escape it
-        if (0 <= code_point <= 31) or (code_point == 127):
-            return f"%{code_point:02x}"
-        return c
-
-    return "".join(escape_char(c) for c in text)
 
 
 def catch_mlflow_exception(func):

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -562,7 +562,14 @@ def _send_artifact(artifact_repository, path):
     # Always send artifacts as attachments to prevent the browser from displaying them on our web
     # server's domain, which might enable XSS.
     mime_type = _guess_mime_type(file_path)
-    file_sender_response = send_file(file_path, mimetype=mime_type, as_attachment=True)
+    # We need to explicitly encode a filename in case the filename includes invalid characters
+    filename = os.path.basename(file_path)
+    file_sender_response = send_file(
+        file_path,
+        mimetype=mime_type,
+        as_attachment=True,
+        download_name=urllib.parse.quote(filename),
+    )
     return _response_with_file_attachment_headers(file_path, file_sender_response)
 
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2395,6 +2395,8 @@ class MlflowClient:
             # Sanitize key to use in filename (replace / with # to avoid subdirectories)
             sanitized_key = re.sub(r"/", "#", key)
             filename_uuid = uuid.uuid4()
+            # TODO: reconsider the separator used here since % has special meaning in URL encoding.
+            # See https://github.com/mlflow/mlflow/issues/14136 for more details.
             uncompressed_filename = (
                 f"images/{sanitized_key}%step%{step}%timestamp%{timestamp}%{filename_uuid}"
             )

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -479,6 +479,8 @@ def validate_path_is_safe(path):
 
     # We must decode path before validating it
     path = _decode(path)
+    # If control characters are included in the path, escape them.
+    path = _escape_control_characters(path)
 
     exc = MlflowException("Invalid path", error_code=INVALID_PARAMETER_VALUE)
     if "#" in path:
@@ -496,6 +498,19 @@ def validate_path_is_safe(path):
         raise exc
 
     return path
+
+
+def _escape_control_characters(text: str) -> str:
+    # Method to escape control characters (e.g. \u0017)
+    def escape_char(c):
+        code_point = ord(c)
+
+        # If it's a control character (ASCII 0-31 or 127), escape it
+        if (0 <= code_point <= 31) or (code_point == 127):
+            return f"%{code_point:02x}"
+        return c
+
+    return "".join(escape_char(c) for c in text)
 
 
 def validate_query_string(query):

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -4,6 +4,7 @@ import pathlib
 import subprocess
 import tempfile
 from collections import namedtuple
+from io import BytesIO
 
 import pytest
 import requests
@@ -373,6 +374,7 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
     mlflow.set_tracking_uri(url)
 
     import numpy as np
+    from PIL import Image
 
     image = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
 
@@ -395,6 +397,11 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
             "attachment; filename=dog%step%100%timestamp%100"
             in get_artifact_response.headers["Content-Disposition"]
         )
+        if path.endswith("png"):
+            loaded_image = np.asarray(
+                Image.open(BytesIO(get_artifact_response.content)), dtype=np.uint8
+            )
+            np.testing.assert_array_equal(loaded_image, image)
 
 
 @pytest.mark.parametrize(

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -392,6 +392,10 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
             url=f"{url}/get-artifact", params={"run_id": run.info.run_id, "path": path}
         )
         get_artifact_response.raise_for_status()
+        assert (
+            "attachment; filename=dog%25step%100%25timestamp%100%"
+            in get_artifact_response.headers["Content-Disposition"]
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -375,7 +375,6 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
     import numpy as np
 
     image = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
-    mlflow.set_experiment("rest_get_artifact_api_test")
 
     with mlflow.start_run() as run:
         mlflow.log_image(image, key="dog", step=100, timestamp=100, synchronous=True)
@@ -393,7 +392,7 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
         )
         get_artifact_response.raise_for_status()
         assert (
-            "attachment; filename=dog%25step%100%25timestamp%100%"
+            "attachment; filename=dog%step%100%timestamp%100"
             in get_artifact_response.headers["Content-Disposition"]
         )
 

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -755,6 +755,7 @@ def test_negative_detection(uri):
         "path",
         "path/",
         "path/to/file",
+        "dog%step%100%timestamp%100",
     ],
 )
 def test_validate_path_is_safe_good(path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14281?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14281/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14281
```

</p>
</details>

### Related Issues/PRs

Resolve #14136

### What changes are proposed in this pull request?

There was an encoding issue in log_model that prevented images from being displayed in the artifact tab.  The root issue of the bug is the usage of "%" separator for the artifact name [here](https://github.com/mlflow/mlflow/pull/11404/files#diff-9ebf3080741cb403b3d007bf3eb7e22121bbde993116b50e916f79f9f44a2310R1603), which causes the encoding issue in HTTP Header of the response. This PR fixes the issue by explicitly encoding the filename used in the HTTP header, however, we may want to reconsider the choice of separator to avoid similar issues.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Before
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/79e9aa94-2f51-4bc6-8a90-a76370b8c4f6" />

After
<img width="1032" alt="Screenshot 2025-01-21 at 14 56 34" src="https://github.com/user-attachments/assets/832eab9d-da2a-46ac-8924-a3b6bd416dd3" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
