### PR TITLE
[1/N] Update test logic for tracing + model serving

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -740,6 +740,8 @@ langchain:
           # Required to run tests/openai/mock_openai.py
           "fastapi",
           "uvicorn",
+          # Some model logging/loading requires langchain community
+          "langchain-community",
         ]
       "< 0.3.0": ["langchain_openai<0.2.0"]
       ">= 0.3.0": [

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -194,8 +194,7 @@ def score_in_model_serving(model_uri: str, model_input: dict):
             return mlflow.pyfunc.load_model(model_uri)
 
         with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(_load_model)
-            model = future.result()
+            model = executor.submit(_load_model).result()
 
         # Score the model
         request_id = uuid.uuid4().hex

--- a/tests/tracing/processor/test_inference_table_processor.py
+++ b/tests/tracing/processor/test_inference_table_processor.py
@@ -1,15 +1,11 @@
 import json
 from unittest import mock
 
-import pytest
-
 from mlflow.entities.span import LiveSpan
 from mlflow.entities.trace_status import TraceStatus
+from mlflow.pyfunc.context import Context, set_prediction_context
 from mlflow.tracing.constant import SpanAttributeKey
-from mlflow.tracing.processor.inference_table import (
-    _HEADER_REQUEST_ID_KEY,
-    InferenceTableSpanProcessor,
-)
+from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 
 from tests.tracing.helper import create_mock_otel_span, create_test_trace_info
@@ -18,17 +14,7 @@ _TRACE_ID = 12345
 _REQUEST_ID = f"tr-{_TRACE_ID}"
 
 
-@pytest.fixture
-def flask_request():
-    with mock.patch(
-        "mlflow.tracing.processor.inference_table._get_flask_request"
-    ) as mock_get_flask_request:
-        request = mock_get_flask_request.return_value
-        request.headers = {_HEADER_REQUEST_ID_KEY: _REQUEST_ID}
-        yield request
-
-
-def test_on_start(flask_request):
+def test_on_start():
     # Root span should create a new trace on start
     span = create_mock_otel_span(
         trace_id=_TRACE_ID, span_id=1, parent_id=None, start_time=5_000_000
@@ -36,7 +22,8 @@ def test_on_start(flask_request):
     trace_manager = InMemoryTraceManager.get_instance()
     processor = InferenceTableSpanProcessor(span_exporter=mock.MagicMock())
 
-    processor.on_start(span)
+    with set_prediction_context(Context(request_id=_REQUEST_ID)):
+        processor.on_start(span)
 
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces
@@ -52,7 +39,9 @@ def test_on_start(flask_request):
     child_span = create_mock_otel_span(
         trace_id=_TRACE_ID, span_id=2, parent_id=1, start_time=8_000_000
     )
-    processor.on_start(child_span)
+
+    with set_prediction_context(Context(request_id=_REQUEST_ID)):
+        processor.on_start(child_span)
 
     assert child_span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -235,7 +235,8 @@ def test_trace_in_databricks_model_serving(
         data = json.loads(flask.request.data.decode("utf-8"))
         request_id = flask.request.headers.get("X-Request-ID")
 
-        prediction = TestModel().predict(**data)
+        with set_prediction_context(Context(request_id=request_id)):
+            prediction = TestModel().predict(**data)
 
         trace = pop_trace(request_id=request_id)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14397?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14397/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14397
```

</p>
</details>

### What changes are proposed in this pull request?

We have some test cases that emulates Databricks model serving environment. However, there is one difference between our suite and real env. The model is loaded in a separate thread in the actual serving. While this is subtle difference for many flavors, sometimes it causes an uncaught issue (e.g. DSPy changed global setting to thread-local, broke trace).

While we also have integration test, ideally we want to catch such regression earlier in cross-version tests. Therefore, this PR add a test helper that is more closer to the real environment, and apply it to LangChain as a starter. PRs for other flavors will follow.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
