### PR TITLE
Use `ModelInfo.model_uri` in keras/TF tests

### DIFF
--- a/tests/keras/test_save.py
+++ b/tests/keras/test_save.py
@@ -33,16 +33,15 @@ def test_keras_save_model_export():
     model_path = "model"
     input_schema = Schema([TensorSpec(np.dtype(np.float32), (-1, 28, 28, 3))])
     signature = ModelSignature(inputs=input_schema)
-    with mlflow.start_run() as run:
-        mlflow.keras.log_model(
+    with mlflow.start_run():
+        model_info = mlflow.keras.log_model(
             model,
             model_path,
             save_exported_model=True,
             signature=signature,
         )
 
-    model_url = f"runs:/{run.info.run_id}/{model_path}"
-    loaded_model = mlflow.keras.load_model(model_url)
+    loaded_model = mlflow.keras.load_model(model_info.model_uri)
 
     # Test the loaded model produces the same output for the same input as the model.
     test_input = np.random.uniform(size=[2, 28, 28, 3]).astype(np.float32)
@@ -52,8 +51,7 @@ def test_keras_save_model_export():
     )
 
     # Test the loaded pyfunc model produces the same output for the same input as the model.
-    logged_model = f"runs:/{run.info.run_id}/{model_path}"
-    loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model)
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     predict_outputs = loaded_pyfunc_model.predict(test_input)
     assert isinstance(predict_outputs, np.ndarray)
     np.testing.assert_allclose(
@@ -71,12 +69,10 @@ def test_keras_save_model_non_export():
         metrics=[keras.metrics.SparseCategoricalAccuracy()],
     )
 
-    model_path = "model"
-    with mlflow.start_run() as run:
-        mlflow.keras.log_model(model, "model", save_exported_model=False)
+    with mlflow.start_run():
+        model_info = mlflow.keras.log_model(model, "model", save_exported_model=False)
 
-    model_url = f"runs:/{run.info.run_id}/{model_path}"
-    loaded_model = mlflow.keras.load_model(model_url)
+    loaded_model = mlflow.keras.load_model(model_info.model_uri)
 
     # Test the loaded model produces the same output for the same input as the model.
     test_input = np.random.uniform(size=[2, 28, 28, 3])
@@ -89,8 +85,7 @@ def test_keras_save_model_non_export():
     assert loaded_model.optimizer.learning_rate == model.optimizer.learning_rate
 
     # Test the loaded pyfunc model produces the same output for the same input as the model.
-    logged_model = f"runs:/{run.info.run_id}/{model_path}"
-    loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model)
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     np.testing.assert_allclose(
         keras.ops.convert_to_numpy(model(test_input)),
         loaded_pyfunc_model.predict(test_input),
@@ -104,11 +99,10 @@ def test_save_model_with_signature():
     signature = get_model_signature(model)
     assert signature.outputs.input_types()[0] == np.dtype("float16")
     model_path = "model"
-    with mlflow.start_run() as run:
-        mlflow.keras.log_model(model, model_path, signature=signature)
+    with mlflow.start_run():
+        model_info = mlflow.keras.log_model(model, model_path, signature=signature)
 
-    logged_model = f"runs:/{run.info.run_id}/{model_path}"
-    loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model)
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
 
     assert signature == loaded_pyfunc_model.metadata.signature
 

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -490,7 +490,8 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(model, keras_
     with mlflow.start_run():
         model_info = mlflow.tensorflow.log_model(model, artifact_path, conda_env=keras_custom_env)
 
-    saved_pip_req_path = os.path.join(model_info.model_uri, "requirements.txt")
+    model_path = _download_artifact_from_uri(model_info.model_uri)
+    saved_pip_req_path = os.path.join(model_path, "requirements.txt")
     _compare_conda_env_requirements(keras_custom_env, saved_pip_req_path)
 
 

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -339,15 +339,11 @@ def test_model_log(model, data, predicted):
                 mlflow.start_run()
             artifact_path = "keras_model"
             model_info = mlflow.tensorflow.log_model(model, artifact_path)
-            model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-            assert model_info.model_uri == model_uri
-
             # Load model
-            model_loaded = mlflow.tensorflow.load_model(model_uri=model_uri)
+            model_loaded = mlflow.tensorflow.load_model(model_uri=model_info.model_uri)
             assert all(model_loaded.predict(x) == predicted)
-
             # Loading pyfunc model
-            pyfunc_loaded = mlflow.pyfunc.load_model(model_uri=model_uri)
+            pyfunc_loaded = mlflow.pyfunc.load_model(model_info.model_uri)
             assert all(pyfunc_loaded.predict(x) == predicted)
         finally:
             mlflow.end_run()
@@ -357,11 +353,12 @@ def test_log_model_calls_register_model(model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.tracking._model_registry.fluent._register_model")
     with mlflow.start_run(), register_model_patch:
-        mlflow.tensorflow.log_model(model, artifact_path, registered_model_name="AdsModel1")
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
+        model_info = mlflow.tensorflow.log_model(
+            model, artifact_path, registered_model_name="AdsModel1"
+        )
         assert_register_model_called_with_local_model_path(
             register_model_mock=mlflow.tracking._model_registry.fluent._register_model,
-            model_uri=model_uri,
+            model_uri=model_info.model_uri,
             registered_model_name="AdsModel1",
         )
 
@@ -420,31 +417,29 @@ def test_log_model_with_pip_requirements(model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(model, "model", pip_requirements=str(req_file))
-        _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
-        )
+        model_info = mlflow.tensorflow.log_model(model, "model", pip_requirements=str(req_file))
+        _assert_pip_requirements(model_info.model_uri, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(
+        model_info = mlflow.tensorflow.log_model(
             model,
             "model",
             pip_requirements=[f"-r {req_file}", "b"],
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
+            model_info.model_uri, [expected_mlflow_version, "a", "b"], strict=True
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(
+        model_info = mlflow.tensorflow.log_model(
             model,
             "model",
             pip_requirements=[f"-c {req_file}", "b"],
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "b", "-c constraints.txt"],
             ["a"],
             strict=True,
@@ -458,31 +453,33 @@ def test_log_model_with_extra_pip_requirements(model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(model, "model", extra_pip_requirements=str(req_file))
+        model_info = mlflow.tensorflow.log_model(
+            model, "model", extra_pip_requirements=str(req_file)
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a"]
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(
+        model_info = mlflow.tensorflow.log_model(
             model,
             "model",
             extra_pip_requirements=[f"-r {req_file}", "b"],
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a", "b"]
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(
+        model_info = mlflow.tensorflow.log_model(
             model,
             "model",
             extra_pip_requirements=[f"-c {req_file}", "b"],
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"],
             ["a"],
         )
@@ -491,22 +488,17 @@ def test_log_model_with_extra_pip_requirements(model, tmp_path):
 def test_model_log_persists_requirements_in_mlflow_model_directory(model, keras_custom_env):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(model, artifact_path, conda_env=keras_custom_env)
-        model_path = _download_artifact_from_uri(
-            f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-        )
+        model_info = mlflow.tensorflow.log_model(model, artifact_path, conda_env=keras_custom_env)
 
-    saved_pip_req_path = os.path.join(model_path, "requirements.txt")
+    saved_pip_req_path = os.path.join(model_info.model_uri, "requirements.txt")
     _compare_conda_env_requirements(keras_custom_env, saved_pip_req_path)
 
 
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(model, keras_custom_env):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(model, artifact_path, conda_env=keras_custom_env)
-        model_path = _download_artifact_from_uri(
-            f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-        )
+        model_info = mlflow.tensorflow.log_model(model, artifact_path, conda_env=keras_custom_env)
+        model_path = _download_artifact_from_uri(model_info.model_uri)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV]["conda"])
@@ -528,11 +520,9 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
 
 
 def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(model):
-    artifact_path = "model"
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-    _assert_pip_requirements(model_uri, mlflow.tensorflow.get_default_pip_requirements())
+        model_info = mlflow.tensorflow.log_model(model, "model")
+    _assert_pip_requirements(model_info.model_uri, mlflow.tensorflow.get_default_pip_requirements())
 
 
 def test_model_load_succeeds_with_missing_data_key_when_data_exists_at_default_path(
@@ -675,10 +665,9 @@ def test_log_model_with_code_paths(model):
         mlflow.start_run(),
         mock.patch("mlflow.tensorflow._add_code_from_conf_to_system_path") as add_mock,
     ):
-        mlflow.tensorflow.log_model(model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.tensorflow.FLAVOR_NAME)
-        mlflow.tensorflow.load_model(model_uri)
+        model_info = mlflow.tensorflow.log_model(model, artifact_path, code_paths=[__file__])
+        _compare_logged_code_paths(__file__, model_info.model_uri, mlflow.tensorflow.FLAVOR_NAME)
+        mlflow.tensorflow.load_model(model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -716,12 +705,11 @@ def test_model_log_with_metadata(tf_keras_model):
     artifact_path = "model"
 
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(
+        model_info = mlflow.tensorflow.log_model(
             tf_keras_model, artifact_path, metadata={"metadata_key": "metadata_value"}
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
@@ -730,8 +718,9 @@ def test_model_log_with_signature_inference(tf_keras_model, data, model_signatur
     example = data[0][:3, :]
 
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(tf_keras_model, artifact_path, input_example=example)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.tensorflow.log_model(
+            tf_keras_model, artifact_path, input_example=example
+        )
 
-    mlflow_model = Model.load(model_uri)
+    mlflow_model = Model.load(model_info.model_uri)
     assert mlflow_model.signature == model_signature

--- a/tests/tensorflow/test_tensorflow2_core_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_core_model_export.py
@@ -87,10 +87,11 @@ def test_model_log_with_signature_inference(tf2_toy_model):
     example = tf2_toy_model.inference_data
 
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(tf2_toy_model.model, artifact_path, input_example=example)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.tensorflow.log_model(
+            tf2_toy_model.model, artifact_path, input_example=example
+        )
 
-    mlflow_model = Model.load(model_uri)
+    mlflow_model = Model.load(model_info.model_uri)
     assert mlflow_model.signature == infer_signature(
         tf2_toy_model.inference_data, tf2_toy_model.expected_results.numpy()
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14650?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14650/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14650
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `ModelInfo.model_uri` in keras/TF tests for mlflow 3.0.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
