### PR TITLE
Simplify LangChain tracing patching

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -1093,4 +1093,4 @@ def autolog(
             patched_callback_manager_merge,
         )
     except Exception:
-        pass
+        logger.debug("Failed to patch RunnableSequence or BaseCallbackManager.", exc_info=True)

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -32,6 +32,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.langchain.databricks_dependencies import _detect_databricks_dependencies
 from mlflow.langchain.langchain_tracer import (
     patched_callback_manager_init,
+    patched_callback_manager_merge,
     patched_runnable_sequence_batch,
 )
 from mlflow.langchain.runnables import _load_runnables, _save_runnables
@@ -1068,6 +1069,12 @@ def autolog(
             BaseCallbackManager,
             "__init__",
             patched_callback_manager_init,
+        )
+        safe_patch(
+            FLAVOR_NAME,
+            BaseCallbackManager,
+            "merge",
+            patched_callback_manager_merge,
         )
     except Exception as e:
         logger.warning(f"Failed to enable tracing for LangChain. Error: {e}")

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -49,9 +49,9 @@ def patched_callback_manager_init(original, self, *args, **kwargs):
     for handler in self.inheritable_handlers:
         if isinstance(handler, MlflowLangchainTracer):
             return
-    else:
-        _handler = MlflowLangchainTracer()
-        self.add_handler(_handler, inherit=True)
+
+    _handler = MlflowLangchainTracer()
+    self.add_handler(_handler, inherit=True)
 
 
 def patched_callback_manager_merge(original, self, *args, **kwargs):

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -1033,6 +1033,15 @@ def _validate_args(
             for key in autologging_call_input.keys():
                 _validate(autologging_call_input[key], user_call_input.get(key, None))
 
+        else:
+            assert (
+                autologging_call_input is user_call_input
+                or autologging_call_input == user_call_input
+            ), (
+                "Input to original function does not match expected input."
+                f" Original: '{autologging_call_input}'. Expected: '{user_call_input}'"
+            )
+
     # Similar validation logic found in _validate, unraveling the list of arguments to exclude
     # checks for any validation exempt positional arguments.
     _assert_autologging_input_positional_args_are_superset(autologging_call_args, user_call_args)

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -703,15 +703,6 @@ def revert_patches(autologging_integration):
     _AUTOLOGGING_PATCHES.pop(autologging_integration, None)
 
 
-def is_langchain_callbacks_manager(callbacks):
-    try:
-        from langchain_core.callbacks.base import BaseCallbackManager
-    except ImportError:
-        return False
-
-    return isinstance(callbacks, BaseCallbackManager)
-
-
 # Represents an active autologging session using two fields:
 # - integration: the name of the autologging integration corresponding to the session
 # - id: a unique session identifier (e.g., a UUID)
@@ -1041,23 +1032,6 @@ def _validate_args(
             _assert_autologging_input_kwargs_are_superset(autologging_call_input, user_call_input)
             for key in autologging_call_input.keys():
                 _validate(autologging_call_input[key], user_call_input.get(key, None))
-        # NB: For LangChain autologging, we replace the callback manager that is passed by
-        # the user with the one we copied and injected our callbacks into. We cannot do this
-        # in-place to avoid side-effects, so create a new callback manager instance. It will
-        # fail at the strict equality check below, so we instead check that their handlers
-        # are effectively the compatible.
-        elif is_langchain_callbacks_manager(
-            autologging_call_input
-        ) and is_langchain_callbacks_manager(user_call_input):
-            _validate(autologging_call_input.handlers, user_call_input.handlers)
-        else:
-            assert (
-                autologging_call_input is user_call_input
-                or autologging_call_input == user_call_input
-            ), (
-                "Input to original function does not match expected input."
-                f" Original: '{autologging_call_input}'. Expected: '{user_call_input}'"
-            )
 
     # Similar validation logic found in _validate, unraveling the list of arguments to exclude
     # checks for any validation exempt positional arguments.

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -532,7 +532,7 @@ def test_agent_autolog(async_logging_enabled):
     assert len(traces) == 4
     for trace in traces:
         spans = [(s.name, s.span_type) for s in trace.data.spans]
-        assert len(spans) == 16
+        assert len(spans) == 18
         assert trace.data.spans[0].inputs == input
         assert trace.data.spans[0].outputs == expected_output
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -600,7 +600,7 @@ def test_retriever_autolog(tmp_path, async_logging_enabled):
         mock.patch("mlflow.langchain.log_model") as log_model_mock,
         mock.patch("mlflow.langchain._langchain_autolog._logger.info") as logger_mock,
     ):
-        model.get_relevant_documents(query)
+        model.invoke(query)
         log_model_mock.assert_not_called()
         logger_mock.assert_called_once_with(UNSUPPORTED_LOG_MODEL_MESSAGE)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14598?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14598/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14598
```

</p>
</details>

### Related Issues/PRs

Resolve https://github.com/mlflow/mlflow/issues/14533

### What changes are proposed in this pull request?

**TL;DR**

Simplify LangChain tracing logic to patch `BaseCallbackHandler` rather than patching every module to inject callbacks. This is an approach used by some other tracing tools.

**Details**

LangChain tracing is done by passing a callback every time calling the model, unlike other frameworks that has global setting object. To automatically inject our callback to each model call, we patch every LangChain module and tweak the input args/kwargs.

However, this does not work for some edge cases, including the linked issue.

Consider the basic graph node demonstrated in the LangGraph [quickstart](https://langchain-ai.github.io/langgraph/tutorials/introduction/#part-1-build-a-basic-chatbot).

```
from langchain_anthropic import ChatAnthropic

llm = ChatAnthropic(model="claude-3-5-sonnet-20240620")


def chatbot(state: State):
    return {"messages": [llm.invoke(state["messages"])]}


# The first argument is the unique node name
# The second argument is the function or object that will be called whenever
# the node is used.
graph_builder.add_node("chatbot", chatbot)
```

The standard way to use a callback in LangChain is to pass it at runtime, for example,
```
graph.invoke(messages, config={"callbacks": [MyCallback]})
```
Then LangChain will propagate this callback through any child components via function arguments.  However, this does work for above graph node case. The callback needs to be passed to the `ChatAnthropic`, but the inference is done in users' code so they cannot simply propagate callbacks as function args.

To address this, LangChain uses thread-local variable to propagate callbacks. This logic is implemented in the [ensure_config](https://github.com/langchain-ai/langchain/blob/96ad09fa2d9deaae42bb93b0e880d4beb4f19448/libs/core/langchain_core/runnables/config.py#L149) function. This is triggered as soon as every inference API is called, and fetch what callbacks should be used during the inference. This way, LangChain can propagate callbacks to `ChatAnthropic` above.

**However**, this does not play nicely with our patching logic. The timing is important - here is what happens in above example:

1. A ChatAnthropic (or custom step) in invoked.
2. Our patch kicks in. It inserts our callback into the arguments of `llm.invoke`.
3. LangChain executes `ensure_config`. It propagates callback inherited from parent modules, including MLflow callback injected earlier.

As a result, two MLflow callbacks are injected and creates multiple traces. Another bad case is that (2) and (3) uses different configuration nobs (e.g. one is RunnableConfig object, the other dictionary), then one overrides the other. This is problematic for a case where other callbacks are inherited from parent module via (3), but (2) takes precedence and discards those callbacks. This is the direct root cause for the linked issue https://github.com/mlflow/mlflow/issues/14533, where LangChain tries to inject their internal callback to stream LLM tokens, which is overridden by our callback injection.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with the provided example in the linked issue.

![Screenshot 2025-02-14 at 13 19 36](https://github.com/user-attachments/assets/cde5a8a6-7c70-4867-b5e8-60a646d46104)

The `on_chat_model_stream` events are emitted and the trace is generated properly.

Also tested with my complex graph:

![Screenshot 2025-02-14 at 13 18 33](https://github.com/user-attachments/assets/44ef65ef-717d-4d29-ad8b-2cfbead0f01e)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix LangChain autologging issue for LangGraph's `astream_events` API.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
