### PR TITLE
Fix ChatCompletionResponse for model serving Pydantic 1.x

### DIFF
--- a/docs/docs/models/index.mdx
+++ b/docs/docs/models/index.mdx
@@ -194,7 +194,7 @@ effective model management and deployment.
   testing model requirements. Additionally, if an input example is provided when logging a model, a model
   signature will be automatically inferred and stored if not explicitly provided.
 - **Model Serving Payload Example**: Provides a json payload example for querying a deployed model endpoint.
-  If an input example is provided when logging a model, a serving paylod example is automatically generated
+  If an input example is provided when logging a model, a serving payload example is automatically generated
   from the input example and saved as `serving_input_example.json`.
 
 Our documentation delves into several key areas:

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -165,6 +165,46 @@ class BaseRequestPayload(BaseModel):
     model: Optional[str] = None
 
 
+# NB: For interface constructs that rely on other BaseModel implementations, in
+# pydantic 1 the **order** in which classes are defined in this module is absolutely
+# critical to prevent ForwardRef errors. Pydantic 2 does not have this limitation.
+# To maintain compatibility with Pydantic 1, ensure that all classes that are defined in
+# this file have dependencies defined higher than the line of usage.
+
+
+class ChatChoice(BaseModel):
+    index: int
+    message: ChatMessage
+    finish_reason: Optional[str] = None
+
+
+class ChatUsage(BaseModel):
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+
+
+class ChatChoiceDelta(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class ChatChunkChoice(BaseModel):
+    index: int
+    finish_reason: Optional[str] = None
+    delta: ChatChoiceDelta
+
+
+class ChatCompletionChunk(BaseModel):
+    """A chunk of a chat completion stream response."""
+
+    id: Optional[str] = None
+    object: str = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: list[ChatChunkChoice]
+
+
 class ChatCompletionRequest(BaseRequestPayload):
     """
     A request to the chat completion API.
@@ -191,36 +231,3 @@ class ChatCompletionResponse(BaseModel):
     model: str
     choices: list[ChatChoice]
     usage: ChatUsage
-
-
-class ChatChoice(BaseModel):
-    index: int
-    message: ChatMessage
-    finish_reason: Optional[str] = None
-
-
-class ChatUsage(BaseModel):
-    prompt_tokens: Optional[int] = None
-    completion_tokens: Optional[int] = None
-    total_tokens: Optional[int] = None
-
-
-class ChatCompletionChunk(BaseModel):
-    """A chunk of a chat completion stream response."""
-
-    id: Optional[str] = None
-    object: str = "chat.completion.chunk"
-    created: int
-    model: str
-    choices: list[ChatChunkChoice]
-
-
-class ChatChoiceDelta(BaseModel):
-    role: Optional[str] = None
-    content: Optional[str] = None
-
-
-class ChatChunkChoice(BaseModel):
-    index: int
-    finish_reason: Optional[str] = None
-    delta: ChatChoiceDelta

--- a/tests/types/test_genai_types.py
+++ b/tests/types/test_genai_types.py
@@ -1,0 +1,57 @@
+import pytest
+from pydantic import ValidationError
+
+from mlflow.types.chat import ChatCompletionResponse
+
+
+def test_instantiation_chat_completion():
+    response_structure = {
+        "id": "1",
+        "object": "1",
+        "created": 1,
+        "model": "model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "user", "content": "hi"},
+                "finish_reason": None,
+            },
+            {
+                "index": 1,
+                "message": {"role": "user", "content": "there"},
+                "finish_reason": "STOP",
+            },
+        ],
+        "usage": {"prompt_tokens": 12, "completion_tokens": 22, "total_tokens": 34},
+    }
+
+    response = ChatCompletionResponse(**response_structure)
+
+    assert response.id == "1"
+    assert response.object == "1"
+    assert response.created == 1
+    assert response.model == "model"
+    assert len(response.choices) == 2
+    assert response.choices[0].index == 0
+    assert response.choices[0].message.content == "hi"
+    assert response.choices[1].finish_reason == "STOP"
+    assert response.usage.prompt_tokens == 12
+    assert response.usage.completion_tokens == 22
+    assert response.usage.total_tokens == 34
+
+
+def test_invalid_chat_completion():
+    invalid_response_structure = {
+        "id": "1",
+        "model": "model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "user", "content": "hi"},
+            }
+        ],
+        "usage": {"prompt_tokens": 12, "completion_tokens": 22, "total_tokens": 34},
+    }
+
+    with pytest.raises(ValidationError, match="1 validation error for ChatCompletionResponse"):
+        ChatCompletionResponse(**invalid_response_structure)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/14332?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14332/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14332
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adjusts the importation order for the changes to ChatModel interfaces in order to have support for legacy Pydantic 1.x. Forward references are automatically handled in pydantic 2.x, but will throw an Exception if there is a forward reference to a class definition when instantiating from a python file. 

This is a critical bug fix to be included in the next patch release.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
