### PR TITLE
Bump minimum pydantic version to 1.8

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -260,14 +260,13 @@ spacy:
       pip install git+https://github.com/explosion/spaCy.git
 
   models:
-    minimum: "3.0.0"
+    minimum: "3.1.0"
     maximum: "3.8.3"
     python:
       ">= 3.8.4": "3.10"
     requirements:
       ">= 0.0.0": ["scikit-learn", "click<8.1.0"]
-      "<= 3.0.9": ["flask<2.1.0", "werkzeug<3"]
-      ">= 3.0.9, < 3.4.0": ["typing_extensions<4.6.0", "sqlalchemy<2.0.25"]
+      ">= 3.1.0, < 3.4.0": ["typing_extensions<4.6.0", "sqlalchemy<2.0.25"]
       "< 3.8": ["numpy<2"]
     run: |
       pytest tests/spacy/test_spacy_model_export.py

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -127,7 +127,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "spacy"
         },
         "models": {
-            "minimum": "3.0.0",
+            "minimum": "3.1.0",
             "maximum": "3.8.3"
         }
     },

--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -32,7 +32,7 @@ dependencies = [
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<25",
   "protobuf<6,>=3.12.0",
-  "pydantic<3,>=1.0",
+  "pydantic<3,>=1.8",
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",
   "sqlparse<1,>=0.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "pandas<3",
   "protobuf<6,>=3.12.0",
   "pyarrow<19,>=4.0.0",
-  "pydantic<3,>=1.0",
+  "pydantic<3,>=1.8",
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",
   "scikit-learn<2",

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -15,5 +15,5 @@ cachetools<6,>=5.0.0
 opentelemetry-api<3,>=1.9.0
 opentelemetry-sdk<3,>=1.9.0
 databricks-sdk<1,>=0.20.0
-pydantic<3,>=1.0
+pydantic<3,>=1.8
 typing-extensions<5,>=4.0.0

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -77,7 +77,7 @@ databricks-sdk:
 
 pydantic:
   pip_release: pydantic
-  minimum: "1.0"
+  minimum: "1.8"
   max_major_version: 2
 
 typing-extensions:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14344?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14344/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14344
```

</p>
</details>

### What changes are proposed in this pull request?

Our [chat schema](https://github.com/mlflow/mlflow/blob/master/mlflow/types/chat.py#L66) uses `Annotation` type hint, which is only supported in Pydantic 1.8 >=. This `mlflow/types/chat` module are imported globally via many different paths, so instead of trying to gate it behind lazy load (e.g., only import when feature xyz is used), bumping the minimum supported version of Pydantic to 1.8.0.

Pydantic 1.8.0 was released 4 years ago so should be fine to drop. Among all ML libraries and their version we support, the only one affected is Spacy 3.0.0 ([test failure](https://github.com/mlflow-automation/mlflow/actions/runs/12975023780/job/36189251496#step:12:716)), which explicitly pin pydantic to < 1.8.0. Spacy 3.0.0 is also very old so dropping it is reasonable. All other libraries are not affected.

Also confirmed all supported Databricks MLR uses Pydantic >= 1.8:
* [MLR 15.4](https://docs.databricks.com/en/release-notes/runtime/15.4lts-ml.html): 1.10.6
* [MLR 14.3](https://docs.databricks.com/en/release-notes/runtime/14.3lts-ml.html): 1.10.6
* [MLR 13.3](https://docs.databricks.com/en/release-notes/runtime/13.3lts-ml.html): 1.10.6
* [MLR 12.2](https://docs.databricks.com/en/release-notes/runtime/12.2lts-ml.html): 1.10.2
* [MLR 11.3](https://docs.databricks.com/en/release-notes/runtime/11.3lts-ml.html): 1.10.2
* [MLR 10.4](https://docs.databricks.com/en/release-notes/runtime/10.4lts-ml.html): 1.8.2
* [MLR 9.1](https://docs.databricks.com/en/release-notes/runtime/9.1lts-ml.html)): 1.8.2

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Drop support for Pydantic <= 1.7.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
