### PR TITLE
[1] Adding basic data model for prompt registry

### DIFF
--- a/mlflow/entities/__init__.py
+++ b/mlflow/entities/__init__.py
@@ -13,6 +13,7 @@ from mlflow.entities.file_info import FileInfo
 from mlflow.entities.input_tag import InputTag
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.entities.metric import Metric
+from mlflow.entities.model_registry import Prompt
 from mlflow.entities.param import Param
 from mlflow.entities.run import Run
 from mlflow.entities.run_data import RunData
@@ -34,6 +35,7 @@ __all__ = [
     "FileInfo",
     "Metric",
     "Param",
+    "Prompt",
     "Run",
     "RunData",
     "RunInfo",

--- a/mlflow/entities/model_registry/__init__.py
+++ b/mlflow/entities/model_registry/__init__.py
@@ -1,12 +1,14 @@
 from mlflow.entities.model_registry.model_version import ModelVersion
 from mlflow.entities.model_registry.model_version_search import ModelVersionSearch
 from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
+from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.registered_model import RegisteredModel
 from mlflow.entities.model_registry.registered_model_alias import RegisteredModelAlias
 from mlflow.entities.model_registry.registered_model_search import RegisteredModelSearch
 from mlflow.entities.model_registry.registered_model_tag import RegisteredModelTag
 
 __all__ = [
+    "Prompt",
     "RegisteredModel",
     "ModelVersion",
     "RegisteredModelAlias",

--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
 from typing import Optional, Union
 
 from mlflow.entities.model_registry.model_version import ModelVersion
@@ -27,7 +26,6 @@ def _is_reserved_tag(key: str) -> bool:
     return key in {IS_PROMPT_TAG_KEY, PROMPT_TEXT_TAG_KEY}
 
 
-@dataclass
 class Prompt(ModelVersion):
     """
     An entity representing a prompt (template) for GenAI applications.

--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from mlflow.entities.model_registry.model_version import ModelVersion
+from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
+from mlflow.exceptions import MlflowException
+
+# A special tag in RegisteredModel to indicate that it is a prompt
+IS_PROMPT_TAG_KEY = "mlflow.prompt.is_prompt"
+# A special tag in ModelVersion to store the prompt text
+PROMPT_TEXT_TAG_KEY = "mlflow.prompt.text"
+
+_PROMPT_TEMPLATE_VARIABLE_PATTERN = re.compile(r"\{\{([a-zA-Z0-9_]+)\}\}")
+
+# Alias type
+PromptVersionTag = ModelVersionTag
+
+
+@dataclass
+class Prompt(ModelVersion):
+    """
+    An entity representing a prompt (template) for GenAI applications.
+
+    Args:
+        name: The name of the prompt.
+        version: The version number of the prompt.
+        template: The template text of the prompt. It can contain variables enclosed in
+            single curly braces, e.g. {variable}, which will be replaced with actual values
+            by the `format` method.
+        description: Text description of the prompt. Optional.
+        creation_timestamp: Timestamp of the prompt creation. Optional.
+        tags: A dictionary of tags associated with the prompt. Optional.
+
+    :meta private:
+    Prompt is implemented as a special type of ModelVersion. MLflow stores both prompts and
+    model versions in the model registry as ModelVersion DB records, but distinguishes them
+    using the special tag "mlflow.prompt.is_prompt".
+    """
+
+    def __init__(
+        self,
+        name: str,
+        version: int,
+        template: str,
+        description: Optional[str] = None,
+        creation_timestamp: Optional[int] = None,
+        tags: Optional[dict[str, str]] = None,
+    ):
+        # Store template text as a tag
+        tags = tags or {}
+
+        if PROMPT_TEXT_TAG_KEY not in tags:
+            tags[PROMPT_TEXT_TAG_KEY] = template
+
+        super().__init__(
+            name=name,
+            version=version,
+            creation_timestamp=creation_timestamp,
+            description=description,
+            tags=[ModelVersionTag(key=key, value=value) for key, value in tags.items()],
+        )
+
+    def __repr__(self) -> str:
+        text = self.template[:30] + "..." if len(self.template) > 30 else self.template
+        return f"Prompt(name={self.name}, version={self.version}, template={text})"
+
+    @property
+    def template(self) -> str:
+        """
+        Return the template text of the prompt.
+        """
+        return self._tags[PROMPT_TEXT_TAG_KEY]
+
+    @property
+    def variables(self) -> set[str]:
+        """
+        Return a list of variables in the template text.
+        The value must be enclosed in curly braces, e.g. {variable}.
+        """
+        if hasattr(self, "_variables"):
+            return self._variables
+
+        variables = _PROMPT_TEMPLATE_VARIABLE_PATTERN.findall(self.template)
+        self._variables = set(variables)
+        return self._variables
+
+    @property
+    def tags(self) -> dict[str, str]:
+        """Return the tags of the prompt as a dictionary."""
+        # Remove the prompt text tag as it should not be user-facing
+        return {key: value for key, value in self._tags.items() if key != PROMPT_TEXT_TAG_KEY}
+
+    @tags.setter
+    def tags(self, tags: dict[str, str]):
+        """Set the tags of the prompt."""
+        self._tags = {
+            **tags,
+            PROMPT_TEXT_TAG_KEY: self.template,
+        }
+
+    def format(self, allow_partial: bool = False, **kwargs) -> Union[Prompt, str]:
+        """
+        Format the template text with the given keyword arguments.
+        By default, it raises an error if there are missing variables. To format
+        the prompt text partially, set `allow_partial=True`.
+
+        Example:
+
+        .. code-block:: python
+
+            prompt = Prompt("my-prompt", 1, "Hello, {{title}} {{name}}!")
+            formatted = prompt.format(title="Ms", name="Alice")
+            print(formatted)
+            # Output: "Hello, Ms Alice!"
+
+            # Partial formatting
+            formatted = prompt.format(title="Ms", allow_partial=True)
+            print(formatted)
+            # Output: Prompt(name=my-prompt, version=1, template="Hello, Ms {{name}}!")
+
+
+        Args:
+            allow_partial: If True, allow partial formatting of the prompt text.
+                If False, raise an error if there are missing variables.
+            kwargs: Keyword arguments to replace the variables in the template.
+        """
+        input_keys = set(kwargs.keys())
+        missing_keys = self.variables - input_keys
+
+        if missing_keys and not allow_partial:
+            raise MlflowException.invalid_parameter_value(
+                f"Missing variables: {missing_keys}. To partially format the prompt, "
+                "set `allow_partial=True`."
+            )
+
+        return self.template.format(**kwargs)
+
+    @classmethod
+    def from_model_version(cls, model_version: ModelVersion) -> Prompt:
+        """
+        Create a Prompt object from a ModelVersion object.
+        """
+        if PROMPT_TEXT_TAG_KEY not in model_version.tags:
+            raise ValueError("ModelVersion object does not contain prompt text.")
+
+        return cls(
+            name=model_version.name,
+            version=model_version.version,
+            template=model_version.tags[PROMPT_TEXT_TAG_KEY],
+            description=model_version.description,
+            creation_timestamp=model_version.creation_timestamp,
+            tags=model_version.tags,
+        )

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -84,10 +84,6 @@ class RegisteredModel(_ModelRegistryEntity):
         # Remove the is_prompt tag as it should not be user-facing
         return {k: v for k, v in self._tags.items() if k != IS_PROMPT_TAG_KEY}
 
-    @tags.setter
-    def tags(self, tags):
-        self._tags = {**tags, IS_PROMPT_TAG_KEY: self._is_prompt}
-
     @property
     def aliases(self):
         """Dictionary of aliases (string) -> version for the current registered model."""

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -1,5 +1,6 @@
 from mlflow.entities.model_registry._model_registry_entity import _ModelRegistryEntity
 from mlflow.entities.model_registry.model_version import ModelVersion
+from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY
 from mlflow.entities.model_registry.registered_model_alias import RegisteredModelAlias
 from mlflow.entities.model_registry.registered_model_tag import RegisteredModelTag
 from mlflow.protos.model_registry_pb2 import RegisteredModel as ProtoRegisteredModel
@@ -80,7 +81,12 @@ class RegisteredModel(_ModelRegistryEntity):
     @property
     def tags(self):
         """Dictionary of tag key (string) -> tag value for the current registered model."""
-        return self._tags
+        # Remove the is_prompt tag as it should not be user-facing
+        return {k: v for k, v in self._tags.items() if k != IS_PROMPT_TAG_KEY}
+
+    @tags.setter
+    def tags(self, tags):
+        self._tags = {**tags, IS_PROMPT_TAG_KEY: self._is_prompt}
 
     @property
     def aliases(self):

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -5,7 +5,6 @@ import sys
 import time
 import urllib
 from os.path import join
-from typing import Optional
 
 from mlflow.entities.model_registry import (
     ModelVersion,
@@ -22,7 +21,6 @@ from mlflow.entities.model_registry.model_version_stages import (
     STAGE_NONE,
     get_canonical_stage,
 )
-from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY
 from mlflow.environment_variables import MLFLOW_REGISTRY_DIR
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
@@ -38,6 +36,7 @@ from mlflow.store.model_registry import (
     SEARCH_REGISTERED_MODEL_MAX_RESULTS_THRESHOLD,
 )
 from mlflow.store.model_registry.abstract_store import AbstractStore
+from mlflow.store.model_registry.prompt.utils import add_prompt_filter_string
 from mlflow.utils.file_utils import (
     contains_path_separator,
     contains_percent,
@@ -381,7 +380,7 @@ class FileStore(AbstractStore):
                 INVALID_PARAMETER_VALUE,
             )
 
-        filter_string = self._add_prompt_filter_string(filter_string)
+        filter_string = add_prompt_filter_string(filter_string, is_prompt=False)
 
         registered_models = self._list_all_registered_models()
         filtered_rms = SearchModelUtils.filter(registered_models, filter_string)
@@ -890,7 +889,7 @@ class FileStore(AbstractStore):
                 file_mv.to_mlflow_entity()
                 for file_mv in self._list_file_model_versions_under_path(path)
             )
-        filter_string = self._add_prompt_filter_string(filter_string)
+        filter_string = add_prompt_filter_string(filter_string, is_prompt=False)
         filtered_mvs = SearchModelVersionUtils.filter(model_versions, filter_string)
 
         sorted_mvs = SearchModelVersionUtils.sort(
@@ -905,16 +904,6 @@ class FileStore(AbstractStore):
         if final_offset < len(sorted_mvs):
             next_page_token = SearchUtils.create_page_token(final_offset)
         return PagedList(paginated_mvs, next_page_token)
-
-    def _add_prompt_filter_string(self, filter_string: Optional[str]) -> str:
-        """Adjust filter string to exclude prompts by default"""
-        if IS_PROMPT_TAG_KEY not in (filter_string or ""):
-            prompt_filter_query = f"tag.`{IS_PROMPT_TAG_KEY}` != 'true'"
-            if filter_string:
-                filter_string = f"{filter_string} AND {prompt_filter_query}"
-            else:
-                filter_string = prompt_filter_query
-        return filter_string
 
     def _get_registered_model_version_tag_path(self, name, version, tag_name):
         _validate_tag_name(tag_name)

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -36,6 +36,7 @@ from mlflow.store.model_registry import (
     SEARCH_REGISTERED_MODEL_MAX_RESULTS_THRESHOLD,
 )
 from mlflow.store.model_registry.abstract_store import AbstractStore
+from mlflow.store.model_registry.prompt.utils import add_prompt_filter_string
 from mlflow.utils.file_utils import (
     contains_path_separator,
     contains_percent,
@@ -343,7 +344,11 @@ class FileStore(AbstractStore):
         return registered_models
 
     def search_registered_models(
-        self, filter_string=None, max_results=None, order_by=None, page_token=None
+        self,
+        filter_string=None,
+        max_results=None,
+        order_by=None,
+        page_token=None,
     ):
         """
         Search for registered models in backend that satisfy the filter criteria.
@@ -374,6 +379,9 @@ class FileStore(AbstractStore):
                 f"{SEARCH_REGISTERED_MODEL_MAX_RESULTS_THRESHOLD}, but got value {max_results}",
                 INVALID_PARAMETER_VALUE,
             )
+
+        # Adjust filter string to exclude prompts by default
+        filter_string = add_prompt_filter_string(filter_string)
 
         registered_models = self._list_all_registered_models()
         filtered_rms = SearchModelUtils.filter(registered_models, filter_string)

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -344,11 +344,7 @@ class FileStore(AbstractStore):
         return registered_models
 
     def search_registered_models(
-        self,
-        filter_string=None,
-        max_results=None,
-        order_by=None,
-        page_token=None,
+        self, filter_string=None, max_results=None, order_by=None, page_token=None
     ):
         """
         Search for registered models in backend that satisfy the filter criteria.

--- a/mlflow/store/model_registry/prompt/utils.py
+++ b/mlflow/store/model_registry/prompt/utils.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY
+
+
+def add_prompt_filter_string(
+    filter_string: Optional[str], is_prompt: bool = False
+) -> Optional[str]:
+    """
+    Additional filter string to include/exclude prompts from the result.
+    By default, exclude prompts from the result.
+    """
+    if IS_PROMPT_TAG_KEY not in (filter_string or ""):
+        prompt_filter_query = (
+            f"tag.`{IS_PROMPT_TAG_KEY}` = 'true'"
+            if is_prompt
+            else f"tag.`{IS_PROMPT_TAG_KEY}` != 'true'"
+        )
+        if filter_string:
+            filter_string = f"{filter_string} AND {prompt_filter_query}"
+        else:
+            filter_string = prompt_filter_query
+    return filter_string

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -436,7 +436,7 @@ class SqlAlchemyStore(AbstractStore):
             )
             rm_query = rm_query.join(
                 prompts_subquery, SqlRegisteredModel.name == prompts_subquery.c.name, isouter=True
-            ).filter(prompts_subquery.c.name is None)
+            ).filter(prompts_subquery.c.name.is_(None))
 
         if tag_filters:
             sql_tag_filters = (sqlalchemy.and_(*x) for x in tag_filters.values())

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -22,6 +22,7 @@ from sqlparse.tokens import Token as TokenType
 
 from mlflow.entities import RunInfo
 from mlflow.entities.model_registry.model_version_stages import STAGE_DELETED_INTERNAL
+from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import MSSQL, MYSQL, POSTGRES, SQLITE
@@ -1097,12 +1098,28 @@ class SearchModelUtils(SearchUtils):
             lhs = getattr(model, key)
             value = int(value)
         elif cls.is_tag(key_type, comparator):
-            # if the filter doesn't apply, do we return False or?
-            lhs = model.tags.get(key, None)
+            # NB: We should use the private attribute `_tags` instead of the `tags` property
+            # to consider all tags including reserved ones.
+            lhs = model._tags.get(key, None)
         else:
             raise MlflowException(
                 f"Invalid search expression type '{key_type}'", error_code=INVALID_PARAMETER_VALUE
             )
+
+        # NB: Handling the special `mlflow.prompt.is_prompt` tag. This tag is used for
+        #   distinguishing between prompt models and normal models. For example, we want to
+        #   search for models only by the following filter string:
+        #
+        #     tags.`mlflow.prompt.is_prompt` != 'true'
+        #     tags.`mlflow.prompt.is_prompt` = 'false'
+        #
+        #   However, models do not have this tag, so lhs is None in this case. Instead of returning
+        #   False like normal tag filter, we need to return True here.
+        if key == IS_PROMPT_TAG_KEY and lhs is None:
+            return (comparator == "=" and value == "false") or (
+                comparator == "!=" and value == "true"
+            )
+
         if lhs is None:
             return False
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1299,6 +1299,21 @@ class SearchModelVersionUtils(SearchUtils):
             raise MlflowException(
                 f"Invalid search expression type '{key_type}'", error_code=INVALID_PARAMETER_VALUE
             )
+
+        # NB: Handling the special `mlflow.prompt.is_prompt` tag. This tag is used for
+        #   distinguishing between prompt models and normal models. For example, we want to
+        #   search for models only by the following filter string:
+        #
+        #     tags.`mlflow.prompt.is_prompt` != 'true'
+        #     tags.`mlflow.prompt.is_prompt` = 'false'
+        #
+        #   However, models do not have this tag, so lhs is None in this case. Instead of returning
+        #   False like normal tag filter, we need to return True here.
+        if key == IS_PROMPT_TAG_KEY and lhs is None:
+            return (comparator == "=" and value == "false") or (
+                comparator == "!=" and value == "true"
+            )
+
         if lhs is None:
             return False
 

--- a/tests/entities/test_prompt.py
+++ b/tests/entities/test_prompt.py
@@ -5,23 +5,23 @@ from mlflow.exceptions import MlflowException
 
 
 def test_prompt_initialization():
-    prompt = Prompt(name="my_prompt", version=1, template="Hello, {name}!")
+    prompt = Prompt(name="my_prompt", version=1, template="Hello, {{name}}!")
     assert prompt.name == "my_prompt"
     assert prompt.version == 1
-    assert prompt.template == "Hello, {name}!"
+    assert prompt.template == "Hello, {{name}}!"
     # Public property should not return the reserved tag
     assert prompt.tags == {}
     assert prompt._tags[IS_PROMPT_TAG_KEY] == "true"
-    assert prompt._tags[PROMPT_TEXT_TAG_KEY] == "Hello, {name}!"
+    assert prompt._tags[PROMPT_TEXT_TAG_KEY] == "Hello, {{name}}!"
 
 
 def test_prompt_variables_extraction():
-    prompt = Prompt(name="test", version=1, template="Hello, {first_name} {last_name}!")
+    prompt = Prompt(name="test", version=1, template="Hello, {{first_name}} {{last_name}}!")
     assert prompt.variables == {"first_name", "last_name"}
 
 
 def test_prompt_format():
-    prompt = Prompt(name="test", version=1, template="Hello, {title} {name}!")
+    prompt = Prompt(name="test", version=1, template="Hello, {{title}} {{name}}!")
     result = prompt.format(title="Ms.", name="Alice")
     assert result == "Hello, Ms. Alice!"
 
@@ -31,5 +31,12 @@ def test_prompt_format():
 
     # Partial formatting
     result = prompt.format(title="Ms.", allow_partial=True)
-    assert result.template == "Hello, Ms. {name}!"
+    assert result.template == "Hello, Ms. {{name}}!"
     assert result.variables == {"name"}
+
+
+def test_prompt_with_spaces():
+    # Prompt template should handle spaces in variable names
+    prompt = Prompt(name="test", version=1, template="Hello, {{ title }} {{  name  }}!")
+    result = prompt.format(title="Ms.", name="Alice")
+    assert result == "Hello, Ms. Alice!"

--- a/tests/entities/test_prompt.py
+++ b/tests/entities/test_prompt.py
@@ -1,0 +1,35 @@
+import pytest
+
+from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY, PROMPT_TEXT_TAG_KEY, Prompt
+from mlflow.exceptions import MlflowException
+
+
+def test_prompt_initialization():
+    prompt = Prompt(name="my_prompt", version=1, template="Hello, {name}!")
+    assert prompt.name == "my_prompt"
+    assert prompt.version == 1
+    assert prompt.template == "Hello, {name}!"
+    # Public property should not return the reserved tag
+    assert prompt.tags == {}
+    assert prompt._tags[IS_PROMPT_TAG_KEY] == "true"
+    assert prompt._tags[PROMPT_TEXT_TAG_KEY] == "Hello, {name}!"
+
+
+def test_prompt_variables_extraction():
+    prompt = Prompt(name="test", version=1, template="Hello, {first_name} {last_name}!")
+    assert prompt.variables == {"first_name", "last_name"}
+
+
+def test_prompt_format():
+    prompt = Prompt(name="test", version=1, template="Hello, {title} {name}!")
+    result = prompt.format(title="Ms.", name="Alice")
+    assert result == "Hello, Ms. Alice!"
+
+    # By default, missing variables raise an error
+    with pytest.raises(MlflowException, match="Missing variables: {'name'}"):
+        prompt.format(title="Ms.")
+
+    # Partial formatting
+    result = prompt.format(title="Ms.", allow_partial=True)
+    assert result.template == "Hello, Ms. {name}!"
+    assert result.variables == {"name"}

--- a/tests/entities/test_prompt.py
+++ b/tests/entities/test_prompt.py
@@ -40,3 +40,4 @@ def test_prompt_with_spaces():
     prompt = Prompt(name="test", version=1, template="Hello, {{ title }} {{  name  }}!")
     result = prompt.format(title="Ms.", name="Alice")
     assert result == "Hello, Ms. Alice!"
+    assert prompt.variables == {"title", "name"}

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1766,6 +1766,8 @@ def test_copy_model_version(store, copy_to_same_model):
 
 
 def test_search_prompts(store):
+    store.create_registered_model("model", tags=[RegisteredModelTag(key="fruit", value="apple")])
+
     store.create_registered_model(
         "prompt_1", tags=[RegisteredModelTag(key=IS_PROMPT_TAG_KEY, value="true")]
     )
@@ -1776,7 +1778,6 @@ def test_search_prompts(store):
             RegisteredModelTag(key="fruit", value="apple"),
         ],
     )
-    store.create_registered_model("model", tags=[RegisteredModelTag(key="fruit", value="apple")])
 
     # By default, should not return prompts
     rms = store.search_registered_models(max_results=10)
@@ -1789,6 +1790,18 @@ def test_search_prompts(store):
 
     rms = store.search_registered_models(filter_string="name = 'prompt_1'", max_results=10)
     assert len(rms) == 0
+
+    rms = store.search_registered_models(
+        filter_string="tags.`mlflow.prompt.is_prompt` = 'false'", max_results=10
+    )
+    assert len(rms) == 1
+    assert rms[0].name == "model"
+
+    rms = store.search_registered_models(
+        filter_string="tags.`mlflow.prompt.is_prompt` != 'true'", max_results=10
+    )
+    assert len(rms) == 1
+    assert rms[0].name == "model"
 
     # Search for prompts
     rms = store.search_registered_models(
@@ -1810,3 +1823,83 @@ def test_search_prompts(store):
     )
     assert len(rms) == 1
     assert rms[0].name == "prompt_2"
+
+
+def test_search_prompts_versions(store):
+    # A Model
+    store.create_registered_model("model")
+    store.create_model_version(
+        "model", "1", "dummy_source", tags=[ModelVersionTag(key="fruit", value="apple")]
+    )
+
+    # A Prompt with 1 version
+    store.create_registered_model(
+        "prompt_1", tags=[RegisteredModelTag(key=IS_PROMPT_TAG_KEY, value="true")]
+    )
+    store.create_model_version(
+        "prompt_1", "1", "dummy_source", tags=[ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true")]
+    )
+
+    # A Prompt with 2 versions
+    store.create_registered_model(
+        "prompt_2",
+        tags=[RegisteredModelTag(key=IS_PROMPT_TAG_KEY, value="true")],
+    )
+    store.create_model_version(
+        "prompt_2",
+        "1",
+        "dummy_source",
+        tags=[
+            ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true"),
+            ModelVersionTag(key="fruit", value="apple"),
+        ],
+    )
+    store.create_model_version(
+        "prompt_2",
+        "2",
+        "dummy_source",
+        tags=[
+            ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true"),
+            ModelVersionTag(key="fruit", value="orange"),
+        ],
+    )
+
+    # Searching model versions should not return prompts by default either
+    mvs = store.search_model_versions(max_results=10)
+    assert len(mvs) == 1
+    assert mvs[0].name == "model"
+
+    mvs = store.search_model_versions(filter_string="tags.fruit = 'apple'", max_results=10)
+    assert len(mvs) == 1
+    assert mvs[0].name == "model"
+
+    mvs = store.search_model_versions(
+        filter_string="tags.`mlflow.prompt.is_prompt` = 'false'", max_results=10
+    )
+    assert len(mvs) == 1
+    assert mvs[0].name == "model"
+
+    mvs = store.search_model_versions(
+        filter_string="tags.`mlflow.prompt.is_prompt` != 'true'", max_results=10
+    )
+    assert len(mvs) == 1
+    assert mvs[0].name == "model"
+
+    # Search for prompts via search_model_versions
+    mvs = store.search_model_versions(
+        filter_string="tags.`mlflow.prompt.is_prompt` = 'true'", max_results=10
+    )
+    assert len(mvs) == 3
+
+    mvs = store.search_model_versions(
+        filter_string="tags.`mlflow.prompt.is_prompt` = 'true' and name = 'prompt_2'",
+        max_results=10,
+    )
+    assert len(mvs) == 2
+
+    mvs = store.search_model_versions(
+        filter_string="tags.`mlflow.prompt.is_prompt` = 'true' and tags.fruit = 'apple'",
+        max_results=10,
+    )
+    assert len(mvs) == 1
+    assert mvs[0].name == "prompt_2"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14493?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14493/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14493
```

</p>
</details>

### What changes are proposed in this pull request?

The first PR for prompt registry backend:

1. Adding the new `Prompt` entity as a subclass of `ModelVersion`
2. File/SQL store implementation. We pretty much re-use model registry APIs. The only change is to update search functionality to limit to either models or prompts only. This is necessary so that the model registry UI won't render prompts and vice versa.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
