### PR TITLE
Fix `Dataset.source` and `Dataset.source_type` docs

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -15159,8 +15159,7 @@ public final class Service {
 
     /**
      * <pre>
-     * Source information for the dataset. Note that the source may not exactly reproduce the
-     * dataset if it was transformed / modified before use with MLflow.
+     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
      * </pre>
      *
      * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -15169,8 +15168,7 @@ public final class Service {
     boolean hasSourceType();
     /**
      * <pre>
-     * Source information for the dataset. Note that the source may not exactly reproduce the
-     * dataset if it was transformed / modified before use with MLflow.
+     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
      * </pre>
      *
      * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -15179,8 +15177,7 @@ public final class Service {
     java.lang.String getSourceType();
     /**
      * <pre>
-     * Source information for the dataset. Note that the source may not exactly reproduce the
-     * dataset if it was transformed / modified before use with MLflow.
+     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
      * </pre>
      *
      * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -15191,7 +15188,8 @@ public final class Service {
 
     /**
      * <pre>
-     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+     * Source information for the dataset. Note that the source may not exactly reproduce the
+     * dataset if it was transformed / modified before use with MLflow.
      * </pre>
      *
      * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -15200,7 +15198,8 @@ public final class Service {
     boolean hasSource();
     /**
      * <pre>
-     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+     * Source information for the dataset. Note that the source may not exactly reproduce the
+     * dataset if it was transformed / modified before use with MLflow.
      * </pre>
      *
      * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -15209,7 +15208,8 @@ public final class Service {
     java.lang.String getSource();
     /**
      * <pre>
-     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+     * Source information for the dataset. Note that the source may not exactly reproduce the
+     * dataset if it was transformed / modified before use with MLflow.
      * </pre>
      *
      * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -15538,8 +15538,7 @@ public final class Service {
     private volatile java.lang.Object sourceType_;
     /**
      * <pre>
-     * Source information for the dataset. Note that the source may not exactly reproduce the
-     * dataset if it was transformed / modified before use with MLflow.
+     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
      * </pre>
      *
      * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -15551,8 +15550,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * Source information for the dataset. Note that the source may not exactly reproduce the
-     * dataset if it was transformed / modified before use with MLflow.
+     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
      * </pre>
      *
      * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -15575,8 +15573,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * Source information for the dataset. Note that the source may not exactly reproduce the
-     * dataset if it was transformed / modified before use with MLflow.
+     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
      * </pre>
      *
      * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -15601,7 +15598,8 @@ public final class Service {
     private volatile java.lang.Object source_;
     /**
      * <pre>
-     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+     * Source information for the dataset. Note that the source may not exactly reproduce the
+     * dataset if it was transformed / modified before use with MLflow.
      * </pre>
      *
      * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -15613,7 +15611,8 @@ public final class Service {
     }
     /**
      * <pre>
-     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+     * Source information for the dataset. Note that the source may not exactly reproduce the
+     * dataset if it was transformed / modified before use with MLflow.
      * </pre>
      *
      * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -15636,7 +15635,8 @@ public final class Service {
     }
     /**
      * <pre>
-     * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+     * Source information for the dataset. Note that the source may not exactly reproduce the
+     * dataset if it was transformed / modified before use with MLflow.
      * </pre>
      *
      * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -16461,8 +16461,7 @@ public final class Service {
       private java.lang.Object sourceType_ = "";
       /**
        * <pre>
-       * Source information for the dataset. Note that the source may not exactly reproduce the
-       * dataset if it was transformed / modified before use with MLflow.
+       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
        * </pre>
        *
        * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -16473,8 +16472,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Source information for the dataset. Note that the source may not exactly reproduce the
-       * dataset if it was transformed / modified before use with MLflow.
+       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
        * </pre>
        *
        * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -16496,8 +16494,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Source information for the dataset. Note that the source may not exactly reproduce the
-       * dataset if it was transformed / modified before use with MLflow.
+       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
        * </pre>
        *
        * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -16518,8 +16515,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Source information for the dataset. Note that the source may not exactly reproduce the
-       * dataset if it was transformed / modified before use with MLflow.
+       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
        * </pre>
        *
        * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -16538,8 +16534,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Source information for the dataset. Note that the source may not exactly reproduce the
-       * dataset if it was transformed / modified before use with MLflow.
+       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
        * </pre>
        *
        * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -16553,8 +16548,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Source information for the dataset. Note that the source may not exactly reproduce the
-       * dataset if it was transformed / modified before use with MLflow.
+       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
        * </pre>
        *
        * <code>optional string source_type = 3 [(.mlflow.validate_required) = true];</code>
@@ -16575,7 +16569,8 @@ public final class Service {
       private java.lang.Object source_ = "";
       /**
        * <pre>
-       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+       * Source information for the dataset. Note that the source may not exactly reproduce the
+       * dataset if it was transformed / modified before use with MLflow.
        * </pre>
        *
        * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -16586,7 +16581,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+       * Source information for the dataset. Note that the source may not exactly reproduce the
+       * dataset if it was transformed / modified before use with MLflow.
        * </pre>
        *
        * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -16608,7 +16604,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+       * Source information for the dataset. Note that the source may not exactly reproduce the
+       * dataset if it was transformed / modified before use with MLflow.
        * </pre>
        *
        * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -16629,7 +16626,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+       * Source information for the dataset. Note that the source may not exactly reproduce the
+       * dataset if it was transformed / modified before use with MLflow.
        * </pre>
        *
        * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -16648,7 +16646,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+       * Source information for the dataset. Note that the source may not exactly reproduce the
+       * dataset if it was transformed / modified before use with MLflow.
        * </pre>
        *
        * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>
@@ -16662,7 +16661,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+       * Source information for the dataset. Note that the source may not exactly reproduce the
+       * dataset if it was transformed / modified before use with MLflow.
        * </pre>
        *
        * <code>optional string source = 4 [(.mlflow.validate_required) = true];</code>

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -745,11 +745,11 @@ message Dataset {
   // within datasets of the same name.
   optional string digest = 2 [(validate_required) = true];
 
-  // Source information for the dataset. Note that the source may not exactly reproduce the
-  // dataset if it was transformed / modified before use with MLflow.
+  // The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
   optional string source_type = 3 [(validate_required) = true];
 
-  // The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
+  // Source information for the dataset. Note that the source may not exactly reproduce the
+  // dataset if it was transformed / modified before use with MLflow.
   optional string source = 4 [(validate_required) = true];
 
   // The schema of the dataset. E.g., MLflow ColSpec JSON for a dataframe, MLflow TensorSpec JSON


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14569?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14569/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14569
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The docs for `Dataset.source` and `Dataset.source_type` are mixed up. This PR fixes it: 

```
  // Source information for the dataset. Note that the source may not exactly reproduce the
  // dataset if it was transformed / modified before use with MLflow.
  optional string source_type = 3 [(validate_required) = true];

  // The type of the dataset source, e.g. ‘databricks-uc-table’, ‘DBFS’, ‘S3’, ...
  optional string source = 4 [(validate_required) = true];
```


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
