### PR TITLE
Add Docker setup for JupyterLab with MLflow proxy

### DIFF
--- a/examples/jupyter-mlflow/Dockerfile
+++ b/examples/jupyter-mlflow/Dockerfile
@@ -1,0 +1,12 @@
+FROM jonathancosme/root-jpy-prox # jupyter image that has jupyter server proxy installed
+
+RUN mamba install -c conda-forge mlflow -y && \
+    mamba clean --all -f -y
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y git
+
+# Create the mlflow directory
+
+
+COPY jupyter_server_config.py /etc/jupyter/

--- a/examples/jupyter-mlflow/README.md
+++ b/examples/jupyter-mlflow/README.md
@@ -1,0 +1,35 @@
+# JupyterLab with MLflow Proxy
+
+This directory contains a Docker setup for running JupyterLab with MLflow as a proxy.
+
+## Prerequisites
+
+- Docker installed on your machine.
+
+
+## Building the Docker Image
+
+
+```bash
+docker build -t jupyter-mlflow-proxy .
+
+
+## Running the Docker Container
+
+Run the Docker container with the following command:
+
+docker run -p 8888:8888 -p 5000:5000 jupyter-mlflow-proxy
+
+
+Accessing JupyterLab
+
+Open your web browser and navigate to http://localhost:8888. You should see the JupyterLab interface.
+
+Verifying MLflow Integration
+
+In a Jupyter notebook, run the following code to verify that MLflow is accessible:
+
+import mlflow
+print(mlflow.__version__)
+mlflow.set_tracking_uri("http://localhost:5000")
+mlflow.list_experiments()

--- a/examples/jupyter-mlflow/jupyter_server_config.py
+++ b/examples/jupyter-mlflow/jupyter_server_config.py
@@ -1,0 +1,156 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+# mypy: ignore-errors
+import os
+import stat
+import subprocess
+
+from jupyter_core.paths import jupyter_data_dir
+
+c = get_config()  # noqa: F821
+c.ServerApp.ip = "0.0.0.0"
+c.ServerApp.port = 8888
+c.ServerApp.open_browser = False
+c.NotebookApp.allow_root = True
+c.ServerProxy.servers = {
+    'mlflow-server': {
+        'command': [
+            'mlflow', 'server',
+                '--backend-store-uri=sqlite:///home/jovyan/work/mlflow/mlflow.db',
+                '--default-artifact-root=/home/jovyan/work/mlflow/artifacts',
+                '--host=0.0.0.0',
+                '--port=5000',
+                '--serve-artifacts',
+            ],
+        'timeout': 30,
+        'launcher_entry': {
+            'title': 'mlflow'
+        },
+        'port':5000
+
+    }
+}
+
+# https://github.com/jupyter/notebook/issues/3130
+c.FileContentsManager.delete_to_trash = False
+
+# Generate a self-signed certificate
+OPENSSL_CONFIG = """\
+[req]
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+"""
+if "GEN_CERT" in os.environ:
+    dir_name = jupyter_data_dir()
+    pem_file = os.path.join(dir_name, "notebook.pem")
+    os.makedirs(dir_name, exist_ok=True)
+
+    # Generate an openssl.cnf file to set the distinguished name
+    cnf_file = os.path.join(os.getenv("CONDA_DIR", "/usr/lib"), "ssl", "openssl.cnf")
+    if not os.path.isfile(cnf_file):
+        with open(cnf_file, "w") as fh:
+            fh.write(OPENSSL_CONFIG)
+
+    # Generate a certificate if one doesn't exist on disk
+    subprocess.check_call(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-newkey=rsa:2048",
+            "-days=365",
+            "-nodes",
+            "-x509",
+            "-subj=/C=XX/ST=XX/L=XX/O=generated/CN=generated",
+            f"-keyout={pem_file}",
+            f"-out={pem_file}",
+        ]
+    )
+    # Restrict access to the file
+    os.chmod(pem_file, stat.S_IRUSR | stat.S_IWUSR)
+    c.ServerApp.certfile = pem_file
+
+# Change default umask for all subprocesses of the notebook server if set in
+# the environment
+if "NB_UMASK" in os.environ:
+    os.umask(int(os.environ["NB_UMASK"], 8))
+[ec2-user@ip-172-31-73-195 kp-mlflow]$ vim Dockerfile
+[ec2-user@ip-172-31-73-195 kp-mlflow]$ ls
+Dockerfile  jupyter_server_config.py
+[ec2-user@ip-172-31-73-195 kp-mlflow]$ cat jupyter_server_config.py 
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+# mypy: ignore-errors
+import os
+import stat
+import subprocess
+
+from jupyter_core.paths import jupyter_data_dir
+
+c = get_config()  # noqa: F821
+c.ServerApp.ip = "0.0.0.0"
+c.ServerApp.port = 8888
+c.ServerApp.open_browser = False
+c.NotebookApp.allow_root = True
+c.ServerProxy.servers = {
+    'mlflow-server': {
+        'command': [
+            'mlflow', 'server',
+                '--backend-store-uri=sqlite:///home/jovyan/work/mlflow/mlflow.db',
+                '--default-artifact-root=/home/jovyan/work/mlflow/artifacts',
+                '--host=0.0.0.0',
+                '--port=5000',
+                '--serve-artifacts',
+            ],
+        'timeout': 30,
+        'launcher_entry': {
+            'title': 'mlflow'
+        },
+        'port':5000
+
+    }
+}
+
+# https://github.com/jupyter/notebook/issues/3130
+c.FileContentsManager.delete_to_trash = False
+
+# Generate a self-signed certificate
+OPENSSL_CONFIG = """\
+[req]
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+"""
+if "GEN_CERT" in os.environ:
+    dir_name = jupyter_data_dir()
+    pem_file = os.path.join(dir_name, "notebook.pem")
+    os.makedirs(dir_name, exist_ok=True)
+
+    # Generate an openssl.cnf file to set the distinguished name
+    cnf_file = os.path.join(os.getenv("CONDA_DIR", "/usr/lib"), "ssl", "openssl.cnf")
+    if not os.path.isfile(cnf_file):
+        with open(cnf_file, "w") as fh:
+            fh.write(OPENSSL_CONFIG)
+
+    # Generate a certificate if one doesn't exist on disk
+    subprocess.check_call(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-newkey=rsa:2048",
+            "-days=365",
+            "-nodes",
+            "-x509",
+            "-subj=/C=XX/ST=XX/L=XX/O=generated/CN=generated",
+            f"-keyout={pem_file}",
+            f"-out={pem_file}",
+        ]
+    )
+    # Restrict access to the file
+    os.chmod(pem_file, stat.S_IRUSR | stat.S_IWUSR)
+    c.ServerApp.certfile = pem_file
+
+# Change default umask for all subprocesses of the notebook server if set in
+# the environment
+if "NB_UMASK" in os.environ:
+    os.umask(int(os.environ["NB_UMASK"], 8))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kolasaniv1996/mlflow/pull/14596?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14596/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14596
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #45

### What changes are proposed in this pull request?

This PR adds a Docker setup for running JupyterLab with MLflow as a proxy. It includes a Dockerfile and configuration files to set up the environment.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

I built the Docker image and ran the container, verifying that JupyterLab starts correctly and that MLflow is accessible within the notebook environment.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

This change adds a Docker setup for running JupyterLab with MLflow as a proxy, making it easier for users to set up and use MLflow within JupyterLab.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: Sage