### PR TITLE
Fix `test_log_model_no_registered_model_name` and `test_log_model_calls_register_model`

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1018,6 +1018,15 @@ class PyFuncModel:
         raise NotImplementedError("`get_raw_model` is not implemented by the underlying model")
 
 
+class DummyPythonModel(PythonModel):
+    """
+    DO NOT USE THIS IN PRODUCTION. This is a dummy model used for testing purposes.
+    """
+
+    def predict(self, context, model_input, params=None):
+        return model_input
+
+
 def _get_pip_requirements_from_model_path(model_path: str):
     req_file_path = os.path.join(model_path, _REQUIREMENTS_FILE_NAME)
     if not os.path.exists(req_file_path):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1018,15 +1018,6 @@ class PyFuncModel:
         raise NotImplementedError("`get_raw_model` is not implemented by the underlying model")
 
 
-class DummyPythonModel(PythonModel):
-    """
-    DO NOT USE THIS IN PRODUCTION. This is a dummy model used for testing purposes.
-    """
-
-    def predict(self, context, model_input, params=None):
-        return model_input
-
-
 def _get_pip_requirements_from_model_path(model_path: str):
     req_file_path = os.path.join(model_path, _REQUIREMENTS_FILE_NAME)
     if not os.path.exists(req_file_path):

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -303,53 +303,31 @@ def test_signature_and_examples_are_saved_correctly(iris_data, main_scoped_model
 
 
 def test_log_model_calls_register_model(sklearn_knn_model, main_scoped_model_class):
-    register_model_patch = mock.patch("mlflow.tracking._model_registry.fluent._register_model")
-    with register_model_patch:
-        sklearn_artifact_path = "sk_model_no_run"
-        with mlflow.start_run():
-            mlflow.sklearn.log_model(sklearn_knn_model, sklearn_artifact_path)
-            sklearn_model_uri = f"runs:/{mlflow.active_run().info.run_id}/{sklearn_artifact_path}"
-
-        def test_predict(sk_model, model_input):
-            return sk_model.predict(model_input) * 2
-
-        pyfunc_artifact_path = "pyfunc_model"
-        assert mlflow.active_run() is None
-        mlflow.pyfunc.log_model(
-            pyfunc_artifact_path,
-            artifacts={"sk_model": sklearn_model_uri},
-            python_model=main_scoped_model_class(test_predict),
-            registered_model_name="AdsModel1",
-        )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{pyfunc_artifact_path}"
+    with mlflow.start_run():
+        with mock.patch(
+            "mlflow.tracking._model_registry.fluent._register_model"
+        ) as register_model_mock:
+            registered_model_name = "AdsModel1"
+            pyfunc_model_info = mlflow.pyfunc.log_model(
+                "pyfunc_model",
+                python_model=mlflow.pyfunc.DummyPythonModel(),
+                registered_model_name=registered_model_name,
+            )
         assert_register_model_called_with_local_model_path(
-            mlflow.tracking._model_registry.fluent._register_model,
-            model_uri,
-            "AdsModel1",
+            register_model_mock, pyfunc_model_info.model_uri, registered_model_name
         )
-        mlflow.end_run()
 
 
 def test_log_model_no_registered_model_name(sklearn_knn_model, main_scoped_model_class):
-    register_model_patch = mock.patch("mlflow.tracking._model_registry.fluent._register_model")
-    with register_model_patch:
-        sklearn_artifact_path = "sk_model_no_run"
-        with mlflow.start_run():
-            mlflow.sklearn.log_model(sklearn_knn_model, sklearn_artifact_path)
-            sklearn_model_uri = f"runs:/{mlflow.active_run().info.run_id}/{sklearn_artifact_path}"
-
-        def test_predict(sk_model, model_input):
-            return sk_model.predict(model_input) * 2
-
-        pyfunc_artifact_path = "pyfunc_model"
-        assert mlflow.active_run() is None
-        mlflow.pyfunc.log_model(
-            pyfunc_artifact_path,
-            artifacts={"sk_model": sklearn_model_uri},
-            python_model=main_scoped_model_class(test_predict),
-        )
-        mlflow.tracking._model_registry.fluent._register_model.assert_not_called()
-        mlflow.end_run()
+    with mlflow.start_run():
+        with mock.patch(
+            "mlflow.tracking._model_registry.fluent._register_model"
+        ) as register_model_mock:
+            mlflow.pyfunc.log_model(
+                "pyfunc_model",
+                python_model=mlflow.pyfunc.DummyPythonModel(),
+            )
+        register_model_mock.assert_not_called()
 
 
 def test_model_load_from_remote_uri_succeeds(

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -302,6 +302,11 @@ def test_signature_and_examples_are_saved_correctly(iris_data, main_scoped_model
                     np.testing.assert_array_equal(_read_example(mlflow_model, path), example)
 
 
+class DummyModel(mlflow.pyfunc.PythonModel):
+    def predict(self, context, model_input, params=None):
+        return model_input
+
+
 def test_log_model_calls_register_model(sklearn_knn_model, main_scoped_model_class):
     with mlflow.start_run():
         with mock.patch(
@@ -310,7 +315,7 @@ def test_log_model_calls_register_model(sklearn_knn_model, main_scoped_model_cla
             registered_model_name = "AdsModel1"
             pyfunc_model_info = mlflow.pyfunc.log_model(
                 "pyfunc_model",
-                python_model=mlflow.pyfunc.DummyPythonModel(),
+                python_model=DummyModel(),
                 registered_model_name=registered_model_name,
             )
         assert_register_model_called_with_local_model_path(
@@ -325,7 +330,7 @@ def test_log_model_no_registered_model_name(sklearn_knn_model, main_scoped_model
         ) as register_model_mock:
             mlflow.pyfunc.log_model(
                 "pyfunc_model",
-                python_model=mlflow.pyfunc.DummyPythonModel(),
+                python_model=DummyModel(),
             )
         register_model_mock.assert_not_called()
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14613?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14613/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14613
```

</p>
</details>

…red_model_name

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix `test_log_model_no_registered_model_name` and `test_log_model_calls_register_model`. They are failing on the mlflow-3 branch.


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
