### PR TITLE
Use `ModelInfo.model_uri` in spark tests

### DIFF
--- a/tests/spark/test_spark_connect_model_export.py
+++ b/tests/spark/test_spark_connect_model_export.py
@@ -122,12 +122,11 @@ def test_sparkml_model_log(spark_model):
 def test_pyfunc_serve_and_score(spark_model):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.spark.log_model(spark_model.model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.spark.log_model(spark_model.model, artifact_path)
 
     input_data = pd.DataFrame({"features": spark_model.pandas_df["features"].map(list)})
     resp = pyfunc_serve_and_score_model(
-        model_uri,
+        model_info.model_uri,
         data=input_data,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -292,15 +292,13 @@ def test_log_model_with_signature_and_examples(spark_model_iris, iris_signature)
     for signature in (None, iris_signature):
         for example in (None, example_):
             with mlflow.start_run():
-                mlflow.spark.log_model(
+                model_info = mlflow.spark.log_model(
                     spark_model_iris.model,
                     artifact_path,
                     signature=signature,
                     input_example=example,
                 )
-                artifact_uri = mlflow.get_artifact_uri()
-                model_path = os.path.join(artifact_uri, artifact_path)
-                mlflow_model = Model.load(model_path)
+                mlflow_model = Model.load(model_info.model_uri)
                 if example is None and signature is None:
                     assert mlflow_model.signature is None
                 else:
@@ -308,7 +306,7 @@ def test_log_model_with_signature_and_examples(spark_model_iris, iris_signature)
                 if example is None:
                     assert mlflow_model.saved_input_example_info is None
                 else:
-                    assert all((_read_example(mlflow_model, model_path) == example).all())
+                    assert all((_read_example(mlflow_model, model_info.model_uri) == example).all())
 
 
 def test_estimator_model_export(spark_model_estimator, model_path, spark_custom_env):
@@ -398,14 +396,15 @@ def test_sparkml_model_log(tmp_path, spark_model_iris, should_start_run, use_dfs
         if should_start_run:
             mlflow.start_run()
         artifact_path = "model"
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_iris.model,
             artifact_path,
             dfs_tmpdir=dfs_tmpdir,
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
 
-        reloaded_model = mlflow.spark.load_model(model_uri=model_uri, dfs_tmpdir=dfs_tmpdir)
+        reloaded_model = mlflow.spark.load_model(
+            model_uri=model_info.model_uri, dfs_tmpdir=dfs_tmpdir
+        )
         preds_df = reloaded_model.transform(spark_model_iris.spark_df)
         preds = [x.prediction for x in preds_df.select("prediction").collect()]
         assert spark_model_iris.predictions == preds
@@ -480,14 +479,15 @@ def test_sparkml_estimator_model_log(
         if should_start_run:
             mlflow.start_run()
         artifact_path = "model"
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_estimator.model,
             artifact_path,
             dfs_tmpdir=dfs_tmpdir,
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
 
-        reloaded_model = mlflow.spark.load_model(model_uri=model_uri, dfs_tmpdir=dfs_tmpdir)
+        reloaded_model = mlflow.spark.load_model(
+            model_uri=model_info.model_uri, dfs_tmpdir=dfs_tmpdir
+        )
         preds_df = reloaded_model.transform(spark_model_estimator.spark_df)
         preds = [x.prediction for x in preds_df.select("prediction").collect()]
         assert spark_model_estimator.predictions == preds
@@ -501,16 +501,15 @@ def test_log_model_calls_register_model(tmp_path, spark_model_iris):
     dfs_tmp_dir = tmp_path.joinpath("test")
     register_model_patch = mock.patch("mlflow.tracking._model_registry.fluent._register_model")
     with mlflow.start_run(), register_model_patch:
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_iris.model,
             artifact_path,
             dfs_tmpdir=dfs_tmp_dir,
             registered_model_name="AdsModel1",
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
         assert_register_model_called_with_local_model_path(
             register_model_mock=mlflow.tracking._model_registry.fluent._register_model,
-            model_uri=model_uri,
+            model_uri=model_info.model_uri,
             registered_model_name="AdsModel1",
         )
 
@@ -579,27 +578,27 @@ def test_log_model_with_pip_requirements(spark_model_iris, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.spark.log_model(spark_model_iris.model, "model", pip_requirements=str(req_file))
-        _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
+        model_info = mlflow.spark.log_model(
+            spark_model_iris.model, "model", pip_requirements=str(req_file)
         )
+        _assert_pip_requirements(model_info.model_uri, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_iris.model, "model", pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
+            model_info.model_uri, [expected_mlflow_version, "a", "b"], strict=True
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_iris.model, "model", pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "b", "-c constraints.txt"],
             ["a"],
             strict=True,
@@ -614,29 +613,29 @@ def test_log_model_with_extra_pip_requirements(spark_model_iris, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_iris.model, "model", extra_pip_requirements=str(req_file)
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a"]
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_iris.model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a", "b"]
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_iris.model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"],
             ["a"],
         )
@@ -668,10 +667,9 @@ def test_sparkml_model_log_persists_specified_conda_env_in_mlflow_model_director
             artifact_path,
             conda_env=spark_custom_env,
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-        assert model_info.model_uri == model_uri
+        assert model_info.model_uri == f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
 
-    model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    model_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV]["conda"])
     assert os.path.exists(saved_conda_env_path)
@@ -689,14 +687,12 @@ def test_sparkml_model_log_persists_requirements_in_mlflow_model_directory(
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_iris.model,
             artifact_path,
             conda_env=spark_custom_env,
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-
-    model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    model_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
     saved_pip_req_path = os.path.join(model_path, "requirements.txt")
     _compare_conda_env_requirements(spark_custom_env, saved_pip_req_path)
 
@@ -713,10 +709,9 @@ def test_sparkml_model_log_without_specified_conda_env_uses_default_env_with_exp
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.spark.log_model(spark_model_iris.model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.spark.log_model(spark_model_iris.model, artifact_path)
 
-    _assert_pip_requirements(model_uri, mlflow.spark.get_default_pip_requirements())
+    _assert_pip_requirements(model_info.model_uri, mlflow.spark.get_default_pip_requirements())
 
 
 def test_pyspark_version_is_logged_without_dev_suffix(spark_model_iris):
@@ -725,10 +720,9 @@ def test_pyspark_version_is_logged_without_dev_suffix(spark_model_iris):
     for dev_suffix in [".dev0", ".dev", ".dev1", "dev.a", ".devb"]:
         with mock.patch("importlib_metadata.version", return_value=unsuffixed_version + dev_suffix):
             with mlflow.start_run():
-                mlflow.spark.log_model(spark_model_iris.model, "model")
-                model_uri = mlflow.get_artifact_uri("model")
+                model_info = mlflow.spark.log_model(spark_model_iris.model, "model")
             _assert_pip_requirements(
-                model_uri, [expected_mlflow_version, f"pyspark=={unsuffixed_version}"]
+                model_info.model_uri, [expected_mlflow_version, f"pyspark=={unsuffixed_version}"]
             )
 
     for unaffected_version in ["2.0", "2.3.4", "2"]:
@@ -935,10 +929,11 @@ def test_log_model_with_code_paths(spark_model_iris):
             wraps=_add_code_from_conf_to_system_path,
         ) as add_mock,
     ):
-        mlflow.spark.log_model(spark_model_iris.model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.spark.FLAVOR_NAME)
-        mlflow.spark.load_model(model_uri)
+        model_info = mlflow.spark.log_model(
+            spark_model_iris.model, artifact_path, code_paths=[__file__]
+        )
+        _compare_logged_code_paths(__file__, model_info.model_uri, mlflow.spark.FLAVOR_NAME)
+        mlflow.spark.load_model(model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -960,17 +955,14 @@ def test_model_save_load_with_metadata(spark_model_iris, model_path):
 
 
 def test_model_log_with_metadata(spark_model_iris):
-    artifact_path = "model"
-
     with mlflow.start_run():
-        mlflow.spark.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model_iris.model,
-            artifact_path,
+            "model",
             metadata={"metadata_key": "metadata_value"},
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
@@ -987,10 +979,11 @@ def test_model_log_with_signature_inference(spark_model_iris, input_example):
     artifact_path = "model"
 
     with mlflow.start_run():
-        mlflow.spark.log_model(spark_model_iris.model, artifact_path, input_example=input_example)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.spark.log_model(
+            spark_model_iris.model, artifact_path, input_example=input_example
+        )
 
-    mlflow_model = Model.load(model_uri)
+    mlflow_model = Model.load(model_info.model_uri)
     input_columns = mlflow_model.signature.inputs.inputs
     assert all(col.type == DataType.double for col in input_columns)
     column_names = [col.name for col in input_columns]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14652?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14652/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14652
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `ModelInfo.model_uri` in spark tests.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
