### PR TITLE
Fix tests that serve a model without `python_env.yml`

### DIFF
--- a/tests/pyfunc/test_virtualenv.py
+++ b/tests/pyfunc/test_virtualenv.py
@@ -161,6 +161,7 @@ def test_python_env_file_does_not_exist(sklearn_model, tmp_path):
         model_info = mlflow.sklearn.log_model(sklearn_model.model, "model")
 
     mlflow.artifacts.download_artifacts(artifact_uri=model_info.model_uri, dst_path=tmp_path)
+    tmp_path = tmp_path / "model"
     python_env = next(tmp_path.rglob(_PYTHON_ENV_FILE_NAME))
     python_env.unlink()
 
@@ -174,6 +175,7 @@ def test_python_env_file_and_requirements_file_do_not_exist(sklearn_model, tmp_p
         model_info = mlflow.sklearn.log_model(sklearn_model.model, "model")
 
     mlflow.artifacts.download_artifacts(artifact_uri=model_info.model_uri, dst_path=tmp_path)
+    tmp_path = tmp_path / "model"
     python_env = next(tmp_path.rglob(_PYTHON_ENV_FILE_NAME))
     python_env.unlink()
     requirements = next(tmp_path.rglob(_REQUIREMENTS_FILE_NAME))
@@ -223,6 +225,7 @@ def test_restore_environment_from_conda_yaml_containing_conda_packages(sklearn_m
         )
 
     mlflow.artifacts.download_artifacts(artifact_uri=model_info.model_uri, dst_path=tmp_path)
+    tmp_path = tmp_path / "model"
     python_env = next(tmp_path.rglob(_PYTHON_ENV_FILE_NAME))
     python_env.unlink()
     serve_and_score(tmp_path, sklearn_model.X_pred)

--- a/tests/pyfunc/test_virtualenv.py
+++ b/tests/pyfunc/test_virtualenv.py
@@ -2,7 +2,6 @@ import os
 import sys
 from collections import namedtuple
 from io import BytesIO
-from pathlib import Path
 from stat import S_IRGRP, S_IROTH, S_IRUSR, S_IXGRP, S_IXOTH, S_IXUSR
 
 import numpy as np
@@ -157,25 +156,30 @@ def test_environment_directory_is_cleaned_up_when_unexpected_error_occurs(
 
 
 @use_temp_mlflow_env_root
-def test_python_env_file_does_not_exist(sklearn_model):
+def test_python_env_file_does_not_exist(sklearn_model, tmp_path):
     with mlflow.start_run():
         model_info = mlflow.sklearn.log_model(sklearn_model.model, "model")
-        model_artifact_path = Path(mlflow.get_artifact_uri("model").replace("file://", ""))
 
-    model_artifact_path.joinpath(_PYTHON_ENV_FILE_NAME).unlink()
-    scores = serve_and_score(model_info.model_uri, sklearn_model.X_pred)
+    mlflow.artifacts.download_artifacts(artifact_uri=model_info.model_uri, dst_path=tmp_path)
+    python_env = next(tmp_path.rglob(_PYTHON_ENV_FILE_NAME))
+    python_env.unlink()
+
+    scores = serve_and_score(tmp_path, sklearn_model.X_pred)
     np.testing.assert_array_almost_equal(scores, sklearn_model.y_pred)
 
 
 @use_temp_mlflow_env_root
-def test_python_env_file_and_requirements_file_do_not_exist(sklearn_model):
+def test_python_env_file_and_requirements_file_do_not_exist(sklearn_model, tmp_path):
     with mlflow.start_run():
         model_info = mlflow.sklearn.log_model(sklearn_model.model, "model")
-        model_artifact_path = Path(mlflow.get_artifact_uri("model").replace("file://", ""))
 
-    model_artifact_path.joinpath(_PYTHON_ENV_FILE_NAME).unlink()
-    model_artifact_path.joinpath(_REQUIREMENTS_FILE_NAME).unlink()
-    scores = serve_and_score(model_info.model_uri, sklearn_model.X_pred)
+    mlflow.artifacts.download_artifacts(artifact_uri=model_info.model_uri, dst_path=tmp_path)
+    python_env = next(tmp_path.rglob(_PYTHON_ENV_FILE_NAME))
+    python_env.unlink()
+    requirements = next(tmp_path.rglob(_REQUIREMENTS_FILE_NAME))
+    requirements.unlink()
+
+    scores = serve_and_score(tmp_path, sklearn_model.X_pred)
     np.testing.assert_array_almost_equal(scores, sklearn_model.y_pred)
 
 
@@ -195,7 +199,7 @@ def test_environment_is_removed_when_package_installation_fails(
 
 
 @use_temp_mlflow_env_root
-def test_restore_environment_from_conda_yaml_containing_conda_packages(sklearn_model):
+def test_restore_environment_from_conda_yaml_containing_conda_packages(sklearn_model, tmp_path):
     conda_env = {
         "name": "mlflow-env",
         "channels": ["conda-forge"],
@@ -217,6 +221,8 @@ def test_restore_environment_from_conda_yaml_containing_conda_packages(sklearn_m
             "model",
             conda_env=conda_env,
         )
-        model_artifact_path = Path(mlflow.get_artifact_uri("model").replace("file://", ""))
-    model_artifact_path.joinpath(_PYTHON_ENV_FILE_NAME).unlink()
-    serve_and_score(model_info.model_uri, sklearn_model.X_pred)
+
+    mlflow.artifacts.download_artifacts(artifact_uri=model_info.model_uri, dst_path=tmp_path)
+    python_env = next(tmp_path.rglob(_PYTHON_ENV_FILE_NAME))
+    python_env.unlink()
+    serve_and_score(tmp_path, sklearn_model.X_pred)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14601?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14601/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14601
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for MLflow 3.0. In MLflow 3.0, `model_info.model_uri` is not a file URI, but a model URI. The following lines to remove `python_env.yml` fail. This PR replaces it with a workaround.

```
model_artifact_path = Path(mlflow.get_artifact_uri("model").replace("file://", ""))
model_artifact_path.joinpath(_PYTHON_ENV_FILE_NAME).unlink()
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
