### PR TITLE
Add limit to the length of experiment artifact locations

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -710,3 +710,8 @@ _MLFLOW_GO_STORE_TESTING = _BooleanEnvironmentVariable("MLFLOW_GO_STORE_TESTING"
 _MLFLOW_IS_IN_SERVING_ENVIRONMENT = _BooleanEnvironmentVariable(
     "_MLFLOW_IS_IN_SERVING_ENVIRONMENT", None
 )
+
+# Specifies the max length (in chars) of an experiment's artifact location
+MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH = _EnvironmentVariable(
+    "MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH", int, 2048
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -711,7 +711,8 @@ _MLFLOW_IS_IN_SERVING_ENVIRONMENT = _BooleanEnvironmentVariable(
     "_MLFLOW_IS_IN_SERVING_ENVIRONMENT", None
 )
 
-# Specifies the max length (in chars) of an experiment's artifact location
+#: Specifies the max length (in chars) of an experiment's artifact location.
+#: The default is 2048.
 MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH = _EnvironmentVariable(
     "MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH", int, 2048
 )

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -91,9 +91,9 @@ from mlflow.utils.uri import (
     resolve_uri_if_local,
 )
 from mlflow.utils.validation import (
-    _validate_experiment_artifact_location_length,
     _validate_batch_log_data,
     _validate_batch_log_limits,
+    _validate_experiment_artifact_location_length,
     _validate_experiment_id,
     _validate_experiment_name,
     _validate_metric,

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -91,6 +91,7 @@ from mlflow.utils.uri import (
     resolve_uri_if_local,
 )
 from mlflow.utils.validation import (
+    _validate_experiment_artifact_location_length,
     _validate_batch_log_data,
     _validate_batch_log_limits,
     _validate_experiment_id,
@@ -403,6 +404,10 @@ class FileStore(AbstractStore):
     def create_experiment(self, name, artifact_location=None, tags=None):
         self._check_root_dir()
         _validate_experiment_name(name)
+
+        if artifact_location:
+            _validate_experiment_artifact_location_length(artifact_location)
+
         self._validate_experiment_does_not_exist(name)
         experiment_id = _generate_unique_integer_id()
         return self._create_experiment_with_id(name, str(experiment_id), artifact_location, tags)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -87,6 +87,7 @@ from mlflow.utils.validation import (
     _validate_batch_log_data,
     _validate_batch_log_limits,
     _validate_dataset_inputs,
+    _validate_experiment_artifact_location_length,
     _validate_experiment_name,
     _validate_experiment_tag,
     _validate_metric,
@@ -267,6 +268,7 @@ class SqlAlchemyStore(AbstractStore):
         _validate_experiment_name(name)
         if artifact_location:
             artifact_location = resolve_uri_if_local(artifact_location)
+            _validate_experiment_artifact_location_length(artifact_location)
         with self.ManagedSessionMaker() as session:
             try:
                 creation_time = get_current_time_millis()

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -10,8 +10,8 @@ import re
 
 from mlflow.entities import Dataset, DatasetInput, InputTag, Param, RunTag
 from mlflow.environment_variables import (
-    MLFLOW_TRUNCATE_LONG_VALUES,
     MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH,
+    MLFLOW_TRUNCATE_LONG_VALUES,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -10,8 +10,8 @@ import re
 
 from mlflow.entities import Dataset, DatasetInput, InputTag, Param, RunTag
 from mlflow.environment_variables import (
-    MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH,
     MLFLOW_TRUNCATE_LONG_VALUES,
+    MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -515,21 +515,11 @@ def _validate_model_alias_name(model_alias_name):
 
 
 def _validate_experiment_artifact_location(artifact_location):
-    if artifact_location is not None:
-        if artifact_location.startswith("runs:"):
-            raise MlflowException(
-                f"Artifact location cannot be a runs:/ URI. Given: '{artifact_location}'",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-
-        max_length = MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH.get()
-        if len(artifact_location) > max_length:
-            raise MlflowException(
-                "Invalid artifact location. The length of the artifact location cannot be "
-                f"greater than {max_length} characters. To configure this limit, please set the "
-                "MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH environment variable.",
-                INVALID_PARAMETER_VALUE,
-            )
+    if artifact_location is not None and artifact_location.startswith("runs:"):
+        raise MlflowException(
+            f"Artifact location cannot be a runs:/ URI. Given: '{artifact_location}'",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
 
 
 def _validate_db_type_string(db_type):
@@ -630,3 +620,14 @@ def _validate_trace_tag(key, value):
     key = _validate_length_limit("key", MAX_TRACE_TAG_KEY_LENGTH, key)
     value = _validate_length_limit("value", MAX_TRACE_TAG_VAL_LENGTH, value, truncate=True)
     return key, value
+
+
+def _validate_experiment_artifact_location_length(artifact_location: str):
+    max_length = MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH.get()
+    if len(artifact_location) > max_length:
+        raise MlflowException(
+            "Invalid artifact location. The length of the artifact location cannot be "
+            f"greater than {max_length} characters. To configure this limit, please set the "
+            "MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH environment variable.",
+            INVALID_PARAMETER_VALUE,
+        )

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -626,7 +626,7 @@ def _validate_experiment_artifact_location_length(artifact_location: str):
     max_length = MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH.get()
     if len(artifact_location) > max_length:
         raise MlflowException(
-            "Invalid artifact location. The length of the artifact location cannot be "
+            "Invalid artifact path length. The length of the artifact path cannot be "
             f"greater than {max_length} characters. To configure this limit, please set the "
             "MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH environment variable.",
             INVALID_PARAMETER_VALUE,

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -350,7 +350,8 @@ def test_validate_experiment_artifact_location_length_good(artifact_location):
 
 
 @pytest.mark.parametrize(
-    "artifact_location", ["s3://test-bucket/" + "a" * 10000, "file:///path/to/" + "directory" * 5000]
+    "artifact_location",
+    ["s3://test-bucket/" + "a" * 10000, "file:///path/to/" + "directory" * 5000],
 )
 def test_validate_experiment_artifact_location_length_bad(artifact_location):
     with pytest.raises(MlflowException, match="Invalid artifact location"):

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -301,15 +301,33 @@ def test_validate_batch_log_data(monkeypatch):
     )
 
 
-@pytest.mark.parametrize("location", ["abcde", None])
+@pytest.mark.parametrize(
+    "location",
+    [
+        "abcde",
+        None,
+        "s3://test-bucket/",
+        "file:///path/to/artifacts",
+        "mlflow-artifacts:/path/to/artifacts",
+        "dbfs:/databricks/mlflow-tracking/some-id",
+    ],
+)
 def test_validate_experiment_artifact_location_good(location):
     _validate_experiment_artifact_location(location)
 
 
 @pytest.mark.parametrize("location", ["runs:/blah/bleh/blergh"])
-def test_validate_experiment_artifact_location_bad(location):
+def test_validate_experiment_artifact_location_bad_runs(location):
     with pytest.raises(MlflowException, match="Artifact location cannot be a runs:/ URI"):
         _validate_experiment_artifact_location(location)
+
+
+@pytest.mark.parametrize(
+    "artifact_location", ["s3://test-bucket/" + "a" * 10000, "file:///path/" + "directory" * 1000]
+)
+def test_validate_experiment_artifact_location_bad_length(artifact_location):
+    with pytest.raises(MlflowException, match="Invalid artifact location"):
+        _validate_experiment_artifact_location(artifact_location)
 
 
 @pytest.mark.parametrize("experiment_name", ["validstring", b"test byte string".decode("utf-8")])

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -352,7 +352,7 @@ def test_validate_experiment_artifact_location_length_good(artifact_location):
 
 @pytest.mark.parametrize(
     "artifact_location",
-    ["s3://test-bucket/" + "a" * 10000, "file:///path/to/" + "directory" * 5000],
+    ["s3://test-bucket/" + "a" * 10000, "file:///path/to/" + "directory" * 1111],
 )
 def test_validate_experiment_artifact_location_length_bad(artifact_location):
     with pytest.raises(MlflowException, match="Invalid artifact path length"):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14416?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14416/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14416
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add a limit to the length of artifact locations, so people can't set 10gb strings.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added new test cases to existing validation

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Artifact locations for experiments now have a character limit that is configured by the `MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH` environment variable. The default limit is 2048 characters.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
