### PR TITLE
Add link to documentation in error message

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -598,7 +598,9 @@ _CHAT_PARAMS_WARNING_MESSAGE = (
 )
 _TYPE_FROM_EXAMPLE_ERROR_MESSAGE = (
     "Input example must be provided when using TypeFromExample as type hint. "
-    "Fix this by passing `input_example` when logging your model."
+    "Fix this by passing `input_example` when logging your model. Check "
+    "https://mlflow.org/docs/latest/model/python_model.html#typefromexample-type-hint-usage "
+    "for more details."
 )
 
 
@@ -3084,10 +3086,11 @@ def save_model(
             # only show the warning here if @pyfunc is not applied on the function
             # since @pyfunc will trigger the warning instead
             if type_hints.input is None and not pyfunc_decorator_used:
-                # TODO: add link to documentation
                 color_warning(
                     "Add type hints to the `predict` method to enable "
-                    "data validation and automatic signature inference.",
+                    "data validation and automatic signature inference. Check "
+                    "https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel"
+                    " for more details.",
                     stacklevel=1,
                     color="yellow",
                 )
@@ -3166,7 +3169,6 @@ def save_model(
         if type_hint_from_example:
             if saved_example is None:
                 _logger.warning(
-                    # TODO: add link to documentation
                     _TYPE_FROM_EXAMPLE_ERROR_MESSAGE,
                     extra={"color": "red"},
                 )
@@ -3250,9 +3252,10 @@ def update_signature_for_type_hint_from_example(input_example: Any, signature: M
         signature._is_type_hint_from_example = True
     else:
         _logger.warning(
-            # TODO: add link to documentation
             "Input example must be one of pandas.DataFrame, pandas.Series "
             f"or list when using TypeFromExample as type hint, got {type(input_example)}. "
+            "Check https://mlflow.org/docs/latest/model/python_model.html#typefromexample-type-hint-usage"
+            " for more details.",
         )
 
 

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -131,10 +131,11 @@ def _get_func_info_if_type_hint_supported(func) -> Optional[FuncInfo]:
         else:
             return FuncInfo(input_type_hint=type_hint, input_param_name=input_param_name)
     else:
-        # TODO: add link to documentation
         color_warning(
             "Add type hints to the `predict` method to enable data validation "
-            "and automatic signature inference during model logging.",
+            "and automatic signature inference during model logging. "
+            "Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel"
+            " for more details.",
             stacklevel=1,
             color="yellow",
         )

--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -39,13 +39,13 @@ except ImportError:
 # special type hint that can be used to convert data to
 # the input example type after data validation
 TypeFromExample = TypeVar("TypeFromExample")
-# TODO: add link to mlflow documentation to include examples
 OPTIONAL_INPUT_MSG = (
     "Input cannot be Optional type. Fix this by removing the "
     "Optional wrapper from the type hint. To use optional fields, "
     "use a Pydantic-based type hint definition. See "
     "https://docs.pydantic.dev/latest/api/base_model/ for pydantic "
-    "BaseModel examples."
+    "BaseModel examples. Check https://mlflow.org/docs/latest/model/python_model.html#supported-type-hints"
+    " for more details."
 )
 
 
@@ -59,11 +59,11 @@ TYPE_HINTS_TO_DATATYPE_MAPPING = {
     datetime: DataType.datetime,
 }
 
-# TODO: add link to documentation
 SUPPORTED_TYPE_HINT_MSG = (
     "Type hints must be a list[...] where collection element type is one of these types: "
     f"{list(TYPE_HINTS_TO_DATATYPE_MAPPING.keys())}, pydantic BaseModel subclasses, "
-    "lists and dictionaries of primitive types, or typing.Any."
+    "lists and dictionaries of primitive types, or typing.Any. Check "
+    "https://mlflow.org/docs/latest/model/python_model.html#supported-type-hints for more details."
 )
 
 
@@ -428,10 +428,11 @@ def _validate_data_against_type_hint(data: Any, type_hint: type[Any]) -> Any:
         try:
             model_validate(type_hint, data_dict)
         except pydantic.ValidationError as e:
-            # TODO: add link to documentation
             raise MlflowException.invalid_parameter_value(
                 message=f"Data doesn't match type hint, error: {e}. Expected fields in the "
-                f"type hint: {model_fields(type_hint)}; passed data: {data_dict}",
+                f"type hint: {model_fields(type_hint)}; passed data: {data_dict}. Check "
+                "https://mlflow.org/docs/latest/model/python_model.html#pydantic-model-type-hints-data-conversion"
+                " for more details.",
             ) from e
         else:
             return type_hint(**data_dict) if isinstance(data, dict) else data

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -138,13 +138,14 @@ def _infer_datatype(data: Any) -> Optional[Union[DataType, Array, Object, AnyTyp
         e.g. [] -> AnyType, [[], []] -> Array(Any)
     """
     if isinstance(data, pydantic.BaseModel):
-        # TODO: add link to documentation
         raise InvalidDataForSignatureInferenceError(
             message="MLflow does not support inferring model signature from input example "
             "with Pydantic objects. To use Pydantic objects, define your PythonModel's "
             "`predict` method with a Pydantic type hint, and model signature will be automatically "
             "inferred when logging the model. e.g. "
-            "`def predict(self, model_input: list[PydanticType])`"
+            "`def predict(self, model_input: list[PydanticType])`. Check "
+            "https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel "
+            "for more details."
         )
 
     if _is_none_or_nan(data) or (isinstance(data, (list, dict)) and not data):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14295?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14295/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14295
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As title: added link to type hint documentation in the error message

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
