### PR TITLE
Fix evaluation tests

### DIFF
--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -116,7 +116,7 @@ def get_local_artifact_path(run_id, artifact_path):
 def iris_dataset():
     X, y = get_iris()
     eval_X, eval_y = X[0::3], y[0::3]
-    constructor_args = {"data": eval_X, "targets": eval_y}
+    constructor_args = {"data": eval_X, "targets": eval_y, "name": "dataset"}
     ds = EvaluationDataset(**constructor_args)
     ds._constructor_args = constructor_args
     return ds
@@ -931,7 +931,6 @@ def test_evaluator_evaluation_interface(multiclass_logistic_regressor_model_uri,
                 mock_can_evaluate.assert_called_once_with(
                     model_type="classifier", evaluator_config=evaluator1_config
                 )
-                iris_dataset._user_specified_name = "dataset"
                 mock_evaluate.assert_called_once_with(
                     model=PyFuncModelMatcher(),
                     model_type="classifier",
@@ -966,7 +965,6 @@ def test_evaluate_with_multi_evaluators(
         )
 
         def get_evaluate_call_arg(model, evaluator_config):
-            iris_dataset._user_specified_name = "dataset"
             return {
                 "model": model,
                 "model_type": "classifier",
@@ -1066,7 +1064,6 @@ def test_custom_evaluators_no_model_or_preds(multiclass_logistic_regressor_model
                 mock_can_evaluate.assert_called_once_with(
                     model_type="classifier", evaluator_config={}
                 )
-                iris_dataset._user_specified_name = "dataset"
                 mock_evaluate.assert_called_once_with(
                     model=None,
                     dataset=iris_dataset,

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -931,9 +931,11 @@ def test_evaluator_evaluation_interface(multiclass_logistic_regressor_model_uri,
                 mock_can_evaluate.assert_called_once_with(
                     model_type="classifier", evaluator_config=evaluator1_config
                 )
+                iris_dataset._user_specified_name = "dataset"
                 mock_evaluate.assert_called_once_with(
                     model=PyFuncModelMatcher(),
                     model_type="classifier",
+                    model_id=multiclass_logistic_regressor_model_uri.split("/")[-1],
                     dataset=iris_dataset,
                     run_id=run.info.run_id,
                     evaluator_config=evaluator1_config,
@@ -964,9 +966,11 @@ def test_evaluate_with_multi_evaluators(
         )
 
         def get_evaluate_call_arg(model, evaluator_config):
+            iris_dataset._user_specified_name = "dataset"
             return {
                 "model": model,
                 "model_type": "classifier",
+                "model_id": model.model_id,
                 "dataset": iris_dataset,
                 "run_id": run.info.run_id,
                 "evaluator_config": evaluator_config,
@@ -1062,11 +1066,13 @@ def test_custom_evaluators_no_model_or_preds(multiclass_logistic_regressor_model
                 mock_can_evaluate.assert_called_once_with(
                     model_type="classifier", evaluator_config={}
                 )
+                iris_dataset._user_specified_name = "dataset"
                 mock_evaluate.assert_called_once_with(
                     model=None,
                     dataset=iris_dataset,
                     predictions=None,
                     model_type="classifier",
+                    model_id=None,
                     run_id=run.info.run_id,
                     evaluator_config={},
                     custom_metrics=None,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14618?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14618/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14618
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix evaluation tests
model_id should exist in the call args; dataset name now should be "dataset" instead of hash

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
