### PR TITLE
Infer signature from example for callable

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3096,8 +3096,6 @@ def save_model(
             predict_func = python_model
         elif isinstance(python_model, PythonModel):
             type_hints = python_model.predict_type_hints
-            context = PythonModelContext(artifacts, model_config)
-            python_model.load_context(context)
             model_for_signature_inference = python_model
             predict_func = python_model.predict
 
@@ -3121,6 +3119,8 @@ def save_model(
             if saved_example is not None:
                 _logger.info("Inferring model signature from input example")
                 try:
+                    context = PythonModelContext(artifacts, model_config)
+                    model_for_signature_inference.load_context(context)
                     mlflow_model.signature = _infer_signature_from_input_example(
                         saved_example,
                         _PythonModelPyfuncWrapper(model_for_signature_inference, None, None),

--- a/tests/pyfunc/sample_code/func_code.py
+++ b/tests/pyfunc/sample_code/func_code.py
@@ -1,8 +1,8 @@
 from mlflow.models import set_model
 
 
-def predict(model_input):
-    return f"This was the input: {model_input}"
+def predict(model_input: list[str]):
+    return f"This was the input: {model_input[0]}"
 
 
 set_model(predict)

--- a/tests/pyfunc/sample_code/func_code_with_config.py
+++ b/tests/pyfunc/sample_code/func_code_with_config.py
@@ -1,10 +1,10 @@
 from mlflow.models import ModelConfig, set_model
 
 
-def predict(model_input):
+def predict(model_input: list[str]):
     model_config = ModelConfig(development_config="tests/pyfunc/sample_code/config.yml")
     timeout = model_config.get("timeout")
-    return f"This was the input: {model_input}, timeout {timeout}"
+    return f"This was the input: {model_input[0]}, timeout {timeout}"
 
 
 set_model(predict)

--- a/tests/pyfunc/sample_code/func_code_with_type_hint.py
+++ b/tests/pyfunc/sample_code/func_code_with_type_hint.py
@@ -1,7 +1,7 @@
 from mlflow.models import set_model
 
 
-def predict(model_input):
+def predict(model_input: list[str]):
     return model_input
 
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2201,7 +2201,21 @@ def test_predict_as_code():
 
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     model_input = "asdf"
-    expected_output = f"This was the input: {model_input}"
+    expected_output = pd.DataFrame([model_input])
+    pandas.testing.assert_frame_equal(loaded_model.predict([model_input]), expected_output)
+
+
+def test_predict_as_code_with_type_hint():
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "model",
+            python_model="tests/pyfunc/sample_code/func_code_with_type_hint.py",
+            input_example=["string"],
+        )
+
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    model_input = "asdf"
+    expected_output = [model_input]
     assert loaded_model.predict([model_input]) == expected_output
 
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1236,7 +1236,8 @@ def test_functional_python_model_no_type_hints(tmp_path):
 
     mlflow.pyfunc.save_model(path=tmp_path, python_model=python_model, input_example=[{"a": "b"}])
     model = Model.load(tmp_path)
-    assert model.signature is None
+    assert model.signature.inputs == Schema([ColSpec("string", name="a")])
+    assert model.signature.outputs == Schema([ColSpec("string", name="a")])
 
 
 def list_to_list(x: List[str]) -> List[str]:  # noqa: UP006
@@ -2195,13 +2196,13 @@ def test_predict_as_code():
         model_info = mlflow.pyfunc.log_model(
             "model",
             python_model="tests/pyfunc/sample_code/func_code.py",
-            input_example="string",
+            input_example=["string"],
         )
 
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     model_input = "asdf"
     expected_output = f"This was the input: {model_input}"
-    assert loaded_model.predict(model_input) == expected_output
+    assert loaded_model.predict([model_input]) == expected_output
 
 
 def test_predict_as_code_with_config():
@@ -2209,14 +2210,14 @@ def test_predict_as_code_with_config():
         model_info = mlflow.pyfunc.log_model(
             "model",
             python_model="tests/pyfunc/sample_code/func_code_with_config.py",
-            input_example="string",
+            input_example=["string"],
             model_config="tests/pyfunc/sample_code/config.yml",
         )
 
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     model_input = "asdf"
     expected_output = f"This was the input: {model_input}, timeout 300"
-    assert loaded_model.predict(model_input) == expected_output
+    assert loaded_model.predict([model_input]) == expected_output
 
 
 def test_model_as_code_pycache_cleaned_up():

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -569,7 +569,8 @@ def test_functional_python_model_only_output_type_hints():
         model_info = mlflow.pyfunc.log_model(
             "model", python_model=python_model, input_example=["a"]
         )
-    assert model_info.signature is None
+    assert model_info.signature.inputs == Schema([ColSpec(type=DataType.string)])
+    assert model_info.signature.outputs == Schema([ColSpec(type=DataType.string, name=0)])
 
 
 class CallableObject:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14294?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14294/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14294
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR introduces a signature inference from input example for callable. The signature is inferred from input example when the input example is passed and the type hint is not provided or `TypeFromExample`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
