### PR TITLE
Fix `OpenAIAdapter.model_to_completions_streaming`

### DIFF
--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -94,10 +94,7 @@ class CohereAdapter(ProviderAdapter):
                 completions.StreamChoice(
                     index=resp.get("index", 0),
                     finish_reason=resp.get("finish_reason"),
-                    delta=completions.StreamDelta(
-                        role=None,
-                        content=resp.get("text"),
-                    ),
+                    text=resp.get("text"),
                 )
             ],
             usage=completions.CompletionsUsage(

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -196,9 +196,7 @@ class OpenAIAdapter(ProviderAdapter):
                 completions.StreamChoice(
                     index=c["index"],
                     finish_reason=c["finish_reason"],
-                    text=completions.StreamDelta(
-                        content=c["delta"].get("content"),
-                    ),
+                    text=c["delta"].get("content"),
                 )
                 for c in resp["choices"]
             ],

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -196,7 +196,7 @@ class OpenAIAdapter(ProviderAdapter):
                 completions.StreamChoice(
                     index=c["index"],
                     finish_reason=c["finish_reason"],
-                    delta=completions.StreamDelta(
+                    text=completions.StreamDelta(
                         content=c["delta"].get("content"),
                     ),
                 )

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -123,7 +123,7 @@ class TogetherAIAdapter(ProviderAdapter):
                     index=idx,
                     # TODO this is questionable since the finish reason comes from togetherai api
                     finish_reason=choice.get("finish_reason"),
-                    delta=completions_schema.StreamDelta(role=None, content=choice.get("text")),
+                    text=choice.get("text"),
                 )
                 for idx, choice in enumerate(resp.get("choices", []))
             ],

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -75,7 +75,7 @@ class StreamDelta(ResponseModel):
 class StreamChoice(ResponseModel):
     index: int
     finish_reason: Optional[str] = None
-    delta: StreamDelta
+    text: Optional[str] = None
 
 
 _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {

--- a/tests/gateway/providers/test_cohere.py
+++ b/tests/gateway/providers/test_cohere.py
@@ -369,7 +369,7 @@ async def test_completions_stream():
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": " Hi"},
+                        "text": " Hi",
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -382,7 +382,7 @@ async def test_completions_stream():
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": " there"},
+                        "text": " there",
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -395,7 +395,7 @@ async def test_completions_stream():
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": None},
+                        "text": None,
                         "finish_reason": "COMPLETE",
                         "index": 0,
                     }

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -320,7 +320,7 @@ async def test_completions_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": ""},
+                        "text": "",
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -332,7 +332,11 @@ async def test_completions_stream(resp):
             },
             {
                 "choices": [
-                    {"delta": {"role": None, "content": "test"}, "finish_reason": None, "index": 0}
+                    {
+                        "text": "test",
+                        "finish_reason": None,
+                        "index": 0,
+                    }
                 ],
                 "created": 1,
                 "id": "test-id",
@@ -342,7 +346,7 @@ async def test_completions_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": None},
+                        "text": None,
                         "finish_reason": "length",
                         "index": 0,
                     }

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -173,7 +173,7 @@ async def test_completions_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": "test"},
+                        "text": "test",
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -185,7 +185,11 @@ async def test_completions_stream(resp):
             },
             {
                 "choices": [
-                    {"delta": {"role": None, "content": "test"}, "finish_reason": None, "index": 0}
+                    {
+                        "text": "test",
+                        "finish_reason": None,
+                        "index": 0,
+                    }
                 ],
                 "created": 1,
                 "id": "test-id",
@@ -195,7 +199,7 @@ async def test_completions_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": "test"},
+                        "text": "test",
                         "finish_reason": "length",
                         "index": 0,
                     }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14381?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14381/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14381
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #14375

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

https://platform.openai.com/docs/api-reference/completions/create

Fixes the streaming (not chat) completion output format.

```python
{
    "id": "cmpl-7iA7iJjj8V2zOkCGvWF2hAkDWBQZe",
    "object": "text_completion",
    "created": 1690759702,
    "choices": [
        {
            # Fix this to:
            # "delta": {
            #     "role": "assistant",
            #     "content": "This ",
            # },
            # This 👇
            "text": "This",
            "index": 0,
            "logprobs": null,
            "finish_reason": null,
        }
    ],
    "model": "gpt-3.5-turbo-instruct",
    "system_fingerprint": "fp_44709d6fcb",
}

```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
