### PR TITLE
Warn if there is a version mismatch between mlflow and mlflow-skinny

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -32,6 +32,12 @@ import contextlib
 from mlflow.version import VERSION
 
 __version__ = VERSION
+
+import mlflow.mismatch
+
+# `check_version_mismatch` must be called here before importing any other modules
+mlflow.mismatch._check_version_mismatch()
+
 from mlflow import (
     artifacts,  # noqa: F401
     client,  # noqa: F401
@@ -115,7 +121,6 @@ from mlflow.config import (
     set_tracking_uri,
 )
 from mlflow.exceptions import MlflowException
-from mlflow.mismatch import _check_version_mismatch
 from mlflow.models import evaluate
 from mlflow.models.evaluation.validation import validate_evaluation_results
 from mlflow.projects import run
@@ -259,6 +264,3 @@ with contextlib.suppress(Exception):
     from mlflow import gateway  # noqa: F401
 
     __all__.append("gateway")
-
-
-_check_version_mismatch()

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -115,6 +115,7 @@ from mlflow.config import (
     set_tracking_uri,
 )
 from mlflow.exceptions import MlflowException
+from mlflow.mismatch import _check_version_mismatch
 from mlflow.models import evaluate
 from mlflow.models.evaluation.validation import validate_evaluation_results
 from mlflow.projects import run
@@ -258,3 +259,6 @@ with contextlib.suppress(Exception):
     from mlflow import gateway  # noqa: F401
 
     __all__.append("gateway")
+
+
+_check_version_mismatch()

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -36,7 +36,10 @@ __version__ = VERSION
 import mlflow.mismatch
 
 # `check_version_mismatch` must be called here before importing any other modules
-mlflow.mismatch._check_version_mismatch()
+try:
+    mlflow.mismatch._check_version_mismatch()
+except Exception:
+    pass
 
 from mlflow import (
     artifacts,  # noqa: F401

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -36,10 +36,8 @@ __version__ = VERSION
 import mlflow.mismatch
 
 # `check_version_mismatch` must be called here before importing any other modules
-try:
+with contextlib.suppress(Exception):
     mlflow.mismatch._check_version_mismatch()
-except Exception:
-    pass
 
 from mlflow import (
     artifacts,  # noqa: F401

--- a/mlflow/mismatch.py
+++ b/mlflow/mismatch.py
@@ -1,0 +1,33 @@
+import importlib.metadata
+import warnings
+from typing import Optional
+
+from packaging.version import Version
+
+
+def _get_version(package_name: str) -> Optional[Version]:
+    try:
+        return Version(importlib.metadata.version(package_name))
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _check_version_mismatch() -> None:
+    """
+    Warns if both mlflow and mlflow-skinny are installed but their versions are not matched.
+    """
+    if (
+        (mlflow_ver := _get_version("mlflow"))
+        and (not mlflow_ver.is_devrelease)
+        and (skinny_ver := _get_version("mlflow-skinny"))
+        and (not skinny_ver.is_devrelease)
+        and mlflow_ver != skinny_ver
+    ):
+        return warnings.warn(
+            (
+                f"Versions of mlflow ({mlflow_ver}) and mlflow-skinny ({skinny_ver}) "
+                "are not matched. This may lead to unexpected behavior. "
+                "Please install the same version of both packages."
+            ),
+            category=UserWarning,
+        )

--- a/mlflow/mismatch.py
+++ b/mlflow/mismatch.py
@@ -14,7 +14,9 @@ def _get_version(package_name: str) -> Optional[Version]:
 
 def _check_version_mismatch() -> None:
     """
-    Warns if both mlflow and mlflow-skinny are installed but their versions are not matched.
+    Warns if both mlflow and mlflow-skinny are installed but their versions are different.
+
+    Reference: https://github.com/pypa/pip/issues/4625
     """
     if (
         (mlflow_ver := _get_version("mlflow"))
@@ -26,7 +28,7 @@ def _check_version_mismatch() -> None:
         return warnings.warn(
             (
                 f"Versions of mlflow ({mlflow_ver}) and mlflow-skinny ({skinny_ver}) "
-                "are not matched. This may lead to unexpected behavior. "
+                "are different. This may lead to unexpected behavior. "
                 "Please install the same version of both packages."
             ),
             category=UserWarning,

--- a/mlflow/mismatch.py
+++ b/mlflow/mismatch.py
@@ -31,5 +31,6 @@ def _check_version_mismatch() -> None:
                 "are different. This may lead to unexpected behavior. "
                 "Please install the same version of both packages."
             ),
+            stacklevel=2,
             category=UserWarning,
         )

--- a/mlflow/mismatch.py
+++ b/mlflow/mismatch.py
@@ -23,7 +23,7 @@ def _check_version_mismatch() -> None:
         and ("dev" not in skinny_ver)
         and mlflow_ver != skinny_ver
     ):
-        return warnings.warn(
+        warnings.warn(
             (
                 f"Versions of mlflow ({mlflow_ver}) and mlflow-skinny ({skinny_ver}) "
                 "are different. This may lead to unexpected behavior. "

--- a/mlflow/mismatch.py
+++ b/mlflow/mismatch.py
@@ -2,12 +2,10 @@ import importlib.metadata
 import warnings
 from typing import Optional
 
-from packaging.version import Version
 
-
-def _get_version(package_name: str) -> Optional[Version]:
+def _get_version(package_name: str) -> Optional[str]:
     try:
-        return Version(importlib.metadata.version(package_name))
+        return importlib.metadata.version(package_name)
     except importlib.metadata.PackageNotFoundError:
         return None
 
@@ -20,9 +18,9 @@ def _check_version_mismatch() -> None:
     """
     if (
         (mlflow_ver := _get_version("mlflow"))
-        and (not mlflow_ver.is_devrelease)
+        and ("dev" not in mlflow_ver)
         and (skinny_ver := _get_version("mlflow-skinny"))
-        and (not skinny_ver.is_devrelease)
+        and ("dev" not in skinny_ver)
         and mlflow_ver != skinny_ver
     ):
         return warnings.warn(

--- a/tests/test_mismatch.py
+++ b/tests/test_mismatch.py
@@ -19,7 +19,7 @@ from mlflow.mismatch import _check_version_mismatch
         (None, None),
     ],
 )
-def test_check_version_mismatch_warn(mlflow_version: str, skinny_version: str):
+def test_check_version_mismatch_no_warn(mlflow_version: str, skinny_version: str):
     def mock_version(package_name: str) -> str:
         if package_name == "mlflow":
             if mlflow_version is None:
@@ -46,7 +46,7 @@ def test_check_version_mismatch_warn(mlflow_version: str, skinny_version: str):
         ("1.0.0rc0", "1.0.0"),
     ],
 )
-def test_check_version_mismatch_warning(mlflow_version: str, skinny_version: str):
+def test_check_version_mismatch_warn(mlflow_version: str, skinny_version: str):
     def mock_version(package_name: str) -> str:
         if package_name == "mlflow":
             return mlflow_version

--- a/tests/test_mismatch.py
+++ b/tests/test_mismatch.py
@@ -1,0 +1,64 @@
+import warnings
+from importlib.metadata import PackageNotFoundError
+from unittest import mock
+
+import pytest
+
+from mlflow.mismatch import _check_version_mismatch
+
+
+@pytest.mark.parametrize(
+    ("mlflow_version", "skinny_version"),
+    [
+        ("1.0.0", "1.0.0"),
+        ("1.0.0.dev0", "1.0.0"),
+        ("1.0.0", "1.0.0.dev0"),
+        ("1.0.0.dev0", "1.0.0.dev0"),
+        ("1.0.0", None),
+        (None, "1.0.0"),
+        (None, None),
+    ],
+)
+def test_check_version_mismatch_warn(mlflow_version: str, skinny_version: str):
+    def mock_version(package_name: str) -> str:
+        if package_name == "mlflow":
+            if mlflow_version is None:
+                raise PackageNotFoundError
+            return mlflow_version
+        elif package_name == "mlflow-skinny":
+            if skinny_version is None:
+                raise PackageNotFoundError
+            return skinny_version
+        raise ValueError(f"Unexpected package: {package_name}")
+
+    with mock.patch("importlib.metadata.version", side_effect=mock_version) as mv:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _check_version_mismatch()
+
+        mv.assert_called()
+
+
+@pytest.mark.parametrize(
+    ("mlflow_version", "skinny_version"),
+    [
+        ("1.0.0", "1.0.1"),
+        ("1.0.0rc0", "1.0.0"),
+    ],
+)
+def test_check_version_mismatch_warning(mlflow_version: str, skinny_version: str):
+    def mock_version(package_name: str) -> str:
+        if package_name == "mlflow":
+            return mlflow_version
+        elif package_name == "mlflow-skinny":
+            return skinny_version
+        raise ValueError(f"Unexpected package: {package_name}")
+
+    with mock.patch("importlib.metadata.version", side_effect=mock_version) as mv:
+        with pytest.warns(
+            UserWarning,
+            match=r"Versions of mlflow \([.\w]+\) and mlflow-skinny \([.\w]+\) are different",
+        ):
+            _check_version_mismatch()
+
+        mv.assert_called()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14349?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14349/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14349
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR makes updates to warn a user if their python environment has both mlflow and mlflow-skinny installed but their versions are **_different_**. Recent versions of mlflow pin mlflow-skinny, but it's still possible to install a different version of mlflow-skinny because pip doesn't enforce that the mlflow requirements are still satisfied AT ALL.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
