### PR TITLE
Fix `_parse_model_id_if_present` to handle pathlib.Path

### DIFF
--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -1,5 +1,6 @@
 import urllib.parse
-from typing import NamedTuple, Optional
+from pathlib import Path
+from typing import NamedTuple, Optional, Union
 
 import mlflow.tracking
 from mlflow.exceptions import MlflowException
@@ -93,7 +94,7 @@ def _parse_model_uri(uri):
         return ParsedModelUri(parts[0])
 
 
-def _parse_model_id_if_present(possible_model_uri: str) -> Optional[str]:
+def _parse_model_id_if_present(possible_model_uri: Union[str, Path]) -> Optional[str]:
     """
     Parses the model ID from the given string. If the string is not a models:/ URI, returns None.
 
@@ -103,8 +104,9 @@ def _parse_model_id_if_present(possible_model_uri: str) -> Optional[str]:
     Returns:
         The model ID if the string is a models:/ URI, otherwise None.
     """
-    if is_models_uri(possible_model_uri):
-        parsed_model_uri = _parse_model_uri(possible_model_uri)
+    uri = str(possible_model_uri)
+    if is_models_uri(uri):
+        parsed_model_uri = _parse_model_uri(uri)
         return parsed_model_uri.model_id
 
     return None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14424?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14424/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14424
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow/mlflow/actions/runs/13109177352/job/36569195014?pr=13211:

```
_______________ test_chat_model_with_context_saves_successfully ________________

tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0')

    def test_chat_model_with_context_saves_successfully(tmp_path):
        model_path = tmp_path / "model"
        predict_path = tmp_path / "predict.pkl"
        predict_path.write_bytes(pickle.dumps(mock_predict))
    
        model = ChatModelWithContext()
        mlflow.pyfunc.save_model(
            python_model=model,
            path=model_path,
            artifacts={"predict_fn": str(predict_path)},
        )
    
>       loaded_model = mlflow.pyfunc.load_model(model_path)

model      = <tests.pyfunc.test_chat_model.ChatModelWithContext object at 0x7f6c32e58130>
model_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model')
predict_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/predict.pkl')
tmp_path   = PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0')

tests/pyfunc/test_chat_model.py:266: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
mlflow/tracing/provider.py:383: in wrapper
    is_func_called, result = True, f(*args, **kwargs)
        args       = (PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model'),)
        f          = <function load_model at 0x7f6c1970f5e0>
        is_func_called = False
        kwargs     = {}
        result     = None
mlflow/pyfunc/__init__.py:1174: in load_model
    model_id=_parse_model_id_if_present(model_uri),
        conf       = {'artifacts': {'predict_fn': {'path': 'artifacts/predict.pkl', 'uri': '/tmp/pytest-of-runner/pytest-0/test_chat_model_...}}, 'cloudpickle_version': '3.1.1', 'code': None, 'env': {'conda': 'conda.yaml', 'virtualenv': 'python_env.yaml'}, ...}
        data_path  = '/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model'
        dst_path   = None
        lineage_header_info = None
        local_path = '/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model'
        model_config = None
        model_impl = <mlflow.pyfunc.loaders.chat_model._ChatModelPyfuncWrapper object at 0x7f6c335fdf10>
        model_meta = <mlflow.models.model.Model object at 0x7f6c328dfd90>
        model_py_version = '3.9.18'
        model_requirements = ['mlflow==2.20.2.dev0', 'cloudpickle==3.1.1', 'opentelemetry-api==1.29.0', 'opentelemetry-exporter-otlp-proto-grpc==1.29.0', 'opentelemetry-exporter-otlp-proto-http==1.29.0', 'opentelemetry-sdk==1.29.0', ...]
        model_uri  = PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model')
        predict_fn = 'predict'
        predict_stream_fn = 'predict_stream'
        streamable = True
        suppress_warnings = False
mlflow/store/artifact/utils/models.py:106: in _parse_model_id_if_present
    if is_models_uri(possible_model_uri):
        possible_model_uri = PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model')
mlflow/utils/uri.py:551: in is_models_uri
    parsed = urllib.parse.urlparse(uri)
        uri        = PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model')
/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/urllib/parse.py:400: in urlparse
    url, scheme, _coerce_result = _coerce_args(url, scheme)
        allow_fragments = True
        scheme     = ''
        url        = PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model')
/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/urllib/parse.py:136: in _coerce_args
    return _decode_args(args) + (_encode_result,)
        arg        = ''
        args       = (PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model'), '')
        str_input  = False
/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/urllib/parse.py:120: in _decode_args
    return tuple(x.decode(encoding, errors) if x else '' for x in args)
        args       = (PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model'), '')
        encoding   = 'ascii'
        errors     = 'strict'
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <tuple_iterator object at 0x7f6c335fd3d0>

>   return tuple(x.decode(encoding, errors) if x else '' for x in args)
E   AttributeError: 'PosixPath' object has no attribute 'decode'

.0         = <tuple_iterator object at 0x7f6c335fd3d0>
encoding   = 'ascii'
errors     = 'strict'
x          = PosixPath('/tmp/pytest-of-runner/pytest-0/test_chat_model_with_context_s0/model')
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
