### PR TITLE
Fix false alert for ChatModel type hint

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -147,8 +147,16 @@ class PythonModel:
         super().__init_subclass__(**kwargs)
 
         # automatically wrap the predict method with pyfunc to ensure data validation
-        # NB: skip wrapping for built-in classes defined in MLflow e.g, ChatModel
+        # NB: skip wrapping for built-in classes defined in MLflow e.g. ChatModel
         if not cls.__module__.startswith("mlflow."):
+            #  TODO: ChatModel uses dataclass type hints which are not supported now, hence
+            #    we need to skip type hint based validation for user-defined subclasses
+            #    of ChatModel. Once we either (1) support dataclass type hints or (2) migrate
+            #    ChatModel to pydantic, we can remove this exclusion.
+            #    NB: issubclass(cls, ChatModel) does not work so we use a hacky attribute check
+            if getattr(cls, "_skip_type_hint_validation", False):
+                return
+
             predict_attr = cls.__dict__.get("predict")
             if predict_attr is not None and callable(predict_attr):
                 func_info = _get_func_info_if_type_hint_supported(predict_attr)
@@ -309,6 +317,8 @@ class ChatModel(PythonModel, metaclass=ABCMeta):
               DataFrames before passing it to PythonModel.
 
     """
+
+    _skip_type_hint_validation = True
 
     @abstractmethod
     def predict(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14343?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14343/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14343
```

</p>
</details>

### What changes are proposed in this pull request?

https://github.com/mlflow/mlflow/pull/14298 fixed the issue of type hint warning being shown when importing `mlflow` module, because of missing handling for builtin classes.

However, it caused a regression for user-defined subclasses of `ChatModel`. They are not under `mlflow` namespace, but has *"invalid"* type hint based on dataclasses. Therefore, the type hint warning is shown although users have nothing to do with it.

```
UserWarning: Type hint used in the model's predict function is not supported for MLflow's schema validation. Unsupported type hint `ChatMessage`. Type hints must be a list[...] where collection element type is one of these types: [<class 'int'>, <class 'str'>, <class 'bool'>, <class 'float'>, <class 'bytes'>, <class 'datetime.datetime'>], pydantic BaseModel subclasses, lists and dictionaries of primitive types, or typing.Any. Check https://mlflow.org/docs/latest/model/python_model.html#supported-type-hints for more details. Remove the type hint to disable this warning. To enable validation for the input data, specify input example or model signature when logging the model.
```
This PR adds a special handling for ChatModel subclasses to bypass the warning.

Note: `ChatAgent` is fine because their type hint is pydantic based. We can remove this fix once ChatModel is migrated to pydantic as well.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

No warning is shown at class definition time:

![Screenshot 2025-01-27 at 13 53 18](https://github.com/user-attachments/assets/b632ad11-7efa-4702-882b-4daeaa734adc)

Logging and prediction passes as well:

![Screenshot 2025-01-27 at 13 54 17](https://github.com/user-attachments/assets/f3f67cc6-470b-4121-bc3b-e575cd2d6901)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix false alert of type hint validation for ChatModel.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
