### PR TITLE
Fix type hint warning when importing builtin class

### DIFF
--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -24,8 +24,6 @@ class DspyModelWrapper(PythonModel):
             used at serving time.
     """
 
-    _skip_wrapping_predict = True
-
     def __init__(
         self,
         model: "dspy.Module",

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -147,9 +147,8 @@ class PythonModel:
         super().__init_subclass__(**kwargs)
 
         # automatically wrap the predict method with pyfunc to ensure data validation
-        # NB: subclasses of PythonModel in MLflow that has customized predict method
-        # should set _skip_wrapping_predict = True to skip this wrapping
-        if not getattr(cls, "_skip_wrapping_predict", False):
+        # NB: skip wrapping for built-in classes defined in MLflow e.g, ChatModel
+        if not cls.__module__.startswith("mlflow."):
             predict_attr = cls.__dict__.get("predict")
             if predict_attr is not None and callable(predict_attr):
                 func_info = _get_func_info_if_type_hint_supported(predict_attr)
@@ -199,8 +198,6 @@ class _FunctionPythonModel(PythonModel):
     When a user specifies a ``python_model`` argument that is a function, we wrap the function
     in an instance of this class.
     """
-
-    _skip_wrapping_predict = True
 
     def __init__(self, func, signature=None):
         self.signature = signature
@@ -287,8 +284,6 @@ class ChatModel(PythonModel, metaclass=ABCMeta):
     outputs that are expected by the ``ChatModel`` API.
     """
 
-    _skip_wrapping_predict = True
-
     @abstractmethod
     def predict(
         self, context, messages: list[ChatMessage], params: ChatParams
@@ -368,8 +363,6 @@ class ChatAgent(PythonModel, metaclass=ABCMeta):
     After logging, you can pass in a single dictionary that conforms to a ChatAgentRequest schema.
     Look at CHAT_AGENT_INPUT_EXAMPLE in mlflow.types.agent for an example.
     """
-
-    _skip_wrapping_predict = True
 
     def _convert_messages_to_dict(self, messages: list[ChatAgentMessage]):
         return [m.model_dump_compat(exclude_none=True) for m in messages]
@@ -807,8 +800,6 @@ class ModelFromDeploymentEndpoint(PythonModel):
     A PythonModel wrapper for invoking an MLflow Deployments endpoint.
     This class is particularly used for running evaluation against an MLflow Deployments endpoint.
     """
-
-    _skip_wrapping_predict = True
 
     def __init__(self, endpoint, params):
         self.endpoint = endpoint

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1,4 +1,5 @@
 import datetime
+import importlib
 import json
 import os
 import sys
@@ -25,6 +26,7 @@ from mlflow.environment_variables import _MLFLOW_IS_IN_SERVING_ENVIRONMENT
 from mlflow.exceptions import MlflowException
 from mlflow.models import convert_input_example_to_serving_input
 from mlflow.models.signature import _extract_type_hints, infer_signature
+from mlflow.pyfunc.model import ChatModel, _FunctionPythonModel
 from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 from mlflow.pyfunc.utils import pyfunc
 from mlflow.pyfunc.utils.environment import _simulate_serving_environment
@@ -1044,3 +1046,26 @@ def test_python_model_without_type_hint_warning():
     with mlflow.start_run():
         with pytest.warns(UserWarning, match=msg):
             mlflow.pyfunc.log_model("model", python_model=predict, input_example="abc")
+
+
+@mock.patch("mlflow.pyfunc.utils.data_validation.color_warning")
+def test_type_hint_warning_not_shown_for_builtin_subclasses(mock_warning):
+    # Class outside "mlflow" module should warn
+    class PythonModelWithoutTypeHint(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input, params=None):
+            return model_input
+
+    assert mock_warning.call_count == 1
+    assert "Add type hints to the `predict` method" in mock_warning.call_args[0][0]
+    mock_warning.reset_mock()
+
+    # Class inside "mlflow" module should not warn
+    ChatModel.__init_subclass__()
+    assert mock_warning.call_count == 0
+
+    _FunctionPythonModel.__init_subclass__()
+    assert mock_warning.call_count == 0
+
+    # Check import does not trigger any warning (from builtin sub-classes)
+    importlib.reload(mlflow.pyfunc.model)
+    assert mock_warning.call_count == 0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14298?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14298/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14298
```

</p>
</details>

### What changes are proposed in this pull request?

Importing `mlflow` raises type hint warning, because of the built-in class`WrappedRecipeModel` does not have either type hint or the `_skip_wrapping_predict` marker. The validation via `__init_subclass__` is called when the class is defined, so that will trigger the warning at import time.

This PR fixes it by skipping validation for any class defined under `mlflow` module instead of keep using `_skip_wrapping_predict`, to avoid human error like this.

<img width="862" alt="Screenshot 2025-01-23 at 8 39 09" src="https://github.com/user-attachments/assets/f8898783-78e0-4bc0-abbb-0cb205b53e7e" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

No warning at import.

<img width="861" alt="Screenshot 2025-01-23 at 9 40 00" src="https://github.com/user-attachments/assets/8a1897ef-987a-454a-941a-9eb0dbb3d1ab" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
