### PR TITLE
Fix describe_run JSON serialization.

### DIFF
--- a/mlflow/entities/dataset.py
+++ b/mlflow/entities/dataset.py
@@ -80,3 +80,13 @@ class Dataset(_MlflowObject):
             proto.schema if proto.HasField("schema") else None,
             proto.profile if proto.HasField("profile") else None,
         )
+
+    def to_dictionary(self):
+        return {
+            "name": self.name,
+            "digest": self.digest,
+            "source_type": self.source_type,
+            "source": self.source,
+            "schema": self.schema,
+            "profile": self.profile,
+        }

--- a/mlflow/entities/dataset_input.py
+++ b/mlflow/entities/dataset_input.py
@@ -43,3 +43,9 @@ class DatasetInput(_MlflowObject):
         for input_tag in proto.tags:
             dataset_input._add_tag(InputTag.from_proto(input_tag))
         return dataset_input
+
+    def to_dictionary(self):
+        return {
+            "dataset": self.dataset.to_dictionary(),
+            "tags": {tag.key: tag.value for tag in self.tags},
+        }

--- a/mlflow/entities/run_inputs.py
+++ b/mlflow/entities/run_inputs.py
@@ -28,9 +28,9 @@ class RunInputs(_MlflowObject):
         )
         return run_inputs
 
-    def to_dictionary(self) -> dict[Any, Any]:
+    def to_dictionary(self) -> dict[str, Any]:
         return {
-            "dataset_inputs": self.dataset_inputs,
+            "dataset_inputs": [d.to_dictionary() for d in self.dataset_inputs],
         }
 
     @classmethod

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from mlflow.entities import (
@@ -73,8 +75,24 @@ def test_creation_and_hydration(run_data, run_info, run_inputs):
             "params": {p.key: p.value for p in params},
             "tags": {t.key: t.value for t in tags},
         },
-        "inputs": {"dataset_inputs": datasets},
+        "inputs": {
+            "dataset_inputs": [
+                {
+                    "dataset": {
+                        "digest": "digest1",
+                        "name": "name1",
+                        "profile": None,
+                        "schema": None,
+                        "source": "source",
+                        "source_type": "my_source_type",
+                    },
+                    "tags": {"key": "value"},
+                }
+            ],
+        },
     }
+    # Run must be json serializable
+    json.dumps(run1.to_dictionary())
 
     proto = run1.to_proto()
     run2 = Run.from_proto(proto)

--- a/tests/entities/test_run_inputs.py
+++ b/tests/entities/test_run_inputs.py
@@ -22,9 +22,21 @@ def test_creation_and_hydration(run_inputs):
     run_inputs, datasets = run_inputs
     _check(run_inputs, datasets)
     as_dict = {
-        "dataset_inputs": datasets,
+        "dataset_inputs": [
+            {
+                "dataset": {
+                    "digest": "digest1",
+                    "name": "name1",
+                    "profile": None,
+                    "schema": None,
+                    "source": "source",
+                    "source_type": "my_source_type",
+                },
+                "tags": {"key": "value"},
+            }
+        ],
     }
-    assert dict(run_inputs) == as_dict
+    assert run_inputs.to_dictionary() == as_dict
     proto = run_inputs.to_proto()
     run_inputs2 = RunInputs.from_proto(proto)
     _check(run_inputs2, datasets)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14496?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14496/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14496
```

</p>
</details>

### Related Issues/PRs

Resolve https://github.com/mlflow/mlflow/issues/14485

### What changes are proposed in this pull request?

The `DatasetInputs` entity is not json serializable, which break `mlflow runs describe --run-id ...` command.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
$ mlflow runs describe --run-id 9771172b653f452092ec645333126de4
{
    "info": {
        "artifact_uri": "file:///..../mlruns/0/9771172b653f452092ec645333126de4/artifacts",
        "end_time": 1738893655469,
        "experiment_id": "0",
        "lifecycle_stage": "active",
        "run_id": "9771172b653f452092ec645333126de4",
        "run_name": "nimble-skunk-532",
        "run_uuid": "9771172b653f452092ec645333126de4",
        "start_time": 1738893655434,
        "status": "FINISHED",
        "user_id": "admin"
    },
    "data": {
        "metrics": {},
        "params": {},
        "tags": {
            "mlflow.user": "admin",
            "mlflow.source.git.commit": "e448dac0c36a7802870213bba63ee347c5efba8e",
            "mlflow.runName": "nimble-skunk-532",
            "mlflow.source.name": "main.py",
            "mlflow.source.type": "LOCAL"
        }
    },
    "inputs": {
        "dataset_inputs": [
            {
                "dataset": {
                    "name": "wine quality - white",
                    "digest": "2a1e42c4",
                    "source_type": "code",
                    "source": "{\"tags\": {\"mlflow.user\": \"admin\", \"mlflow.source.name\": \"main.py\", \"mlflow.source.type\": \"LOCAL\", \"mlflow.source.git.commit\": \"e448dac0c36a7802870213bba63ee347c5efba8e\"}}",
                    "schema": "{\"mlflow_colspec\": [{\"type\": \"double\", \"name\": \"fixed acidity\", \"required\": true}, {\"type\": \"double\", \"name\": \"volatile acidity\", \"required\": true}, {\"type\": \"double\", \"name\": \"citric acid\", \"required\": true}, {\"type\": \"double\", \"name\": \"residual sugar\", \"required\": true}, {\"type\": \"double\", \"name\": \"chlorides\", \"required\": true}, {\"type\": \"double\", \"name\": \"free sulfur dioxide\", \"required\": true}, {\"type\": \"double\", \"name\": \"total sulfur dioxide\", \"required\": true}, {\"type\": \"double\", \"name\": \"density\", \"required\": true}, {\"type\": \"double\", \"name\": \"pH\", \"required\": true}, {\"type\": \"double\", \"name\": \"sulphates\", \"required\": true}, {\"type\": \"double\", \"name\": \"alcohol\", \"required\": true}, {\"type\": \"long\", \"name\": \"quality\", \"required\": true}]}",
                    "profile": "{\"num_rows\": 4898, \"num_elements\": 58776}"
                },
                "tags": {
                    "mlflow.data.context": "training"
                }
            }
        ]
    }
}
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
