### PR TITLE
Fix default evaluator tests

### DIFF
--- a/mlflow/models/evaluation/evaluators/shap.py
+++ b/mlflow/models/evaluation/evaluators/shap.py
@@ -219,7 +219,7 @@ class ShapEvaluator(BuiltInEvaluator):
             _logger.debug("", exc_info=True)
             return
         try:
-            mlflow.shap.log_explainer(explainer, artifact_path="explainer")
+            mlflow.shap.log_explainer(explainer, name="explainer")
         except Exception as e:
             # TODO: The explainer saver is buggy, if `get_underlying_model_flavor` return "unknown",
             #   then fallback to shap explainer saver, and shap explainer will call `model.save`

--- a/mlflow/shap/__init__.py
+++ b/mlflow/shap/__init__.py
@@ -350,6 +350,7 @@ def log_explainer(
     """
 
     Model.log(
+        artifact_path=None,
         name=name,
         flavor=mlflow.shap,
         explainer=explainer,

--- a/mlflow/shap/__init__.py
+++ b/mlflow/shap/__init__.py
@@ -291,7 +291,7 @@ def log_explanation(predict_function, features, artifact_path=None):
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def log_explainer(
     explainer,
-    name: Optional[str],
+    artifact_path: Optional[str] = None,
     serialize_model_using_mlflow=True,
     conda_env=None,
     code_paths=None,
@@ -301,6 +301,7 @@ def log_explainer(
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
     pip_requirements=None,
     extra_pip_requirements=None,
+    name: Optional[str] = None,
     metadata=None,
     params: Optional[dict[str, Any]] = None,
     tags: Optional[dict[str, Any]] = None,
@@ -313,7 +314,7 @@ def log_explainer(
 
     Args:
         explainer: SHAP explainer to be saved.
-        name: {{ name }}
+        artifact_path: Deprecated. Use `name` instead.
         serialize_model_using_mlflow: When set to True, MLflow will extract the underlying
             model and serialize it as an MLmodel, otherwise it uses SHAP's internal serialization.
             Defaults to True. Currently MLflow serialization is only supported for models of
@@ -341,6 +342,7 @@ def log_explainer(
             minutes. Specify 0 or None to skip waiting.
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
+        name: {{ name }}
         metadata: {{ metadata }}
         params: {{ params }}
         tags: {{ tags }}
@@ -350,7 +352,7 @@ def log_explainer(
     """
 
     Model.log(
-        artifact_path=None,
+        artifact_path=artifact_path,
         name=name,
         flavor=mlflow.shap,
         explainer=explainer,

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -4169,26 +4169,26 @@ def test_xgboost_model_evaluate_work_with_shap_explainer():
     with mlflow.start_run() as run:
         xgb_model.fit(X_train, y_train)
 
-    logged_models = mlflow.search_logged_models(
-        filter_string=f"source_run_id='{run.info.run_id}'", output_format="list"
-    )
-    model_uri = logged_models[0].model_uri
-    eval_data = X_test
-    eval_data["label"] = y_test
+        logged_models = mlflow.search_logged_models(
+            filter_string=f"source_run_id='{run.info.run_id}'", output_format="list"
+        )
+        model_uri = logged_models[0].model_uri
+        eval_data = X_test
+        eval_data["label"] = y_test
 
-    with mock.patch("mlflow.models.evaluation.evaluators.shap._logger.warning") as mock_warning:
-        mlflow.evaluate(
-            model_uri,
-            eval_data,
-            targets="label",
-            model_type="classifier",
-            evaluators=["default"],
-        )
-        assert not any(
-            "Shap evaluation failed." in call_arg[0]
-            for call_arg in mock_warning.call_args or []
-            if isinstance(call_arg, tuple)
-        )
+        with mock.patch("mlflow.models.evaluation.evaluators.shap._logger.warning") as mock_warning:
+            mlflow.evaluate(
+                model_uri,
+                eval_data,
+                targets="label",
+                model_type="classifier",
+                evaluators=["default"],
+            )
+            assert not any(
+                "Shap evaluation failed." in call_arg[0]
+                for call_arg in mock_warning.call_args or []
+                if isinstance(call_arg, tuple)
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -636,10 +636,11 @@ def test_pipeline_model_kernel_explainer_on_categorical_features(pipeline_model_
         "shap_summary_plot.png",
     }.issubset(run_data.artifacts)
 
+    # TODO: add `and name='explainer'` once sqlAlchemyStore search_logged_models supports it
     model = mlflow.search_logged_models(
-        filter_string=f"source_run_id='{run_id}' and name='explainer'", output_format="list"
-    )[0]
-    explainer = mlflow.shap.load_explainer(model.model_id)
+        filter_string=f"source_run_id='{run_id}", output_format="list"
+    )[1]
+    explainer = mlflow.shap.load_explainer(model.model_uri)
     assert isinstance(explainer, _PatchedKernelExplainer)
 
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -156,7 +156,7 @@ def test_regressor_evaluation(
     )
 
     assert json.loads(tags["mlflow.datasets"]) == [
-        {**diabetes_dataset._metadata, "model": model.metadata.model_uuid}
+        {**diabetes_dataset._metadata, "name": "dataset", "model": model.metadata.model_uuid}
     ]
 
     for metric_key, expected_metric_val in expected_metrics.items():
@@ -166,10 +166,6 @@ def test_regressor_evaluation(
             rtol=1e-3,
         )
         assert np.isclose(expected_metric_val, result.metrics[metric_key], rtol=1e-3)
-
-    assert json.loads(tags["mlflow.datasets"]) == [
-        {**diabetes_dataset._metadata, "model": model.metadata.model_uuid}
-    ]
 
     assert set(artifacts) == {
         "explainer",
@@ -270,7 +266,7 @@ def test_multi_classifier_evaluation(
         assert np.isclose(expected_metric_val, result.metrics[metric_key], rtol=1e-3)
 
     assert json.loads(tags["mlflow.datasets"]) == [
-        {**iris_dataset._metadata, "model": model.metadata.model_uuid}
+        {**iris_dataset._metadata, "name": "dataset", "model": model.metadata.model_uuid}
     ]
 
     assert set(artifacts) == {
@@ -365,7 +361,7 @@ def test_bin_classifier_evaluation(
         assert np.isclose(expected_metric_val, result.metrics[metric_key], rtol=1e-3)
 
     assert json.loads(tags["mlflow.datasets"]) == [
-        {**breast_cancer_dataset._metadata, "model": model.metadata.model_uuid}
+        {**breast_cancer_dataset._metadata, "name": "dataset", "model": model.metadata.model_uuid}
     ]
 
     assert set(artifacts) == {
@@ -456,7 +452,7 @@ def test_spark_regressor_model_evaluation(
     model = mlflow.pyfunc.load_model(spark_linear_regressor_model_uri)
 
     assert json.loads(tags["mlflow.datasets"]) == [
-        {**diabetes_spark_dataset._metadata, "model": model.metadata.model_uuid}
+        {**diabetes_spark_dataset._metadata, "name": "dataset", "model": model.metadata.model_uuid}
     ]
 
     assert set(artifacts) == set()
@@ -543,7 +539,7 @@ def test_svm_classifier_evaluation(svm_model_uri, breast_cancer_dataset):
         assert np.isclose(expected_metric_val, result.metrics[metric_key], rtol=1e-3)
 
     assert json.loads(tags["mlflow.datasets"]) == [
-        {**breast_cancer_dataset._metadata, "model": model.metadata.model_uuid}
+        {**breast_cancer_dataset._metadata, "name": "dataset", "model": model.metadata.model_uuid}
     ]
 
     assert set(artifacts) == {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14559?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14559/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14559
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
name is passed on mlflow-3 branch https://github.com/mlflow/mlflow/blob/ca2d7ef1d625f45ac651cddaae8f7170f7ef26fa/mlflow/data/numpy_dataset.py#L151 and its default value is "dataset" https://github.com/mlflow/mlflow/blob/ca2d7ef1d625f45ac651cddaae8f7170f7ef26fa/mlflow/data/dataset.py#L75
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
