### PR TITLE
Fix scoring docker server test

### DIFF
--- a/examples/gateway/mlflow_models/README.md
+++ b/examples/gateway/mlflow_models/README.md
@@ -86,14 +86,14 @@ After assigning a valid port and ensuring that the model server starts correctly
 
 ```commandline
 2023/08/08 17:36:44 INFO mlflow.models.flavor_backend_registry: Selected backend for flavor 'python_function'
-2023/08/08 17:36:44 INFO mlflow.pyfunc.backend: === Running command 'exec gunicorn --timeout=60 -b 127.0.0.1:9020 -w 1 ${GUNICORN_CMD_ARGS} -- mlflow.pyfunc.scoring_server.wsgi:app'
-[2023-08-08 17:36:45 -0400] [54917] [INFO] Starting gunicorn 20.1.0
-[2023-08-08 17:36:45 -0400] [54917] [INFO] Listening at: http://127.0.0.1:9020 (54917)
-[2023-08-08 17:36:45 -0400] [54917] [INFO] Using worker: sync
-[2023-08-08 17:36:45 -0400] [54919] [INFO] Booting worker with pid: 54919
+2023/08/08 17:36:44 INFO mlflow.pyfunc.backend: === Running command 'exec uvicorn --host 127.0.0.1 --port 9020 --workers 1 mlflow.pyfunc.scoring_server.app:app'
+INFO:     Started server process [6992]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:9020
 ```
 
-The flask app is ready to receive traffic.
+The scoring server is ready to receive traffic.
 
 Update the MLflow AI Gateway configuration file (config.yaml) with the new endpoint:
 
@@ -160,11 +160,11 @@ Ensure that the MLflow serving endpoint starts and is ready for traffic.
 
 ```commandline
 2023/08/08 17:39:14 INFO mlflow.models.flavor_backend_registry: Selected backend for flavor 'python_function'
-2023/08/08 17:39:14 INFO mlflow.pyfunc.backend: === Running command 'exec gunicorn --timeout=60 -b 127.0.0.1:9010 -w 1 ${GUNICORN_CMD_ARGS} -- mlflow.pyfunc.scoring_server.wsgi:app'
-[2023-08-08 17:39:15 -0400] [55722] [INFO] Starting gunicorn 20.1.0
-[2023-08-08 17:39:15 -0400] [55722] [INFO] Listening at: http://127.0.0.1:9010 (55722)
-[2023-08-08 17:39:15 -0400] [55722] [INFO] Using worker: sync
-[2023-08-08 17:39:15 -0400] [55722] [INFO] Booting worker with pid: 55724
+2023/08/08 17:39:14 INFO mlflow.pyfunc.backend: === Running command 'exec uvicorn --host 127.0.0.1 --port 9010 --workers 1 mlflow.pyfunc.scoring_server.app:app'
+INFO:     Started server process [6992]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:9010
 ```
 
 Add the entry to the MLflow AI Gateway configuration file. The final file should match [the config file](config.yaml)

--- a/mlflow/models/container/scoring_server/nginx.conf
+++ b/mlflow/models/container/scoring_server/nginx.conf
@@ -14,7 +14,7 @@ http {
   default_type application/octet-stream;
   access_log /var/log/nginx/access.log combined;
   
-  upstream gunicorn {
+  upstream uvicorn {
     server 127.0.0.1:8000;
   }
 
@@ -28,7 +28,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
-      proxy_pass http://gunicorn;
+      proxy_pass http://uvicorn;
       client_max_body_size 100m;
     }
 

--- a/mlflow/models/container/scoring_server/wsgi.py
+++ b/mlflow/models/container/scoring_server/wsgi.py
@@ -1,4 +1,0 @@
-from mlflow import pyfunc
-from mlflow.pyfunc import scoring_server
-
-app = scoring_server.init(pyfunc.load_model("/opt/ml/model/"))

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -109,7 +109,8 @@ def start_container(port: int):
                 response = requests.get(url=f"http://localhost:{port}/ping")
                 if response.ok:
                     break
-            except requests.exceptions.ConnectionError:
+            except requests.exceptions.ConnectionError as e:
+                sys.stdout.write(f"An exception occurred when calling the server: {e}\n")
                 time.sleep(5)
 
             container.reload()  # update container status
@@ -117,6 +118,7 @@ def start_container(port: int):
                 raise Exception("Container exited unexpectedly.")
 
             sys.stdout.write(f"Container status: {container.status}\n")
+            time.sleep(1)
 
         else:
             raise TimeoutError("Failed to start server.")

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -111,14 +111,13 @@ def start_container(port: int):
                     break
             except requests.exceptions.ConnectionError as e:
                 sys.stdout.write(f"An exception occurred when calling the server: {e}\n")
-                time.sleep(5)
 
             container.reload()  # update container status
             if container.status == "exited":
                 raise Exception("Container exited unexpectedly.")
 
             sys.stdout.write(f"Container status: {container.status}\n")
-            time.sleep(1)
+            time.sleep(5)
 
         else:
             raise TimeoutError("Failed to start server.")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14506?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14506/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14506
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?
This PR is for fixing the failure of the docker scoring server test suites. Also, this PR modified files and docs related to the migration of the scoring server framework.
https://github.com/mlflow-automation/mlflow/actions/runs/13179725082/job/36787242336

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
