### PR TITLE
Use `ModelInfo.model_uri` in onnx and paddle tests

### DIFF
--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -446,12 +446,10 @@ def test_model_log(onnx_model):
                 mlflow.start_run()
             artifact_path = "onnx_model"
             model_info = mlflow.onnx.log_model(onnx_model, artifact_path)
-            model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-            assert model_info.model_uri == model_uri
 
             # Load model
             onnx.checker.check_model = mock.Mock()
-            mlflow.onnx.load_model(model_uri)
+            mlflow.onnx.load_model(model_info.model_uri)
             assert onnx.checker.check_model.called
         finally:
             mlflow.end_run()
@@ -461,16 +459,15 @@ def test_log_model_calls_register_model(onnx_model, onnx_custom_env):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.tracking._model_registry.fluent._register_model")
     with mlflow.start_run(), register_model_patch:
-        mlflow.onnx.log_model(
+        model_info = mlflow.onnx.log_model(
             onnx_model,
             artifact_path,
             conda_env=onnx_custom_env,
             registered_model_name="AdsModel1",
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
         assert_register_model_called_with_local_model_path(
             register_model_mock=mlflow.tracking._model_registry.fluent._register_model,
-            model_uri=model_uri,
+            model_uri=model_info.model_uri,
             registered_model_name="AdsModel1",
         )
 
@@ -486,13 +483,12 @@ def test_log_model_no_registered_model_name(onnx_model, onnx_custom_env):
 def test_model_log_evaluate_pyfunc_format(onnx_model, data, predicted):
     x = data[0]
 
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         artifact_path = "onnx_model"
-        mlflow.onnx.log_model(onnx_model, artifact_path)
-        model_uri = f"runs:/{run.info.run_id}/{artifact_path}"
+        model_info = mlflow.onnx.log_model(onnx_model, artifact_path)
 
         # Loading pyfunc model
-        pyfunc_loaded = mlflow.pyfunc.load_model(model_uri=model_uri)
+        pyfunc_loaded = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
         np.testing.assert_allclose(
             pyfunc_loaded.predict(x).values.flatten(), predicted, rtol=1e-05, atol=1e-05
         )
@@ -564,23 +560,25 @@ def test_log_model_with_pip_requirements(onnx_model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model, "model", pip_requirements=str(req_file))
-        _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
-        )
+        model_info = mlflow.onnx.log_model(onnx_model, "model", pip_requirements=str(req_file))
+        _assert_pip_requirements(model_info.model_uri, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model, "model", pip_requirements=[f"-r {req_file}", "b"])
+        model_info = mlflow.onnx.log_model(
+            onnx_model, "model", pip_requirements=[f"-r {req_file}", "b"]
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
+            model_info.model_uri, [expected_mlflow_version, "a", "b"], strict=True
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model, "model", pip_requirements=[f"-c {req_file}", "b"])
+        model_info = mlflow.onnx.log_model(
+            onnx_model, "model", pip_requirements=[f"-c {req_file}", "b"]
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "b", "-c constraints.txt"],
             ["a"],
             strict=True,
@@ -595,23 +593,29 @@ def test_log_model_with_extra_pip_requirements(onnx_model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model, "model", extra_pip_requirements=str(req_file))
+        model_info = mlflow.onnx.log_model(
+            onnx_model, "model", extra_pip_requirements=str(req_file)
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a"]
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model, "model", extra_pip_requirements=[f"-r {req_file}", "b"])
+        model_info = mlflow.onnx.log_model(
+            onnx_model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a", "b"]
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model, "model", extra_pip_requirements=[f"-c {req_file}", "b"])
+        model_info = mlflow.onnx.log_model(
+            onnx_model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"],
             ["a"],
         )
@@ -636,10 +640,8 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model, artifact_path, conda_env=onnx_custom_env)
-        model_path = _download_artifact_from_uri(
-            f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-        )
+        model_info = mlflow.onnx.log_model(onnx_model, artifact_path, conda_env=onnx_custom_env)
+        model_path = _download_artifact_from_uri(model_info.model_uri)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV]["conda"])
@@ -656,10 +658,8 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
 def test_model_log_persists_requirements_in_mlflow_model_directory(onnx_model, onnx_custom_env):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model, artifact_path, conda_env=onnx_custom_env)
-        model_path = _download_artifact_from_uri(
-            f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-        )
+        model_info = mlflow.onnx.log_model(onnx_model, artifact_path, conda_env=onnx_custom_env)
+        model_path = _download_artifact_from_uri(model_info.model_uri)
 
     saved_pip_req_path = os.path.join(model_path, "requirements.txt")
     _compare_conda_env_requirements(onnx_custom_env, saved_pip_req_path)
@@ -677,9 +677,8 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-    _assert_pip_requirements(model_uri, mlflow.onnx.get_default_pip_requirements())
+        model_info = mlflow.onnx.log_model(onnx_model, artifact_path)
+    _assert_pip_requirements(model_info.model_uri, mlflow.onnx.get_default_pip_requirements())
 
 
 def test_pyfunc_predict_supports_models_with_list_outputs(onnx_sklearn_model, model_path, data):
@@ -701,10 +700,9 @@ def test_log_model_with_code_paths(onnx_model):
         mlflow.start_run(),
         mock.patch("mlflow.onnx._add_code_from_conf_to_system_path") as add_mock,
     ):
-        mlflow.onnx.log_model(onnx_model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.onnx.FLAVOR_NAME)
-        mlflow.onnx.load_model(model_uri)
+        model_info = mlflow.onnx.log_model(onnx_model, artifact_path, code_paths=[__file__])
+        _compare_logged_code_paths(__file__, model_info.model_uri, mlflow.onnx.FLAVOR_NAME)
+        mlflow.onnx.load_model(model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -727,10 +725,9 @@ def test_model_log_with_metadata(onnx_model):
     artifact_path = "model"
 
     with mlflow.start_run():
-        mlflow.onnx.log_model(
+        model_info = mlflow.onnx.log_model(
             onnx_model, artifact_path, metadata={"metadata_key": "metadata_value"}
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -162,17 +162,15 @@ def test_model_log(pd_model, model_path, tmp_path):
         _mlflow_conda_env(conda_env, additional_pip_deps=["paddle"])
 
         model_info = mlflow.paddle.log_model(model, artifact_path, conda_env=conda_env)
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-        assert model_info.model_uri == model_uri
 
-        reloaded_pd_model = mlflow.paddle.load_model(model_uri=model_uri)
+        reloaded_pd_model = mlflow.paddle.load_model(model_uri=model_info.model_uri)
         np.testing.assert_array_almost_equal(
             model(paddle.to_tensor(pd_model.inference_dataframe)),
             reloaded_pd_model(paddle.to_tensor(pd_model.inference_dataframe)),
             decimal=5,
         )
 
-        model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+        model_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
         model_config = Model.load(os.path.join(model_path, "MLmodel"))
         assert pyfunc.FLAVOR_NAME in model_config.flavors
         assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
@@ -186,15 +184,14 @@ def test_log_model_calls_register_model(pd_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.tracking._model_registry.fluent._register_model")
     with mlflow.start_run(), register_model_patch:
-        mlflow.paddle.log_model(
+        model_info = mlflow.paddle.log_model(
             pd_model.model,
             artifact_path,
             registered_model_name="AdsModel1",
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
         assert_register_model_called_with_local_model_path(
             register_model_mock=mlflow.tracking._model_registry.fluent._register_model,
-            model_uri=model_uri,
+            model_uri=model_info.model_uri,
             registered_model_name="AdsModel1",
         )
 
@@ -262,10 +259,9 @@ def test_signature_and_examples_are_saved_correctly(pd_model, pd_model_signature
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(pd_model, pd_custom_env):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.paddle.log_model(pd_model.model, artifact_path, conda_env=pd_custom_env)
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
+        model_info = mlflow.paddle.log_model(pd_model.model, artifact_path, conda_env=pd_custom_env)
 
-    model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    model_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV]["conda"])
     assert os.path.exists(saved_conda_env_path)
@@ -290,9 +286,8 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.paddle.log_model(pd_model.model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-    _assert_pip_requirements(model_uri, mlflow.paddle.get_default_pip_requirements())
+        model_info = mlflow.paddle.log_model(pd_model.model, artifact_path)
+    _assert_pip_requirements(model_info.model_uri, mlflow.paddle.get_default_pip_requirements())
 
 
 @pytest.fixture(scope="module")
@@ -379,10 +374,9 @@ def test_model_built_in_high_level_api_log(pd_model_built_in_high_level_api, mod
         conda_env = os.path.join(tmp_path, "conda_env.yaml")
         _mlflow_conda_env(conda_env, additional_pip_deps=["paddle"])
 
-        mlflow.paddle.log_model(model, artifact_path, conda_env=conda_env)
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
+        model_info = mlflow.paddle.log_model(model, artifact_path, conda_env=conda_env)
 
-        reloaded_pd_model = mlflow.paddle.load_model(model_uri=model_uri)
+        reloaded_pd_model = mlflow.paddle.load_model(model_uri=model_info.model_uri)
         low_level_test_dataset = [x[0] for x in test_dataset]
         np.testing.assert_array_almost_equal(
             np.array(model.predict(test_dataset)).squeeze(),
@@ -390,7 +384,7 @@ def test_model_built_in_high_level_api_log(pd_model_built_in_high_level_api, mod
             decimal=5,
         )
 
-        model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+        model_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
         model_config = Model.load(os.path.join(model_path, "MLmodel"))
         assert pyfunc.FLAVOR_NAME in model_config.flavors
         assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
@@ -465,20 +459,23 @@ def test_log_model_built_in_high_level_api(
         conda_env = os.path.join(tmp_path, "conda_env.yaml")
         _mlflow_conda_env(conda_env, additional_pip_deps=["paddle"])
 
-        mlflow.paddle.log_model(model, artifact_path, conda_env=conda_env, training=True)
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
+        model_info = mlflow.paddle.log_model(
+            model, artifact_path, conda_env=conda_env, training=True
+        )
 
         model_retrain = paddle.Model(UCIHousing())
         optim = paddle.optimizer.Adam(learning_rate=0.015, parameters=model.parameters())
         model_retrain.prepare(optim, paddle.nn.MSELoss())
-        model_retrain = mlflow.paddle.load_model(model_uri=model_uri, model=model_retrain)
+        model_retrain = mlflow.paddle.load_model(
+            model_uri=model_info.model_uri, model=model_retrain
+        )
 
         np.testing.assert_array_almost_equal(
             np.array(model.predict(test_dataset)).squeeze(),
             np.array(model_retrain.predict(test_dataset)).squeeze(),
             decimal=5,
         )
-        model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+        model_path = _download_artifact_from_uri(artifact_uri=model_info.model_uri)
         model_config = Model.load(os.path.join(model_path, "MLmodel"))
         assert pyfunc.FLAVOR_NAME in model_config.flavors
         assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
@@ -490,27 +487,28 @@ def test_log_model_built_in_high_level_api(
 
 def test_log_model_with_pip_requirements(pd_model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
-    # Path to a requirements file
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.paddle.log_model(pd_model.model, "model", pip_requirements=str(req_file))
+        model_info = mlflow.paddle.log_model(
+            pd_model.model, "model", pip_requirements=str(req_file)
+        )
+        _assert_pip_requirements(model_info.model_uri, [expected_mlflow_version, "a"], strict=True)
+
+    with mlflow.start_run():
+        model_info = mlflow.paddle.log_model(
+            pd_model.model, "model", pip_requirements=[f"-r {req_file}", "b"]
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
+            model_info.model_uri, [expected_mlflow_version, "a", "b"], strict=True
         )
 
-    # List of requirements
     with mlflow.start_run():
-        mlflow.paddle.log_model(pd_model.model, "model", pip_requirements=[f"-r {req_file}", "b"])
-        _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
+        model_info = mlflow.paddle.log_model(
+            pd_model.model, "model", pip_requirements=[f"-c {req_file}", "b"]
         )
-
-    # Constraints file
-    with mlflow.start_run():
-        mlflow.paddle.log_model(pd_model.model, "model", pip_requirements=[f"-c {req_file}", "b"])
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "b", "-c constraints.txt"],
             ["a"],
             strict=True,
@@ -525,27 +523,29 @@ def test_log_model_with_extra_pip_requirements(pd_model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.paddle.log_model(pd_model.model, "model", extra_pip_requirements=str(req_file))
+        model_info = mlflow.paddle.log_model(
+            pd_model.model, "model", extra_pip_requirements=str(req_file)
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a"]
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.paddle.log_model(
+        model_info = mlflow.paddle.log_model(
             pd_model.model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a", "b"]
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.paddle.log_model(
+        model_info = mlflow.paddle.log_model(
             pd_model.model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"],
             ["a"],
         )
@@ -584,10 +584,9 @@ def test_log_model_with_code_paths(pd_model):
         mlflow.start_run(),
         mock.patch("mlflow.paddle._add_code_from_conf_to_system_path") as add_mock,
     ):
-        mlflow.paddle.log_model(pd_model.model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.paddle.FLAVOR_NAME)
-        mlflow.paddle.load_model(model_uri)
+        model_info = mlflow.paddle.log_model(pd_model.model, artifact_path, code_paths=[__file__])
+        _compare_logged_code_paths(__file__, model_info.model_uri, mlflow.paddle.FLAVOR_NAME)
+        mlflow.paddle.load_model(model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -604,12 +603,11 @@ def test_model_log_with_metadata(pd_model):
     artifact_path = "model"
 
     with mlflow.start_run():
-        mlflow.paddle.log_model(
+        model_info = mlflow.paddle.log_model(
             pd_model.model, artifact_path, metadata={"metadata_key": "metadata_value"}
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
@@ -619,8 +617,7 @@ def test_model_log_with_signature_inference(pd_model, pd_model_signature):
     example = test_dataset[:3, :]
 
     with mlflow.start_run():
-        mlflow.paddle.log_model(pd_model.model, artifact_path, input_example=example)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.paddle.log_model(pd_model.model, artifact_path, input_example=example)
 
-    mlflow_model = Model.load(model_uri)
+    mlflow_model = Model.load(model_info.model_uri)
     assert mlflow_model.signature == pd_model_signature


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14662?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14662/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14662
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `ModelInfo.model_uri` in onnx and paddle tests.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
