### PR TITLE
Fix UI crash when artifact location is too long

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/HomePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/HomePage.tsx
@@ -66,7 +66,7 @@ const HomePage = () => {
         </div>
 
         {/* Main content with the experiment view */}
-        <div css={{ height: '100%', flex: 1, padding: theme.spacing.md, paddingTop: theme.spacing.lg }}>
+        <div css={{ height: '100%', flex: 1, padding: theme.spacing.md, paddingTop: theme.spacing.lg, minWidth: 0 }}>
           <GetExperimentsContextProvider actions={getExperimentActions}>
             {hasExperiments ? <ExperimentView /> : <NoExperimentView />}
           </GetExperimentsContextProvider>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewArtifactLocation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewArtifactLocation.tsx
@@ -15,7 +15,7 @@ export const ExperimentViewArtifactLocation = ({ artifactLocation }: ExperimentV
         textOverflow: 'ellipsis',
       }}
     >
-      {artifactLocation.slice(0, EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT)}
+      {artifactLocation}
     </span>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewArtifactLocation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewArtifactLocation.tsx
@@ -1,9 +1,21 @@
 import React from 'react';
+import { EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT } from '@mlflow/mlflow/src/experiment-tracking/constants';
 
 export interface ExperimentViewArtifactLocationProps {
   artifactLocation: string;
 }
 
 export const ExperimentViewArtifactLocation = ({ artifactLocation }: ExperimentViewArtifactLocationProps) => {
-  return <>{artifactLocation}</>;
+  return (
+    <span
+      css={{
+        maxWidth: 400,
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+      }}
+    >
+      {artifactLocation.slice(0, EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT)}
+    </span>
+  );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
@@ -15,6 +15,7 @@ import { InfoIcon } from '@databricks/design-system';
 import { Popover } from '@databricks/design-system';
 import {
   EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT,
+  EXPERIMENT_ARTIFACT_LOCATION_TRUNCATED_MESSAGE,
   EXPERIMENT_PAGE_FEEDBACK_URL,
 } from '@mlflow/mlflow/src/experiment-tracking/constants';
 
@@ -119,7 +120,7 @@ export const ExperimentViewHeader = React.memo(
                     description="Label for displaying the experiment artifact location"
                   />
                   : <ExperimentViewArtifactLocation artifactLocation={experiment.artifactLocation} />{' '}
-                  {experiment.artifactLocation.length <= EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT && (
+                  {experiment.artifactLocation !== EXPERIMENT_ARTIFACT_LOCATION_TRUNCATED_MESSAGE && (
                     <ExperimentViewCopyArtifactLocation experiment={experiment} />
                   )}
                 </div>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
@@ -13,7 +13,10 @@ import { ExperimentViewCopyArtifactLocation } from './ExperimentViewCopyArtifact
 import { LegacyTooltip } from '@databricks/design-system';
 import { InfoIcon } from '@databricks/design-system';
 import { Popover } from '@databricks/design-system';
-import { EXPERIMENT_PAGE_FEEDBACK_URL } from '@mlflow/mlflow/src/experiment-tracking/constants';
+import {
+  EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT,
+  EXPERIMENT_PAGE_FEEDBACK_URL,
+} from '@mlflow/mlflow/src/experiment-tracking/constants';
 
 /**
  * Header for a single experiment page. Displays title, breadcrumbs and provides
@@ -94,7 +97,7 @@ export const ExperimentViewHeader = React.memo(
                 }}
                 data-testid="experiment-view-header-info-tooltip-content"
               >
-                <div style={{ whiteSpace: 'nowrap' }}>
+                <div style={{ whiteSpace: 'nowrap', display: 'flex', flexDirection: 'row' }}>
                   <FormattedMessage
                     defaultMessage="Path"
                     description="Label for displaying the current experiment path"
@@ -102,7 +105,7 @@ export const ExperimentViewHeader = React.memo(
                   : {experiment.name + ' '}
                   <ExperimentViewCopyTitle experiment={experiment} size="md" />
                 </div>
-                <div style={{ whiteSpace: 'nowrap' }}>
+                <div style={{ whiteSpace: 'nowrap', display: 'flex', flexDirection: 'row' }}>
                   <FormattedMessage
                     defaultMessage="Experiment ID"
                     description="Label for displaying the current experiment in view"
@@ -110,13 +113,15 @@ export const ExperimentViewHeader = React.memo(
                   : {experiment.experimentId + ' '}
                   <ExperimentViewCopyExperimentId experiment={experiment} />
                 </div>
-                <div style={{ whiteSpace: 'nowrap' }}>
+                <div style={{ whiteSpace: 'nowrap', display: 'flex', flexDirection: 'row' }}>
                   <FormattedMessage
                     defaultMessage="Artifact Location"
                     description="Label for displaying the experiment artifact location"
                   />
                   : <ExperimentViewArtifactLocation artifactLocation={experiment.artifactLocation} />{' '}
-                  <ExperimentViewCopyArtifactLocation experiment={experiment} />
+                  {experiment.artifactLocation.length <= EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT && (
+                    <ExperimentViewCopyArtifactLocation experiment={experiment} />
+                  )}
                 </div>
               </div>
             }

--- a/mlflow/server/js/src/experiment-tracking/constants.ts
+++ b/mlflow/server/js/src/experiment-tracking/constants.ts
@@ -119,6 +119,7 @@ export const MLFLOW_MODEL_METRIC_NAME = 'Model metrics';
 export const EXPERIMENT_PAGE_VIEW_STATE_SHARE_URL_PARAM_KEY = 'viewStateShareKey';
 export const EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX = 'mlflow.sharedViewState.';
 export const EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT = 10000;
+export const EXPERIMENT_ARTIFACT_LOCATION_TRUNCATED_MESSAGE = '(artifact location too long to display)';
 
 export const MLFLOW_LOGGED_IMAGE_ARTIFACTS_PATH = 'images';
 export const IMAGE_FILE_EXTENSION = 'png';

--- a/mlflow/server/js/src/experiment-tracking/constants.ts
+++ b/mlflow/server/js/src/experiment-tracking/constants.ts
@@ -118,6 +118,7 @@ export const MLFLOW_MODEL_METRIC_NAME = 'Model metrics';
 
 export const EXPERIMENT_PAGE_VIEW_STATE_SHARE_URL_PARAM_KEY = 'viewStateShareKey';
 export const EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX = 'mlflow.sharedViewState.';
+export const EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT = 10000;
 
 export const MLFLOW_LOGGED_IMAGE_ARTIFACTS_PATH = 'images';
 export const IMAGE_FILE_EXTENSION = 'png';

--- a/mlflow/server/js/src/experiment-tracking/reducers/Reducers.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/Reducers.ts
@@ -44,6 +44,10 @@ import { ErrorWrapper } from '../../common/utils/ErrorWrapper';
 import { imagesByRunUuid } from './ImageReducer';
 import { colorByRunUuid } from './RunColorReducer';
 import { isExperimentLoggedModelsUIEnabled } from '../../common/utils/FeatureUtils';
+import {
+  EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT,
+  EXPERIMENT_ARTIFACT_LOCATION_TRUNCATED_MESSAGE,
+} from '@mlflow/mlflow/src/experiment-tracking/constants';
 
 export type ApisReducerReduxState = Record<
   string,
@@ -80,6 +84,9 @@ export const experimentsById = (state = {}, action: any): any => {
         newState = {};
         action.payload.experiments.forEach((eJson: any) => {
           const experiment: ExperimentEntity = eJson;
+          if ((experiment?.artifactLocation ?? '').length > EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT) {
+            experiment.artifactLocation = EXPERIMENT_ARTIFACT_LOCATION_TRUNCATED_MESSAGE;
+          }
           newState = Object.assign(newState, { [experiment.experimentId]: experiment });
         });
       }
@@ -87,6 +94,9 @@ export const experimentsById = (state = {}, action: any): any => {
     }
     case fulfilled(GET_EXPERIMENT_API): {
       const { experiment } = action.payload;
+      if ((experiment?.artifactLocation ?? '').length > EXPERIMENT_ARTIFACT_LOCATION_CHAR_LIMIT) {
+        experiment.artifactLocation = EXPERIMENT_ARTIFACT_LOCATION_TRUNCATED_MESSAGE;
+      }
 
       const existingExperiment = (state as any)[experiment.experimentId] || {};
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14402?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14402/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14402
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR prevents UI crashes (and weird rendering) for large experiment artifact locations and descriptions. We do this by detecting if the artifact location is > 10000 chars, and truncating the string to `(artifact location too long to display)` if so. As far as I can tell, the experiment artifact location isn't used in any core UI workflows, it seems to just be for display.

The proper fix for this would be to set a limit on the backend, but this helps some edge cases.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

95mb artifact location can render. however, the bottleneck is still downloading the experiment data and processing it. while this prevents a crash in this case, if a user sets a 1gb name, probably the app will crash while attempting to truncate the string, so i do think a proper fix needs to happen.


https://github.com/user-attachments/assets/f192c78d-91b3-41d9-b24f-c3e7c09c9377




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
