### PR TITLE
[2] Add API for logging assessment (feedback, expectation)

### DIFF
--- a/docs/api_reference/source/conf.py
+++ b/docs/api_reference/source/conf.py
@@ -436,7 +436,8 @@ nitpick_ignore = [
     ("py:class", "ChatMessage"),
     ("py:class", "ChatTool"),
     # sphinx can't resolve alias import e.g. from xyz import abc as xyz_abc in type annotations
-    ("py:class", "mlflow.entities.assessment_source.AssessmentSource"),
+    ("py:class", "mlflow.entities.assessment.Expectation"),
+    ("py:class", "mlflow.entities.assessment.Feedback"),
 ]
 
 

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -125,6 +125,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import evaluate
 from mlflow.models.evaluation.validation import validate_evaluation_results
 from mlflow.projects import run
+from mlflow.tracing.assessment import log_expectation, log_feedback
 from mlflow.tracing.fluent import (
     add_trace,
     get_current_active_span,
@@ -227,7 +228,6 @@ __all__ = [
     "log_params",
     "log_table",
     "log_text",
-    "log_trace",
     "login",
     "pyfunc",
     "register_model",
@@ -256,7 +256,11 @@ __all__ = [
     "start_span",
     "trace",
     "add_trace",
+    "log_trace",
     "update_current_trace",
+    # Assessment APIs
+    "log_expectation",
+    "log_feedback",
 ]
 
 

--- a/mlflow/entities/__init__.py
+++ b/mlflow/entities/__init__.py
@@ -3,6 +3,12 @@ The ``mlflow.entities`` module defines entities returned by the MLflow
 `REST API <../rest-api.html>`_.
 """
 
+from mlflow.entities.assessment import (
+    Assessment,
+    AssessmentError,
+    AssessmentSource,
+    AssessmentSourceType,
+)
 from mlflow.entities.dataset import Dataset
 from mlflow.entities.dataset_input import DatasetInput
 from mlflow.entities.dataset_summary import _DatasetSummary
@@ -59,4 +65,8 @@ __all__ = [
     "SpanStatusCode",
     "_DatasetSummary",
     "Document",
+    "Assessment",
+    "AssessmentError",
+    "AssessmentSource",
+    "AssessmentSourceType",
 ]

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Union
 
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.assessment_error import AssessmentError
-from mlflow.entities.assessment_source import AssessmentSource
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType  # noqa: F401
 from mlflow.exceptions import MlflowException
 from mlflow.protos.service_pb2 import Assessment as ProtoAssessment
 from mlflow.protos.service_pb2 import Expectation as ProtoExpectation

--- a/mlflow/entities/assessment_source.py
+++ b/mlflow/entities/assessment_source.py
@@ -14,7 +14,7 @@ class AssessmentSource(_MlflowObject):
     """
     Source of an assessment (human, LLM as a judge with GPT-4, etc).
 
-    Attributes:
+    Args:
         source_type: The type of the assessment source. Must be one of the values in
             the AssessmentSourceType enum.
         source_id: An identifier for the source, e.g. user ID or LLM judge ID.

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -3,10 +3,12 @@ import logging
 from typing import Optional
 
 from mlflow.entities import DatasetInput, Experiment, Metric, Run, RunInfo, TraceInfo, ViewType
+from mlflow.entities.assessment import Assessment
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.service_pb2 import (
+    CreateAssessment,
     CreateExperiment,
     CreateRun,
     DeleteExperiment,
@@ -48,6 +50,7 @@ from mlflow.utils.rest_utils import (
     _REST_API_PATH_PREFIX,
     call_endpoint,
     extract_api_info_for_service,
+    get_create_assessment_endpoint,
     get_set_trace_tag_endpoint,
     get_single_trace_endpoint,
     get_trace_info_endpoint,
@@ -386,7 +389,22 @@ class RestStore(AbstractStore):
             DeleteTraceTag, req_body, endpoint=get_set_trace_tag_endpoint(request_id)
         )
 
-    def log_metric(self, run_id, metric):
+    def create_assessment(self, assessment: Assessment):
+        """
+        Create an assessment entity in the backend store.
+
+        Args:
+            assessment: The assessment to log.
+        """
+        req_body = message_to_json(CreateAssessment(assessment=assessment.to_proto()))
+        response_proto = self._call_endpoint(
+            CreateAssessment,
+            req_body,
+            endpoint=get_create_assessment_endpoint(assessment.trace_id),
+        )
+        return Assessment.from_proto(response_proto.assessment)
+
+    def log_metric(self, run_id: str, metric: Metric):
         """
         Log a metric for the specified run
 

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -389,12 +389,15 @@ class RestStore(AbstractStore):
             DeleteTraceTag, req_body, endpoint=get_set_trace_tag_endpoint(request_id)
         )
 
-    def create_assessment(self, assessment: Assessment):
+    def create_assessment(self, assessment: Assessment) -> Assessment:
         """
         Create an assessment entity in the backend store.
 
         Args:
-            assessment: The assessment to log.
+            assessment: The assessment to log (without an assessment_id).
+
+        Returns:
+            The created Assessment object.
         """
         req_body = message_to_json(CreateAssessment(assessment=assessment.to_proto()))
         response_proto = self._call_endpoint(

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -28,7 +28,7 @@ def log_expectation(
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment_source import AssessmentSourceType
+        from mlflow.entities.assessment import AssessmentSourceType
 
         log_expectation(
             trace_id="1234",
@@ -42,14 +42,15 @@ def log_expectation(
         name: The name of the expectation assessment e.g., "expected_answer
         value: The value of the expectation. It can be any JSON-serializable value.
         source: The source of the expectation assessment. Must be either an instance of
-                :py:class:`AssessmentSource` or a string that is a valid value in the
-                :py:class:`AssessmentSourceType` enum.
+                :py:class:`~mlflow.entities.AssessmentSource` or a string that
+                is a valid value in the
+                :py:class:`~mlflow.entities.AssessmentSourceType` enum.
         metadata: Additional metadata for the expectation.
         span_id: The ID of the span associated with the expectation, if it needs be
                 associated with a specific span in the trace.
 
     Returns:
-        :py:class:`Assessment`: The created expectation assessment.
+        :py:class:`~mlflow.entities.Assessment`: The created expectation assessment.
     """
     if value is None:
         raise MlflowException.invalid_parameter_value("Expectation value cannot be None.")
@@ -82,7 +83,7 @@ def log_feedback(
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment_source import AssessmentSourceType
+        from mlflow.entities.assessment import AssessmentSourceType
 
         source = AssessmentSource(
             source_type=Type.LLM_JUDGE,
@@ -98,13 +99,13 @@ def log_feedback(
         )
 
     You can also log an error information during the feedback generation process. To do so,
-    provide an instance of :py:class:`AssessmentError` to the `error` parameter, and leave
-    the `value` parameter as `None`.
+    provide an instance of :py:class:`~mlflow.entities.AssessmentError` to the `error`
+    parameter, and leave the `value` parameter as `None`.
 
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment_error import AssessmentError
+        from mlflow.entities.assessment import AssessmentError
 
         source = AssessmentSource(
             source_type=Type.LLM_JUDGE,
@@ -126,8 +127,10 @@ def log_feedback(
     Args:
         trace_id: The ID of the trace.
         name: The name of the feedback assessment e.g., "faithfulness"
-        source: The source of the feedback. Must be one of the values
-                in the :py:class:`AssessmentSource` enum.
+        source: The source of the expectation assessment. Must be either an instance of
+                :py:class:`~mlflow.entities.AssessmentSource` or a string that
+                is a valid value in the
+                :py:class:`~mlflow.entities.AssessmentSourceType` enum.
         value: The value of the expectation. It can be any JSON-serializable value.
         error: An error object representing any issues encountered while computing the
             feedback, e.g., a timeout error from an LLM judge. Either this or `value`
@@ -138,7 +141,7 @@ def log_feedback(
                 associated with a specific span in the trace.
 
     Returns:
-        :py:class:`Assessment`: The created feedback assessment.
+        :py:class:`~mlflow.entities.Assessment`: The created feedback assessment.
     """
     return MlflowClient().log_assessment(
         trace_id=trace_id,

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -6,12 +6,14 @@ from mlflow.entities.assessment import (
     AssessmentValueType,
     Expectation,
     Feedback,
+    experimental,
 )
 from mlflow.entities.assessment_source import AssessmentSource
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 
 
+@experimental
 def log_expectation(
     trace_id: str,
     name: str,
@@ -21,21 +23,13 @@ def log_expectation(
     span_id: Optional[str] = None,
 ) -> Assessment:
     """
+
+    .. important::
+
+        This API is currently only available for [Databricks Managed MLflow](https://www.databricks.com/product/managed-mlflow).
+
     Logs an expectation (ground truth) to a Trace.
 
-    The following code annotates a trace with human-provided ground truth.
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.entities.assessment import AssessmentSourceType
-
-        log_expectation(
-            trace_id="1234",
-            name="expected_answer",
-            value=42,
-            source=AssessmentSourceType.HUMAN,
-        )
 
     Args:
         trace_id: The ID of the trace.
@@ -51,6 +45,23 @@ def log_expectation(
 
     Returns:
         :py:class:`~mlflow.entities.Assessment`: The created expectation assessment.
+
+    Example:
+
+    The following code annotates a trace with human-provided ground truth.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.entities.assessment import AssessmentSourceType
+
+        mlflow.log_expectation(
+            trace_id="1234",
+            name="expected_answer",
+            value=42,
+            source=AssessmentSourceType.HUMAN,
+        )
+
     """
     if value is None:
         raise MlflowException.invalid_parameter_value("Expectation value cannot be None.")
@@ -65,6 +76,7 @@ def log_expectation(
     )
 
 
+@experimental
 def log_feedback(
     trace_id: str,
     name: str,
@@ -76,7 +88,33 @@ def log_feedback(
     span_id: Optional[str] = None,
 ) -> Assessment:
     """
+
+    .. important::
+
+        This API is currently only available for [Databricks Managed MLflow](https://www.databricks.com/product/managed-mlflow).
+
     Logs a feedback to a Trace.
+
+    Args:
+        trace_id: The ID of the trace.
+        name: The name of the feedback assessment e.g., "faithfulness"
+        source: The source of the expectation assessment. Must be either an instance of
+                :py:class:`~mlflow.entities.AssessmentSource` or a string that
+                is a valid value in the
+                :py:class:`~mlflow.entities.AssessmentSourceType` enum.
+        value: The value of the expectation. It can be any JSON-serializable value.
+        error: An error object representing any issues encountered while computing the
+            feedback, e.g., a timeout error from an LLM judge. Either this or `value`
+            must be provided.
+        rationale: The rationale / justification for the feedback.
+        metadata: Additional metadata for the expectation.
+        span_id: The ID of the span associated with the expectation, if it needs be
+                associated with a specific span in the trace.
+
+    Returns:
+        :py:class:`~mlflow.entities.Assessment`: The created feedback assessment.
+
+    Example:
 
     The following code annotates a trace with a feedback provided by LLM-as-a-Judge.
 
@@ -124,24 +162,6 @@ def log_feedback(
             error=error,
         )
 
-    Args:
-        trace_id: The ID of the trace.
-        name: The name of the feedback assessment e.g., "faithfulness"
-        source: The source of the expectation assessment. Must be either an instance of
-                :py:class:`~mlflow.entities.AssessmentSource` or a string that
-                is a valid value in the
-                :py:class:`~mlflow.entities.AssessmentSourceType` enum.
-        value: The value of the expectation. It can be any JSON-serializable value.
-        error: An error object representing any issues encountered while computing the
-            feedback, e.g., a timeout error from an LLM judge. Either this or `value`
-            must be provided.
-        rationale: The rationale / justification for the feedback.
-        metadata: Additional metadata for the expectation.
-        span_id: The ID of the span associated with the expectation, if it needs be
-                associated with a specific span in the trace.
-
-    Returns:
-        :py:class:`~mlflow.entities.Assessment`: The created feedback assessment.
     """
     return MlflowClient().log_assessment(
         trace_id=trace_id,

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -1,0 +1,166 @@
+from typing import Any, Optional, Union
+
+from mlflow.entities.assessment import (
+    Assessment,
+    AssessmentError,
+    AssessmentValueType,
+    Expectation,
+    Feedback,
+)
+from mlflow.entities.assessment_source import AssessmentSource
+from mlflow.exceptions import MlflowException
+from mlflow.tracking.client import MlflowClient
+
+
+def log_expectation(
+    trace_id: str,
+    name: str,
+    value: AssessmentValueType,
+    source: Union[str, AssessmentSource],
+    metadata: Optional[dict[str, Any]] = None,
+    span_id: Optional[str] = None,
+) -> Assessment:
+    """
+    Logs an expectation (ground truth) to a Trace.
+
+    The following code annotates a trace with human-provided ground truth.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.entities.assessment_source import AssessmentSourceType
+
+        log_expectation(
+            trace_id="1234",
+            name="expected_answer",
+            value=42,
+            source=AssessmentSourceType.HUMAN,
+        )
+
+    Args:
+        trace_id: The ID of the trace.
+        name: The name of the expectation assessment e.g., "expected_answer
+        value: The value of the expectation. It can be any JSON-serializable value.
+        source: The source of the expectation assessment. Must be either an instance of
+                :py:class:`AssessmentSource` or a string that is a valid value in the
+                :py:class:`AssessmentSourceType` enum.
+        metadata: Additional metadata for the expectation.
+        span_id: The ID of the span associated with the expectation, if it needs be
+                associated with a specific span in the trace.
+
+    Returns:
+        :py:class:`Assessment`: The created expectation assessment.
+    """
+    if value is None:
+        raise MlflowException.invalid_parameter_value("Expectation value cannot be None.")
+
+    return MlflowClient().log_assessment(
+        trace_id=trace_id,
+        name=name,
+        source=_parse_source(source),
+        value=Expectation(value) if value is not None else None,
+        metadata=metadata,
+        span_id=span_id,
+    )
+
+
+def log_feedback(
+    trace_id: str,
+    name: str,
+    source: Union[str, AssessmentSource],
+    value: Optional[AssessmentValueType] = None,
+    error: Optional[AssessmentError] = None,
+    rationale: Optional[str] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    span_id: Optional[str] = None,
+) -> Assessment:
+    """
+    Logs a feedback to a Trace.
+
+    The following code annotates a trace with a feedback provided by LLM-as-a-Judge.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.entities.assessment_source import AssessmentSourceType
+
+        source = AssessmentSource(
+            source_type=Type.LLM_JUDGE,
+            source_id="faithfulness-judge",
+        )
+
+        mlflow.log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            value=0.9,
+            rationale="The model is faithful to the input.",
+            metadata={"model": "gpt-4o-mini"},
+        )
+
+    You can also log an error information during the feedback generation process. To do so,
+    provide an instance of :py:class:`AssessmentError` to the `error` parameter, and leave
+    the `value` parameter as `None`.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.entities.assessment_error import AssessmentError
+
+        source = AssessmentSource(
+            source_type=Type.LLM_JUDGE,
+            source_id="faithfulness-judge",
+        )
+
+        error = AssessmentError(
+            error_code="RATE_LIMIT_EXCEEDED",
+            error_message="Rate limit for the judge exceeded.",
+        )
+
+        mlflow.log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            source=source,
+            error=error,
+        )
+
+    Args:
+        trace_id: The ID of the trace.
+        name: The name of the feedback assessment e.g., "faithfulness"
+        source: The source of the feedback. Must be one of the values
+                in the :py:class:`AssessmentSource` enum.
+        value: The value of the expectation. It can be any JSON-serializable value.
+        error: An error object representing any issues encountered while computing the
+            feedback, e.g., a timeout error from an LLM judge. Either this or `value`
+            must be provided.
+        rationale: The rationale / justification for the feedback.
+        metadata: Additional metadata for the expectation.
+        span_id: The ID of the span associated with the expectation, if it needs be
+                associated with a specific span in the trace.
+
+    Returns:
+        :py:class:`Assessment`: The created feedback assessment.
+    """
+    return MlflowClient().log_assessment(
+        trace_id=trace_id,
+        name=name,
+        source=_parse_source(source),
+        value=Feedback(value) if value is not None else None,
+        error=error,
+        rationale=rationale,
+        metadata=metadata,
+        span_id=span_id,
+    )
+
+
+def _parse_source(source: Union[str, AssessmentSource]) -> AssessmentSource:
+    if source is None:
+        raise MlflowException.invalid_parameter_value("`source` must be provided.")
+
+    if isinstance(source, str):
+        return AssessmentSource(source_type=source)
+    elif isinstance(source, AssessmentSource):
+        return source
+
+    raise MlflowException.invalid_parameter_value(
+        "Invalid source type. Must be one of str, AssessmentSource, or AssessmentSourceType."
+    )

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -17,8 +17,8 @@ from mlflow.tracking.client import MlflowClient
 def log_expectation(
     trace_id: str,
     name: str,
-    value: AssessmentValueType,
     source: Union[str, AssessmentSource],
+    value: AssessmentValueType,
     metadata: Optional[dict[str, Any]] = None,
     span_id: Optional[str] = None,
 ) -> Assessment:
@@ -34,11 +34,11 @@ def log_expectation(
     Args:
         trace_id: The ID of the trace.
         name: The name of the expectation assessment e.g., "expected_answer
-        value: The value of the expectation. It can be any JSON-serializable value.
         source: The source of the expectation assessment. Must be either an instance of
                 :py:class:`~mlflow.entities.AssessmentSource` or a string that
                 is a valid value in the
                 :py:class:`~mlflow.entities.AssessmentSourceType` enum.
+        value: The value of the expectation. It can be any JSON-serializable value.
         metadata: Additional metadata for the expectation.
         span_id: The ID of the span associated with the expectation, if it needs be
                 associated with a specific span in the trace.

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -419,6 +419,12 @@ class TrackingServiceClient:
             assessment: The assessment to create. This contains the target
                 trace_id as well.
         """
+        if not is_databricks_uri(self.tracking_uri):
+            raise MlflowException(
+                "This API is currently only available for Databricks Managed MLflow. This "
+                "will be available in the open-source version of MLflow in a future release."
+            )
+
         return self.store.create_assessment(assessment)
 
     def search_experiments(

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -22,6 +22,7 @@ from mlflow.entities import (
     TraceInfo,
     ViewType,
 )
+from mlflow.entities.assessment import Assessment
 from mlflow.entities.dataset_input import DatasetInput
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_info import TraceInfo
@@ -409,6 +410,16 @@ class TrackingServiceClient:
             _logger.warning(f"Tag '{key}' is immutable and cannot be deleted on a trace.")
         else:
             self.store.delete_trace_tag(request_id, key)
+
+    def create_assessment(self, assessment: Assessment):
+        """
+        Create an assessment on a trace.
+
+        Args:
+            assessment: The assessment to create. This contains the target
+                trace_id as well.
+        """
+        return self.store.create_assessment(assessment)
 
     def search_experiments(
         self,

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -384,10 +384,6 @@ def call_endpoint(host_creds, endpoint, method, json_body, response_proto, extra
     response_to_parse = response.text
     js_dict = json.loads(response_to_parse)
 
-    # TODO: hack, revert this before merging, once the DB backend prot is fixed
-    if "assessment_id" in js_dict:
-        js_dict = {"assessment": js_dict}
-
     parse_dict(js_dict=js_dict, message=response_proto)
     return response_proto
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -358,6 +358,10 @@ def get_set_trace_tag_endpoint(request_id):
     return f"{get_single_trace_endpoint(request_id)}/tags"
 
 
+def get_create_assessment_endpoint(trace_id: str):
+    return f"{_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments"
+
+
 def call_endpoint(host_creds, endpoint, method, json_body, response_proto, extra_headers=None):
     # Convert json string to json dictionary, to pass to requests
     if json_body is not None:
@@ -379,6 +383,11 @@ def call_endpoint(host_creds, endpoint, method, json_body, response_proto, extra
     response = verify_rest_response(response, endpoint)
     response_to_parse = response.text
     js_dict = json.loads(response_to_parse)
+
+    # TODO: hack, revert this before merging, once the DB backend prot is fixed
+    if "assessment_id" in js_dict:
+        js_dict = {"assessment": js_dict}
+
     parse_dict(js_dict=js_dict, message=response_proto)
     return response_proto
 

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -1,4 +1,5 @@
 import json
+import time
 from unittest import mock
 
 import pytest
@@ -17,12 +18,15 @@ from mlflow.entities import (
     SourceType,
     ViewType,
 )
+from mlflow.entities.assessment import Assessment, Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.protos.service_pb2 import (
+    CreateAssessment,
     CreateRun,
     DeleteExperiment,
     DeleteRun,
@@ -715,3 +719,54 @@ def test_set_trace_tag():
             mock_http, creds, f"traces/{request_id}/tags", "PATCH", message_to_json(request)
         )
         assert res is None
+
+
+def test_log_assessment():
+    creds = MlflowHostCreds("https://hello")
+    store = RestStore(lambda: creds)
+    response = mock.MagicMock()
+    response.status_code = 200
+    response.text = json.dumps(
+        {
+            "assessment": {
+                "assessment_id": "1234",
+                "assessment_name": "assessment_name",
+                "trace_id": "tr-1234",
+                "source": {
+                    "source_type": "LLM_JUDGE",
+                    "source_id": "gpt-4o-mini",
+                },
+                "create_time": "2025-02-20T05:47:23Z",
+                "last_update_time": "2025-02-20T05:47:23Z",
+                "feedback": {"value": True},
+                "rationale": "rationale",
+                "metadata": {"model": "gpt-4o-mini"},
+                "error": None,
+                "span_id": None,
+            }
+        }
+    )
+
+    assessment = Assessment(
+        trace_id="tr-1234",
+        name="assessment_name",
+        source=AssessmentSource(
+            source_type=AssessmentSourceType.LLM_JUDGE, source_id="gpt-4o-mini"
+        ),
+        create_time_ms=int(time.time() * 1000),
+        last_update_time_ms=int(time.time() * 1000),
+        value=Feedback(value=True),
+        rationale="rationale",
+        metadata={"model": "gpt-4o-mini"},
+        error=None,
+        span_id=None,
+    )
+
+    request = CreateAssessment(assessment=assessment.to_proto())
+    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
+        res = store.create_assessment(assessment)
+
+    _verify_requests(
+        mock_http, creds, "traces/tr-1234/assessments", "POST", message_to_json(request)
+    )
+    assert isinstance(res, Assessment)

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -1,0 +1,153 @@
+from unittest import mock
+
+import pytest
+
+from mlflow.entities.assessment import AssessmentError, Expectation, Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.exceptions import MlflowException
+from mlflow.tracing.assessment import log_expectation, log_feedback
+
+
+# TODO: This test mocks out the tracking client and only test if the fluent API implementation
+# passes the correct arguments to the low-level client. Once the OSS backend is implemented,
+# we should also test the end-to-end assessment CRUD functionality.
+@pytest.fixture
+def mock_tracking_client():
+    mock_client = mock.MagicMock()
+    with mock.patch("mlflow.tracking.client.TrackingServiceClient", return_value=mock_client):
+        yield mock_client
+
+
+def test_log_expectation(mock_tracking_client):
+    log_expectation(
+        trace_id="1234",
+        name="expected_answer",
+        value="MLflow",
+        source=AssessmentSourceType.HUMAN,
+        metadata={"key": "value"},
+    )
+
+    assert mock_tracking_client.create_assessment.call_count == 1
+    assessment = mock_tracking_client.create_assessment.call_args[0][0]
+    assert assessment.name == "expected_answer"
+    assert assessment.trace_id == "1234"
+    assert assessment.span_id is None
+    assert assessment.source.source_type == "HUMAN"
+    assert assessment.source.source_id is None
+    assert assessment.create_time_ms is not None
+    assert assessment.last_update_time_ms is not None
+    assert isinstance(assessment.value, Expectation)
+    assert assessment.value.value == "MLflow"
+    assert assessment.rationale is None
+    assert assessment.metadata == {"key": "value"}
+    assert assessment.error is None
+
+
+def test_log_expectation_invalid_parameters():
+    with pytest.raises(MlflowException, match=r"Expectation value cannot be None."):
+        log_expectation(
+            trace_id="1234",
+            name="expected_answer",
+            value=None,
+            source=AssessmentSourceType.HUMAN,
+        )
+
+    with pytest.raises(MlflowException, match=r"`source` must be provided."):
+        log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            value=1.0,
+            source=None,
+        )
+
+    with pytest.raises(MlflowException, match=r"Invalid assessment source type"):
+        log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            value=1.0,
+            source="INVALID_SOURCE_TYPE",
+        )
+
+
+def test_log_feedback(mock_tracking_client):
+    log_feedback(
+        trace_id="1234",
+        name="faithfulness",
+        value=1.0,
+        source=AssessmentSource(
+            source_type=AssessmentSourceType.LLM_JUDGE,
+            source_id="faithfulness-judge",
+        ),
+        rationale="This answer is very faithful.",
+        metadata={"model": "gpt-4o-mini"},
+    )
+
+    assert mock_tracking_client.create_assessment.call_count == 1
+    assessment = mock_tracking_client.create_assessment.call_args[0][0]
+    assert assessment.name == "faithfulness"
+    assert assessment.trace_id == "1234"
+    assert assessment.span_id is None
+    assert assessment.source.source_type == "LLM_JUDGE"
+    assert assessment.source.source_id == "faithfulness-judge"
+    assert assessment.create_time_ms is not None
+    assert assessment.last_update_time_ms is not None
+    assert isinstance(assessment.value, Feedback)
+    assert assessment.value.value == 1.0
+    assert assessment.rationale == "This answer is very faithful."
+    assert assessment.metadata == {"model": "gpt-4o-mini"}
+    assert assessment.error is None
+
+
+def test_log_feedback_with_error(mock_tracking_client):
+    log_feedback(
+        trace_id="1234",
+        name="faithfulness",
+        source=AssessmentSourceType.LLM_JUDGE,
+        error=AssessmentError(
+            error_code="RATE_LIMIT_EXCEEDED",
+            error_message="Rate limit for the judge exceeded.",
+        ),
+    )
+
+    assert mock_tracking_client.create_assessment.call_count == 1
+    assessment = mock_tracking_client.create_assessment.call_args[0][0]
+    assert assessment.name == "faithfulness"
+    assert assessment.trace_id == "1234"
+    assert assessment.span_id is None
+    assert assessment.source.source_type == "LLM_JUDGE"
+    assert assessment.source.source_id is None
+    assert assessment.create_time_ms is not None
+    assert assessment.last_update_time_ms is not None
+    assert assessment.value is None
+    assert assessment.rationale is None
+    assert assessment.error.error_code == "RATE_LIMIT_EXCEEDED"
+    assert assessment.error.error_message == "Rate limit for the judge exceeded."
+
+
+def test_log_feedback_invalid_parameters():
+    with pytest.raises(MlflowException, match=r"Either `value` or `error` must be specified."):
+        log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            source=AssessmentSourceType.LLM_JUDGE,
+        )
+
+    with pytest.raises(MlflowException, match=r"Only one of `value` or `error` should be "):
+        log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            source=AssessmentSourceType.LLM_JUDGE,
+            value=1.0,
+            error=AssessmentError(
+                error_code="RATE_LIMIT_EXCEEDED",
+                error_message="Rate limit for the judge exceeded.",
+            ),
+        )
+
+    with pytest.raises(MlflowException, match=r"`source` must be provided."):
+        log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            value=1.0,
+            source=None,
+        )


### PR DESCRIPTION
### Related Issues/PRs

~This PR depends on https://github.com/mlflow/mlflow/pull/14663~ (merged)

### What changes are proposed in this pull request?

Adding `log_expectation` and `log_feedback` APIs for creating assessment entities on a trace.

The initial design was to have a single `log_assessment` API, but we decided not to overload a single API because:
1. If we overload, users need to construct a `Feedback` or `Expectation` object as a value, which is a bit clunky.
```
log_assessment(trace_id="my_trace_id", name="answer_correctness", value=Feedback(value=1.0))
vs
log_feedback(trace_id="my_trace_id", name="answer_correctness", value=1.0)
```
2.  Some fields are not naturally applicable to both entities. For example, `error` field represents an error during generating assessment, for example, a rate limit error for LLM judge. However, it does not naturally fit when creating an Expectation.
3. According to the core JTBD we analyzed, almost all steps of using assessment only touches either of two, not both. It is better to align API name with what job users can achieve e.g. "I want to add user's feedback on a trace" -> `log_feedback()`.

Note: Update / Read / Delete API will be added in follow-up PRs once the DB backend is ready.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
