### PR TITLE
[Docusaurus] Improve card shadow style

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -7,11 +7,11 @@
 /* You can override the default Infima variables here. */
 :root {
   --card-border-radius: 4px;
-  --card-shadow1: rgba(50, 50, 93, 0.01);
-  --card-shadow2: rgba(50, 50, 93, 0.1);
-  --card-shadow3: rgba(0, 0, 0, 0.02);
+  --card-shadow1: rgba(50, 50, 93, 0.05);
+  --card-shadow2: rgba(50, 50, 93, 0.08);
+  --card-shadow3: rgba(0, 0, 0, 0.05);
   --card-hover-shadow: 0 0 0 1px var(--card-shadow1),
-    0 7px 14px 0 var(--card-shadow2), 0 3px 6px 0 var(--card-shadow3);
+    0 0 14px 5px var(--card-shadow2), 0 0 10px 3px var(--card-shadow3);
 
   --ifm-color-primary: #0194e2;
   --ifm-color-primary-dark: #0086cf;
@@ -74,9 +74,9 @@
   --ifm-color-primary-lightest: #54cef0;
 
   /* Inverted shadows */
-  --card-shadow1: rgba(205, 205, 162, 0.99);
-  --card-shadow2: rgba(205, 205, 162, 0.9);
-  --card-shadow3: rgba(255, 255, 255, 0.98);
+  --card-shadow1: rgba(162, 162, 162, 0.5);
+  --card-shadow2: rgba(162, 162, 162, 0.5);
+  --card-shadow3: rgba(255, 255, 255, 0.3);
 
   /* Temporary secondary styles */
   --ifm-color-secondary: #c2a025;
@@ -164,7 +164,6 @@ In headlines Ducousaurus adds this for us. */
   font-weight: bold;
 }
 
-
 .sidebar-top-level-category > .menu__list-item-collapsible > .menu__link {
   font-weight: bold;
 }
@@ -173,15 +172,17 @@ In headlines Ducousaurus adds this for us. */
   font-size: 0.9rem;
 }
 
-.menu__list-item:not(.sidebar-top-level-category) > .menu__list-item-collapsible > .menu__link {
+.menu__list-item:not(.sidebar-top-level-category)
+  > .menu__list-item-collapsible
+  > .menu__link {
   font-size: 0.9rem;
 }
 
 /* Make the collapse button smaller */
 .menu__caret:before {
-  background: var(--ifm-menu-link-sublist-icon) 50% / 1.5rem 1.5rem
+  background: var(--ifm-menu-link-sublist-icon) 50% / 1.5rem 1.5rem;
 }
 
 .menu__link--sublist-caret:after {
-  background: var(--ifm-menu-link-sublist-icon) 50% / 1.5rem 1.5rem
+  background: var(--ifm-menu-link-sublist-icon) 50% / 1.5rem 1.5rem;
 }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14481?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14481/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14481
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently the card hover shadow looks like this:

in light mode, it's not very visible, and in dark mode, it's a golden shadow which is a little strange to me.

This PR makes the shadow more centered and also a bit less golden.


https://github.com/user-attachments/assets/31e27ad5-ca83-4b6b-9239-f81457cd39fd



### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

After (i know dark mode images look bad but i don't think there's a great solution for that right now):



https://github.com/user-attachments/assets/a672be26-14b1-4deb-935c-7ee6bc32ff78




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
