### PR TITLE
Simplify LangGraph ChatAgent to not override internal methods

### DIFF
--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -2,11 +2,17 @@ import json
 import uuid
 from typing import Annotated, Any, Generator, Optional, TypedDict
 
-from langchain_core.messages import AnyMessage, BaseMessage
-from langchain_core.runnables import RunnableConfig
-from langchain_core.runnables.utils import Input
-from langgraph.graph.state import CompiledStateGraph
-from langgraph.prebuilt.tool_node import ToolNode
+try:
+    from langchain_core.messages import AnyMessage, BaseMessage, convert_to_messages
+    from langchain_core.runnables import RunnableConfig
+    from langchain_core.runnables.utils import Input
+    from langgraph.graph.state import CompiledStateGraph
+    from langgraph.prebuilt.tool_node import ToolNode
+except ImportError:
+    raise ImportError(
+        "Please install `langchain>=0.2.17` and `langgraph>=0.2.0` to use LangGraph ChatAgent"
+        "helpers."
+    )
 
 from mlflow.langchain.utils.chat import convert_lc_message_to_chat_message
 from mlflow.pyfunc.model import ChatAgent
@@ -75,11 +81,6 @@ class ChatAgentToolNode(ToolNode):
     Parse ``attachments`` and ``custom_outputs`` keys from the string output of a
     LangGraph tool.
     """
-
-    try:
-        from langchain_core.messages import convert_to_messages
-    except ImportError:
-        raise ImportError("Please install `langchain>=0.3.0` to use `ChatAgentToolNode`.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Annotated, Any, Generator, Optional, TypedDict
 
 from langchain_core.messages import AnyMessage, BaseMessage
-from langchain_core.messages.utils import _convert_to_message
+from langchain_core.messages.utils import convert_to_messages
 from langchain_core.runnables import RunnableConfig
 from langchain_core.runnables.utils import Input
 from langgraph.graph.state import CompiledStateGraph
@@ -92,7 +92,7 @@ class ChatAgentToolNode(ToolNode):
             for tool_call in msg.get("tool_calls", []):
                 tool_call["name"] = tool_call["function"]["name"]
                 tool_call["args"] = json.loads(tool_call["function"]["arguments"])
-        input["messages"] = [_convert_to_message(msg) for msg in messages]
+        input["messages"] = convert_to_messages(messages)
 
         result = super().invoke(input, config, **kwargs)
 

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -8,11 +8,11 @@ try:
     from langchain_core.runnables.utils import Input
     from langgraph.graph.state import CompiledStateGraph
     from langgraph.prebuilt.tool_node import ToolNode
-except ImportError:
+except ImportError as e:
     raise ImportError(
         "Please install `langchain>=0.2.17` and `langgraph>=0.2.0` to use LangGraph ChatAgent"
         "helpers."
-    )
+    ) from e
 
 from mlflow.langchain.utils.chat import convert_lc_message_to_chat_message
 from mlflow.pyfunc.model import ChatAgent

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -3,7 +3,6 @@ import uuid
 from typing import Annotated, Any, Generator, Optional, TypedDict
 
 from langchain_core.messages import AnyMessage, BaseMessage
-from langchain_core.messages.utils import convert_to_messages
 from langchain_core.runnables import RunnableConfig
 from langchain_core.runnables.utils import Input
 from langgraph.graph.state import CompiledStateGraph
@@ -76,6 +75,14 @@ class ChatAgentToolNode(ToolNode):
     Parse ``attachments`` and ``custom_outputs`` keys from the string output of a
     LangGraph tool.
     """
+
+    try:
+        from langchain_core.messages import convert_to_messages
+    except ImportError:
+        raise ImportError(
+            "Please update `langchain` and `langchain-core` to the latest version to use "
+            "`ChatAgentToolNode`."
+        )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -79,10 +79,7 @@ class ChatAgentToolNode(ToolNode):
     try:
         from langchain_core.messages import convert_to_messages
     except ImportError:
-        raise ImportError(
-            "Please update `langchain` and `langchain-core` to the latest version to use "
-            "`ChatAgentToolNode`."
-        )
+        raise ImportError("Please install `langchain>=0.3.0` to use `ChatAgentToolNode`.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -82,9 +82,10 @@ class ChatAgentToolNode(ToolNode):
 
     def invoke(self, input: Input, config: Optional[RunnableConfig] = None, **kwargs: Any) -> Any:
         """
-        Wraps the standard ToolNode invoke method with parsing logic for dictionary string outputs
-        for both UC function tools and standard LangChain python tools that include keys
-        ``attachments`` and ``custom_outputs``.
+        Wraps the standard ToolNode invoke method to:
+        - Parse ChatAgentState into LangChain messages
+        - Parse dictionary string outputs from both UC function and standard LangChain python tools
+          that include keys ``content``, ``attachments``, and ``custom_outputs``.
         """
         messages = input["messages"]
         for msg in messages:

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -1,15 +1,13 @@
 import json
 import uuid
-from typing import Annotated, Any, Generator, Literal, Optional, TypedDict, Union
+from typing import Annotated, Any, Generator, Optional, TypedDict
 
 from langchain_core.messages import AnyMessage, BaseMessage
-from langchain_core.messages import ToolCall as LCToolCall
+from langchain_core.messages.utils import _convert_to_message
 from langchain_core.runnables import RunnableConfig
 from langchain_core.runnables.utils import Input
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt.tool_node import ToolNode
-from langgraph.store.base import BaseStore
-from pydantic import BaseModel
 
 from mlflow.langchain.utils.chat import convert_lc_message_to_chat_message
 from mlflow.pyfunc.model import ChatAgent
@@ -88,7 +86,15 @@ class ChatAgentToolNode(ToolNode):
         for both UC function tools and standard LangChain python tools that include keys
         ``attachments`` and ``custom_outputs``.
         """
+        messages = input["messages"]
+        for msg in messages:
+            for tool_call in msg.get("tool_calls", []):
+                tool_call["name"] = tool_call["function"]["name"]
+                tool_call["args"] = json.loads(tool_call["function"]["arguments"])
+        input["messages"] = [_convert_to_message(msg) for msg in messages]
+
         result = super().invoke(input, config, **kwargs)
+
         messages = []
         custom_outputs = None
         for m in result["messages"]:
@@ -106,53 +112,6 @@ class ChatAgentToolNode(ToolNode):
             except Exception:
                 messages.append(parse_message(m))
         return {"messages": messages, "custom_outputs": custom_outputs}
-
-    def inject_tool_args(
-        self,
-        tool_call: LCToolCall,
-        input: Union[
-            list[AnyMessage],
-            dict[str, Any],
-            BaseModel,
-        ],
-        store: BaseStore,
-    ) -> LCToolCall:
-        """
-        Slightly modified version of `inject_tool_args` that adds the function args from a
-        ChatAgentMessage tool call to a format that is compatible with LangChain tool invocation.
-        """
-        tool_call["name"] = tool_call["function"]["name"]
-        tool_call["args"] = json.loads(tool_call["function"]["arguments"])
-        return super().inject_tool_args(tool_call, input, store)
-
-    def _parse_input(
-        self,
-        input: Union[
-            list[AnyMessage],
-            dict[str, Any],
-            BaseModel,
-        ],
-        store: BaseStore,
-    ) -> tuple[list[LCToolCall], Literal["list", "dict"]]:
-        """
-        Slightly modified version of the LangGraph ToolNode `_parse_input` method that skips
-        verifying the last message is an LangChain AIMessage, allowing the state to be of the
-        ChatAgentMessage format.
-        """
-        if isinstance(input, list):
-            input_type = "list"
-            message: AnyMessage = input[-1]
-        elif isinstance(input, dict) and (messages := input.get(self.messages_key, [])):
-            input_type = "dict"
-            message = messages[-1]
-        elif messages := getattr(input, self.messages_key, None):
-            # Assume dataclass-like state that can coerce from dict
-            input_type = "dict"
-            message = messages[-1]
-        else:
-            raise ValueError("No message found in input")
-        tool_calls = [self.inject_tool_args(call, input, store) for call in message["tool_calls"]]
-        return tool_calls, input_type
 
 
 @experimental


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bbqiu/mlflow/pull/14510?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14510/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14510
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We shouldn't try to override internal methods because they're subject to change, which would cause us to need to update our method overrides, like in https://github.com/mlflow/mlflow/pull/14491. By parsing the input into a format that is compatible with the normal underlying LangGraph ToolNode, we'll be able to avoid future breaking changes to the private methods.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
