### PR TITLE
Support fetching trace request ID from Flask context for supporting streaming in model serving

### DIFF
--- a/mlflow/tracing/processor/inference_table.py
+++ b/mlflow/tracing/processor/inference_table.py
@@ -21,6 +21,17 @@ from mlflow.tracing.utils import (
 _logger = logging.getLogger(__name__)
 
 
+_HEADER_REQUEST_ID_KEY = "X-Request-Id"
+
+
+# Extracting for testing purposes
+def _get_flask_request():
+    import flask
+
+    if flask.has_request_context():
+        return flask.request
+
+
 class InferenceTableSpanProcessor(SimpleSpanProcessor):
     """
     Defines custom hooks to be executed when a span is started or ended (before exporting).
@@ -45,10 +56,25 @@ class InferenceTableSpanProcessor(SimpleSpanProcessor):
         """
         request_id = maybe_get_request_id()
         if request_id is None:
-            _logger.warning(
-                "Failed to get request ID from the request headers because "
-                "request context is not available. Skipping trace processing."
-            )
+            # NB: This is currently used for streaming inference in Databricks Model Serving.
+            # In normal prediction, serving logic pass the request ID using the
+            # `with set_prediction_context` context manager that wraps `model.predict`
+            # call. However, in streaming case, the context manager is not applicable
+            # so we still need to rely on Flask request context (which is set to the
+            # stream response via flask.stream_with_context()
+            if flask_request := _get_flask_request():
+                request_id = flask_request.headers.get(_HEADER_REQUEST_ID_KEY)
+                if not request_id:
+                    _logger.warning(
+                        "Request ID not found in the request headers. Skipping trace processing."
+                    )
+                    return
+            else:
+                _logger.warning(
+                    "Failed to get request ID from the request headers because "
+                    "request context is not available. Skipping trace processing."
+                )
+                return
 
         span.set_attribute(SpanAttributeKey.REQUEST_ID, json.dumps(request_id))
         tags = {}

--- a/tests/tracing/processor/test_inference_table_processor.py
+++ b/tests/tracing/processor/test_inference_table_processor.py
@@ -1,6 +1,9 @@
 import json
 from unittest import mock
 
+import pytest
+
+from build.lib.mlflow.tracing.processor.inference_table import _HEADER_REQUEST_ID_KEY
 from mlflow.entities.span import LiveSpan
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.pyfunc.context import Context, set_prediction_context
@@ -14,7 +17,8 @@ _TRACE_ID = 12345
 _REQUEST_ID = f"tr-{_TRACE_ID}"
 
 
-def test_on_start():
+@pytest.mark.parametrize("context_type", ["mlflow", "flask"])
+def test_on_start(context_type):
     # Root span should create a new trace on start
     span = create_mock_otel_span(
         trace_id=_TRACE_ID, span_id=1, parent_id=None, start_time=5_000_000
@@ -22,8 +26,17 @@ def test_on_start():
     trace_manager = InMemoryTraceManager.get_instance()
     processor = InferenceTableSpanProcessor(span_exporter=mock.MagicMock())
 
-    with set_prediction_context(Context(request_id=_REQUEST_ID)):
-        processor.on_start(span)
+    if context_type == "mlflow":
+        with set_prediction_context(Context(request_id=_REQUEST_ID)):
+            processor.on_start(span)
+    else:
+        with mock.patch(
+            "mlflow.tracing.processor.inference_table._get_flask_request"
+        ) as mock_get_flask_request:
+            request = mock_get_flask_request.return_value
+            request.headers = {_HEADER_REQUEST_ID_KEY: _REQUEST_ID}
+
+            processor.on_start(span)
 
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces

--- a/tests/tracing/processor/test_inference_table_processor.py
+++ b/tests/tracing/processor/test_inference_table_processor.py
@@ -3,12 +3,14 @@ from unittest import mock
 
 import pytest
 
-from build.lib.mlflow.tracing.processor.inference_table import _HEADER_REQUEST_ID_KEY
 from mlflow.entities.span import LiveSpan
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.pyfunc.context import Context, set_prediction_context
 from mlflow.tracing.constant import SpanAttributeKey
-from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
+from mlflow.tracing.processor.inference_table import (
+    _HEADER_REQUEST_ID_KEY,
+    InferenceTableSpanProcessor,
+)
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 
 from tests.tracing.helper import create_mock_otel_span, create_test_trace_info


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14475?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14475/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14475
```

</p>
</details>

### What changes are proposed in this pull request?

#### Problem
Resolve regression in master branch that tracing + custom pyfunc (ChatAgent) + streaming + DB model serving does not work in model serving.

The root cause is, [this PR](https://github.com/bbqiu/mlflow/commit/bd075810f7e71992be8bd734c5d3ac1b8ff1d5de) removed a line that fetches trace request ID from Flask context, because the correct way to pass request ID is to use `set_prediction_context()` context manager. So for non-streaming pyfunc, model serving invokes MLflow model like this:

```
with set_prdiction_context(Context(request_id="123")):
      response = model.predict(inputs)
``` 

This context is fetched within [InferenceTableSpanProcessor](https://github.com/mlflow/mlflow/blob/master/mlflow/tracing/processor/inference_table.py#L46) and MLflow generates a trace with that ID.

However, this context is not set for streaming case, therefore the request ID is not passed and MLflow does not generate a trace.

#### Solution 

**TL;DR**
Add back the logic to fetch request ID from Flask contet.

**Detailed Reason**

One might guess adding the context manager in model serving side resolves the issue.

```
with set_prdiction_context(Context(request_id="123")):
      stream = model.predict_stream(inputs)
``` 

However, this does **not** work. The reason is that, for streaming case, the actual prediction only happens when the iterator is consumed. `predict_stream()` call itself is no-op and just returns a iterator. Therefore, the trace is also generated when the iterator is consumed.

```
stream = model.predict_stream(inputs)

for chunk in stream:   # <- model inference happens here first, so as trace generation
    ...
``` 

And in the Flask app, this iteration is handled by the framework and we don't write `for` loop by ourselves. Therefore, we cannot use context manager here.

Luckily, Flask itself has a solution, indeed, they faced the same issue with Flask context. They need to propagate similar context object (Flask context, which carries flask request ID), and came up with `stream_with_context` wrapper like this. If this is applied, we can access to the flask request ID during iteration.
```
          return flask.Response(
                response=flask.stream_with_context(stream),
                ...
          )
```

Model serving already uses this wrapper. Therefore, we have access to Flask context inside [InferenceTableSpanProcessor](https://github.com/mlflow/mlflow/blob/master/mlflow/tracing/processor/inference_table.py#L46). Therefore, adding back the logic to fetch request ID from Flask context resolves the tracing + stream + serving problem🙂 


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (WIP)

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
