### PR TITLE
Implement tool standard for Groq tracing

### DIFF
--- a/mlflow/groq/_groq_autolog.py
+++ b/mlflow/groq/_groq_autolog.py
@@ -2,6 +2,7 @@ import logging
 
 import mlflow
 from mlflow.entities import SpanType
+from mlflow.tracing.utils import set_span_chat_messages, set_span_chat_tools
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 
 _logger = logging.getLogger(__name__)
@@ -23,6 +24,8 @@ def _get_span_type(resource: type) -> str:
 
 
 def patched_call(original, self, *args, **kwargs):
+    from groq.types.chat.chat_completion import ChatCompletion
+
     config = AutoLoggingConfig.init(flavor_name=mlflow.groq.FLAVOR_NAME)
 
     if config.log_traces:
@@ -31,6 +34,23 @@ def patched_call(original, self, *args, **kwargs):
             span_type=_get_span_type(self.__class__),
         ) as span:
             span.set_inputs(kwargs)
+
+            if (tools := kwargs.get("tools")) is not None:
+                try:
+                    set_span_chat_tools(span, tools)
+                except Exception as e:
+                    _logger.debug(f"Failed to set tools for {span}. Error: {e}")
+
             outputs = original(self, *args, **kwargs)
             span.set_outputs(outputs)
+
+            if isinstance(outputs, ChatCompletion):
+                try:
+                    messages = kwargs.get("messages", [])
+                    set_span_chat_messages(
+                        span, [*messages, outputs.choices[0].message.model_dump()]
+                    )
+                except Exception as e:
+                    _logger.debug(f"Failed to set chat messages for {span}. Error: {e}")
+
             return outputs

--- a/mlflow/groq/_groq_autolog.py
+++ b/mlflow/groq/_groq_autolog.py
@@ -35,11 +35,11 @@ def patched_call(original, self, *args, **kwargs):
         ) as span:
             span.set_inputs(kwargs)
 
-            if (tools := kwargs.get("tools")) is not None:
+            if tools := kwargs.get("tools"):
                 try:
                     set_span_chat_tools(span, tools)
-                except Exception as e:
-                    _logger.debug(f"Failed to set tools for {span}. Error: {e}")
+                except Exception:
+                    _logger.debug(f"Failed to set tools for {span}.", exc_info=True)
 
             outputs = original(self, *args, **kwargs)
             span.set_outputs(outputs)
@@ -50,7 +50,7 @@ def patched_call(original, self, *args, **kwargs):
                     set_span_chat_messages(
                         span, [*messages, outputs.choices[0].message.model_dump()]
                     )
-                except Exception as e:
-                    _logger.debug(f"Failed to set chat messages for {span}. Error: {e}")
+                except Exception:
+                    _logger.debug(f"Failed to set chat messages for {span}.", exc_info=True)
 
             return outputs

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -967,7 +967,7 @@ groq:
       pip install git+https://github.com/groq/groq-python
   autologging:
     minimum: "0.13.0"
-    maximum: "0.15.0"
+    maximum: "0.18.0"
     requirements:
     run: pytest tests/groq
 

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -381,7 +381,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.13.0",
-            "maximum": "0.15.0"
+            "maximum": "0.18.0"
         }
     },
     "bedrock": {

--- a/tests/groq/test_groq_autolog.py
+++ b/tests/groq/test_groq_autolog.py
@@ -1,5 +1,4 @@
 import json
-import os
 from unittest.mock import patch
 
 import groq
@@ -61,17 +60,18 @@ DUMMY_CHAT_COMPLETION_RESPONSE = ChatCompletion(
 
 
 @pytest.fixture(autouse=True)
-def init_state():
+def init_state(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test_key")
     yield
     mlflow.groq.autolog(disable=True)
 
 
-@patch.dict(os.environ, {"GROQ_API_KEY": "test_key"})
-@patch("groq._client.Groq.post", return_value=DUMMY_CHAT_COMPLETION_RESPONSE)
-def test_chat_completion_autolog(mock_post):
+def test_chat_completion_autolog():
     mlflow.groq.autolog()
     client = groq.Groq()
-    client.chat.completions.create(**DUMMY_CHAT_COMPLETION_REQUEST)
+
+    with patch("groq._client.Groq.post", return_value=DUMMY_CHAT_COMPLETION_RESPONSE):
+        client.chat.completions.create(**DUMMY_CHAT_COMPLETION_REQUEST)
 
     traces = get_traces()
     assert len(traces) == 1
@@ -85,7 +85,9 @@ def test_chat_completion_autolog(mock_post):
 
     mlflow.groq.autolog(disable=True)
     client = groq.Groq()
-    client.chat.completions.create(**DUMMY_CHAT_COMPLETION_REQUEST)
+
+    with patch("groq._client.Groq.post", return_value=DUMMY_CHAT_COMPLETION_RESPONSE):
+        client.chat.completions.create(**DUMMY_CHAT_COMPLETION_REQUEST)
 
     # No new trace should be created
     traces = get_traces()
@@ -151,13 +153,12 @@ DUMMY_TOOL_CALL_RESPONSE = ChatCompletion(
 )
 
 
-@patch.dict(os.environ, {"GROQ_API_KEY": "test_key"})
-@patch("groq._client.Groq.post", return_value=DUMMY_TOOL_CALL_RESPONSE)
-def test_tool_calling_autolog(mock_post):
+def test_tool_calling_autolog():
     mlflow.groq.autolog()
     client = groq.Groq()
 
-    client.chat.completions.create(**DUMMY_TOOL_CALL_REQUEST)
+    with patch("groq._client.Groq.post", return_value=DUMMY_TOOL_CALL_RESPONSE):
+        client.chat.completions.create(**DUMMY_TOOL_CALL_REQUEST)
 
     traces = get_traces()
     assert len(traces) == 1
@@ -222,13 +223,12 @@ DUMMY_TOOL_RESPONSE_RESPONSE = ChatCompletion(
 )
 
 
-@patch.dict(os.environ, {"GROQ_API_KEY": "test_key"})
-@patch("groq._client.Groq.post", return_value=DUMMY_TOOL_RESPONSE_RESPONSE)
-def test_tool_response_autolog(mock_post):
+def test_tool_response_autolog():
     mlflow.groq.autolog()
     client = groq.Groq()
 
-    client.chat.completions.create(**DUMMY_TOOL_RESPONSE_REQUEST)
+    with patch("groq._client.Groq.post", return_value=DUMMY_TOOL_RESPONSE_RESPONSE):
+        client.chat.completions.create(**DUMMY_TOOL_RESPONSE_REQUEST)
 
     traces = get_traces()
     assert len(traces) == 1
@@ -255,12 +255,12 @@ DUMMY_AUDIO_TRANSCRIPTION_REQUEST = {
 DUMMY_AUDIO_TRANSCRIPTION_RESPONSE = Transcription(text="Test audio", x_groq={"id": "req_test"})
 
 
-@patch.dict(os.environ, {"GROQ_API_KEY": "test_key"})
-@patch("groq._client.Groq.post", return_value=DUMMY_AUDIO_TRANSCRIPTION_RESPONSE)
-def test_audio_transcription_autolog(mock_post):
+def test_audio_transcription_autolog():
     mlflow.groq.autolog()
     client = groq.Groq()
-    client.audio.transcriptions.create(**DUMMY_AUDIO_TRANSCRIPTION_REQUEST)
+
+    with patch("groq._client.Groq.post", return_value=DUMMY_AUDIO_TRANSCRIPTION_RESPONSE):
+        client.audio.transcriptions.create(**DUMMY_AUDIO_TRANSCRIPTION_REQUEST)
 
     traces = get_traces()
     assert len(traces) == 1
@@ -276,7 +276,9 @@ def test_audio_transcription_autolog(mock_post):
 
     mlflow.groq.autolog(disable=True)
     client = groq.Groq()
-    client.audio.transcriptions.create(**DUMMY_AUDIO_TRANSCRIPTION_REQUEST)
+
+    with patch("groq._client.Groq.post", return_value=DUMMY_AUDIO_TRANSCRIPTION_RESPONSE):
+        client.audio.transcriptions.create(**DUMMY_AUDIO_TRANSCRIPTION_REQUEST)
 
     # No new trace should be created
     traces = get_traces()
@@ -291,12 +293,12 @@ DUMMY_AUDIO_TRANSLATION_REQUEST = {
 DUMMY_AUDIO_TRANSLATION_RESPONSE = Translation(text="Test audio", x_groq={"id": "req_test"})
 
 
-@patch.dict(os.environ, {"GROQ_API_KEY": "test_key"})
-@patch("groq._client.Groq.post", return_value=DUMMY_AUDIO_TRANSLATION_RESPONSE)
-def test_audio_translation_autolog(mock_post):
+def test_audio_translation_autolog():
     mlflow.groq.autolog()
     client = groq.Groq()
-    client.audio.translations.create(**DUMMY_AUDIO_TRANSLATION_REQUEST)
+
+    with patch("groq._client.Groq.post", return_value=DUMMY_AUDIO_TRANSLATION_RESPONSE):
+        client.audio.translations.create(**DUMMY_AUDIO_TRANSLATION_REQUEST)
 
     traces = get_traces()
     assert len(traces) == 1
@@ -312,7 +314,9 @@ def test_audio_translation_autolog(mock_post):
 
     mlflow.groq.autolog(disable=True)
     client = groq.Groq()
-    client.audio.translations.create(**DUMMY_AUDIO_TRANSLATION_REQUEST)
+
+    with patch("groq._client.Groq.post", return_value=DUMMY_AUDIO_TRANSLATION_RESPONSE):
+        client.audio.translations.create(**DUMMY_AUDIO_TRANSLATION_REQUEST)
 
     # No new trace should be created
     traces = get_traces()

--- a/tests/groq/test_groq_autolog.py
+++ b/tests/groq/test_groq_autolog.py
@@ -25,6 +25,16 @@ DUMMY_CHAT_COMPLETION_REQUEST = {
     "messages": [{"role": "user", "content": "test message"}],
 }
 
+DUMMY_COMPLETION_USAGE = CompletionUsage(
+    completion_tokens=648,
+    prompt_tokens=20,
+    total_tokens=668,
+    completion_time=0.54,
+    prompt_time=0.000181289,
+    queue_time=0.012770949,
+    total_time=0.540181289,
+)
+
 DUMMY_CHAT_COMPLETION_RESPONSE = ChatCompletion(
     id="chatcmpl-test-id",
     choices=[
@@ -45,15 +55,7 @@ DUMMY_CHAT_COMPLETION_RESPONSE = ChatCompletion(
     model="llama3-8b-8192",
     object="chat.completion",
     system_fingerprint="fp_test",
-    usage=CompletionUsage(
-        completion_tokens=648,
-        prompt_tokens=20,
-        total_tokens=668,
-        completion_time=0.54,
-        prompt_time=0.000181289,
-        queue_time=0.012770949,
-        total_time=0.540181289,
-    ),
+    usage=DUMMY_COMPLETION_USAGE,
     x_groq={"id": "req_test"},
 )
 
@@ -144,15 +146,7 @@ DUMMY_TOOL_CALL_RESPONSE = ChatCompletion(
     model="llama3-8b-8192",
     object="chat.completion",
     system_fingerprint="fp_test",
-    usage=CompletionUsage(
-        completion_tokens=648,
-        prompt_tokens=20,
-        total_tokens=668,
-        completion_time=0.54,
-        prompt_time=0.000181289,
-        queue_time=0.012770949,
-        total_time=0.540181289,
-    ),
+    usage=DUMMY_COMPLETION_USAGE,
     x_groq={"id": "req_test"},
 )
 
@@ -223,15 +217,7 @@ DUMMY_TOOL_RESPONSE_RESPONSE = ChatCompletion(
     model="llama3-8b-8192",
     object="chat.completion",
     system_fingerprint="fp_test",
-    usage=CompletionUsage(
-        completion_tokens=648,
-        prompt_tokens=20,
-        total_tokens=668,
-        completion_time=0.54,
-        prompt_time=0.000181289,
-        queue_time=0.012770949,
-        total_time=0.540181289,
-    ),
+    usage=DUMMY_COMPLETION_USAGE,
     x_groq={"id": "req_test"},
 )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14632?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14632/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14632
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR implements the tool standardization for Groq flavor.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
