### PR TITLE
Use `ModelInfo.mode_uri` in statsmodels tests

### DIFF
--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -469,5 +469,5 @@ def test_model_log_with_signature_inference():
     with mlflow.start_run():
         model_info = mlflow.statsmodels.log_model(model, artifact_path, input_example=example)
 
-    model_info = Model.load(model_info.model_uri)
-    assert model_info.signature == ols_model_signature()
+    loaded_model = Model.load(model_info.model_uri)
+    assert loaded_model.signature == ols_model_signature()

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -197,16 +197,15 @@ def test_log_model_calls_register_model():
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
         conda_env = os.path.join(tmp.path(), "conda_env.yaml")
         _mlflow_conda_env(conda_env, additional_pip_deps=["statsmodels"])
-        mlflow.statsmodels.log_model(
+        model_info = mlflow.statsmodels.log_model(
             ols.model,
             artifact_path,
             conda_env=conda_env,
             registered_model_name="OLSModel1",
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
         assert_register_model_called_with_local_model_path(
             register_model_mock=mlflow.tracking._model_registry.fluent._register_model,
-            model_uri=model_uri,
+            model_uri=model_info.model_uri,
             registered_model_name="OLSModel1",
         )
 
@@ -261,23 +260,27 @@ def test_log_model_with_pip_requirements(tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(ols.model, "model", pip_requirements=str(req_file))
-        _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
+        model_info = mlflow.statsmodels.log_model(
+            ols.model, "model", pip_requirements=str(req_file)
         )
+        _assert_pip_requirements(model_info.model_uri, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(ols.model, "model", pip_requirements=[f"-r {req_file}", "b"])
+        model_info = mlflow.statsmodels.log_model(
+            ols.model, "model", pip_requirements=[f"-r {req_file}", "b"]
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
+            model_info.model_uri, [expected_mlflow_version, "a", "b"], strict=True
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(ols.model, "model", pip_requirements=[f"-c {req_file}", "b"])
+        model_info = mlflow.statsmodels.log_model(
+            ols.model, "model", pip_requirements=[f"-c {req_file}", "b"]
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "b", "-c constraints.txt"],
             ["a"],
             strict=True,
@@ -293,27 +296,29 @@ def test_log_model_with_extra_pip_requirements(tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(ols.model, "model", extra_pip_requirements=str(req_file))
+        model_info = mlflow.statsmodels.log_model(
+            ols.model, "model", extra_pip_requirements=str(req_file)
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a"]
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(
+        model_info = mlflow.statsmodels.log_model(
             ols.model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a", "b"]
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(
+        model_info = mlflow.statsmodels.log_model(
             ols.model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"],
             ["a"],
         )
@@ -336,16 +341,14 @@ def test_model_save_accepts_conda_env_as_dict(model_path):
 
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(statsmodels_custom_env):
     ols = ols_model()
-    artifact_path = "model"
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(
+        model_info = mlflow.statsmodels.log_model(
             ols.model,
-            artifact_path,
+            "model",
             conda_env=statsmodels_custom_env,
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
 
-    model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    model_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV]["conda"])
     assert os.path.exists(saved_conda_env_path)
@@ -362,14 +365,13 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(statsmodels_c
     ols = ols_model()
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(
+        model_info = mlflow.statsmodels.log_model(
             ols.model,
             artifact_path,
             conda_env=statsmodels_custom_env,
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
 
-    model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    model_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
     saved_pip_req_path = os.path.join(model_path, "requirements.txt")
     _compare_conda_env_requirements(statsmodels_custom_env, saved_pip_req_path)
 
@@ -386,9 +388,10 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     ols = ols_model()
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(ols.model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-    _assert_pip_requirements(model_uri, mlflow.statsmodels.get_default_pip_requirements())
+        model_info = mlflow.statsmodels.log_model(ols.model, artifact_path)
+    _assert_pip_requirements(
+        model_info.model_uri, mlflow.statsmodels.get_default_pip_requirements()
+    )
 
 
 def test_pyfunc_serve_and_score():
@@ -419,10 +422,9 @@ def test_log_model_with_code_paths():
         mlflow.start_run(),
         mock.patch("mlflow.statsmodels._add_code_from_conf_to_system_path") as add_mock,
     ):
-        mlflow.statsmodels.log_model(ols.model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.statsmodels.FLAVOR_NAME)
-        mlflow.statsmodels.load_model(model_uri)
+        model_info = mlflow.statsmodels.log_model(ols.model, artifact_path, code_paths=[__file__])
+        _compare_logged_code_paths(__file__, model_info.model_uri, mlflow.statsmodels.FLAVOR_NAME)
+        mlflow.statsmodels.load_model(model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -450,12 +452,11 @@ def test_model_log_with_metadata():
     artifact_path = "model"
 
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(
+        model_info = mlflow.statsmodels.log_model(
             ols.model, artifact_path, metadata={"metadata_key": "metadata_value"}
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
@@ -466,8 +467,7 @@ def test_model_log_with_signature_inference():
     example = X[0:3, :]
 
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(model, artifact_path, input_example=example)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.statsmodels.log_model(model, artifact_path, input_example=example)
 
-    model_info = Model.load(model_uri)
-    assert model_info.signature == ols_model_signature()
+    model = Model.load(model_info.model_uri)
+    assert model.signature == ols_model_signature()

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -469,5 +469,5 @@ def test_model_log_with_signature_inference():
     with mlflow.start_run():
         model_info = mlflow.statsmodels.log_model(model, artifact_path, input_example=example)
 
-    model = Model.load(model_info.model_uri)
-    assert model.signature == ols_model_signature()
+    model_info = Model.load(model_info.model_uri)
+    assert model_info.signature == ols_model_signature()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14647?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14647/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14647
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `ModelInfo.mode_uri` in statsmodels tests.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
