### PR TITLE
Retry PR creation in sync job

### DIFF
--- a/.github/workflows/sync.py
+++ b/.github/workflows/sync.py
@@ -8,6 +8,7 @@
 import os
 import subprocess
 import sys
+import time
 import uuid
 
 import requests
@@ -77,19 +78,38 @@ def main():
 
     # Create a pull request
     subprocess.check_call(["git", "push", "origin", PR_BRANCH_NAME])
-    pr = requests.post(
-        f"https://api.github.com/repos/{OWNER}/{REPO}/pulls",
-        headers={"Authorization": f"token {GITHUB_TOKEN}"},
-        json={
-            "title": PR_TITLE,
-            "head": PR_BRANCH_NAME,
-            "base": MLFLOW_3_BRANCH_NAME,
-            "body": "This PR was created automatically by the sync workflow.",
-        },
-    )
-    pr.raise_for_status()
-    pr_data = pr.json()
-    print(f"PR created: {pr_data['html_url']}")
+    # PR creation right after the push occasionally fails with 422,
+    # so retry up to 5 times with an exponential backoff
+    for i in range(5):
+        pr = requests.post(
+            f"https://api.github.com/repos/{OWNER}/{REPO}/pulls",
+            headers={"Authorization": f"token {GITHUB_TOKEN}"},
+            json={
+                "title": PR_TITLE,
+                "head": PR_BRANCH_NAME,
+                "base": MLFLOW_3_BRANCH_NAME,
+                "body": "This PR was created automatically by the sync workflow.",
+            },
+        )
+        try:
+            pr.raise_for_status()
+        except requests.HTTPError as e:
+            if e.response.status_code == 422:
+                print(
+                    f"Failed to create PR (error: {e}), retrying in {2**i} seconds", file=sys.stderr
+                )
+                time.sleep(2**i)
+                continue
+            raise
+        else:
+            pr_data = pr.json()
+            print(f"PR created: {pr_data['html_url']}")
+            break
+    else:
+        # Clean up the remote branch
+        subprocess.check_call(["git", "push", "origin", "--delete", PR_BRANCH_NAME])
+        print("Failed to create PR", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/sync.py
+++ b/.github/workflows/sync.py
@@ -78,7 +78,7 @@ def main():
 
     # Create a pull request
     subprocess.check_call(["git", "push", "origin", PR_BRANCH_NAME])
-    # PR creation right after the push occasionally fails with 422,
+    # PR creation right after the push sometimes fails with 422,
     # so retry up to 5 times with an exponential backoff
     for i in range(5):
         pr = requests.post(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14514?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14514/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14514
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for the following error in the sync job (job which sync master and mlflow-3 branch). PR creation occa

https://github.com/mlflow/mlflow/actions/runs/13220418142/job/36904687953

```
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/.github/workflows/sync.py", line 96, in <module>
    main()
  File "/home/runner/work/mlflow/mlflow/.github/workflows/sync.py", line 90, in main
    pr.raise_for_status()
  File "/home/runner/work/_temp/setup-uv-cache/archive-v0/pMXAODk64Nmz5my4mxdfe/lib/python3.10/site-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 422 Client Error: Unprocessable Entity for url: https://api.github.com/repos/mlflow/mlflow/pulls
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
