### PR TITLE
Define DB models for logged models

### DIFF
--- a/mlflow/store/db_migrations/versions/400f98739977_add_logged_model_tables.py
+++ b/mlflow/store/db_migrations/versions/400f98739977_add_logged_model_tables.py
@@ -1,0 +1,124 @@
+"""add logged model tables
+
+Revision ID: 400f98739977
+Revises: 0584bdc529eb
+Create Date: 2025-02-06 22:05:35.542613
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "400f98739977"
+down_revision = "0584bdc529eb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "logged_models",
+        sa.Column("model_id", sa.String(length=36), nullable=False),
+        sa.Column("experiment_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=500), nullable=False),
+        sa.Column("artifact_location", sa.String(length=1000), nullable=False),
+        sa.Column("creation_timestamp_ms", sa.BigInteger(), nullable=False),
+        sa.Column("last_updated_timestamp_ms", sa.BigInteger(), nullable=False),
+        sa.Column("status", sa.Integer(), nullable=False),
+        sa.Column("lifecycle_stage", sa.String(length=32), nullable=True),
+        sa.Column("model_type", sa.String(length=500), nullable=True),
+        sa.Column("source_run_id", sa.String(length=32), nullable=True),
+        sa.Column("status_message", sa.String(length=1000), nullable=True),
+        sa.CheckConstraint(
+            "lifecycle_stage IN ('active', 'deleted')", name="logged_models_lifecycle_stage_check"
+        ),
+        sa.ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_logged_models_experiment_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("model_id", name="logged_models_pk"),
+    )
+    op.create_table(
+        "logged_model_metrics",
+        sa.Column("model_id", sa.String(length=36), nullable=False),
+        sa.Column("metric_name", sa.String(length=500), nullable=False),
+        sa.Column("metric_timestamp_ms", sa.BigInteger(), nullable=False),
+        sa.Column("metric_step", sa.BigInteger(), nullable=False),
+        sa.Column("metric_value", sa.Float(precision=53), nullable=True),
+        sa.Column("experiment_id", sa.Integer(), nullable=False),
+        sa.Column("run_id", sa.String(length=32), nullable=False),
+        sa.Column("dataset_uuid", sa.String(length=36), nullable=True),
+        sa.Column("dataset_name", sa.String(length=500), nullable=True),
+        sa.Column("dataset_digest", sa.String(length=36), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_logged_model_metrics_experiment_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["model_id"],
+            ["logged_models.model_id"],
+            name="fk_logged_model_metrics_model_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["runs.run_uuid"], name="fk_logged_model_metrics_run_id", ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint(
+            "model_id",
+            "metric_name",
+            "metric_timestamp_ms",
+            "metric_step",
+            "run_id",
+            name="logged_model_metrics_pk",
+        ),
+    )
+    with op.batch_alter_table("logged_model_metrics", schema=None) as batch_op:
+        batch_op.create_index("index_logged_model_metrics_model_id", ["model_id"], unique=False)
+
+    op.create_table(
+        "logged_model_params",
+        sa.Column("model_id", sa.String(length=36), nullable=False),
+        sa.Column("experiment_id", sa.Integer(), nullable=False),
+        sa.Column("param_key", sa.String(length=255), nullable=False),
+        sa.Column("param_value", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_logged_model_params_experiment_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["model_id"],
+            ["logged_models.model_id"],
+            name="fk_logged_model_params_model_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("model_id", "param_key", name="logged_model_params_pk"),
+    )
+    op.create_table(
+        "logged_model_tags",
+        sa.Column("model_id", sa.String(length=36), nullable=False),
+        sa.Column("experiment_id", sa.Integer(), nullable=False),
+        sa.Column("tag_key", sa.String(length=255), nullable=False),
+        sa.Column("tag_value", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_logged_model_tags_experiment_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["model_id"],
+            ["logged_models.model_id"],
+            name="fk_logged_model_tags_model_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("model_id", "tag_key", name="logged_model_tags_pk"),
+    )
+
+
+def downgrade():
+    pass

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -5,10 +5,12 @@ from sqlalchemy import (
     CheckConstraint,
     Column,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     PrimaryKeyConstraint,
     String,
+    Text,
     UnicodeText,
 )
 from sqlalchemy.orm import backref, relationship
@@ -30,6 +32,9 @@ from mlflow.entities import (
     ViewType,
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
+from mlflow.entities.logged_model import LoggedModel
+from mlflow.entities.logged_model_parameter import LoggedModelParameter
+from mlflow.entities.logged_model_tag import LoggedModelTag
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.store.db.base_sql_model import Base
@@ -753,3 +758,277 @@ class SqlTraceRequestMetadata(Base):
         PrimaryKeyConstraint("request_id", "key", name="trace_request_metadata_pk"),
         Index(f"index_{__tablename__}_request_id"),
     )
+
+
+class SqlLoggedModel(Base):
+    __tablename__ = "logged_models"
+
+    model_id = Column(String(36), nullable=False)
+    """
+    Model ID: `String` (limit 36 characters). *Primary Key* for ``logged_models`` table.
+    """
+
+    experiment_id = Column(Integer, nullable=False)
+    """
+    Experiment ID to which this model belongs: *Foreign Key* into ``experiments`` table.
+    """
+
+    name = Column(String(500), nullable=False)
+    """
+    Model name: `String` (limit 500 characters).
+    """
+
+    artifact_location = Column(String(1000), nullable=False)
+    """
+    Artifact location: `String` (limit 1000 characters).
+    """
+
+    creation_timestamp_ms = Column(BigInteger, nullable=False)
+    """
+    Creation timestamp: `BigInteger`.
+    """
+
+    last_updated_timestamp_ms = Column(BigInteger, nullable=False)
+    """
+    Last updated timestamp: `BigInteger`.
+    """
+
+    status = Column(Integer, nullable=False)
+    """
+    Status: `Integer`.
+    """
+
+    lifecycle_stage = Column(String(32), default=LifecycleStage.ACTIVE)
+    """
+    Lifecycle Stage of model: `String` (limit 32 characters).
+    """
+
+    model_type = Column(String(500), nullable=True)
+    """
+    Model type: `String` (limit 500 characters).
+    """
+
+    source_run_id = Column(String(32), nullable=True)
+    """
+    Source run ID: `String` (limit 32 characters).
+    """
+
+    status_message = Column(String(1000), nullable=True)
+    """
+    Status message: `String` (limit 1000 characters).
+    """
+
+    __table_args__ = (
+        PrimaryKeyConstraint("model_id", name="logged_models_pk"),
+        CheckConstraint(
+            lifecycle_stage.in_(LifecycleStage.view_type_to_stages(ViewType.ALL)),
+            name="logged_models_lifecycle_stage_check",
+        ),
+        ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            ondelete="CASCADE",
+            name="fk_logged_models_experiment_id",
+        ),
+    )
+
+    def to_mlflow_entity(self) -> LoggedModel:
+        return LoggedModel(
+            model_id=self.model_id,
+            experiment_id=self.experiment_id,
+            name=self.name,
+            artifact_location=self.artifact_location,
+            creation_timestamp=self.creation_timestamp_ms,
+            last_updated_timestamp=self.last_updated_timestamp_ms,
+            status=self.status,
+            model_type=self.model_type,
+            source_run_id=self.source_run_id,
+            status_message=self.status_message,
+        )
+
+
+class SqlLoggedModelMetric(Base):
+    __tablename__ = "logged_model_metrics"
+
+    model_id = Column(String(36), nullable=False)
+    """
+    Model ID: `String` (limit 36 characters).
+    """
+
+    metric_name = Column(String(500), nullable=False)
+    """
+    Metric name: `String` (limit 500 characters).
+    """
+
+    metric_timestamp_ms = Column(BigInteger, nullable=False)
+    """
+    Metric timestamp: `BigInteger`.
+    """
+
+    metric_step = Column(BigInteger, nullable=False)
+    """
+    Metric step: `BigInteger`.
+    """
+
+    metric_value = Column(sa.types.Float(precision=53), nullable=True)
+    """
+    Metric value: `Float`.
+    """
+
+    experiment_id = Column(Integer, nullable=False)
+    """
+    Experiment ID: `Integer`.
+    """
+
+    run_id = Column(String(32), nullable=False)
+    """
+    Run ID: `String` (limit 32 characters).
+    """
+
+    dataset_uuid = Column(String(36), nullable=True)
+    """
+    Dataset UUID: `String` (limit 36 characters).
+    """
+
+    dataset_name = Column(String(500), nullable=True)
+    """
+    Dataset name: `String` (limit 500 characters).
+    """
+
+    dataset_digest = Column(String(36), nullable=True)
+    """
+    Dataset digest: `String` (limit 36 characters).
+    """
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "model_id",
+            "metric_name",
+            "metric_timestamp_ms",
+            "metric_step",
+            "run_id",
+            name="logged_model_metrics_pk",
+        ),
+        ForeignKeyConstraint(
+            ["model_id"],
+            ["logged_models.model_id"],
+            ondelete="CASCADE",
+            name="fk_logged_model_metrics_model_id",
+        ),
+        ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_logged_model_metrics_experiment_id",
+        ),
+        ForeignKeyConstraint(
+            ["run_id"],
+            ["runs.run_uuid"],
+            ondelete="CASCADE",
+            name="fk_logged_model_metrics_run_id",
+        ),
+        Index("index_logged_model_metrics_model_id", "model_id"),
+    )
+
+    def to_mlflow_entity(self) -> Metric:
+        return Metric(
+            key=self.metric_name,
+            value=self.metric_value,
+            timestamp=self.metric_timestamp_ms,
+            step=self.metric_step,
+            run_id=self.run_id,
+            dataset_name=self.dataset_name,
+            dataset_digest=self.dataset_digest,
+            model_id=self.model_id,
+        )
+
+
+class SqlLoggedModelParam(Base):
+    __tablename__ = "logged_model_params"
+
+    model_id = Column(String(36), nullable=False)
+    """
+    Model ID: `String` (limit 36 characters).
+    """
+
+    experiment_id = Column(Integer, nullable=False)
+    """
+    Experiment ID: `Integer`.
+    """
+
+    param_key = Column(String(255), nullable=False)
+    """
+    Param key: `String` (limit 255 characters).
+    """
+
+    param_value = Column(Text(), nullable=False)
+    """
+    Param value: `Text`.
+    """
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "model_id",
+            "param_key",
+            name="logged_model_params_pk",
+        ),
+        ForeignKeyConstraint(
+            ["model_id"],
+            ["logged_models.model_id"],
+            name="fk_logged_model_params_model_id",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_logged_model_params_experiment_id",
+        ),
+    )
+
+    def to_mlflow_entity(self) -> LoggedModelParameter:
+        return LoggedModelParameter(key=self.param_key, value=self.param_value)
+
+
+class SqlLoggedModelTag(Base):
+    __tablename__ = "logged_model_tags"
+
+    model_id = Column(String(36), nullable=False)
+    """
+    Model ID: `String` (limit 36 characters).
+    """
+
+    experiment_id = Column(Integer, nullable=False)
+    """
+    Experiment ID: `Integer`.
+    """
+
+    tag_key = Column(String(255), nullable=False)
+    """
+    Tag key: `String` (limit 255 characters).
+    """
+
+    tag_value = Column(Text(), nullable=False)
+    """
+    Tag value: `Text`.
+    """
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "model_id",
+            "tag_key",
+            name="logged_model_tags_pk",
+        ),
+        ForeignKeyConstraint(
+            ["model_id"],
+            ["logged_models.model_id"],
+            name="fk_logged_model_tags_model_id",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_logged_model_tags_experiment_id",
+        ),
+    )
+
+    def to_mlflow_entity(self) -> LoggedModelTag:
+        return LoggedModelTag(key=self.tag_key, value=self.tag_value)

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -66,6 +66,23 @@ CREATE TABLE experiment_tags (
 )
 
 
+CREATE TABLE logged_models (
+	model_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	name VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	artifact_location VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	creation_timestamp_ms BIGINT NOT NULL,
+	last_updated_timestamp_ms BIGINT NOT NULL,
+	status INTEGER NOT NULL,
+	lifecycle_stage VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	model_type VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	source_run_id VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	status_message VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
+	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE model_versions (
 	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	version INTEGER NOT NULL,
@@ -143,6 +160,46 @@ CREATE TABLE latest_metrics (
 	run_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT latest_metric_pk PRIMARY KEY (key, run_uuid),
 	CONSTRAINT "FK__latest_me__run_u__52593CB8" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+)
+
+
+CREATE TABLE logged_model_metrics (
+	model_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	metric_name VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	metric_timestamp_ms BIGINT NOT NULL,
+	metric_step BIGINT NOT NULL,
+	metric_value FLOAT,
+	experiment_id INTEGER NOT NULL,
+	run_id VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	dataset_uuid VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	dataset_name VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	dataset_digest VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	CONSTRAINT logged_model_metrics_pk PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_params (
+	model_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	param_key VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	param_value VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	CONSTRAINT logged_model_params_pk PRIMARY KEY (model_id, param_key),
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_tags (
+	model_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	tag_key VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	tag_value VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -67,6 +67,24 @@ CREATE TABLE experiment_tags (
 )
 
 
+CREATE TABLE logged_models (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	name VARCHAR(500) NOT NULL,
+	artifact_location VARCHAR(1000) NOT NULL,
+	creation_timestamp_ms BIGINT NOT NULL,
+	last_updated_timestamp_ms BIGINT NOT NULL,
+	status INTEGER NOT NULL,
+	lifecycle_stage VARCHAR(32),
+	model_type VARCHAR(500),
+	source_run_id VARCHAR(32),
+	status_message VARCHAR(1000),
+	PRIMARY KEY (model_id),
+	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
+	CONSTRAINT logged_models_lifecycle_stage_check CHECK ((`lifecycle_stage` in (_utf8mb4'active',_utf8mb4'deleted')))
+)
+
+
 CREATE TABLE model_versions (
 	name VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
@@ -148,6 +166,46 @@ CREATE TABLE latest_metrics (
 	PRIMARY KEY (key, run_uuid),
 	CONSTRAINT latest_metrics_ibfk_1 FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid),
 	CONSTRAINT latest_metrics_chk_1 CHECK ((`is_nan` in (0,1)))
+)
+
+
+CREATE TABLE logged_model_metrics (
+	model_id VARCHAR(36) NOT NULL,
+	metric_name VARCHAR(500) NOT NULL,
+	metric_timestamp_ms BIGINT NOT NULL,
+	metric_step BIGINT NOT NULL,
+	metric_value DOUBLE,
+	experiment_id INTEGER NOT NULL,
+	run_id VARCHAR(32) NOT NULL,
+	dataset_uuid VARCHAR(36),
+	dataset_name VARCHAR(500),
+	dataset_digest VARCHAR(36),
+	PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_params (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	param_key VARCHAR(255) NOT NULL,
+	param_value TEXT NOT NULL,
+	PRIMARY KEY (model_id, param_key),
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_tags (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	tag_key VARCHAR(255) NOT NULL,
+	tag_value TEXT NOT NULL,
+	PRIMARY KEY (model_id, tag_key),
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -68,6 +68,24 @@ CREATE TABLE experiment_tags (
 )
 
 
+CREATE TABLE logged_models (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	name VARCHAR(500) NOT NULL,
+	artifact_location VARCHAR(1000) NOT NULL,
+	creation_timestamp_ms BIGINT NOT NULL,
+	last_updated_timestamp_ms BIGINT NOT NULL,
+	status INTEGER NOT NULL,
+	lifecycle_stage VARCHAR(32),
+	model_type VARCHAR(500),
+	source_run_id VARCHAR(32),
+	status_message VARCHAR(1000),
+	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
+	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
+	CONSTRAINT logged_models_lifecycle_stage_check CHECK (lifecycle_stage::text = ANY (ARRAY['active'::character varying, 'deleted'::character varying]::text[]))
+)
+
+
 CREATE TABLE model_versions (
 	name VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
@@ -148,6 +166,46 @@ CREATE TABLE latest_metrics (
 	run_uuid VARCHAR(32) NOT NULL,
 	CONSTRAINT latest_metric_pk PRIMARY KEY (key, run_uuid),
 	CONSTRAINT latest_metrics_run_uuid_fkey FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+)
+
+
+CREATE TABLE logged_model_metrics (
+	model_id VARCHAR(36) NOT NULL,
+	metric_name VARCHAR(500) NOT NULL,
+	metric_timestamp_ms BIGINT NOT NULL,
+	metric_step BIGINT NOT NULL,
+	metric_value DOUBLE PRECISION,
+	experiment_id INTEGER NOT NULL,
+	run_id VARCHAR(32) NOT NULL,
+	dataset_uuid VARCHAR(36),
+	dataset_name VARCHAR(500),
+	dataset_digest VARCHAR(36),
+	CONSTRAINT logged_model_metrics_pk PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_params (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	param_key VARCHAR(255) NOT NULL,
+	param_value TEXT NOT NULL,
+	CONSTRAINT logged_model_params_pk PRIMARY KEY (model_id, param_key),
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_tags (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	tag_key VARCHAR(255) NOT NULL,
+	tag_value TEXT NOT NULL,
+	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -69,6 +69,24 @@ CREATE TABLE experiment_tags (
 )
 
 
+CREATE TABLE logged_models (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	name VARCHAR(500) NOT NULL,
+	artifact_location VARCHAR(1000) NOT NULL,
+	creation_timestamp_ms BIGINT NOT NULL,
+	last_updated_timestamp_ms BIGINT NOT NULL,
+	status INTEGER NOT NULL,
+	lifecycle_stage VARCHAR(32),
+	model_type VARCHAR(500),
+	source_run_id VARCHAR(32),
+	status_message VARCHAR(1000),
+	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
+	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
+	CONSTRAINT logged_models_lifecycle_stage_check CHECK (lifecycle_stage IN ('active', 'deleted'))
+)
+
+
 CREATE TABLE model_versions (
 	name VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
@@ -150,6 +168,46 @@ CREATE TABLE latest_metrics (
 	CONSTRAINT latest_metric_pk PRIMARY KEY (key, run_uuid),
 	FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid),
 	CHECK (is_nan IN (0, 1))
+)
+
+
+CREATE TABLE logged_model_metrics (
+	model_id VARCHAR(36) NOT NULL,
+	metric_name VARCHAR(500) NOT NULL,
+	metric_timestamp_ms BIGINT NOT NULL,
+	metric_step BIGINT NOT NULL,
+	metric_value FLOAT,
+	experiment_id INTEGER NOT NULL,
+	run_id VARCHAR(32) NOT NULL,
+	dataset_uuid VARCHAR(36),
+	dataset_name VARCHAR(500),
+	dataset_digest VARCHAR(36),
+	CONSTRAINT logged_model_metrics_pk PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_params (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	param_key VARCHAR(255) NOT NULL,
+	param_value TEXT NOT NULL,
+	CONSTRAINT logged_model_params_pk PRIMARY KEY (model_id, param_key),
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_tags (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	tag_key VARCHAR(255) NOT NULL,
+	tag_value TEXT NOT NULL,
+	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -69,6 +69,24 @@ CREATE TABLE experiment_tags (
 )
 
 
+CREATE TABLE logged_models (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	name VARCHAR(500) NOT NULL,
+	artifact_location VARCHAR(1000) NOT NULL,
+	creation_timestamp_ms BIGINT NOT NULL,
+	last_updated_timestamp_ms BIGINT NOT NULL,
+	status INTEGER NOT NULL,
+	lifecycle_stage VARCHAR(32),
+	model_type VARCHAR(500),
+	source_run_id VARCHAR(32),
+	status_message VARCHAR(1000),
+	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
+	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
+	CONSTRAINT logged_models_lifecycle_stage_check CHECK (lifecycle_stage IN ('active', 'deleted'))
+)
+
+
 CREATE TABLE model_versions (
 	name VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
@@ -150,6 +168,46 @@ CREATE TABLE latest_metrics (
 	CONSTRAINT latest_metric_pk PRIMARY KEY (key, run_uuid),
 	FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid),
 	CHECK (is_nan IN (0, 1))
+)
+
+
+CREATE TABLE logged_model_metrics (
+	model_id VARCHAR(36) NOT NULL,
+	metric_name VARCHAR(500) NOT NULL,
+	metric_timestamp_ms BIGINT NOT NULL,
+	metric_step BIGINT NOT NULL,
+	metric_value FLOAT,
+	experiment_id INTEGER NOT NULL,
+	run_id VARCHAR(32) NOT NULL,
+	dataset_uuid VARCHAR(36),
+	dataset_name VARCHAR(500),
+	dataset_digest VARCHAR(36),
+	CONSTRAINT logged_model_metrics_pk PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_params (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	param_key VARCHAR(255) NOT NULL,
+	param_value TEXT NOT NULL,
+	CONSTRAINT logged_model_params_pk PRIMARY KEY (model_id, param_key),
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE logged_model_tags (
+	model_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	tag_key VARCHAR(255) NOT NULL,
+	tag_value TEXT NOT NULL,
+	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14443?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14443/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14443
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Defines DB models for logged models and adds a migration script. I won't update `SqlAlchemyStore` in this PR.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
