### PR TITLE
Fix `set_signature` to allow setting signature with `models:/<model_id>`

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -602,12 +602,14 @@ def set_signature(
             - ``s3://my_bucket/path/to/model``
             - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
             - ``mlflow-artifacts:/path/to/model``
+            - ``models:/<model_id>``
 
             For more information about supported URI schemes, see
             `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
             artifact-locations>`_.
 
-            Please note that model URIs with the ``models:/`` scheme are not supported.
+            Please note that model URIs with the ``models:/<name>/<version>`` scheme are not
+            supported.
 
         signature: ModelSignature to set on the model.
 
@@ -634,16 +636,19 @@ def set_signature(
     assert isinstance(signature, ModelSignature), (
         "The signature argument must be a ModelSignature object"
     )
-    if ModelsArtifactRepository.is_models_uri(model_uri):
+    resolved_uri = model_uri
+    if RunsArtifactRepository.is_runs_uri(model_uri):
+        resolved_uri = RunsArtifactRepository.get_underlying_uri(model_uri)
+    elif ModelsArtifactRepository._is_logged_model_uri(model_uri):
+        resolved_uri = ModelsArtifactRepository.get_underlying_uri(model_uri)
+    elif ModelsArtifactRepository.is_models_uri(model_uri):
         raise MlflowException(
-            f'Failed to set signature on "{model_uri}". '
-            + "Model URIs with the `models:/` scheme are not supported.",
+            f"Failed to set signature on {model_uri!r}. "
+            "Model URIs with the `models:/<name>/<version>` scheme are not supported.",
             INVALID_PARAMETER_VALUE,
         )
+
     try:
-        resolved_uri = model_uri
-        if RunsArtifactRepository.is_runs_uri(model_uri):
-            resolved_uri = RunsArtifactRepository.get_underlying_uri(model_uri)
         ml_model_file = _download_artifact_from_uri(
             artifact_uri=append_to_uri_path(resolved_uri, MLMODEL_FILE_NAME)
         )

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -249,7 +249,8 @@ def test_set_signature_overwrite():
 def test_cannot_set_signature_on_models_scheme_uris():
     signature = infer_signature(np.array([1]))
     with pytest.raises(
-        MlflowException, match="Model URIs with the `models:/` scheme are not supported."
+        MlflowException,
+        match="Model URIs with the `models:/<name>/<version>` scheme are not supported.",
     ):
         set_signature("models:/dummy_model@champion", signature)
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix `set_signature` to allow setting signature with `models:/<model_id>`. `set_signature` should not reject `models:/<model_id>`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
