### PR TITLE
Add a job to sync mlflow-3 branch with master

### DIFF
--- a/.github/workflows/sync.md
+++ b/.github/workflows/sync.md
@@ -1,0 +1,30 @@
+# How to sync the `mlflow-3` branch with the `master` branch manually
+
+## Steps
+
+1. Run the following commands to prepare a sync branch:
+
+   ```bash
+   # Sync the local `master` branch with the remote `master` branch
+   git checkout master
+   git pull upstream master
+
+   # Sync the local `mlflow-3` branch with the remote `mlflow-3` branch
+   git checkout mlflow-3
+   git pull upstream mlflow-3
+
+   # Cut a new branch from the `mlflow-3` branch
+   git checkout -b mlflow-3-sync mlflow-3
+
+   # Merge the `master` branch into the sync branch
+   git merge master
+   # Resolve any conflicts
+   git add .
+   git merge --continue
+
+   # Push the sync branch
+   git push origin mlflow-3-sync
+   ```
+
+2. Once the sync branch is pushed, create a pull request from the sync branch to the 🚨 `mlflow-3` 🚨 branch.
+3. Once the PR is reviewed and approved, merge it with the 🚨 `rebase and merge` 🚨 option.

--- a/.github/workflows/sync.py
+++ b/.github/workflows/sync.py
@@ -1,0 +1,96 @@
+# /// script
+# requires-python = "==3.10"
+# dependencies = [
+#   "requests",
+# ]
+# ///
+# ruff: noqa: T201
+import os
+import subprocess
+import sys
+import uuid
+
+import requests
+
+
+def main():
+    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+    if not GITHUB_TOKEN:
+        print("GITHUB_TOKEN not found in environment variables", file=sys.stderr)
+        sys.exit(1)
+
+    OWNER = "mlflow"
+    REPO = "mlflow"
+    MLFLOW_3_BRANCH_NAME = "mlflow-3"
+    PR_TITLE = "Sync with master"
+    PR_BRANCH_NAME = f"sync-{uuid.uuid4()}"
+
+    # Exit if there is already a PR with the same title
+    def iter_pull_requests():
+        per_page = 100
+        page = 1
+        while True:
+            resp = requests.get(
+                f"https://api.github.com/repos/{OWNER}/{REPO}/pulls",
+                headers={"Authorization": f"token {GITHUB_TOKEN}"},
+                params={
+                    "state": "open",
+                    "base": MLFLOW_3_BRANCH_NAME,
+                    "per_page": per_page,
+                    "page": page,
+                },
+            )
+            resp.raise_for_status()
+            prs = resp.json()
+            yield from prs
+            if len(prs) < per_page:
+                break
+            page += 1
+
+    if pr := next((pr for pr in iter_pull_requests() if pr["title"] == PR_TITLE), None):
+        print(f"PR already exists: {pr['html_url']}")
+        sys.exit(0)
+
+    # Fetch master and mlflow-3 branches
+    subprocess.check_call(["git", "config", "user.name", "mlflow-automation"])
+    subprocess.check_call(
+        ["git", "config", "user.email", "mlflow-automation@users.noreply.github.com"]
+    )
+    subprocess.check_call(["git", "fetch", "origin", "master"])
+    subprocess.check_call(["git", "fetch", "origin", MLFLOW_3_BRANCH_NAME])
+
+    # Sync mlflow-3 branch with master
+    subprocess.check_call(
+        ["git", "checkout", "-b", PR_BRANCH_NAME, f"origin/{MLFLOW_3_BRANCH_NAME}"]
+    )
+    prc = subprocess.run(["git", "merge", "origin/master"])
+    if prc.returncode != 0:
+        print(
+            (
+                "Merge failed, possibly due to conflicts. "
+                "Follow the instructions in `sync.md` to resolve the conflicts "
+                "and create a PR manually."
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Create a pull request
+    subprocess.check_call(["git", "push", "origin", PR_BRANCH_NAME])
+    pr = requests.post(
+        f"https://api.github.com/repos/{OWNER}/{REPO}/pulls",
+        headers={"Authorization": f"token {GITHUB_TOKEN}"},
+        json={
+            "title": PR_TITLE,
+            "head": PR_BRANCH_NAME,
+            "base": MLFLOW_3_BRANCH_NAME,
+            "body": "This PR was created automatically by the sync workflow.",
+        },
+    )
+    pr.raise_for_status()
+    pr_data = pr.json()
+    print(f"PR created: {pr_data['html_url']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  # Uncomment to test this workflow
+  # pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -exo pipefail {0}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: ./.github/actions/setup-python
+      - name:
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          uv run .github/workflows/sync.py


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14414?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14414/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14414
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

To make it easier to sync mlflow and mlflow-3 branch, add a job that performs a sync for us to reduce maintenance burden. We'll need to work on the `mlflow-3` branch **_until mid May_**.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
