### PR TITLE
Fix pytorch-related test failures

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -695,7 +695,7 @@ def load_model(model_uri, dst_path=None, **kwargs):
     return _load_model(path=torch_model_artifacts_path, **kwargs)
 
 
-def _load_pyfunc(path, model_config=None):  # noqa: D417
+def _load_pyfunc(path, model_config=None, weights_only=False):  # noqa: D417
     """
     Load PyFunc implementation. Called by ``pyfunc.load_model``.
 
@@ -716,6 +716,11 @@ def _load_pyfunc(path, model_config=None):  # noqa: D417
             device = _TORCH_DEFAULT_GPU_DEVICE_NAME
         else:
             device = _TORCH_CPU_DEVICE_NAME
+
+    if Version(torch.__version__) >= Version("2.6.0"):
+        return _PyTorchWrapper(
+            _load_model(path, device=device, weights_only=weights_only), device=device
+        )
 
     return _PyTorchWrapper(_load_model(path, device=device), device=device)
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -717,6 +717,10 @@ def _load_pyfunc(path, model_config=None, weights_only=False):  # noqa: D417
         else:
             device = _TORCH_CPU_DEVICE_NAME
 
+    # in pytorch >= 2.6.0, the `weights_only` kwarg default has been changed from
+    # `False` to `True`. this can cause pickle deserialization errors when loading
+    # models, unless the model classes have been explicitly marked as safe using
+    # `torch.serialization.add_safe_globals()`
     if Version(torch.__version__) >= Version("2.6.0"):
         return _PyTorchWrapper(
             _load_model(path, device=device, weights_only=weights_only), device=device

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -59,6 +59,10 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
     [] if _is_available_on_pypi("torch") else ["--env-manager", "local"]
 )
 
+# in pytorch >= 2.6.0, the `weights_only` kwarg default has been changed from
+# `False` to `True`. this can cause pickle deserialization errors when loading
+# models, unless the model classes have been explicitly marked as safe using
+# `torch.serialization.add_safe_globals()`
 ENABLE_LEGACY_DESERIALIZATION = Version(torch.__version__) >= Version("2.6.0")
 
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1271,17 +1271,11 @@ def test_load_model_to_device(sequential_model):
         with mlflow.start_run():
             model_info = mlflow.pytorch.log_model(sequential_model, "pytorch")
             model_config = {"device": "cuda"}
+            if Version(torch.__version__) >= Version("2.6.0"):
+                model_config["weights_only"] = False
 
             mlflow.pyfunc.load_model(model_uri=model_info.model_uri, model_config=model_config)
 
-            expected_kwargs = model_config
-            if Version(torch.__version__) >= Version("2.6.0"):
-                expected_kwargs["weights_only"] = False
-
-            load_model_mock.assert_called_with(mock.ANY, **expected_kwargs)
-            mlflow.pytorch.load_model(
-                model_uri=model_info.model_uri,
-                device="cuda",
-                weights_only=False,
-            )
-            load_model_mock.assert_called_with(path=mock.ANY, **expected_kwargs)
+            load_model_mock.assert_called_with(mock.ANY, **model_config)
+            mlflow.pytorch.load_model(model_uri=model_info.model_uri, **model_config)
+            load_model_mock.assert_called_with(path=mock.ANY, **model_config)

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 import torch
 import yaml
+from packaging.version import Version
 from sklearn import datasets
 from torch import nn
 from torch.utils.data import DataLoader
@@ -697,7 +698,11 @@ def test_load_pyfunc_loads_torch_model_using_pickle_module_specified_at_save_tim
         import_mock.side_effect = track_module_imports
         pyfunc.load_model(model_path)
 
-    torch_load_mock.assert_called_with(mock.ANY, pickle_module=custom_pickle_module)
+    expected_kwargs = {"pickle_module": custom_pickle_module}
+    if Version(torch.__version__) >= Version("2.6.0"):
+        expected_kwargs["weights_only"] = False
+
+    torch_load_mock.assert_called_with(mock.ANY, **expected_kwargs)
     assert custom_pickle_module.__name__ in imported_modules
 
 
@@ -729,7 +734,11 @@ def test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time
         import_mock.side_effect = track_module_imports
         pyfunc.load_model(model_uri=model_uri)
 
-    torch_load_mock.assert_called_with(mock.ANY, pickle_module=custom_pickle_module)
+    expected_kwargs = {"pickle_module": custom_pickle_module}
+    if Version(torch.__version__) >= Version("2.6.0"):
+        expected_kwargs["weights_only"] = False
+
+    torch_load_mock.assert_called_with(mock.ANY, **expected_kwargs)
     assert custom_pickle_module.__name__ in imported_modules
 
 
@@ -1261,9 +1270,14 @@ def test_load_model_to_device(sequential_model):
     with mock.patch("mlflow.pytorch._load_model") as load_model_mock:
         with mlflow.start_run():
             model_info = mlflow.pytorch.log_model(sequential_model, "pytorch")
-            mlflow.pyfunc.load_model(
-                model_uri=model_info.model_uri, model_config={"device": "cuda"}
-            )
-            load_model_mock.assert_called_with(mock.ANY, device="cuda")
+            model_config = {"device": "cuda"}
+
+            mlflow.pyfunc.load_model(model_uri=model_info.model_uri, model_config=model_config)
+
+            expected_kwargs = model_config
+            if Version(torch.__version__) >= Version("2.6.0"):
+                expected_kwargs["weights_only"] = False
+
+            load_model_mock.assert_called_with(mock.ANY, **expected_kwargs)
             mlflow.pytorch.load_model(model_uri=model_info.model_uri, device="cuda")
-            load_model_mock.assert_called_with(path=mock.ANY, device="cuda")
+            load_model_mock.assert_called_with(path=mock.ANY, **expected_kwargs)

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -59,6 +59,8 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
     [] if _is_available_on_pypi("torch") else ["--env-manager", "local"]
 )
 
+ENABLE_LEGACY_DESERIALIZATION = Version(torch.__version__) >= Version("2.6.0")
+
 
 @pytest.fixture(scope="module")
 def data():
@@ -699,7 +701,7 @@ def test_load_pyfunc_loads_torch_model_using_pickle_module_specified_at_save_tim
         pyfunc.load_model(model_path)
 
     expected_kwargs = {"pickle_module": custom_pickle_module}
-    if Version(torch.__version__) >= Version("2.6.0"):
+    if ENABLE_LEGACY_DESERIALIZATION:
         expected_kwargs["weights_only"] = False
 
     torch_load_mock.assert_called_with(mock.ANY, **expected_kwargs)
@@ -735,7 +737,7 @@ def test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time
         pyfunc.load_model(model_uri=model_uri)
 
     expected_kwargs = {"pickle_module": custom_pickle_module}
-    if Version(torch.__version__) >= Version("2.6.0"):
+    if ENABLE_LEGACY_DESERIALIZATION:
         expected_kwargs["weights_only"] = False
 
     torch_load_mock.assert_called_with(mock.ANY, **expected_kwargs)
@@ -1271,7 +1273,7 @@ def test_load_model_to_device(sequential_model):
         with mlflow.start_run():
             model_info = mlflow.pytorch.log_model(sequential_model, "pytorch")
             model_config = {"device": "cuda"}
-            if Version(torch.__version__) >= Version("2.6.0"):
+            if ENABLE_LEGACY_DESERIALIZATION:
                 model_config["weights_only"] = False
 
             mlflow.pyfunc.load_model(model_uri=model_info.model_uri, model_config=model_config)

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1279,5 +1279,9 @@ def test_load_model_to_device(sequential_model):
                 expected_kwargs["weights_only"] = False
 
             load_model_mock.assert_called_with(mock.ANY, **expected_kwargs)
-            mlflow.pytorch.load_model(model_uri=model_info.model_uri, device="cuda")
+            mlflow.pytorch.load_model(
+                model_uri=model_info.model_uri,
+                device="cuda",
+                weights_only=False,
+            )
             load_model_mock.assert_called_with(path=mock.ANY, **expected_kwargs)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14411?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14411/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14411
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Pytorch 2.6.0 added a new default for the `weights_only` kwarg to improve security of pickled models. Now, you must either explicitly specify `weights_only=False`, or mark all the classes in your models as safe via `torch.serialization.add_safe_globals`.

For this PR, I add the `weights_only` option to `mlflow.pytorch._load_model()`. I chose to make the default `False` to preserve compatibility with old mlflow versions. However, I can just change this and update tests instead.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

x-version tests pass. i believe this is affecting other flavors as well

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
