### PR TITLE
Use `ModelInfo.model_uri` in sentence-transformers tests

### DIFF
--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -194,16 +194,15 @@ def test_log_model_calls_register_model(tmp_path, basic_model):
         _mlflow_conda_env(
             conda_env, additional_pip_deps=["transformers", "torch", "sentence-transformers"]
         )
-        mlflow.sentence_transformers.log_model(
+        model_info = mlflow.sentence_transformers.log_model(
             basic_model,
             artifact_path,
             conda_env=str(conda_env),
             registered_model_name="My super cool encoder",
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
         assert_register_model_called_with_local_model_path(
             register_model_mock=mlflow.tracking._model_registry.fluent._register_model,
-            model_uri=model_uri,
+            model_uri=model_info.model_uri,
             registered_model_name="My super cool encoder",
         )
 
@@ -230,33 +229,33 @@ def test_log_with_pip_requirements(tmp_path, basic_model):
     requirements_file = tmp_path.joinpath("requirements.txt")
     requirements_file.write_text("some-clever-package")
     with mlflow.start_run():
-        mlflow.sentence_transformers.log_model(
+        model_info = mlflow.sentence_transformers.log_model(
             basic_model, "model", pip_requirements=str(requirements_file)
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "some-clever-package"],
             strict=True,
         )
     with mlflow.start_run():
-        mlflow.sentence_transformers.log_model(
+        model_info = mlflow.sentence_transformers.log_model(
             basic_model,
             "model",
             pip_requirements=[f"-r {requirements_file}", "a-hopefully-useful-package"],
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "some-clever-package", "a-hopefully-useful-package"],
             strict=True,
         )
     with mlflow.start_run():
-        mlflow.sentence_transformers.log_model(
+        model_info = mlflow.sentence_transformers.log_model(
             basic_model,
             "model",
             pip_requirements=[f"-c {requirements_file}", "i-dunno-maybe-its-good"],
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "i-dunno-maybe-its-good", "-c constraints.txt"],
             ["some-clever-package"],
             strict=True,
@@ -269,31 +268,31 @@ def test_log_with_extra_pip_requirements(basic_model, tmp_path):
     requirements_file = tmp_path.joinpath("requirements.txt")
     requirements_file.write_text("effective-package")
     with mlflow.start_run():
-        mlflow.sentence_transformers.log_model(
+        model_info = mlflow.sentence_transformers.log_model(
             basic_model, "model", extra_pip_requirements=str(requirements_file)
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, *default_requirements, "effective-package"],
         )
     with mlflow.start_run():
-        mlflow.sentence_transformers.log_model(
+        model_info = mlflow.sentence_transformers.log_model(
             basic_model,
             "model",
             extra_pip_requirements=[f"-r {requirements_file}", "useful-package"],
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, *default_requirements, "effective-package", "useful-package"],
         )
     with mlflow.start_run():
-        mlflow.sentence_transformers.log_model(
+        model_info = mlflow.sentence_transformers.log_model(
             basic_model,
             "model",
             extra_pip_requirements=[f"-c {requirements_file}", "constrained-pkg"],
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [
                 expected_mlflow_version,
                 *default_requirements,
@@ -318,9 +317,10 @@ def test_model_log_without_conda_env_uses_default_env_with_expected_dependencies
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.sentence_transformers.log_model(basic_model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-    _assert_pip_requirements(model_uri, mlflow.sentence_transformers.get_default_pip_requirements())
+        model_info = mlflow.sentence_transformers.log_model(basic_model, artifact_path)
+    _assert_pip_requirements(
+        model_info.model_uri, mlflow.sentence_transformers.get_default_pip_requirements()
+    )
 
 
 def test_log_model_with_code_paths(basic_model):
@@ -329,10 +329,13 @@ def test_log_model_with_code_paths(basic_model):
         mlflow.start_run(),
         mock.patch("mlflow.sentence_transformers._add_code_from_conf_to_system_path") as add_mock,
     ):
-        mlflow.sentence_transformers.log_model(basic_model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.sentence_transformers.FLAVOR_NAME)
-        mlflow.sentence_transformers.load_model(model_uri)
+        model_info = mlflow.sentence_transformers.log_model(
+            basic_model, artifact_path, code_paths=[__file__]
+        )
+        _compare_logged_code_paths(
+            __file__, model_info.model_uri, mlflow.sentence_transformers.FLAVOR_NAME
+        )
+        mlflow.sentence_transformers.load_model(model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -535,11 +538,12 @@ def test_model_log_with_signature_inference(basic_model):
     artifact_path = "model"
 
     with mlflow.start_run():
-        mlflow.sentence_transformers.log_model(basic_model, artifact_path, input_example=SENTENCES)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.sentence_transformers.log_model(
+            basic_model, artifact_path, input_example=SENTENCES
+        )
 
-    model_info = Model.load(model_uri)
-    assert model_info.signature == SIGNATURE
+    loaded_model_info = Model.load(model_info.model_uri)
+    assert loaded_model_info.signature == SIGNATURE
 
 
 def test_verify_task_and_update_metadata():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14637?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14637/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14637
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Automatic update using https://gist.github.com/harupy/bc281c07d1a2d0678f97cf519aa81131 to replace `get_artifact_uri`, which doesn't work with `ModelInfo.model_uri`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
