### PR TITLE
Improve docusaurus notebook formatting

### DIFF
--- a/docs/docs/deep-learning/keras/quickstart/quickstart_keras.ipynb
+++ b/docs/docs/deep-learning/keras/quickstart/quickstart_keras.ipynb
@@ -12,14 +12,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "    <a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/deep-learning/keras/quickstart/quickstart_keras.ipynb\"\n",
-    "    class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/deep-learning/pytorch/quickstart/pytorch_quickstart.ipynb
+++ b/docs/docs/deep-learning/pytorch/quickstart/pytorch_quickstart.ipynb
@@ -14,13 +14,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/deep-learning/pytorch/quickstart/pytorch_quickstart.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "CZwvVcIg0Z1P"

--- a/docs/docs/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
+++ b/docs/docs/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
@@ -16,13 +16,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "9btw8G129PH9"

--- a/docs/docs/getting-started/intro-quickstart/notebooks/tracking_quickstart.ipynb
+++ b/docs/docs/getting-started/intro-quickstart/notebooks/tracking_quickstart.ipynb
@@ -8,13 +8,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/intro-quickstart/notebooks/tracking_quickstart.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br/>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/custom-pyfunc-for-llms/notebooks/custom-pyfunc-advanced-llm.ipynb
+++ b/docs/docs/llms/custom-pyfunc-for-llms/notebooks/custom-pyfunc-advanced-llm.ipynb
@@ -8,13 +8,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/custom-pyfunc-for-llms/notebooks/custom-pyfunc-advanced-llm.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/langchain/notebooks/langchain-quickstart.ipynb
+++ b/docs/docs/llms/langchain/notebooks/langchain-quickstart.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/langchain/notebooks/langchain-quickstart.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/langchain/notebooks/langchain-retriever.ipynb
+++ b/docs/docs/llms/langchain/notebooks/langchain-retriever.ipynb
@@ -8,13 +8,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/llama-index/notebooks/llama_index_quickstart.ipynb
+++ b/docs/docs/llms/llama-index/notebooks/llama_index_quickstart.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/llama-index/notebooks/llama_index_quickstart.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/llama-index/notebooks/llama_index_workflow_tutorial.ipynb
+++ b/docs/docs/llms/llama-index/notebooks/llama_index_workflow_tutorial.ipynb
@@ -42,13 +42,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/llama-index/notebooks/llama_index_workflow_tutorial.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {

--- a/docs/docs/llms/llm-evaluate/notebooks/huggingface-evaluation.ipynb
+++ b/docs/docs/llms/llm-evaluate/notebooks/huggingface-evaluation.ipynb
@@ -12,13 +12,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/llm-evaluate/notebooks/huggingface-evaluation.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/llm-evaluate/notebooks/question-answering-evaluation.ipynb
+++ b/docs/docs/llms/llm-evaluate/notebooks/question-answering-evaluation.ipynb
@@ -18,13 +18,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/llm-evaluate/notebooks/question-answering-evaluation.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {

--- a/docs/docs/llms/llm-evaluate/notebooks/rag-evaluation-llama2.ipynb
+++ b/docs/docs/llms/llm-evaluate/notebooks/rag-evaluation-llama2.ipynb
@@ -18,13 +18,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/llm-evaluate/notebooks/rag-evaluation-llama2.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/llm-evaluate/notebooks/rag-evaluation.ipynb
+++ b/docs/docs/llms/llm-evaluate/notebooks/rag-evaluation.ipynb
@@ -18,13 +18,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/llm-evaluate/notebooks/rag-evaluation.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/notebooks/chat-model-tool-calling.ipynb
+++ b/docs/docs/llms/notebooks/chat-model-tool-calling.ipynb
@@ -8,17 +8,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {
-    "vscode": {
-     "languageId": "raw"
-    }
-   },
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/notebooks/chat-model-tool-calling.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/openai/notebooks/openai-chat-completions.ipynb
+++ b/docs/docs/llms/openai/notebooks/openai-chat-completions.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/openai/notebooks/openai-code-helper.ipynb
+++ b/docs/docs/llms/openai/notebooks/openai-code-helper.ipynb
@@ -12,13 +12,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-code-helper.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/openai/notebooks/openai-embeddings-generation.ipynb
+++ b/docs/docs/llms/openai/notebooks/openai-embeddings-generation.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/openai/notebooks/openai-quickstart.ipynb
+++ b/docs/docs/llms/openai/notebooks/openai-quickstart.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/rag/notebooks/mlflow-e2e-evaluation.ipynb
+++ b/docs/docs/llms/rag/notebooks/mlflow-e2e-evaluation.ipynb
@@ -8,13 +8,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/rag/notebooks/mlflow-e2e-evaluation.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {

--- a/docs/docs/llms/rag/notebooks/question-generation-retrieval-evaluation.ipynb
+++ b/docs/docs/llms/rag/notebooks/question-generation-retrieval-evaluation.ipynb
@@ -8,13 +8,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/rag/notebooks/question-generation-retrieval-evaluation.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {

--- a/docs/docs/llms/rag/notebooks/retriever-evaluation-tutorial.ipynb
+++ b/docs/docs/llms/rag/notebooks/retriever-evaluation-tutorial.ipynb
@@ -8,13 +8,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/rag/notebooks/retriever-evaluation-tutorial.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {

--- a/docs/docs/llms/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
+++ b/docs/docs/llms/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/quickstart/paraphrase-mining-sentence-transformers.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/sentence-transformers/tutorials/quickstart/sentence-transformers-quickstart.ipynb
+++ b/docs/docs/llms/sentence-transformers/tutorials/quickstart/sentence-transformers-quickstart.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/quickstart/sentence-transformers-quickstart.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/sentence-transformers/tutorials/semantic-search/semantic-search-sentence-transformers.ipynb
+++ b/docs/docs/llms/sentence-transformers/tutorials/semantic-search/semantic-search-sentence-transformers.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/quickstart/semantic-search-sentence-transformers.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/sentence-transformers/tutorials/semantic-similarity/semantic-similarity-sentence-transformers.ipynb
+++ b/docs/docs/llms/sentence-transformers/tutorials/semantic-similarity/semantic-similarity-sentence-transformers.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/semantic-search/semantic-similarity-sentence-transformers.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/transformers/tutorials/audio-transcription/whisper.ipynb
+++ b/docs/docs/llms/transformers/tutorials/audio-transcription/whisper.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/transformers/tutorials/audio-transcription/whisper.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/transformers/tutorials/conversational/conversational-model.ipynb
+++ b/docs/docs/llms/transformers/tutorials/conversational/conversational-model.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/transformers/tutorials/conversational/conversational-model.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/transformers/tutorials/fine-tuning/transformers-fine-tuning.ipynb
+++ b/docs/docs/llms/transformers/tutorials/fine-tuning/transformers-fine-tuning.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/transformers/tutorials/fine-tuning/transformers-fine-tuning.ipynb\" class=\"notebook-download-btn\">Download the Fine Tuning Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/transformers/tutorials/fine-tuning/transformers-peft.ipynb
+++ b/docs/docs/llms/transformers/tutorials/fine-tuning/transformers-peft.ipynb
@@ -8,13 +8,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/transformers/tutorials/fine-tuning/transformers-peft.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {

--- a/docs/docs/llms/transformers/tutorials/prompt-templating/prompt-templating.ipynb
+++ b/docs/docs/llms/transformers/tutorials/prompt-templating/prompt-templating.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/transformers/tutorials/prompt-templating/prompt-templating.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/transformers/tutorials/text-generation/text-generation.ipynb
+++ b/docs/docs/llms/transformers/tutorials/text-generation/text-generation.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/transformers/tutorials/text-generation/text-generation.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/llms/transformers/tutorials/translation/component-translation.ipynb
+++ b/docs/docs/llms/transformers/tutorials/translation/component-translation.ipynb
@@ -10,13 +10,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/transformers/tutorials/translation/component-translation.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/docs/tracing/notebooks/jupyter-trace-demo.ipynb
+++ b/docs/docs/tracing/notebooks/jupyter-trace-demo.ipynb
@@ -14,19 +14,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "e20f7af3",
-   "metadata": {
-    "vscode": {
-     "languageId": "raw"
-    }
-   },
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/tracing/notebooks/jupyter-trace-demo.ipynb\" \n",
-    "   class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "8b0f6c4a",
    "metadata": {},

--- a/docs/scripts/convert-notebooks.py
+++ b/docs/scripts/convert-notebooks.py
@@ -104,7 +104,7 @@ def convert_path(nb_path: Path):
 
 
 def main():
-    nb_paths = list(SOURCE_DIR.rglob("transformers-peft.ipynb"))
+    nb_paths = list(SOURCE_DIR.rglob("*.ipynb"))
 
     with multiprocessing.Pool() as pool:
         pool.map(convert_path, nb_paths)

--- a/docs/scripts/convert-notebooks.py
+++ b/docs/scripts/convert-notebooks.py
@@ -51,9 +51,7 @@ def add_frontmatter(
     body: str,
     nb_path: Path,
 ) -> str:
-    frontmatter = {
-        "custom_edit_url": NOTEBOOK_BASE_EDIT_URL + str(nb_path)
-    }
+    frontmatter = {"custom_edit_url": NOTEBOOK_BASE_EDIT_URL + str(nb_path)}
     formatted_frontmatter = "\n".join(f"{key}: {value}" for key, value in frontmatter.items())
 
     return f"""---
@@ -61,6 +59,7 @@ def add_frontmatter(
 ---
 
 {body}"""
+
 
 def add_download_button(
     body: str,
@@ -80,7 +79,9 @@ def add_download_button(
 
     # should not occur due to maxsplit=1
     if len(parts) > 3:
-        raise Exception(f"Error while parsing notebook at {nb_path}. Please check the format of the notebook.")
+        raise Exception(
+            f"Error while parsing notebook at {nb_path}. Please check the format of the notebook."
+        )
 
     # parts[0] = everything before the first header
     # parts[1] = the first header (match group from the regex)

--- a/docs/src/components/NotebookCellOutput/index.tsx
+++ b/docs/src/components/NotebookCellOutput/index.tsx
@@ -1,17 +1,14 @@
 export const NotebookCellOutput = ({ children, isStderr }): JSX.Element => (
-  <div style={{ display: "flex", flexDirection: "row" }}>
-    <div style={{ width: "2rem", flexShrink: 0 }} />
-    <pre
-      style={{
-        margin: 0,
-        borderRadius: 0,
-        background: "none",
-        fontSize: "0.85rem",
-        flexGrow: 1,
-        padding: `var(--padding-sm)`,
-      }}
-    >
-      {children}
-    </pre>
-  </div>
+  <pre
+    style={{
+      margin: 0,
+      borderRadius: 0,
+      background: "none",
+      fontSize: "0.85rem",
+      flexGrow: 1,
+      padding: `var(--padding-sm)`,
+    }}
+  >
+    {children}
+  </pre>
 );

--- a/docs/src/components/NotebookCodeCell/index.tsx
+++ b/docs/src/components/NotebookCodeCell/index.tsx
@@ -4,19 +4,14 @@ import styles from "./styles.module.css";
 export const NotebookCodeCell = ({ children, executionCount }): JSX.Element => (
   <div
     style={{
-      display: "flex",
-      flexDirection: "row",
+      flexGrow: 1,
+      minWidth: 0,
       marginTop: "var(--padding-md)",
       width: "100%",
     }}
   >
-    <div style={{ width: "2rem", flexShrink: 0, fontSize: "0.8rem" }}>
-      {`[${executionCount}]`}
-    </div>
-    <div style={{ flexGrow: 1, minWidth: 0 }}>
-      <CodeBlock className={styles.codeBlock} language="python">
-        {children}
-      </CodeBlock>
-    </div>
+    <CodeBlock className={styles.codeBlock} language="python">
+      {children}
+    </CodeBlock>
   </div>
 );

--- a/docs/src/components/NotebookDownloadButton/index.tsx
+++ b/docs/src/components/NotebookDownloadButton/index.tsx
@@ -34,6 +34,7 @@ export function NotebookDownloadButton({
   return (
     <a
       className="button button--primary"
+      style={{ marginBottom: "1rem", display: "block", width: "min-content" }}
       href={href}
       download
       onClick={handleClick}

--- a/docs/src/components/NotebookHTMLOutput/index.tsx
+++ b/docs/src/components/NotebookHTMLOutput/index.tsx
@@ -1,14 +1,5 @@
 export const NotebookHTMLOutput = ({ children }): JSX.Element => (
-  <div
-    style={{
-      display: "flex",
-      flexDirection: "row",
-      width: "100%",
-    }}
-  >
-    <div style={{ width: "2rem", flexShrink: 0 }} />
-    <div style={{ flexGrow: 1, minWidth: 0, fontSize: "0.8rem" }}>
-      {children}
-    </div>
+  <div style={{ flexGrow: 1, minWidth: 0, fontSize: "0.8rem", width: "100%" }}>
+    {children}
   </div>
 );


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14290?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14290/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14290
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR does 3 things:

1. Update the custom_edit_url for the notebooks
2. Automatically add a download button below the title of every notebook
3. Remove the execution count (e.g. `[4]`) indicator beside code cells

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

changed url from `master` to `docusaurus` since this branch hasn't been merged yet

https://github.com/user-attachments/assets/77cfd08d-e2e2-4011-891b-95c92f7ef3d7



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
