### PR TITLE
Fix `_parse_model_uri` tests

### DIFF
--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -48,7 +48,7 @@ class ParsedModelUri(NamedTuple):
     alias: Optional[str] = None
 
 
-def _parse_model_uri(uri):
+def _parse_model_uri(uri) -> ParsedModelUri:
     """
     Returns a ParsedModelUri tuple. Since a models:/ URI can only have one of
     {version, stage, 'latest', alias}, it will return

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -20,7 +20,8 @@ from mlflow.store.artifact.utils.models import _parse_model_uri, get_model_name_
     ],
 )
 def test_parse_models_uri_with_version(uri, expected_name, expected_version):
-    (name, version, stage, alias) = _parse_model_uri(uri)
+    (model_id, name, version, stage, alias) = _parse_model_uri(uri)
+    assert model_id is None
     assert name == expected_name
     assert version == expected_version
     assert stage is None
@@ -45,7 +46,8 @@ def test_parse_models_uri_with_version(uri, expected_name, expected_version):
     ],
 )
 def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
-    (name, version, stage, alias) = _parse_model_uri(uri)
+    (model_id, name, version, stage, alias) = _parse_model_uri(uri)
+    assert model_id is None
     assert name == expected_name
     assert version is None
     assert stage == expected_stage
@@ -65,7 +67,8 @@ def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
     ],
 )
 def test_parse_models_uri_with_latest(uri, expected_name):
-    (name, version, stage, alias) = _parse_model_uri(uri)
+    (model_id, name, version, stage, alias) = _parse_model_uri(uri)
+    assert model_id is None
     assert name == expected_name
     assert version is None
     assert stage is None
@@ -91,11 +94,21 @@ def test_parse_models_uri_with_latest(uri, expected_name):
     ],
 )
 def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
-    (name, version, stage, alias) = _parse_model_uri(uri)
+    (model_id, name, version, stage, alias) = _parse_model_uri(uri)
+    assert model_id is None
     assert name == expected_name
     assert version is None
     assert stage is None
     assert alias == expected_alias
+
+
+def test_parse_models_uri_model_id():
+    (model_id, name, version, stage, alias) = _parse_model_uri("models:/12345")
+    assert model_id == "12345"
+    assert name is None
+    assert version is None
+    assert stage is None
+    assert alias is None
 
 
 @pytest.mark.parametrize(
@@ -106,12 +119,10 @@ def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
         "notmodels:/NameOfModel@alias",  # wrong scheme with alias
         "models:/",  # no model name
         "models:/ /Stage",  # empty name
-        "models:/Name",  # no specifiers
         "models:/Name/",  # empty suffix
         "models:/Name@",  # empty alias
         "models:/Name/Stage/0",  # too many specifiers
         "models:Name/Stage",  # missing slash
-        "models://Name/Stage",  # hostnames are ignored, path too short
     ],
 )
 def test_parse_models_uri_invalid_input(uri):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14441?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14441/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14441
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow/mlflow/actions/runs/13127479351/job/36626457620?pr=13211:

```
_____ test_parse_models_uri_with_version[models:/12345/67890-12345-67890] ______

uri = 'models:/12345/67890', expected_name = '12345', expected_version = '67890'

    @pytest.mark.parametrize(
        ("uri", "expected_name", "expected_version"),
        [
            ("models:/AdsModel1/0", "AdsModel1", "0"),
            ("models:/Ads Model 1/12345", "Ads Model 1", "12345"),
            ("models://////Ads Model 1/12345", "Ads Model 1", "12345"),  # many slashes
            ("models:/12345/67890", "12345", "67890"),
            ("models://profile@databricks/12345/67890", "12345", "67890"),
            ("models:/catalog.schema.model/0", "catalog.schema.model", "0"),  # UC Model format
        ],
    )
    def test_parse_models_uri_with_version(uri, expected_name, expected_version):
>       (name, version, stage, alias) = _parse_model_uri(uri)
E       ValueError: too many values to unpack (expected 4)

expected_name = '12345'
expected_version = '67890'
uri        = 'models:/12345/67890'
```



### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
