### PR TITLE
Fix LiteLLM autologging

### DIFF
--- a/mlflow/litellm/__init__.py
+++ b/mlflow/litellm/__init__.py
@@ -45,7 +45,7 @@ def autolog(
         from litellm.integrations.mlflow import MlflowLogger
     except ImportError:
         _logger.warning(
-            "MLflow LiteLLM integration is not supported for the installed LiteLLM version."
+            "MLflow LiteLLM integration is not supported for the installed LiteLLM version. "
             "Please upgrade to a newer version to enable MLflow LiteLLM autologging."
         )
         return

--- a/mlflow/litellm/__init__.py
+++ b/mlflow/litellm/__init__.py
@@ -1,5 +1,9 @@
+import importlib.metadata
+import logging
 from contextlib import contextmanager
 from threading import Thread
+
+from packaging.version import Version
 
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
@@ -9,6 +13,8 @@ from mlflow.utils.autologging_utils import (
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 
 FLAVOR_NAME = "litellm"
+
+_logger = logging.getLogger(__name__)
 
 
 @experimental
@@ -35,9 +41,25 @@ def autolog(
     # TODO: since this implementation is inconsistent, explore a universal way to solve the issue.
     _autolog(log_traces=log_traces, disable=disable, silent=silent)
 
+    try:
+        from litellm.integrations.mlflow import MlflowLogger
+    except ImportError:
+        _logger.warning(
+            "MLflow LiteLLM integration is not supported for the installed LiteLLM version."
+            "Please upgrade to a newer version to enable MLflow LiteLLM autologging."
+        )
+        return
+
     if log_traces and not disable:
         litellm.success_callback = _append_mlflow_callbacks(litellm.success_callback)
         litellm.failure_callback = _append_mlflow_callbacks(litellm.failure_callback)
+
+        # Workaround for https://github.com/BerriAI/litellm/issues/8013
+        # TODO: Add upper bound version check when the issue is fixed.
+        if Version(importlib.metadata.version("litellm")) >= Version("1.59.4"):
+            litellm.failure_callback = [
+                cb if cb != "mlflow" else MlflowLogger() for cb in litellm.failure_callback
+            ]
 
         if is_in_databricks_runtime():
             # Patch main APIs e.g. completion to inject custom handling for threading.
@@ -138,15 +160,16 @@ def _patch_thread_start():
 
 
 def _append_mlflow_callbacks(callbacks):
-    if not any(cb == "mlflow" for cb in callbacks):
+    from litellm.integrations.mlflow import MlflowLogger
+
+    # MLflow callback can be stored as a string or the actual logger object
+    if not any(cb == "mlflow" or isinstance(cb, MlflowLogger) for cb in callbacks):
         return callbacks + ["mlflow"]
+
     return callbacks
 
 
 def _remove_mlflow_callbacks(callbacks):
-    try:
-        from litellm.integrations.mlflow import MlflowLogger
+    from litellm.integrations.mlflow import MlflowLogger
 
-        return [cb for cb in callbacks if not (cb == "mlflow" or isinstance(cb, MlflowLogger))]
-    except ImportError:
-        return callbacks
+    return [cb for cb in callbacks if not (cb == "mlflow" or isinstance(cb, MlflowLogger))]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14340?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14340/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14340
```

</p>
</details>

### What changes are proposed in this pull request?

Fixing two issues that broke LiteLLM tracing in the latest version. https://github.com/mlflow-automation/mlflow/actions/runs/12975023780/job/36189281662

Both issues are related to how LiteLLM manage callbacks. The standard way to specify callback in LiteLLM is to use a string name of it, e.g., `litellm.success_callback = ["mlflow"]`. Then LiteLLM internally converts it into the actual callback instance, which is [MlflowLogger](https://github.com/BerriAI/litellm/blob/main/litellm/integrations/mlflow.py#L9) in this case. The two issues emerged due to some behavior change in this conversion.

if not any(cb == "mlflow" or isinstance(cb, MlflowLogger) for cb in callbacks):

1. Previously, the conversion happens in immutable manner, in other words, `litellm.success_callback` field remain to be a list strings. However, they changed it to mutable, hence the `litellm.success_callback` field can contain the actual `MlflowLogger` instance not only a string. Therefore, we need to update [this check](https://github.com/mlflow/mlflow/blob/master/mlflow/litellm/__init__.py#L141) to check not only a string but also the callback class as well, to avoid adding duplicated callbacks.

2. The new logic contains [a bug ](https://github.com/BerriAI/litellm/issues/8013) in handling failure callbacks. This PR adds a temporary fix for it as well.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix broken LiteLLM tracing behavior due to a callback handling bug in LiteLLM >= 1.59.5.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
