### PR TITLE
Type hint doc fix

### DIFF
--- a/docs/docs/model/index.mdx
+++ b/docs/docs/model/index.mdx
@@ -3417,6 +3417,65 @@ The following examples demonstrate how you can use the <APILink fn="mlflow.pyfun
 module to create custom Python models. For additional information about model customization with MLflow's
 `python_function` utilities, see the <Link target="_blank" to="/api_reference/python_api/mlflow.pyfunc.html#pyfunc-create-custom">python_function custom models documentation</Link>.
 
+#### Example: Creating a model with type hints
+
+This example demonstrates how to create a custom Python model with type hints, enabling MLflow to perform data
+validation based on the type hints specified for the model input. For additional information about 
+PythonModel type hints support, see the [PythonModel Type Hints Guide](../model/python_model#type-hint-usage-in-pythonmodel).
+
+:::note
+PythonModel with type hints supports data validation starting from MLflow version 2.20.0.
+:::
+
+```python
+import pydantic
+import mlflow
+from mlflow.pyfunc import PythonModel
+
+
+# Define the pydantic model input
+class Message(pydantic.BaseModel):
+    role: str
+    content: str
+
+
+class CustomModel(PythonModel):
+    # Define the model_input type hint
+    # NB: it must be list[...], check the python model type hints guide for more information
+    def predict(self, model_input: list[Message], params=None) -> list[str]:
+        return [m.content for m in model_input]
+
+
+# Construct the model and test
+model = CustomModel()
+
+# The input_example can be a list of Message objects as defined in the type hint
+input_example = [
+    Message(role="system", content="Hello"),
+    Message(role="user", content="Hi"),
+]
+assert model.predict(input_example) == ["Hello", "Hi"]
+
+# The input example can also be a list of dictionaries that match the Message schema
+input_example = [
+    {"role": "system", "content": "Hello"},
+    {"role": "user", "content": "Hi"},
+]
+assert model.predict(input_example) == ["Hello", "Hi"]
+
+# Log the model
+with mlflow.start_run():
+    model_info = mlflow.pyfunc.log_model(
+        artifact_path="model",
+        python_model=model,
+        input_example=input_example,
+    )
+
+# Load the model as pyfunc
+pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+assert pyfunc_model.predict(input_example) == ["Hello", "Hi"]
+```
+
 #### Example: Creating a custom “add n” model
 
 This example defines a class for a custom model that adds a specified numeric value, `n`, to all

--- a/docs/docs/model/signatures/index.mdx
+++ b/docs/docs/model/signatures/index.mdx
@@ -524,7 +524,7 @@ automatically infer the model's signature based on this input example and the mo
 
 :::tip
 Starting MLflow 2.20.0, model signature is automatically inferred when logging a PythonModel with type hints. Check 
-[PythonModel with type hints guidance](python_model#type-hint-usage-in-pythonmodel) for more details.
+[PythonModel with type hints guidance](python_model#model-signature-inference-based-on-type-hints) for more details.
 :::
 
 Alternatively, you can explicitly attach a signature object to your model. This is done by passing a <APILink fn="mlflow.models.ModelSignature">`signature object`</APILink>

--- a/docs/docs/model/signatures/index.mdx
+++ b/docs/docs/model/signatures/index.mdx
@@ -522,6 +522,11 @@ Including a signature with your model in MLflow is straightforward. Simply provi
 call to either the log_model or save_model functions, such as with <APILink fn="mlflow.sklearn.log_model">`sklearn.log_model()`</APILink>. MLflow will then
 automatically infer the model's signature based on this input example and the model's predicted output for the given example.
 
+:::tip
+Starting MLflow 2.20.0, model signature is automatically inferred when logging a PythonModel with type hints. Check 
+[PythonModel with type hints guidance](python_model#type-hint-usage-in-pythonmodel) for more details.
+:::
+
 Alternatively, you can explicitly attach a signature object to your model. This is done by passing a <APILink fn="mlflow.models.ModelSignature">`signature object`</APILink>
 to your log_model or save_model function. You can manually create a model signature object or use the <APILink fn="mlflow.models.infer_signature">`infer_signature`</APILink>
 function to generate it from datasets with valid model inputs (for instance, a training dataset minus the target column), valid model outputs (such as

--- a/docs/docs/model/signatures/index.mdx
+++ b/docs/docs/model/signatures/index.mdx
@@ -524,7 +524,7 @@ automatically infer the model's signature based on this input example and the mo
 
 :::tip
 Starting MLflow 2.20.0, model signature is automatically inferred when logging a PythonModel with type hints. Check 
-[PythonModel with type hints guidance](python_model#model-signature-inference-based-on-type-hints) for more details.
+[PythonModel with type hints guidance](../python_model#model-signature-inference-based-on-type-hints) for more details.
 :::
 
 Alternatively, you can explicitly attach a signature object to your model. This is done by passing a <APILink fn="mlflow.models.ModelSignature">`signature object`</APILink>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14328?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14328/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14328
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add back missing content during docusaurus rebase + add link to type hint guid in signature page

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
