### PR TITLE
Fix build.py to restore specific files #14444

### DIFF
--- a/dev/build.py
+++ b/dev/build.py
@@ -26,7 +26,14 @@ def restore_changes():
     try:
         yield
     finally:
-        subprocess.check_call(["git", "restore", ":^dev/build.py"])
+        subprocess.check_call(
+            [
+                "git",
+                "restore",
+                "README.md",
+                "pyproject.toml",
+            ]
+        )
 
 
 def main():
@@ -45,7 +52,8 @@ def main():
         if args.package_type == "skinny":
             readme = Path("README.md")
             readme_skinny = Path("README_SKINNY.md")
-            readme.write_text(readme_skinny.read_text() + "\n" + readme.read_text())
+            readme.write_text(readme_skinny.read_text() +
+                              "\n" + readme.read_text())
 
             pyproject.write_text(Path("pyproject.skinny.toml").read_text())
 

--- a/dev/build.py
+++ b/dev/build.py
@@ -52,8 +52,7 @@ def main():
         if args.package_type == "skinny":
             readme = Path("README.md")
             readme_skinny = Path("README_SKINNY.md")
-            readme.write_text(readme_skinny.read_text() +
-                              "\n" + readme.read_text())
+            readme.write_text(readme_skinny.read_text() + "\n" + readme.read_text())
 
             pyproject.write_text(Path("pyproject.skinny.toml").read_text())
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/arunkothari84/mlflow/pull/14448?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14448/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14448
```

</p>
</details>

### Related Issues/PRs

Resolve #14444 

### What changes are proposed in this pull request?

This PR modifies `dev/build.py` to restore only `README.md` and `pyproject.toml` instead of all files except `dev/build.py`. The previous code restored all changes except for the `dev/build.py` file, but now it is explicitly restricted to just two files to prevent unintended changes from being reverted.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Since this is a small change to a build script, it will be tested using the existing build process. No new tests are required.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components:
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface:
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language:
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations:
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section.
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section.
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes.
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes.
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes.

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release).
- [ ] No (this PR will be included in the next minor release).
