### PR TITLE
Make `tests/db/update_schemas.sh` run fast

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -129,12 +129,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/untracked
       - name: Build
         run: |
           ./tests/db/compose.sh pull -q postgresql mysql mssql
           docker images
           ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(cat requirements/skinny-requirements.txt requirements/core-requirements.txt | grep -Ev '^(#|$)')"
+          python dev/build.py
       - name: Run tests
         run: |
           set +e

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -133,6 +133,7 @@ jobs:
       - uses: ./.github/actions/untracked
       - name: Build
         run: |
+          pip install build
           python dev/build.py
           ./tests/db/compose.sh pull -q postgresql mysql mssql
           docker images

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -133,10 +133,10 @@ jobs:
       - uses: ./.github/actions/untracked
       - name: Build
         run: |
+          python dev/build.py
           ./tests/db/compose.sh pull -q postgresql mysql mssql
           docker images
           ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(cat requirements/skinny-requirements.txt requirements/core-requirements.txt | grep -Ev '^(#|$)')"
-          python dev/build.py
       - name: Run tests
         run: |
           set +e

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -27,6 +27,7 @@ implement mutual exclusion manually.
 For a lower level API, see the :py:mod:`mlflow.client` module.
 """
 
+
 import contextlib
 
 from mlflow.version import VERSION

--- a/tests/db/compose.sh
+++ b/tests/db/compose.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -ex
 
+# Is a wheel present in dist directory?
+if [ ! -f dist/*.whl ]; then
+  echo "No wheel found in dist directory. Run 'python dev/build.py' to build a wheel."
+  exit 1
+fi
+
 docker compose --project-directory tests/db down --volumes --remove-orphans > /dev/null 2>&1
 docker compose --project-directory tests/db "$@"

--- a/tests/db/entrypoint.sh
+++ b/tests/db/entrypoint.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Install mlflow (assuming the repository root is mounted to the working directory)
 if [ "$INSTALL_MLFLOW_FROM_REPO" = "true" ]; then
-  pip install --no-deps -e .
+  pip install --no-deps dist/*.whl
 fi
 
 # For Microsoft SQL server, wait until the database is up and running


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14462?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14462/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14462
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

While I'm working on #14443, I found `/tests/db/update_schemas.sh` is really slow because it rebuilds a wheel for each database type (4 in total). This PR makes updates to pre-build it for fast execution.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
