### PR TITLE
Fix entity tests

### DIFF
--- a/tests/entities/model_registry/test_model_version.py
+++ b/tests/entities/model_registry/test_model_version.py
@@ -96,6 +96,9 @@ def test_creation_and_hydration():
         "status_message": "Model version #5 is ready to use.",
         "tags": {tag.key: tag.value for tag in (tags or [])},
         "aliases": ["test_alias"],
+        "model_id": None,
+        "metrics": None,
+        "params": None,
     }
     model_version_as_dict = dict(mvd)
     assert model_version_as_dict == expected_dict
@@ -165,13 +168,11 @@ def test_string_repr():
         aliases=[],
     )
 
-    assert (
-        str(model_version) == "<ModelVersion: aliases=[], creation_timestamp=12, "
-        "current_stage='Archived', description='This is a test "
-        "model.', last_updated_timestamp=100, "
-        "name='myname', "
-        "run_id='some run', run_link='http://localhost:5000/path/"
-        "to/run', source='path/to/a/notebook', "
-        "status='PENDING_REGISTRATION', status_message='Copying!', "
-        "tags={}, user_id='user one', version='43'>"
+    assert str(model_version) == (
+        "<ModelVersion: aliases=[], creation_timestamp=12, current_stage='Archived', "
+        "description='This is a test model.', last_updated_timestamp=100, metrics=None, "
+        "model_id=None, name='myname', params=None, run_id='some run', "
+        "run_link='http://localhost:5000/path/to/run', source='path/to/a/notebook', "
+        "status='PENDING_REGISTRATION', status_message='Copying!', tags={}, user_id='user one', "
+        "version='43'>"
     )

--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -26,7 +26,16 @@ def test_creation_and_hydration():
     metric = Metric(key, value, ts, step)
     _check(metric, key, value, ts, step)
 
-    as_dict = {"key": key, "value": value, "timestamp": ts, "step": step}
+    as_dict = {
+        "key": key,
+        "value": value,
+        "timestamp": ts,
+        "step": step,
+        "model_id": None,
+        "dataset_digest": None,
+        "dataset_name": None,
+        "run_id": None,
+    }
     assert dict(metric) == as_dict
 
     proto = metric.to_proto()
@@ -50,6 +59,10 @@ def test_metric_to_from_dictionary():
         "value": 0.95,
         "timestamp": 1623079352000,
         "step": 1,
+        "model_id": None,
+        "dataset_digest": None,
+        "dataset_name": None,
+        "run_id": None,
     }
     assert metric_dict == expected_dict
 

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -73,7 +73,7 @@ def test_creation_and_hydration(run_data, run_info, run_inputs):
             "params": {p.key: p.value for p in params},
             "tags": {t.key: t.value for t in tags},
         },
-        "inputs": {"dataset_inputs": datasets},
+        "inputs": {"dataset_inputs": datasets, "model_inputs": []},
     }
 
     proto = run1.to_proto()
@@ -116,7 +116,7 @@ def test_string_repr():
         "run_uuid='hi', start_time=0, status=4, user_id='user-id'>, inputs=<RunInputs: "
         "dataset_inputs=<DatasetInput: dataset=<Dataset: digest='digest1', "
         "name='name1', profile=None, schema=None, source='source', "
-        "source_type='my_source_type'>, tags=[]>>>"
+        "source_type='my_source_type'>, tags=[]>, model_inputs=[]>, outputs=None>"
     )
     assert str(run1) == expected
 

--- a/tests/entities/test_run_inputs.py
+++ b/tests/entities/test_run_inputs.py
@@ -23,6 +23,7 @@ def test_creation_and_hydration(run_inputs):
     _check(run_inputs, datasets)
     as_dict = {
         "dataset_inputs": datasets,
+        "model_inputs": [],
     }
     assert dict(run_inputs) == as_dict
     proto = run_inputs.to_proto()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14435?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14435/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14435
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
