### PR TITLE
Support generating traces from DSPy built-in compilation and evaluation

### DIFF
--- a/docs/docs/tracing/integrations/dspy.mdx
+++ b/docs/docs/tracing/integrations/dspy.mdx
@@ -112,6 +112,7 @@ class Counter(dspy.Signature):
         desc="Should only contain a single number as an answer"
     )
 
+
 cot = dspy.ChainOfThought(Counter)
 
 # Evaluate the programs
@@ -153,6 +154,17 @@ You can enable tracing for these steps by calling the <APILink fn="mlflow.dspy.a
 
 By default, MLflow does **NOT** generate traces during complication, because complication can trigger hundreds or thousands of invocations of DSPy modules. To enable tracing for compilation, you can call the <APILink fn="mlflow.dspy.autolog" /> function with the `log_traces_from_compile` parameter set to `True`.
 
+```python
+import dspy
+import mlflow
+
+# Enable auto-tracing for compilation
+mlflow.dspy.autolog(log_traces_from_compile=True)
+
+# Optimize the DSPy program as usual
+tp = dspy.MIPROv2(metric=metric, auto="medium", num_threads=24)
+optimized = tp.compile(cot, trainset=trainset, ...)
+```
 
 ### Disable auto-tracing
 

--- a/docs/docs/tracing/integrations/dspy.mdx
+++ b/docs/docs/tracing/integrations/dspy.mdx
@@ -76,14 +76,11 @@ summarizer(
 )
 ```
 
+### Tracing during Evaluation
 
-### Tracing during Compilation and Evaluation
+Evaluating DSPy models is an important step in the development of AI systems. MLflow Tracing can help you track the performance of your programs after the evaluation, by providing detailed information about the execution of your programs for each input.
 
-Compilation (optimization) and evaluation are two important steps in the development of a DSPy program. MLflow Tracing can help you track the performance of your programs during these steps.
-
-Since those steps involves many invocation of DSPy modules, MLflow by default does not generate traces during compilation and evaluation. You can enable tracing for these steps by calling the <APILink fn="mlflow.dspy.autolog" /> function with the `log_traces_from_compile` and `log_traces_from_eval` parameters set to `True`.
-
-The following example demonstrates how to enable tracing for evaluation:
+When MLflow auto-tracing is enabled for DSPy, traces will be automatically generated when you execute DSPy's [built-in evaluation suites](https://dspy.ai/learn/evaluation/overview/). The following example demonstrates how to run evaluation and review traces in MLflow:
 
 ```python
 import dspy
@@ -115,7 +112,6 @@ class Counter(dspy.Signature):
         desc="Should only contain a single number as an answer"
     )
 
-
 cot = dspy.ChainOfThought(Counter)
 
 # Evaluate the programs
@@ -142,7 +138,20 @@ with mlflow.start_run(run_name="CoT Evaluation"):
     )
 ```
 
-If you open the MLflow UI and go to the "CoT Evaluation" run, you will see the evaluation result and the list of traces generated for each input question.
+If you open the MLflow UI and go to the "CoT Evaluation" run, you will see the evaluation result, and the list of traces generated during the evaluation on the ``Traces`` tab.
+
+
+:::note
+
+You can enable tracing for these steps by calling the <APILink fn="mlflow.dspy.autolog" /> function with the `log_traces_from_eval` parameters set to `False`.
+
+:::
+
+### Tracing during Compilation (Optimization)
+
+[Compilation (optimization)](https://dspy.ai/learn/optimization/overview/) is the core concept of DSPy. Through compilation, DSPy automatically optimizes the prompts and weights of your DSPy program to achieve the best performance.
+
+By default, MLflow does **NOT** generate traces during complication, because complication can trigger hundreds or thousands of invocations of DSPy modules. To enable tracing for compilation, you can call the <APILink fn="mlflow.dspy.autolog" /> function with the `log_traces_from_compile` parameter set to `True`.
 
 
 ### Disable auto-tracing

--- a/docs/docs/tracing/integrations/dspy.mdx
+++ b/docs/docs/tracing/integrations/dspy.mdx
@@ -77,16 +77,74 @@ summarizer(
 ```
 
 
-### LlamaIndex workflow
+### Tracing Evaluation
 
-The `Workflow` is LlamaIndex’s next-generation GenAI orchestration framework. It is designed as a flexible and interpretable framework for building arbitrary LLM applications such as an agent, a RAG flow, a data extraction pipeline, etc. MLflow supports tracking, evaluating, and tracing the Workflow objects, which makes them more observable and maintainable.
+DSPy provides a [built-in evaluation suite](https://dspy.ai/learn/evaluation/overview/) for measuring the performance of your programs. After the evaluation, it is important to understand the individual results and identify gaps to improve the program. MLflow help you to track the evaluation results and inspect why the model is performing well or poorly.
 
-Automatic tracing for LlamaIndex workflow works off-the-shelf by calling the same `mlflow.llama_index.autolog()`.
+:::note
 
-To learn more about MLflow's integration with LlamaIndex Workflow, continue to the following tutorials:
+    By default, MLflow does not generate traces during DSPy evaluation. You can enable tracing for evaluation by calling the <APILink fn="mlflow.dspy.autolog" /> function with the `log_traces_from_eval` parameter set to `True`.
 
-* [Building a Tool-calling Agent with LlamaIndex Workflow and MLflow](/llms/llama-index/notebooks/llama_index_workflow_tutorial)
-* [Building Advanced RAG with MLflow and LlamaIndex Workflow](https://mlflow.org/blog/mlflow-llama-index-workflow)
+:::
+
+```python
+import dspy
+from dspy.evaluate.metrics import answer_exact_match
+
+import mlflow
+
+# Enabling tracing for DSPy evaluation
+mlflow.dspy.autolog(log_traces_from_eval=True)
+
+# Define a simple evaluation set
+eval_set = [
+    dspy.Example(
+        question="How many 'r's are in the word 'strawberry'?", answer="3"
+    ).with_inputs("question"),
+    dspy.Example(
+        question="How many 'a's are in the word 'banana'?", answer="3"
+    ).with_inputs("question"),
+    dspy.Example(
+        question="How many 'e's are in the word 'elephant'?", answer="2"
+    ).with_inputs("question"),
+]
+
+
+# Define a program
+class Counter(dspy.Signature):
+    question: str = dspy.InputField()
+    answer: str = dspy.OutputField(
+        desc="Should only contain a single number as an answer"
+    )
+
+
+cot = dspy.ChainOfThought(Counter)
+
+# Evaluate the programs
+with mlflow.start_run(run_name="CoT Evaluation"):
+    evaluator = dspy.evaluate.Evaluate(
+        devset=eval_set,
+        return_all_scores=True,
+        return_outputs=True,
+        show_progress=True,
+    )
+    aggregated_score, outputs, all_scores = evaluator(cot, metric=answer_exact_match)
+
+    # Log the aggregated score
+    mlflow.log_metric("exact_match", aggregated_score)
+    # Log the detailed evaluation results as a table
+    mlflow.log_table(
+        {
+            "question": [example.question for example in eval_set],
+            "answer": [example.answer for example in eval_set],
+            "output": outputs,
+            "exact_match": all_scores,
+        },
+        artifact_file="eval_results.json",
+    )
+```
+
+If you open the MLflow UI and go to the "CoT Evaluation" run, you will see the evaluation result and the list of traces generated for each input question.
 
 
 ### Disable auto-tracing

--- a/docs/docs/tracing/integrations/dspy.mdx
+++ b/docs/docs/tracing/integrations/dspy.mdx
@@ -77,15 +77,13 @@ summarizer(
 ```
 
 
-### Tracing Evaluation
+### Tracing during Compilation and Evaluation
 
-DSPy provides a [built-in evaluation suite](https://dspy.ai/learn/evaluation/overview/) for measuring the performance of your programs. After the evaluation, it is important to understand the individual results and identify gaps to improve the program. MLflow help you to track the evaluation results and inspect why the model is performing well or poorly.
+Compilation (optimization) and evaluation are two important steps in the development of a DSPy program. MLflow Tracing can help you track the performance of your programs during these steps.
 
-:::note
+Since those steps involves many invocation of DSPy modules, MLflow by default does not generate traces during compilation and evaluation. You can enable tracing for these steps by calling the <APILink fn="mlflow.dspy.autolog" /> function with the `log_traces_from_compile` and `log_traces_from_eval` parameters set to `True`.
 
-    By default, MLflow does not generate traces during DSPy evaluation. You can enable tracing for evaluation by calling the <APILink fn="mlflow.dspy.autolog" /> function with the `log_traces_from_eval` parameter set to `True`.
-
-:::
+The following example demonstrates how to enable tracing for evaluation:
 
 ```python
 import dspy

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -16,7 +16,7 @@ _logger = logging.getLogger(__name__)
 def autolog(
     log_traces: bool = True,
     log_traces_from_compile: bool = False,
-    log_traces_from_eval: bool = False,
+    log_traces_from_eval: bool = True,
     disable: bool = False,
     silent: bool = False,
 ):
@@ -33,7 +33,7 @@ def autolog(
         log_traces_from_eval: If ``True``, traces are logged for DSPy models when running DSPy's
             `built-in evaluator <https://dspy.ai/learn/evaluation/metrics/#evaluation>`_.
             If ``False``, traces are only logged from normal model inference and disabled when
-            running the evaluator. Default to ``False``.
+            running the evaluator. Default to ``True``.
         disable: If ``True``, disables the DSPy autologging integration. If ``False``,
             enables the DSPy autologging integration.
         silent: If ``True``, suppress all event logs and warnings from MLflow during DSPy
@@ -111,12 +111,11 @@ def autolog(
             trace_disabled_fn,
         )
 
-    if not log_traces_from_compile and not log_traces_from_eval:
+    if not log_traces_from_compile:
         _logger.info(
             "Enabled DSPy tracing. By default, MLflow only generates traces for normal"
-            "model inference, and disables tracing when running the compilation and "
-            "evaluation. To enable tracing during evaluation, set log_traces_from_eval=True "
-            "and log_traces_from_compile=True in the autologging call."
+            "model inference and evaluation, but disables it during compilation (optimization). "
+            "To enable it set log_traces_from_compile=True in the autologging call."
         )
 
 

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -15,6 +15,7 @@ _logger = logging.getLogger(__name__)
 @experimental
 def autolog(
     log_traces: bool = True,
+    log_traces_from_compile: bool = False,
     log_traces_from_eval: bool = False,
     disable: bool = False,
     silent: bool = False,
@@ -26,10 +27,13 @@ def autolog(
     Args:
         log_traces: If ``True``, traces are logged for DSPy models by using. If ``False``,
             no traces are collected during inference. Default to ``True``.
+        log_traces_from_compile: If ``True``, traces are logged when compiling (optimizing)
+            DSPy programs. If ``False``, traces are only logged from normal model inference and
+            disabled when compiling. Default to ``False``.
         log_traces_from_eval: If ``True``, traces are logged for DSPy models when running DSPy's
-            `built-in evaluator <https://dspy.ai/learn/evaluation/metrics/#evaluation>`_. If ``False``,
-            traces are only logged from normal model inference and disabled when running the evaluator.
-            Default to ``False``.
+            `built-in evaluator <https://dspy.ai/learn/evaluation/metrics/#evaluation>`_.
+            If ``False``, traces are only logged from normal model inference and disabled when
+            running the evaluator. Default to ``False``.
         disable: If ``True``, disables the DSPy autologging integration. If ``False``,
             enables the DSPy autologging integration.
         silent: If ``True``, suppress all event logs and warnings from MLflow during DSPy
@@ -43,6 +47,7 @@ def autolog(
     # TODO: since this implementation is inconsistent, explore a universal way to solve the issue.
     _autolog(
         log_traces=log_traces,
+        log_traces_from_compile=log_traces_from_compile,
         log_traces_from_eval=log_traces_from_eval,
         disable=disable,
         silent=silent,
@@ -61,8 +66,20 @@ def autolog(
             callbacks=[c for c in dspy.settings.callbacks if not isinstance(c, MlflowCallback)]
         )
 
-    # Patch teleprompter not to generate traces
+    # Patch teleprompter/evaluator not to generate traces by default
     def trace_disabled_fn(original, self, *args, **kwargs):
+        # NB: Since calling mlflow.dspy.autolog() again does not unpatch a function, we need to
+        # check this flag at runtime to determine if we should generate traces.
+        if isinstance(self, Teleprompter) and get_autologging_config(
+            FLAVOR_NAME, "log_traces_from_compile"
+        ):
+            return original(self, *args, **kwargs)
+
+        if isinstance(self, Evaluate) and get_autologging_config(
+            FLAVOR_NAME, "log_traces_from_eval"
+        ):
+            return original(self, *args, **kwargs)
+
         @trace_disabled
         def _fn(self, *args, **kwargs):
             return original(self, *args, **kwargs)
@@ -85,35 +102,21 @@ def autolog(
                 trace_disabled_fn,
             )
 
-    # Patch evaluate to generate traces only when opted in
     call_patch = "__call__"
-
-    def trace_disabled_fn_for_eval(original, self, *args, **kwargs):
-        # NB: Since calling mlflow.dspy.autolog() again does not unpatch a function, we need to
-        # check this flag at runtime to determine if we should generate traces.
-        if get_autologging_config(FLAVOR_NAME, "log_traces_from_eval"):
-            func = original
-        else:
-
-            @trace_disabled
-            def _fn(self, *args, **kwargs):
-                return original(self, *args, **kwargs)
-
-            func = _fn
-        return func(self, *args, **kwargs)
-
-    if hasattr(Evaluate, call_patch) and not log_traces_from_eval:
+    if hasattr(Evaluate, call_patch):
         safe_patch(
             FLAVOR_NAME,
             Evaluate,
             call_patch,
             trace_disabled_fn,
         )
+
+    if not log_traces_from_compile and not log_traces_from_eval:
         _logger.info(
             "Enabled DSPy tracing. By default, MLflow only generates traces for normal"
-            "model inference, and disables tracing when running the evaluator "
-            "(dspy.evaluate.Evaluate). To enable tracing during evaluation, set "
-            "log_traces_from_eval=True in the autologging call."
+            "model inference, and disables tracing when running the compilation and "
+            "evaluation. To enable tracing during evaluation, set log_traces_from_eval=True "
+            "and log_traces_from_compile=True in the autologging call."
         )
 
 
@@ -124,6 +127,7 @@ autolog.integration_name = FLAVOR_NAME
 @autologging_integration(FLAVOR_NAME)
 def _autolog(
     log_traces: bool,
+    log_traces_from_compile: bool,
     log_traces_from_eval: bool,
     disable: bool = False,
     silent: bool = False,

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -1,5 +1,3 @@
-import logging
-
 from mlflow.dspy.save import FLAVOR_NAME
 from mlflow.tracing.provider import trace_disabled
 from mlflow.utils.annotations import experimental
@@ -8,8 +6,6 @@ from mlflow.utils.autologging_utils import (
     get_autologging_config,
     safe_patch,
 )
-
-_logger = logging.getLogger(__name__)
 
 
 @experimental
@@ -109,13 +105,6 @@ def autolog(
             Evaluate,
             call_patch,
             trace_disabled_fn,
-        )
-
-    if not log_traces_from_compile:
-        _logger.info(
-            "Enabled DSPy tracing. By default, MLflow only generates traces for normal"
-            "model inference and evaluation, but disables it during compilation (optimization). "
-            "To enable it set log_traces_from_compile=True in the autologging call."
         )
 
 

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -1,12 +1,21 @@
+import logging
+
 from mlflow.dspy.save import FLAVOR_NAME
 from mlflow.tracing.provider import trace_disabled
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import autologging_integration, safe_patch
+from mlflow.utils.autologging_utils import (
+    autologging_integration,
+    get_autologging_config,
+    safe_patch,
+)
+
+_logger = logging.getLogger(__name__)
 
 
 @experimental
 def autolog(
     log_traces: bool = True,
+    log_traces_from_eval: bool = False,
     disable: bool = False,
     silent: bool = False,
 ):
@@ -17,6 +26,10 @@ def autolog(
     Args:
         log_traces: If ``True``, traces are logged for DSPy models by using. If ``False``,
             no traces are collected during inference. Default to ``True``.
+        log_traces_from_eval: If ``True``, traces are logged for DSPy models when running DSPy's
+            `built-in evaluator <https://dspy.ai/learn/evaluation/metrics/#evaluation>`_. If ``False``,
+            traces are only logged from normal model inference and disabled when running the evaluator.
+            Default to ``False``.
         disable: If ``True``, disables the DSPy autologging integration. If ``False``,
             enables the DSPy autologging integration.
         silent: If ``True``, suppress all event logs and warnings from MLflow during DSPy
@@ -28,7 +41,12 @@ def autolog(
     # annotate _autolog() instead of this entrypoint, and define the cleanup logic outside it.
     # This needs to be called before doing any safe-patching (otherwise safe-patch will be no-op).
     # TODO: since this implementation is inconsistent, explore a universal way to solve the issue.
-    _autolog(log_traces=log_traces, disable=disable, silent=silent)
+    _autolog(
+        log_traces=log_traces,
+        log_traces_from_eval=log_traces_from_eval,
+        disable=disable,
+        silent=silent,
+    )
 
     import dspy
 
@@ -43,7 +61,7 @@ def autolog(
             callbacks=[c for c in dspy.settings.callbacks if not isinstance(c, MlflowCallback)]
         )
 
-    # Patch teleprompter and evaluate not to generate traces
+    # Patch teleprompter not to generate traces
     def trace_disabled_fn(original, self, *args, **kwargs):
         @trace_disabled
         def _fn(self, *args, **kwargs):
@@ -67,13 +85,35 @@ def autolog(
                 trace_disabled_fn,
             )
 
+    # Patch evaluate to generate traces only when opted in
     call_patch = "__call__"
-    if hasattr(Evaluate, call_patch):
+
+    def trace_disabled_fn_for_eval(original, self, *args, **kwargs):
+        # NB: Since calling mlflow.dspy.autolog() again does not unpatch a function, we need to
+        # check this flag at runtime to determine if we should generate traces.
+        if get_autologging_config(FLAVOR_NAME, "log_traces_from_eval"):
+            func = original
+        else:
+
+            @trace_disabled
+            def _fn(self, *args, **kwargs):
+                return original(self, *args, **kwargs)
+
+            func = _fn
+        return func(self, *args, **kwargs)
+
+    if hasattr(Evaluate, call_patch) and not log_traces_from_eval:
         safe_patch(
             FLAVOR_NAME,
             Evaluate,
             call_patch,
             trace_disabled_fn,
+        )
+        _logger.info(
+            "Enabled DSPy tracing. By default, MLflow only generates traces for normal"
+            "model inference, and disables tracing when running the evaluator "
+            "(dspy.evaluate.Evaluate). To enable tracing during evaluation, set "
+            "log_traces_from_eval=True in the autologging call."
         )
 
 
@@ -84,6 +124,7 @@ autolog.integration_name = FLAVOR_NAME
 @autologging_integration(FLAVOR_NAME)
 def _autolog(
     log_traces: bool,
+    log_traces_from_eval: bool,
     disable: bool = False,
     silent: bool = False,
 ):

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -330,7 +330,7 @@ def test_autolog_custom_module():
     ]
 
 
-def test_autolog_tracing_during_compilation_by_default():
+def test_autolog_tracing_during_compilation_disabled_by_default():
     mlflow.dspy.autolog()
 
     dspy.settings.configure(
@@ -372,7 +372,7 @@ def test_autolog_tracing_during_compilation_by_default():
     assert len(get_traces()) == 2  # no new traces
 
 
-def test_autolog_tracing_during_evaluation_by_default():
+def test_autolog_tracing_during_evaluation_enabled_by_default():
     mlflow.dspy.autolog()
 
     dspy.settings.configure(
@@ -392,16 +392,8 @@ def test_autolog_tracing_during_evaluation_by_default():
 
     program = Predict("question -> answer")
 
-    # Evaluate should NOT generate traces by default
+    # Evaluate should generate traces by default
     evaluator = Evaluate(devset=trainset)
-    score = evaluator(program, metric=answer_exact_match)
-
-    assert score == 50.0
-    assert len(get_traces()) == 0
-
-    # If opted in, traces should be generated during evaluation
-    mlflow.dspy.autolog(log_traces_from_eval=True)
-
     score = evaluator(program, metric=answer_exact_match)
 
     assert score == 50.0
@@ -409,7 +401,7 @@ def test_autolog_tracing_during_evaluation_by_default():
     assert len(traces) == 2
     assert all(trace.info.status == "OK" for trace in traces)
 
-    # Opt-out again
+    # If opted out, traces should NOT be generated during evaluation
     mlflow.dspy.autolog(log_traces_from_eval=False)
 
     score = evaluator(program, metric=answer_exact_match)

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -6,6 +6,8 @@ from unittest import mock
 import dspy
 import pytest
 from dspy.evaluate import Evaluate
+from dspy.evaluate.metrics import answer_exact_match
+from dspy.predict import Predict
 from dspy.primitives.example import Example
 from dspy.teleprompt import BootstrapFewShot
 from dspy.utils.callback import BaseCallback, with_callbacks
@@ -328,47 +330,54 @@ def test_autolog_custom_module():
     ]
 
 
-def test_autolog_tracing_disabled_during_compile_evaluate():
+def test_autolog_tracing_during_compile_evaluate():
     mlflow.dspy.autolog()
 
     dspy.settings.configure(
         lm=DummyLM(
-            [
-                {
-                    "answer": "John Townes Van Zandt",
-                    "reasoning": "No more responses",
-                }
-            ]
+            {
+                "What is 1 + 1?": {"answer": "2"},
+                "What is 2 + 2?": {"answer": "1000"},
+            }
         )
     )
 
     # Samples from HotpotQA dataset
     trainset = [
-        Example(
-            {
-                "question": "At My Window was released by which American singer-songwriter?",
-                "answer": "John Townes Van Zandt",
-            }
-        ).with_inputs("question"),
-        Example(
-            {
-                "question": "which  American actor was Candace Kita  guest starred with ",
-                "answer": "Bill Murray",
-            }
-        ).with_inputs("question"),
+        Example(question="What is 1 + 1?", answer="2").with_inputs("question"),
+        Example(question="What is 2 + 2?", answer="4").with_inputs("question"),
     ]
 
+    program = Predict("question -> answer")
+
+    # Compile should NOT generate traces by default
     teleprompter = BootstrapFewShot()
-    teleprompter.compile(RAG(), trainset=trainset)
+    teleprompter.compile(program, trainset=trainset)
 
-    assert mlflow.get_last_active_trace() is None
+    assert len(get_traces()) == 0
 
-    # Evaluate the model
+    # Evaluate should NOT generate traces by default
     evaluator = Evaluate(devset=trainset)
-    score = evaluator(RAG(), metric=lambda example, pred, _: example.answer == pred.answer)
+    score = evaluator(program, metric=answer_exact_match)
 
-    assert score == 0.0
-    assert mlflow.get_last_active_trace() is None
+    assert score == 50.0
+    assert len(get_traces()) == 0
+
+    # If opted in, traces should be generated during evaluation
+    mlflow.dspy.autolog(log_traces_from_eval=True)
+
+    score = evaluator(program, metric=answer_exact_match)
+
+    assert score == 50.0
+    traces = get_traces()
+    assert len(traces) == 2
+    assert all(trace.info.status == "OK" for trace in traces)
+
+    # Opt-out again
+    mlflow.dspy.autolog(log_traces_from_eval=False)
+
+    score = evaluator(program, metric=answer_exact_match)
+    assert len(get_traces()) == 2
 
 
 def test_autolog_should_not_override_existing_callbacks():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14400?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14400/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14400
```

</p>
</details>

### What changes are proposed in this pull request?

Currently, we disable auto-tracing when users run DSPy's built-in evaluator `dspy.evaluate.Evaluator`, because it can generates hundreds of traces and slows down the execution.

We got a customer request to enable it for inspecting the results, similarly to MLflow's evaluation. This PR adds a opt-in flag for `mlflow.dspy.autolog()` to enable that. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support generating traces for DSPy's built-in evaluation suite `dspy.evaluate.Evaluate`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
