### PR TITLE
Fix `log_input` to avoid passing `[None]` to models

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1185,7 +1185,7 @@ def log_input(
         [DatasetInput(dataset=dataset._to_mlflow_entity(), tags=tags_to_log)] if dataset else None
     )
 
-    MlflowClient().log_inputs(run_id=run_id, datasets=datasets, models=[model])
+    MlflowClient().log_inputs(run_id=run_id, datasets=datasets, models=model and [model])
 
 
 def set_experiment_tags(tags: dict[str, Any]) -> None:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14442?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14442/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14442
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow/mlflow/actions/runs/13127479351/job/36626458350?pr=13211#step:13:4294

```
mlflow/tracking/fluent.py:1188: in log_input
    MlflowClient().log_inputs(run_id=run_id, datasets=datasets, models=[model])
        context    = 'train'
        dataset    = <mlflow.data.pandas_dataset.PandasDataset object at 0x7f011c9643a0>
        datasets   = [<DatasetInput: dataset=<Dataset: digest='f0f3e026', name='dataset', profile='{"num_rows": 2, "num_elements": 6}', sch...ource_type='local'>, tags=[<InputTag: key='foo', value='baz'>,
 <InputTag: key='mlflow.data.context', value='train'>]>]
        model      = None
        run_id     = 'dbc7a45d8f4d484a9bf62c84709cf524'
        tags       = {'foo': 'baz'}
        tags_to_log = [<InputTag: key='foo', value='baz'>, <InputTag: key='mlflow.data.context', value='train'>]
mlflow/tracking/client.py:1948: in log_inputs
    self._tracking_client.log_inputs(run_id, datasets, models)
        datasets   = [<DatasetInput: dataset=<Dataset: digest='f0f3e026', name='dataset', profile='{"num_rows": 2, "num_elements": 6}', sch...ource_type='local'>, tags=[<InputTag: key='foo', value='baz'>,
 <InputTag: key='mlflow.data.context', value='train'>]>]
        models     = [None]
        run_id     = 'dbc7a45d8f4d484a9bf62c84709cf524'
        self       = <mlflow.tracking.client.MlflowClient object at 0x7f011cc21a90>
mlflow/tracking/_tracking_service/client.py:840: in log_inputs
    self.store.log_inputs(run_id=run_id, datasets=datasets, models=models)
        datasets   = [<DatasetInput: dataset=<Dataset: digest='f0f3e026', name='dataset', profile='{"num_rows": 2, "num_elements": 6}', sch...ource_type='local'>, tags=[<InputTag: key='foo', value='baz'>,
 <InputTag: key='mlflow.data.context', value='train'>]>]
        models     = [None]
        run_id     = 'dbc7a45d8f4d484a9bf62c84709cf524'
        self       = <mlflow.tracking._tracking_service.client.TrackingServiceClient object at 0x7f011cc217c0>
mlflow/store/tracking/rest_store.py:744: in log_inputs
    models_protos = [model.to_proto() for model in models or []]
        datasets   = [<DatasetInput: dataset=<Dataset: digest='f0f3e026', name='dataset', profile='{"num_rows": 2, "num_elements": 6}', sch...ource_type='local'>, tags=[<InputTag: key='foo', value='baz'>,
 <InputTag: key='mlflow.data.context', value='train'>]>]
        datasets_protos = [tags {
  key: "foo"
  value: "baz"
}
tags {
  key: "mlflow.data.context"
  value: "train"
}
dataset {
  name: "datase...}, {\"type\": \"long\", \"name\": \"c\", \"required\": true}]}"
  profile: "{\"num_rows\": 2, \"num_elements\": 6}"
}
]
        models     = [None]
        run_id     = 'dbc7a45d8f4d484a9bf62c84709cf524'
        self       = <mlflow.store.tracking.rest_store.RestStore object at 0x7f011c9649d0>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <list_iterator object at 0x7f011cc217f0>

>   models_protos = [model.to_proto() for model in models or []]
E   AttributeError: 'NoneType' object has no attribute 'to_proto'

.0         = <list_iterator object at 0x7f011cc217f0>
model      = None
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
