### PR TITLE
Use `ModelInfo.model_uri` in catboost tests

### DIFF
--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -515,6 +515,8 @@ def test_model_log_with_signature_inference(cb_model):
         ]
     )
     assert loaded_model_info.signature.outputs in [
+        # when the model output is a 1D numpy array, it is cast into a `ColSpec`
         Schema([ColSpec(type=DataType.double)]),
+        # when the model output is a higher dimensional numpy array, it remains a `TensorSpec`
         Schema([TensorSpec(np.dtype("int64"), (-1, 1))]),
     ]

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -160,8 +160,8 @@ def test_model_save_load(cb_model, model_path):
 def test_log_model_logs_model_type(cb_model):
     with mlflow.start_run():
         artifact_path = "model"
-        mlflow.catboost.log_model(cb_model.model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.catboost.log_model(cb_model.model, artifact_path)
+        model_uri = model_info.model_uri  # Use model_uri if needed
 
     flavor_conf = Model.load(model_uri).flavors["catboost"]
     assert "model_type" in flavor_conf
@@ -179,18 +179,17 @@ save_formats = SUPPORTS_DESERIALIZATION + ["python", "cpp", "pmml"]
 def test_log_model_logs_save_format(reg_model, save_format):
     with mlflow.start_run():
         artifact_path = "model"
-        mlflow.catboost.log_model(reg_model.model, artifact_path, format=save_format)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.catboost.log_model(reg_model.model, artifact_path, format=save_format)
 
-    flavor_conf = Model.load(model_uri).flavors["catboost"]
+    flavor_conf = Model.load(model_info.model_uri).flavors["catboost"]
     assert "save_format" in flavor_conf
     assert flavor_conf["save_format"] == save_format
 
     if save_format in SUPPORTS_DESERIALIZATION:
-        mlflow.catboost.load_model(model_uri)
+        mlflow.catboost.load_model(model_info.model_uri)
     else:
         with pytest.raises(cb.CatBoostError, match="deserialization not supported or missing"):
-            mlflow.catboost.load_model(model_uri)
+            mlflow.catboost.load_model(model_info.model_uri)
 
 
 @pytest.mark.parametrize("signature", [None, get_reg_model_signature()])
@@ -236,16 +235,14 @@ def test_log_model(cb_model, tmp_path):
         _mlflow_conda_env(conda_env, additional_pip_deps=["catboost"])
 
         model_info = mlflow.catboost.log_model(model, artifact_path, conda_env=conda_env)
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-        assert model_info.model_uri == model_uri
 
-        loaded_model = mlflow.catboost.load_model(model_uri)
+        loaded_model = mlflow.catboost.load_model(model_info.model_uri)
         np.testing.assert_array_almost_equal(
             model.predict(inference_dataframe),
             loaded_model.predict(inference_dataframe),
         )
 
-        local_path = _download_artifact_from_uri(model_uri)
+        local_path = _download_artifact_from_uri(model_info.model_uri)
         model_config = Model.load(os.path.join(local_path, "MLmodel"))
         assert pyfunc.FLAVOR_NAME in model_config.flavors
         assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
@@ -257,21 +254,20 @@ def test_log_model_calls_register_model(cb_model, tmp_path):
     artifact_path = "model"
     registered_model_name = "registered_model"
     with (
-        mlflow.start_run() as run,
+        mlflow.start_run(),
         mock.patch("mlflow.tracking._model_registry.fluent._register_model"),
     ):
         conda_env_path = os.path.join(tmp_path, "conda_env.yaml")
         _mlflow_conda_env(conda_env_path, additional_pip_deps=["catboost"])
-        mlflow.catboost.log_model(
+        model_info = mlflow.catboost.log_model(
             cb_model.model,
             artifact_path,
             conda_env=conda_env_path,
             registered_model_name=registered_model_name,
         )
-        model_uri = f"runs:/{run.info.run_id}/{artifact_path}"
         assert_register_model_called_with_local_model_path(
             register_model_mock=mlflow.tracking._model_registry.fluent._register_model,
-            model_uri=model_uri,
+            model_uri=model_info.model_uri,
             registered_model_name=registered_model_name,
         )
 
@@ -319,10 +315,9 @@ def test_model_save_accepts_conda_env_as_dict(reg_model, model_path):
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(reg_model, custom_env):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.catboost.log_model(reg_model.model, artifact_path, conda_env=custom_env)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.catboost.log_model(reg_model.model, artifact_path, conda_env=custom_env)
 
-    local_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
     pyfunc_conf = _get_flavor_configuration(model_path=local_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(local_path, pyfunc_conf[pyfunc.ENV]["conda"])
     assert os.path.exists(saved_conda_env_path)
@@ -331,12 +326,10 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(reg_mo
 
 
 def test_model_log_persists_requirements_in_mlflow_model_directory(reg_model, custom_env):
-    artifact_path = "model"
     with mlflow.start_run():
-        mlflow.catboost.log_model(reg_model.model, artifact_path, conda_env=custom_env)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.catboost.log_model(reg_model.model, "model", conda_env=custom_env)
 
-    local_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
     saved_pip_req_path = os.path.join(local_path, "requirements.txt")
     _compare_conda_env_requirements(custom_env, saved_pip_req_path)
 
@@ -347,27 +340,27 @@ def test_log_model_with_pip_requirements(reg_model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.catboost.log_model(reg_model.model, "model", pip_requirements=str(req_file))
-        _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
+        model_info = mlflow.catboost.log_model(
+            reg_model.model, "model", pip_requirements=str(req_file)
         )
+        _assert_pip_requirements(model_info.model_uri, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.catboost.log_model(
+        model_info = mlflow.catboost.log_model(
             reg_model.model, "model", pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
+            model_info.model_uri, [expected_mlflow_version, "a", "b"], strict=True
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.catboost.log_model(
+        model_info = mlflow.catboost.log_model(
             reg_model.model, "model", pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "b", "-c constraints.txt"],
             ["a"],
             strict=True,
@@ -382,27 +375,29 @@ def test_log_model_with_extra_pip_requirements(reg_model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.catboost.log_model(reg_model.model, "model", extra_pip_requirements=str(req_file))
+        model_info = mlflow.catboost.log_model(
+            reg_model.model, "model", extra_pip_requirements=str(req_file)
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a"]
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.catboost.log_model(
+        model_info = mlflow.catboost.log_model(
             reg_model.model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a", "b"]
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.catboost.log_model(
+        model_info = mlflow.catboost.log_model(
             reg_model.model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"],
             ["a"],
         )
@@ -418,12 +413,10 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
 def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     reg_model,
 ):
-    artifact_path = "model"
     with mlflow.start_run():
-        mlflow.catboost.log_model(reg_model.model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.catboost.log_model(reg_model.model, "model")
 
-    _assert_pip_requirements(model_uri, mlflow.catboost.get_default_pip_requirements())
+    _assert_pip_requirements(model_info.model_uri, mlflow.catboost.get_default_pip_requirements())
 
 
 def test_pyfunc_serve_and_score(reg_model):
@@ -475,10 +468,9 @@ def test_log_model_with_code_paths(cb_model):
         mlflow.start_run(),
         mock.patch("mlflow.catboost._add_code_from_conf_to_system_path") as add_mock,
     ):
-        mlflow.catboost.log_model(cb_model.model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.catboost.FLAVOR_NAME)
-        mlflow.catboost.load_model(model_uri=model_uri)
+        model_info = mlflow.catboost.log_model(cb_model.model, artifact_path, code_paths=[__file__])
+        _compare_logged_code_paths(__file__, model_info.model_uri, mlflow.catboost.FLAVOR_NAME)
+        mlflow.catboost.load_model(model_uri=model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -500,15 +492,12 @@ def test_model_save_load_with_metadata(cb_model, model_path):
 
 
 def test_model_log_with_metadata(cb_model):
-    artifact_path = "model"
-
     with mlflow.start_run():
-        mlflow.catboost.log_model(
-            cb_model.model, artifact_path, metadata={"metadata_key": "metadata_value"}
+        model_info = mlflow.catboost.log_model(
+            cb_model.model, "model", metadata={"metadata_key": "metadata_value"}
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
@@ -517,19 +506,16 @@ def test_model_log_with_signature_inference(cb_model):
     example = cb_model.inference_dataframe.head(3)
 
     with mlflow.start_run():
-        mlflow.catboost.log_model(cb_model.model, artifact_path, input_example=example)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.catboost.log_model(cb_model.model, artifact_path, input_example=example)
 
-    model_info = Model.load(model_uri)
-    assert model_info.signature.inputs == Schema(
+    loaded_model_info = Model.load(model_info.model_uri)
+    assert loaded_model_info.signature.inputs == Schema(
         [
             ColSpec(name="sepal length (cm)", type=DataType.double),
             ColSpec(name="sepal width (cm)", type=DataType.double),
         ]
     )
-    assert model_info.signature.outputs in [
-        # when the model output is a 1D numpy array, it is cast into a `ColSpec`
+    assert loaded_model_info.signature.outputs in [
         Schema([ColSpec(type=DataType.double)]),
-        # when the model output is a higher dimensional numpy array, it remains a `TensorSpec`
         Schema([TensorSpec(np.dtype("int64"), (-1, 1))]),
     ]

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -161,9 +161,8 @@ def test_log_model_logs_model_type(cb_model):
     with mlflow.start_run():
         artifact_path = "model"
         model_info = mlflow.catboost.log_model(cb_model.model, artifact_path)
-        model_uri = model_info.model_uri  # Use model_uri if needed
 
-    flavor_conf = Model.load(model_uri).flavors["catboost"]
+    flavor_conf = Model.load(model_info.model_uri).flavors["catboost"]
     assert "model_type" in flavor_conf
     assert flavor_conf["model_type"] == cb_model.model.__class__.__name__
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14634?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14634/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14634
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `ModelInfo.model_uri` in catboost tests.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
