### PR TITLE
Add intermediate_outputs property to trace

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -264,11 +264,6 @@ class Span:
                 INVALID_PARAMETER_VALUE,
             ) from e
 
-    @property
-    def _intermediate_outputs(self) -> Optional[dict[str, Any]]:
-        """The intermediate outputs attribute of the span."""
-        return self.get_attribute(SpanAttributeKey.INTERMEDIATE_OUTPUTS)
-
 
 class LiveSpan(Span):
     """

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -264,6 +264,11 @@ class Span:
                 INVALID_PARAMETER_VALUE,
             ) from e
 
+    @property
+    def _intermediate_outputs(self) -> Optional[dict[str, Any]]:
+        """The intermediate outputs attribute of the span."""
+        return self.get_attribute(SpanAttributeKey.INTERMEDIATE_OUTPUTS)
+
 
 class LiveSpan(Span):
     """

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -12,6 +12,7 @@ from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.tracing.constant import SpanAttributeKey
 
 _logger = logging.getLogger(__name__)
 
@@ -237,14 +238,14 @@ class Trace(_MlflowObject):
         """
         Returns intermediate outputs within the trace.
         There are mainly two flows to return intermediate outputs:
-        1. When a trace only has one dummy root span,
+        1. When a trace only has one root span,
         return `intermediate_outputs` attribute of the span.
         2. When a trace is created normally with a tree of spans,
         aggregate the outputs of non-root spans.
         """
         root_span = self._get_root_span()
-        if root_span and root_span._intermediate_outputs:
-            return root_span._intermediate_outputs
+        if root_span and root_span.get_attribute(SpanAttributeKey.INTERMEDIATE_OUTPUTS):
+            return root_span.get_attribute(SpanAttributeKey.INTERMEDIATE_OUTPUTS)
         # TODO: handle the second case for a normal trace with spans
 
     def _get_root_span(self) -> Optional[Span]:

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -231,3 +231,23 @@ class Trace(_MlflowObject):
             "spans",
             "tags",
         ]
+
+    @property
+    def intermediate_outputs(self) -> Optional[dict[str, Any]]:
+        """
+        Returns intermediate outputs within the trace.
+        There are mainly two flows to return intermediate outputs:
+        1. When a trace only has one dummy root span,
+        return `intermediate_outputs` attribute of the span.
+        2. When a trace is created normally with a tree of spans,
+        aggregate the outputs of non-root spans.
+        """
+        root_span = self._get_root_span()
+        if root_span and root_span._intermediate_outputs:
+            return root_span._intermediate_outputs
+        # TODO: handle the second case for a normal trace with spans
+
+    def _get_root_span(self) -> Optional[Span]:
+        for span in self.data.spans:
+            if span.parent_id is None:
+                return span

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -26,6 +26,9 @@ class SpanAttributeKey:
     # such as evaluation
     CHAT_MESSAGES = "mlflow.chat.messages"
     CHAT_TOOLS = "mlflow.chat.tools"
+    # This attribute is not empty only on the root span.
+    # Used to populate `intermediate_output` field of a trace.
+    INTERMEDIATE_OUTPUTS = "mlflow.trace.intermediate_outputs"
 
 
 # All storage backends are guaranteed to support key values up to 250 characters

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -296,3 +296,30 @@ def test_search_spans_raise_for_invalid_param_type():
 
     with pytest.raises(MlflowException, match="Invalid type for 'name'"):
         trace.search_spans(name=123)
+
+
+def test_intermediate_outputs_from_attribute():
+    intermediate_outputs = {
+        "retrieved_documents": ["document 1", "document 2"],
+        "generative_prompt": "prompt",
+    }
+
+    def run():
+        with mlflow.start_span(name="run") as span:
+            span.set_attribute("mlflow.trace.intermediate_outputs", intermediate_outputs)
+
+    run()
+    trace = mlflow.get_last_active_trace()
+
+    assert trace.intermediate_outputs == intermediate_outputs
+
+
+def test_intermediate_outputs_no_value():
+    def run():
+        with mlflow.start_span(name="run") as span:
+            span.set_outputs(1)
+
+    run()
+    trace = mlflow.get_last_active_trace()
+
+    assert trace.intermediate_outputs is None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14395?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14395/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14395
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR introduces a new reserved attribute to spans and adds a new attribute to traces for intermediate outputs.

```
trace = mlflow.get_last_active_trace()
trace.intermediate_outputs
-> {
        "retrieved_documents": ["document 1", "document 2"],
        "generative_prompt": "prompt",
    }
```


### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

A new property `intermediate_outputs` is populated to Trace entity.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
