### PR TITLE
[Safe-patch 2] Remove PatchFunction

### DIFF
--- a/mlflow/keras/autologging.py
+++ b/mlflow/keras/autologging.py
@@ -17,7 +17,6 @@ from mlflow.tracking.context import registry as context_registry
 from mlflow.utils import is_iterator
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
-    PatchFunction,
     autologging_integration,
     get_autologging_config,
     log_fn_args_as_params,
@@ -196,76 +195,73 @@ def autolog(
             model.fit(data, label, batch_size=4, epochs=2)
     """
 
-    class FitPatch(PatchFunction):
-        def __init__(self):
-            pass
+    def _patched_inference(original, inst, *args, **kwargs):
+        unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
-        def _infer_batch_size(self, inst, *args, **kwargs):
-            batch_size = None
-            if "batch_size" in kwargs:
-                batch_size = kwargs["batch_size"]
+        batch_size, args, kwargs = _infer_batch_size(inst, *args, **kwargs)
+
+        if batch_size is not None:
+            mlflow.log_param("batch_size", batch_size)
+            unlogged_params.append("batch_size")
+
+        log_fn_args_as_params(original, [], kwargs, unlogged_params)
+
+        if log_datasets:
+            try:
+                context_tags = context_registry.resolve_tags()
+                source = CodeDatasetSource(tags=context_tags)
+                x, y = _parse_dataset(*args, **kwargs)
+                _log_dataset(x, source, "train", targets=y)
+
+                if "validation_data" in kwargs:
+                    _log_dataset(kwargs["validation_data"], source, "eval")
+
+            except Exception as e:
+                _logger.warning(f"Failed to log dataset information to MLflow. Reason: {e}")
+
+        # Add `MlflowCallback` to the callback list.
+        callbacks = args[5] if len(args) >= 6 else kwargs.get("callbacks", [])
+        mlflow_callback = MlflowCallback(
+            log_every_epoch=log_every_epoch,
+            log_every_n_steps=log_every_n_steps,
+        )
+        _check_existing_mlflow_callback(callbacks)
+        callbacks.append(mlflow_callback)
+        kwargs["callbacks"] = callbacks
+        history = original(inst, *args, **kwargs)
+
+        if log_models:
+            _log_keras_model(inst, save_exported_model, log_model_signatures, save_model_kwargs)
+        return history
+
+    safe_patch(
+        "keras", keras.Model, "fit", _patched_inference, manage_run=True, extra_tags=extra_tags
+    )
+
+
+def _infer_batch_size(inst, *args, **kwargs):
+    batch_size = None
+    if "batch_size" in kwargs:
+        batch_size = kwargs["batch_size"]
+    else:
+        training_data = kwargs["x"] if "x" in kwargs else args[0]
+        if _batch_size := getattr(training_data, "batch_size", None):
+            batch_size = _batch_size
+        elif _batch_size := getattr(training_data, "_batch_size", None):
+            batch_size = _batch_size if isinstance(_batch_size, int) else _batch_size.numpy()
+        elif is_iterator(training_data):
+            is_single_input_model = isinstance(inst.input_shape, tuple)
+            peek = next(training_data)
+            batch_size = len(peek[0]) if is_single_input_model else len(peek[0][0])
+
+            def origin_training_data_generator_fn():
+                yield peek
+                yield from training_data
+
+            origin_training_data = origin_training_data_generator_fn()
+
+            if "x" in kwargs:
+                kwargs["x"] = origin_training_data
             else:
-                training_data = kwargs["x"] if "x" in kwargs else args[0]
-                if _batch_size := getattr(training_data, "batch_size", None):
-                    batch_size = _batch_size
-                elif _batch_size := getattr(training_data, "_batch_size", None):
-                    batch_size = (
-                        _batch_size if isinstance(_batch_size, int) else _batch_size.numpy()
-                    )
-                elif is_iterator(training_data):
-                    is_single_input_model = isinstance(inst.input_shape, tuple)
-                    peek = next(training_data)
-                    batch_size = len(peek[0]) if is_single_input_model else len(peek[0][0])
-
-                    def origin_training_data_generator_fn():
-                        yield peek
-                        yield from training_data
-
-                    origin_training_data = origin_training_data_generator_fn()
-
-                    if "x" in kwargs:
-                        kwargs["x"] = origin_training_data
-                    else:
-                        args = (origin_training_data,) + args[1:]
-            return batch_size, args, kwargs
-
-        def _patch_implementation(self, original, inst, *args, **kwargs):
-            unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
-
-            batch_size, args, kwargs = self._infer_batch_size(inst, *args, **kwargs)
-
-            if batch_size is not None:
-                mlflow.log_param("batch_size", batch_size)
-                unlogged_params.append("batch_size")
-
-            log_fn_args_as_params(original, [], kwargs, unlogged_params)
-
-            if log_datasets:
-                try:
-                    context_tags = context_registry.resolve_tags()
-                    source = CodeDatasetSource(tags=context_tags)
-                    x, y = _parse_dataset(*args, **kwargs)
-                    _log_dataset(x, source, "train", targets=y)
-
-                    if "validation_data" in kwargs:
-                        _log_dataset(kwargs["validation_data"], source, "eval")
-
-                except Exception as e:
-                    _logger.warning(f"Failed to log dataset information to MLflow. Reason: {e}")
-
-            # Add `MlflowCallback` to the callback list.
-            callbacks = args[5] if len(args) >= 6 else kwargs.get("callbacks", [])
-            mlflow_callback = MlflowCallback(
-                log_every_epoch=log_every_epoch,
-                log_every_n_steps=log_every_n_steps,
-            )
-            _check_existing_mlflow_callback(callbacks)
-            callbacks.append(mlflow_callback)
-            kwargs["callbacks"] = callbacks
-            history = original(inst, *args, **kwargs)
-
-            if log_models:
-                _log_keras_model(inst, save_exported_model, log_model_signatures, save_model_kwargs)
-            return history
-
-    safe_patch("keras", keras.Model, "fit", FitPatch, manage_run=True, extra_tags=extra_tags)
+                args = (origin_training_data,) + args[1:]
+    return batch_size, args, kwargs

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -38,7 +38,6 @@ from mlflow.tracking.fluent import _shut_down_async_logging
 from mlflow.types.schema import TensorSpec
 from mlflow.utils import is_iterator
 from mlflow.utils.autologging_utils import (
-    PatchFunction,
     autologging_integration,
     get_autologging_config,
     log_fn_args_as_params,
@@ -1242,11 +1241,9 @@ def autolog(
             keras_model_kwargs=keras_model_kwargs,
         )
 
-    class FitPatch(PatchFunction):
-        def __init__(self):
-            self.log_dir = None
-
-        def _patch_implementation(self, original, inst, *args, **kwargs):
+    def _patched_inference(original, inst, *args, **kwargs):
+        log_dir = None
+        try:
             unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
             batch_size = None
@@ -1298,7 +1295,7 @@ def autolog(
                 # modifying their contents for future training invocations. Introduce
                 # TensorBoard & tf.keras callbacks if necessary
                 callbacks = list(args[5])
-                callbacks, self.log_dir = _setup_callbacks(
+                callbacks, log_dir = _setup_callbacks(
                     callbacks,
                     log_every_epoch=log_every_epoch,
                     log_every_n_steps=log_every_n_steps,
@@ -1311,7 +1308,7 @@ def autolog(
                 # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
                 # & tf.keras callbacks if necessary
                 callbacks = list(kwargs.get("callbacks") or [])
-                kwargs["callbacks"], self.log_dir = _setup_callbacks(
+                kwargs["callbacks"], log_dir = _setup_callbacks(
                     callbacks,
                     log_every_epoch=log_every_epoch,
                     log_every_n_steps=log_every_n_steps,
@@ -1364,27 +1361,30 @@ def autolog(
             _shut_down_async_logging()
 
             mlflow.log_artifacts(
-                local_dir=self.log_dir.location,
+                local_dir=log_dir.location,
                 artifact_path="tensorboard_logs",
             )
-            if self.log_dir.is_temp:
-                shutil.rmtree(self.log_dir.location)
+            if log_dir.is_temp:
+                shutil.rmtree(log_dir.location)
             return history
 
-        def _on_exception(self, exception):
-            if (
-                self.log_dir is not None
-                and self.log_dir.is_temp
-                and os.path.exists(self.log_dir.location)
-            ):
-                shutil.rmtree(self.log_dir.location)
+        except (Exception, KeyboardInterrupt) as e:
+            try:
+                if log_dir is not None and log_dir.is_temp and os.path.exists(log_dir.location):
+                    shutil.rmtree(log_dir.location)
+            finally:
+                # Regardless of what happens during the `_on_exception` callback, reraise
+                # the original implementation exception once the callback completes
+                raise e
 
-    managed = [
-        (tf.keras.Model, "fit", FitPatch),
-    ]
-
-    for p in managed:
-        safe_patch(FLAVOR_NAME, *p, manage_run=True, extra_tags=extra_tags)
+    safe_patch(
+        FLAVOR_NAME,
+        tf.keras.Model,
+        "fit",
+        _patched_inference,
+        manage_run=True,
+        extra_tags=extra_tags,
+    )
 
 
 def _log_tensorflow_dataset(tensorflow_dataset, source, context, name=None, targets=None):

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -31,7 +31,6 @@ from mlflow.utils.autologging_utils.logging_and_warnings import (
 from mlflow.utils.autologging_utils.safety import (  # noqa: F401
     ExceptionSafeAbstractClass,
     ExceptionSafeClass,
-    PatchFunction,
     exception_safe_function_for_class,
     is_testing,
     picklable_exception_safe_function,

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -4,7 +4,6 @@ import inspect
 import itertools
 import typing
 import uuid
-from abc import abstractmethod
 from contextlib import contextmanager
 from typing import Optional
 
@@ -129,54 +128,6 @@ ExceptionSafeClass = _exception_safe_class_factory(type)
 ExceptionSafeAbstractClass = _exception_safe_class_factory(abc.ABCMeta)
 
 
-class PatchFunction:
-    """
-    Base class representing a function patch implementation with a callback for error handling.
-    `PatchFunction` should be subclassed and used in conjunction with `safe_patch` to
-    safely modify the implementation of a function. Subclasses of `PatchFunction` should
-    use `_patch_implementation` to define modified ("patched") function implementations and
-    `_on_exception` to define cleanup logic when `_patch_implementation` terminates due
-    to an unhandled exception.
-    """
-
-    @abstractmethod
-    def _patch_implementation(self, original, *args, **kwargs):
-        """
-        Invokes the patch function code.
-
-        Args:
-            original: The original, underlying function over which the `PatchFunction`
-                is being applied.
-            *args: The positional arguments passed to the original function.
-            **kwargs: The keyword arguments passed to the original function.
-        """
-
-    @abstractmethod
-    def _on_exception(self, exception):
-        """Called when an unhandled standard Python exception (i.e. an exception inheriting from
-        `Exception`) or a `KeyboardInterrupt` prematurely terminates the execution of
-        `_patch_implementation`.
-
-        Args:
-            exception: The unhandled exception thrown by `_patch_implementation`.
-        """
-
-    @classmethod
-    def call(cls, original, *args, **kwargs):
-        return cls().__call__(original, *args, **kwargs)
-
-    def __call__(self, original, *args, **kwargs):
-        try:
-            return self._patch_implementation(original, *args, **kwargs)
-        except (Exception, KeyboardInterrupt) as e:
-            try:
-                self._on_exception(e)
-            finally:
-                # Regardless of what happens during the `_on_exception` callback, reraise
-                # the original implementation exception once the callback completes
-                raise e
-
-
 def with_managed_run(autologging_integration, patch_function, tags=None):
     """Given a `patch_function`, returns an `augmented_patch_function` that wraps the execution of
     `patch_function` with an active MLflow run. The following properties apply:
@@ -197,8 +148,7 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
     Args:
         autologging_integration: The autologging integration associated
             with the `patch_function`.
-        patch_function: A `PatchFunction` class definition or a function object
-            compatible with `safe_patch`.
+        patch_function: A function object compatible with `safe_patch`.
         tags: A dictionary of string tags to set on each managed run created during the
             execution of `patch_function`.
     """
@@ -215,61 +165,30 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
         )
         return managed_run
 
-    if inspect.isclass(patch_function):
+    def patch_with_managed_run(original, *args, **kwargs):
+        managed_run = None
+        # If there is an active training session but there is no active run
+        # in current thread, it means the thread is spawned by `estimator.fit`
+        # as a worker thread, we should disable autologging in
+        # these worker threads, so skip creating managed run.
+        if not mlflow.active_run() and not _has_active_training_session():
+            managed_run = create_managed_run()
 
-        class PatchWithManagedRun(patch_function):
-            def __init__(self):
-                super().__init__()
-                self.managed_run = None
+        try:
+            result = patch_function(original, *args, **kwargs)
+        except (Exception, KeyboardInterrupt):
+            # In addition to standard Python exceptions, handle keyboard interrupts to ensure
+            # that runs are terminated if a user prematurely interrupts training execution
+            # (e.g. via sigint / ctrl-c)
+            if managed_run:
+                mlflow.end_run(RunStatus.to_string(RunStatus.FAILED))
+            raise
+        else:
+            if managed_run:
+                mlflow.end_run(RunStatus.to_string(RunStatus.FINISHED))
+            return result
 
-            def _patch_implementation(self, original, *args, **kwargs):
-                # If there is an active training session but there is no active run
-                # in current thread, it means the thread is spawned by `estimator.fit`
-                # as a worker thread, we should disable autologging in
-                # these worker threads, so skip creating managed run.
-                if not mlflow.active_run() and not _has_active_training_session():
-                    self.managed_run = create_managed_run()
-
-                result = super()._patch_implementation(original, *args, **kwargs)
-
-                if self.managed_run:
-                    mlflow.end_run(RunStatus.to_string(RunStatus.FINISHED))
-
-                return result
-
-            def _on_exception(self, e):
-                if self.managed_run:
-                    mlflow.end_run(RunStatus.to_string(RunStatus.FAILED))
-                super()._on_exception(e)
-
-        return PatchWithManagedRun
-
-    else:
-
-        def patch_with_managed_run(original, *args, **kwargs):
-            managed_run = None
-            # If there is an active training session but there is no active run
-            # in current thread, it means the thread is spawned by `estimator.fit`
-            # as a worker thread, we should disable autologging in
-            # these worker threads, so skip creating managed run.
-            if not mlflow.active_run() and not _has_active_training_session():
-                managed_run = create_managed_run()
-
-            try:
-                result = patch_function(original, *args, **kwargs)
-            except (Exception, KeyboardInterrupt):
-                # In addition to standard Python exceptions, handle keyboard interrupts to ensure
-                # that runs are terminated if a user prematurely interrupts training execution
-                # (e.g. via sigint / ctrl-c)
-                if managed_run:
-                    mlflow.end_run(RunStatus.to_string(RunStatus.FAILED))
-                raise
-            else:
-                if managed_run:
-                    mlflow.end_run(RunStatus.to_string(RunStatus.FINISHED))
-                return result
-
-        return patch_with_managed_run
+    return patch_with_managed_run
 
 
 def is_testing():
@@ -326,11 +245,9 @@ def safe_patch(
             patch.
         destination: The Python class on which the patch is being defined.
         function_name: The name of the function to patch on the specified `destination` class.
-        patch_function: The patched function code to apply. This is either a `PatchFunction`
-            class definition or a function object. If it is a function object, the
-            first argument should be reserved for an `original` method argument
-            representing the underlying / original function. Subsequent arguments
-            should be identical to those of the original function being patched.
+        patch_function: The patched function code to apply. The first argument should be reserved
+            for an `original` argument representing the underlying / original function. Subsequent
+            arguments should be identical to those of the original function being patched.
         manage_run: If `True`, applies the `with_managed_run` wrapper to the specified
             `patch_function`, which automatically creates & terminates an MLflow
             active run during patch code execution if necessary. If `False`,
@@ -347,12 +264,6 @@ def safe_patch(
             patch_function,
             tags=tags,
         )
-
-    patch_is_class = inspect.isclass(patch_function)
-    if patch_is_class:
-        assert issubclass(patch_function, PatchFunction)
-    else:
-        assert callable(patch_function)
 
     original_fn = gorilla.get_original_attribute(
         destination, function_name, bypass_descriptor_protocol=False
@@ -586,10 +497,7 @@ def safe_patch(
                         kwargs,
                     )
 
-                    if patch_is_class:
-                        patch_function.call(call_original, *args, **kwargs)
-                    else:
-                        patch_function(call_original, *args, **kwargs)
+                    patch_function(call_original, *args, **kwargs)
 
                     session.state = "succeeded"
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14666?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14666/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14666
```

</p>
</details>

### What changes are proposed in this pull request?


***This is a part of `safe_patch` refactoring effort as a preparation for supporting async/stream functions. To support these use cases, the inner function `safe_patch_function` cannot be re-used as is, because we need a different function signature e.g. `async def`. The goal is to simplify the inner function so that we don't need to duplicate hundreds of lines to support new use cases.***

Remove the `PatchFunction` abstraction that is not adding complexity while the use case can be covered by normal function-based patch.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
