### PR TITLE
MLflow 3.0 Support Registering Model from runs:/ as well as models:/

### DIFF
--- a/examples/mlflow-3/register_model.py
+++ b/examples/mlflow-3/register_model.py
@@ -4,9 +4,12 @@ from sklearn.linear_model import LinearRegression
 
 import mlflow
 
+client = mlflow.MlflowClient()
+
 with mlflow.start_run():
     model = LinearRegression().fit([[1], [2]], [3, 4])
     model_info = mlflow.sklearn.log_model(model, "model")
+    model_info_2 = mlflow.sklearn.log_model(model, "model", step=2)
 
 mlflow.register_model(model_info.model_uri, name="model")
 m = mlflow.get_logged_model(model_info.model_id)
@@ -18,6 +21,12 @@ m = mlflow.get_logged_model(model_info.model_id)
 assert len(json.loads(m.tags["mlflow.modelVersions"])) == 2
 print(m.tags)
 
+# Support backwards compatibility for runs:/... in addition to models:/...
+model_uri = f"runs:/{model_info.run_id}/model"
+mlflow.register_model(model_uri, name="model_from_runs_path")
+mv = client.get_model_version("model_from_runs_path", 1)
+assert mv.model_id == model_info_2.model_id  # model at largest step is registered
+
 # Register model in log_model() directly
 with mlflow.start_run():
     model_1 = LinearRegression().fit([[1], [2]], [3, 4])
@@ -27,5 +36,5 @@ m = mlflow.get_logged_model(model_info_1.model_id)
 assert len(json.loads(m.tags["mlflow.modelVersions"])) == 1
 print(m.tags)
 
-client = mlflow.MlflowClient()
-m = client.get_model_version("model_1", 1)
+mv = client.get_model_version("model_1", 1)
+assert mv.model_id == model_info_1.model_id

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -2235,7 +2235,7 @@ class FileStore(AbstractStore):
             models = self._list_models(experiment_id)
             all_models.extend(models)
         filtered = SearchUtils.filter_logged_models(models, filter_string)
-        return SearchUtils.sort_logged_models(filtered, order_by)[:max_results]
+        return PagedList(SearchUtils.sort_logged_models(filtered, order_by)[:max_results], None)
 
     def _list_models(self, experiment_id: str) -> list[LoggedModel]:
         self._check_root_dir()

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -116,7 +116,8 @@ def _register_model(
         else:
             raise e
 
-    run_id, model_id = None, None
+    run_id = None
+    model_id = None
     source = model_uri
     if RunsArtifactRepository.is_runs_uri(model_uri):
         # If the uri is of the form runs:/...

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -145,7 +145,7 @@ def _register_model(
             )[0].model_id
             source = f"models:/{model_id}"
             _logger.warning(
-                f"Run with id {run_id} has no artifacts at artifact path <{artifact_path}>, "
+                f"Run with id {run_id} has no artifacts at artifact path {artifact_path!r}, "
                 f"registering model based on {source} instead"
             )
 

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -145,7 +145,7 @@ def _register_model(
             source = f"models:/{model_id}"
             _logger.warning(
                 f"Run with id {run_id} has no artifacts at artifact path <{artifact_path}>, "
-                + f"registering model based on {source} instead"
+                f"registering model based on {source} instead"
             )
 
     # Otherwise if the uri is of the form models:/..., try to get the model_id from the uri directly

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -140,9 +140,7 @@ def _register_model(
                 )
             # If there are multiple such logged models, get the one logged at the largest step
             model_id_to_step = {m_o.model_id: m_o.step for m_o in run.outputs.model_outputs}
-            model_id = max(
-                logged_models, key=lambda lm: model_id_to_step[lm.model_id]
-            ).model_id
+            model_id = max(logged_models, key=lambda lm: model_id_to_step[lm.model_id]).model_id
             source = f"models:/{model_id}"
             _logger.warning(
                 f"Run with id {run_id} has no artifacts at artifact path {artifact_path!r}, "

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -196,6 +196,8 @@ def _get_logged_models_from_run(source_run: str, model_name: str) -> LoggedModel
     while True:
         logged_models_page = client.search_logged_models(
             experiment_ids=[source_run.info.experiment_id],
+            # TODO: Use filter_string once the backend supports it
+            # filter_string="...",
             page_token=page_token,
         )
         logged_models.extend(

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -1,9 +1,16 @@
 import json
+import logging
 from typing import Any, Optional
 
+from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import ALREADY_EXISTS, RESOURCE_ALREADY_EXISTS, ErrorCode
+from mlflow.protos.databricks_pb2 import (
+    ALREADY_EXISTS,
+    NOT_FOUND,
+    RESOURCE_ALREADY_EXISTS,
+    ErrorCode,
+)
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.utils.models import _parse_model_id_if_present
 from mlflow.store.model_registry import (
@@ -14,6 +21,8 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils import get_results_from_paginated_fn, mlflow_tags
 from mlflow.utils.logging_utils import eprint
+
+_logger = logging.getLogger(__name__)
 
 
 def register_model(
@@ -107,12 +116,40 @@ def _register_model(
         else:
             raise e
 
-    run_id = None
+    run_id, model_id = None, None
     source = model_uri
     if RunsArtifactRepository.is_runs_uri(model_uri):
-        source = RunsArtifactRepository.get_underlying_uri(model_uri)
-        (run_id, _) = RunsArtifactRepository.parse_runs_uri(model_uri)
+        # If the uri is of the form runs:/...
+        (run_id, artifact_path) = RunsArtifactRepository.parse_runs_uri(model_uri)
+        runs_artifact_repo = RunsArtifactRepository(model_uri)
+        if runs_artifact_repo._is_directory(artifact_path):
+            # First check if run has artifact at artifact_path, 
+            # if so use the run's artifact location as source
+            source = RunsArtifactRepository.get_underlying_uri(model_uri)
+        else:
+            # Otherwise check if there's a logged model with 
+            # name artifact_path and source_run_id run_id
+            run = client.get_run(run_id)
+            logged_models = _get_logged_models_from_run(run, artifact_path)
+            if not logged_models:
+                raise MlflowException(
+                    f"Unable to find a logged_model with artifact_path {artifact_path} " +
+                    f"under run {run_id}",
+                    error_code=ErrorCode.Name(NOT_FOUND),
+                )
+            # If there are multiple such logged models, get the one logged at the largest step
+            model_id_to_step = {m_o.model_id: m_o.step for m_o in run.outputs.model_outputs}
+            model_id = sorted(
+                logged_models, key=lambda lm: model_id_to_step[lm.model_id], reverse=True
+            )[0].model_id
+            source = f"models:/{model_id}"
+            _logger.warning(
+                f"Run with id {run_id} has no artifacts at artifact path <{artifact_path}>, "
+                + f"registering model based on {source} instead"
+            )
 
+    # Otherwise if the uri is of the form models:/..., try to get the model_id from the uri directly
+    model_id = _parse_model_id_if_present(model_uri) if not model_id else model_id
     create_version_response = client._create_model_version(
         name=name,
         source=source,
@@ -120,14 +157,14 @@ def _register_model(
         tags=tags,
         await_creation_for=await_registration_for,
         local_model_path=local_model_path,
-        model_id=_parse_model_id_if_present(model_uri),
+        model_id=model_id,
     )
     eprint(
         f"Created version '{create_version_response.version}' of model "
         f"'{create_version_response.name}'."
     )
 
-    if model_id := _parse_model_id_if_present(model_uri):
+    if model_id:
         new_value = [
             {
                 "name": create_version_response.name,
@@ -144,6 +181,36 @@ def _register_model(
         )
 
     return create_version_response
+
+
+def _get_logged_models_from_run(source_run: str, model_name: str) -> LoggedModel:
+    """Get all logged models from the source rnu that have the specified model name.
+
+    Args:
+        source_run: Source run from which to retrieve logged models.
+        model_name: Name of the model to retrieve.
+    """
+    client = MlflowClient()
+    logged_models, page_token = [], None
+
+    while True:
+        logged_models_page = client.search_logged_models(
+            experiment_ids=[source_run.info.experiment_id],
+            page_token=page_token,
+        )
+        logged_models.extend(
+            [
+                logged_model
+                for logged_model in logged_models_page
+                if logged_model.source_run_id == source_run.info.run_id
+                and logged_model.name == model_name
+            ]
+        )
+        if not logged_models_page.token:
+            break
+        page_token = logged_models_page.token
+
+    return logged_models
 
 
 def search_registered_models(

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -141,7 +141,7 @@ def _register_model(
             # If there are multiple such logged models, get the one logged at the largest step
             model_id_to_step = {m_o.model_id: m_o.step for m_o in run.outputs.model_outputs}
             model_id = max(
-                logged_models, key=lambda lm: model_id_to_step[lm.model_id], reverse=True
+                logged_models, key=lambda lm: model_id_to_step[lm.model_id]
             ).model_id
             source = f"models:/{model_id}"
             _logger.warning(

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -135,7 +135,7 @@ def _register_model(
             if not logged_models:
                 raise MlflowException(
                     f"Unable to find a logged_model with artifact_path {artifact_path} "
-                    + f"under run {run_id}",
+                    f"under run {run_id}",
                     error_code=ErrorCode.Name(NOT_FOUND),
                 )
             # If there are multiple such logged models, get the one logged at the largest step

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -183,7 +183,7 @@ def _register_model(
     return create_version_response
 
 
-def _get_logged_models_from_run(source_run: str, model_name: str) -> LoggedModel:
+def _get_logged_models_from_run(source_run: str, model_name: str) -> list[LoggedModel]:
     """Get all logged models from the source rnu that have the specified model name.
 
     Args:

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -191,7 +191,8 @@ def _get_logged_models_from_run(source_run: str, model_name: str) -> LoggedModel
         model_name: Name of the model to retrieve.
     """
     client = MlflowClient()
-    logged_models, page_token = [], None
+    logged_models = []
+    page_token = None
 
     while True:
         logged_models_page = client.search_logged_models(

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -140,9 +140,9 @@ def _register_model(
                 )
             # If there are multiple such logged models, get the one logged at the largest step
             model_id_to_step = {m_o.model_id: m_o.step for m_o in run.outputs.model_outputs}
-            model_id = sorted(
+            model_id = max(
                 logged_models, key=lambda lm: model_id_to_step[lm.model_id], reverse=True
-            )[0].model_id
+            ).model_id
             source = f"models:/{model_id}"
             _logger.warning(
                 f"Run with id {run_id} has no artifacts at artifact path {artifact_path!r}, "

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -123,18 +123,18 @@ def _register_model(
         (run_id, artifact_path) = RunsArtifactRepository.parse_runs_uri(model_uri)
         runs_artifact_repo = RunsArtifactRepository(model_uri)
         if runs_artifact_repo._is_directory(artifact_path):
-            # First check if run has artifact at artifact_path, 
+            # First check if run has artifact at artifact_path,
             # if so use the run's artifact location as source
             source = RunsArtifactRepository.get_underlying_uri(model_uri)
         else:
-            # Otherwise check if there's a logged model with 
+            # Otherwise check if there's a logged model with
             # name artifact_path and source_run_id run_id
             run = client.get_run(run_id)
             logged_models = _get_logged_models_from_run(run, artifact_path)
             if not logged_models:
                 raise MlflowException(
-                    f"Unable to find a logged_model with artifact_path {artifact_path} " +
-                    f"under run {run_id}",
+                    f"Unable to find a logged_model with artifact_path {artifact_path} "
+                    + f"under run {run_id}",
                     error_code=ErrorCode.Name(NOT_FOUND),
                 )
             # If there are multiple such logged models, get the one logged at the largest step


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/raymondzhou-db/mlflow/pull/14487?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14487/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14487
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add backward compatibility support for registering a model using `mlflow.register_model()` with a model_uri of the form `runs:/` (currently only `models:/` is supported. As part of previous MLflow 3.0 changes, we're uploading artifacts to the logged model's artifact repo instead of the the run's. So the logic is as follow

1. Check if the Run with ID run_id has an artifact at path <artifact_path>. If so, treat it like a model directory & try to register it as a Model Version
2. Otherwise, check if there's a logged model with name <artifact_path> and source run run_id . If so, register it.
If there are multiple, pick the one that was logged at the largest step

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

Added unit test for the `runs:/` behaviour specifically. Also manually tested that this works

<!-- Attach code, screenshot, video used for manual testing here. -->

In scenario 1, we use the MLflow 3.0 client to create and run and log a model, then check that we can register a model using both `runs:/` and `models:/`

```%pip install --force-reinstall git+https://github.com/raymondzhou-db/mlflow.git@raymond-zhou_data/runs-register-model```
<img width="1356" alt="image" src="https://github.com/user-attachments/assets/7f897e99-a774-4bb3-bf91-6a843a3ab12b" />

In scenario 2, we use the MLflow 2.20.X client to create a run and log a model, then the 3.0 client to register it with `runs:/`. In this case, we confirm there is no warning indicating that the logged model artifact repo was used and the previous runs artifact repo behaviour is still correct

```%pip install --force-reinstall mlflow```
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/3fa6cff4-89b9-4e3f-894f-a460ed3bbd7c" />

```%pip install --force-reinstall git+https://github.com/raymondzhou-db/mlflow.git@raymond-zhou_data/runs-register-model```
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/c26d673f-bf24-4b37-8efe-0a2e63194269" />

Checked that the model versions exist (8 and 9 for runs_uri, 21 for models_uri)

<img width="961" alt="image" src="https://github.com/user-attachments/assets/0262cb80-082d-4f63-acb3-4777236db344" />

<img width="948" alt="image" src="https://github.com/user-attachments/assets/a37428c2-8516-4df8-805b-1f216ae72528" />



### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
