### PR TITLE
Add pagination to S3ArtifactRepository.delete_artifacts

### DIFF
--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -344,9 +344,11 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         paginator = s3_client.get_paginator("list_objects_v2")
         results = paginator.paginate(Bucket=self.bucket, Prefix=prefix)
         for result in results:
+            keys = []
             for to_delete_obj in result.get("Contents", []):
                 file_path = to_delete_obj.get("Key")
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=dest_path
                 )
-                s3_client.delete_object(Bucket=self.bucket, Key=file_path)
+                keys.append({"Key": file_path})
+            s3_client.delete_objects(Bucket=self.bucket, Delete={"Objects": keys})

--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -339,13 +339,14 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
 
+        prefix = dest_path + "/" if dest_path else ""
         s3_client = self._get_s3_client()
-        list_objects = s3_client.list_objects(Bucket=self.bucket, Prefix=dest_path).get(
-            "Contents", []
-        )
-        for to_delete_obj in list_objects:
-            file_path = to_delete_obj.get("Key")
-            self._verify_listed_object_contains_artifact_path_prefix(
-                listed_object_path=file_path, artifact_path=dest_path
-            )
-            s3_client.delete_object(Bucket=self.bucket, Key=file_path)
+        paginator = s3_client.get_paginator("list_objects_v2")
+        results = paginator.paginate(Bucket=self.bucket, Prefix=prefix)
+        for result in results:
+            for to_delete_obj in result.get("Contents", []):
+                file_path = to_delete_obj.get("Key")
+                self._verify_listed_object_contains_artifact_path_prefix(
+                    listed_object_path=file_path, artifact_path=dest_path
+                )
+                s3_client.delete_object(Bucket=self.bucket, Key=file_path)

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -250,14 +250,17 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
 
+        prefix = dest_path + "/" if dest_path else ""
         s3_client = self._get_s3_client()
-        list_objects = s3_client.list_objects(Bucket=bucket, Prefix=dest_path).get("Contents", [])
-        for to_delete_obj in list_objects:
-            file_path = to_delete_obj.get("Key")
-            self._verify_listed_object_contains_artifact_path_prefix(
-                listed_object_path=file_path, artifact_path=dest_path
-            )
-            s3_client.delete_object(Bucket=bucket, Key=file_path)
+        paginator = s3_client.get_paginator("list_objects_v2")
+        results = paginator.paginate(Bucket=bucket, Prefix=prefix)
+        for result in results:
+            for to_delete_obj in result.get("Contents", []):
+                file_path = to_delete_obj.get("Key")
+                self._verify_listed_object_contains_artifact_path_prefix(
+                    listed_object_path=file_path, artifact_path=dest_path
+                )
+                s3_client.delete_object(Bucket=bucket, Key=file_path)
 
     def create_multipart_upload(self, local_file, num_parts=1, artifact_path=None):
         (bucket, dest_path) = self.parse_s3_compliant_uri(self.artifact_uri)

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -255,12 +255,14 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         paginator = s3_client.get_paginator("list_objects_v2")
         results = paginator.paginate(Bucket=bucket, Prefix=prefix)
         for result in results:
+            keys = []
             for to_delete_obj in result.get("Contents", []):
                 file_path = to_delete_obj.get("Key")
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=dest_path
                 )
-                s3_client.delete_object(Bucket=bucket, Key=file_path)
+                keys.append({"Key": file_path})
+            s3_client.delete_objects(Bucket=bucket, Delete={"Objects": keys})
 
     def create_multipart_upload(self, local_file, num_parts=1, artifact_path=None):
         (bucket, dest_path) = self.parse_s3_compliant_uri(self.artifact_uri)

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -353,8 +353,7 @@ def test_delete_artifacts(s3_artifact_repo, tmp_path):
     assert "nested" in artifact_file_names
 
     s3_artifact_repo.delete_artifacts()
-    tmpdir_objects = s3_artifact_repo.list_artifacts()
-    assert not tmpdir_objects
+    assert s3_artifact_repo.list_artifacts() == []
 
 
 def test_delete_artifacts_pagination(s3_artifact_repo, tmp_path):
@@ -373,8 +372,7 @@ def test_delete_artifacts_pagination(s3_artifact_repo, tmp_path):
         assert f"{i}.txt" in artifact_file_names
 
     s3_artifact_repo.delete_artifacts()
-    tmpdir_objects = s3_artifact_repo.list_artifacts()
-    assert not tmpdir_objects
+    assert s3_artifact_repo.list_artifacts() == []
 
 
 def test_create_multipart_upload(s3_artifact_root):

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -335,21 +335,16 @@ def test_get_s3_file_upload_extra_args_invalid_json():
 def test_delete_artifacts(s3_artifact_repo, tmp_path):
     subdir = tmp_path / "subdir"
     subdir.mkdir()
-    subdir_path = str(subdir)
-    nested_path = os.path.join(subdir_path, "nested")
-    os.makedirs(nested_path)
-    path_a = os.path.join(subdir_path, "a.txt")
-    path_b = os.path.join(subdir_path, "b.tar.gz")
-    path_c = os.path.join(nested_path, "c.csv")
+    nested_path = subdir / "nested"
+    nested_path.mkdir()
+    path_a = subdir / "a.txt"
 
-    with open(path_a, "w") as f:
-        f.write("A")
-    with tarfile.open(path_b, "w:gz") as f:
-        f.add(path_a)
-    with open(path_c, "w") as f:
-        f.write("col1,col2\n1,3\n2,4\n")
+    path_a.write_text("A")
+    with tarfile.open(str(subdir / "b.tar.gz"), "w:gz") as f:
+        f.add(str(path_a))
+    (nested_path / "c.csv").write_text("col1,col2\n1,3\n2,4\n")
 
-    s3_artifact_repo.log_artifacts(subdir_path)
+    s3_artifact_repo.log_artifacts(str(subdir))
 
     # confirm that artifacts are present
     artifact_file_names = [obj.path for obj in s3_artifact_repo.list_artifacts()]
@@ -365,14 +360,12 @@ def test_delete_artifacts(s3_artifact_repo, tmp_path):
 def test_delete_artifacts_pagination(s3_artifact_repo, tmp_path):
     subdir = tmp_path / "subdir"
     subdir.mkdir()
-    subdir_path = str(subdir)
     # The maximum number of objects that can be listed in a single call is 1000
     # https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
     for i in range(1100):
-        with open(os.path.join(subdir_path, f"{i}.txt"), "w") as f:
-            f.write("A")
+        (subdir / f"{i}.txt").write_text("A")
 
-    s3_artifact_repo.log_artifacts(subdir_path)
+    s3_artifact_repo.log_artifacts(str(subdir))
 
     # confirm that artifacts are present
     artifact_file_names = [obj.path for obj in s3_artifact_repo.list_artifacts()]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -454,14 +454,14 @@ def test_mlflow_gc_sqlite_with_s3_artifact_repository(
     fake_artifact_path = os.path.join(dest_path, "fake_artifact.txt")
     with Stubber(artifact_repo._get_s3_client()) as s3_stubber:
         s3_stubber.add_response(
-            "list_objects",
+            "list_objects_v2",
             {"Contents": [{"Key": fake_artifact_path}]},
-            {"Bucket": bucket, "Prefix": dest_path},
+            {"Bucket": bucket, "Prefix": dest_path + "/"},
         )
         s3_stubber.add_response(
-            "delete_object",
-            {"DeleteMarker": True},
-            {"Bucket": bucket, "Key": fake_artifact_path},
+            "delete_objects",
+            {"Deleted": [{"Key": fake_artifact_path}]},
+            {"Bucket": bucket, "Delete": {"Objects": [{"Key": fake_artifact_path}]}},
         )
 
         CliRunner().invoke(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14660?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14660/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14660
```

</p>
</details>

### Related Issues/PRs
Resolve #14654

### What changes are proposed in this pull request?

The S3ArtifactRepository.delete_artifacts API does not consider the cases where the number of artifacts withing a specified path is more than 1000 that requires pagination. As a result, `mlflow gc` could not remove all the artefacts. This PR introduces pagination to the method to fix the issue.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
