### PR TITLE
[Safe-patch 3] DRY autologging event logger

### DIFF
--- a/mlflow/utils/autologging_utils/events.py
+++ b/mlflow/utils/autologging_utils/events.py
@@ -1,6 +1,113 @@
 import warnings
+from typing import Any
 
 from mlflow.utils.autologging_utils import _logger
+
+
+class AutologgingRuntimeLogger:
+    """
+    Wrapper class for an `AutologgingEventLogger
+    """
+
+    def __init__(self, session, destinatinon, function_name):
+        self._logger = AutologgingEventLogger.get_logger()
+        self._session = session
+        self._destination = destinatinon
+        self._function_name = function_name
+
+
+def _catch_exception(fn):
+    """A decorator that catches exceptions thrown by the wrapped function and logs them."""
+
+    def wrapper(*args):
+        try:
+            fn(*args)
+        except Exception as e:
+            _logger.debug(f"Failed to log autologging event via '{fn}'. Exception: {e}")
+
+    return wrapper
+
+
+class AutologgingEventLoggerWrapper:
+    """
+    A wrapper around AutologgingEventLogger for DRY:
+      - Store common arguments to avoid passing them to each logger method
+      - Catches exceptions thrown by the logger and logs them
+
+    NB: We could not modify the AutologgingEventLogger class directly because
+        it is used in Databricks code base as well.
+    """
+
+    def __init__(
+        self, session, destination: Any, function_name: str, call_args: tuple, call_kwargs: dict
+    ):
+        self._session = session
+        self._destination = destination
+        self._function_name = function_name
+        self._call_args = call_args
+        self._call_kwargs = call_kwargs
+
+    @_catch_exception
+    def log_patch_function_start(self):
+        AutologgingEventLogger.get_logger().log_patch_function_start(
+            self._session,
+            self._destination,
+            self._function_name,
+            self._call_args,
+            self._call_kwargs,
+        )
+
+    @_catch_exception
+    def log_patch_function_success(self):
+        AutologgingEventLogger.get_logger().log_patch_function_success(
+            self._session,
+            self._destination,
+            self._function_name,
+            self._call_args,
+            self._call_kwargs,
+        )
+
+    @_catch_exception
+    def log_patch_function_error(self, exception):
+        AutologgingEventLogger.get_logger().log_patch_function_error(
+            self._session,
+            self._destination,
+            self._function_name,
+            self._call_args,
+            self._call_kwargs,
+            exception,
+        )
+
+    @_catch_exception
+    def log_original_function_start(self):
+        AutologgingEventLogger.get_logger().log_original_function_start(
+            self._session,
+            self._destination,
+            self._function_name,
+            self._call_args,
+            self._call_kwargs,
+        )
+
+    @_catch_exception
+    def log_original_function_success(self):
+        AutologgingEventLogger.get_logger().log_original_function_success(
+            self._session,
+            self._destination,
+            self._function_name,
+            self._call_args,
+            self._call_kwargs,
+        )
+
+    @_catch_exception
+    def log_original_function_error(self, exception):
+        AutologgingEventLogger.get_logger().log_original_function_error(
+            self._session,
+            self._destination,
+            self._function_name,
+            self._call_args,
+            self._call_kwargs,
+            exception,
+        )
 
 
 class AutologgingEventLogger:

--- a/mlflow/utils/autologging_utils/events.py
+++ b/mlflow/utils/autologging_utils/events.py
@@ -38,74 +38,70 @@ class AutologgingEventLoggerWrapper:
         it is used in Databricks code base as well.
     """
 
-    def __init__(
-        self, session, destination: Any, function_name: str, call_args: tuple, call_kwargs: dict
-    ):
+    def __init__(self, session, destination: Any, function_name: str):
         self._session = session
         self._destination = destination
         self._function_name = function_name
-        self._call_args = call_args
-        self._call_kwargs = call_kwargs
 
     @_catch_exception
-    def log_patch_function_start(self):
+    def log_patch_function_start(self, args, kwargs):
         AutologgingEventLogger.get_logger().log_patch_function_start(
             self._session,
             self._destination,
             self._function_name,
-            self._call_args,
-            self._call_kwargs,
+            args,
+            kwargs,
         )
 
     @_catch_exception
-    def log_patch_function_success(self):
+    def log_patch_function_success(self, args, kwargs):
         AutologgingEventLogger.get_logger().log_patch_function_success(
             self._session,
             self._destination,
             self._function_name,
-            self._call_args,
-            self._call_kwargs,
+            args,
+            kwargs,
         )
 
     @_catch_exception
-    def log_patch_function_error(self, exception):
+    def log_patch_function_error(self, args, kwargs, exception):
         AutologgingEventLogger.get_logger().log_patch_function_error(
             self._session,
             self._destination,
             self._function_name,
-            self._call_args,
-            self._call_kwargs,
+            args,
+            kwargs,
             exception,
         )
 
     @_catch_exception
-    def log_original_function_start(self):
+    def log_original_function_start(self, args, kwargs):
         AutologgingEventLogger.get_logger().log_original_function_start(
             self._session,
             self._destination,
             self._function_name,
-            self._call_args,
-            self._call_kwargs,
+            args,
+            kwargs,
         )
 
     @_catch_exception
-    def log_original_function_success(self):
+    def log_original_function_success(self, args, kwargs):
         AutologgingEventLogger.get_logger().log_original_function_success(
             self._session,
             self._destination,
             self._function_name,
-            self._call_args,
-            self._call_kwargs,
+            args,
+            kwargs,
         )
 
     @_catch_exception
-    def log_original_function_error(self, exception):
+    def log_original_function_error(self, args, kwargs, exception):
         AutologgingEventLogger.get_logger().log_original_function_error(
             self._session,
             self._destination,
             self._function_name,
-            self._call_args,
-            self._call_kwargs,
+            args,
+            kwargs,
             exception,
         )
 

--- a/mlflow/utils/autologging_utils/events.py
+++ b/mlflow/utils/autologging_utils/events.py
@@ -4,18 +4,6 @@ from typing import Any
 from mlflow.utils.autologging_utils import _logger
 
 
-class AutologgingRuntimeLogger:
-    """
-    Wrapper class for an `AutologgingEventLogger
-    """
-
-    def __init__(self, session, destinatinon, function_name):
-        self._logger = AutologgingEventLogger.get_logger()
-        self._session = session
-        self._destination = destinatinon
-        self._function_name = function_name
-
-
 def _catch_exception(fn):
     """A decorator that catches exceptions thrown by the wrapped function and logs them."""
 
@@ -42,67 +30,42 @@ class AutologgingEventLoggerWrapper:
         self._session = session
         self._destination = destination
         self._function_name = function_name
+        self._logger = AutologgingEventLogger.get_logger()
 
     @_catch_exception
     def log_patch_function_start(self, args, kwargs):
-        AutologgingEventLogger.get_logger().log_patch_function_start(
-            self._session,
-            self._destination,
-            self._function_name,
-            args,
-            kwargs,
+        self._logger.log_patch_function_start(
+            self._session, self._destination, self._function_name, args, kwargs
         )
 
     @_catch_exception
     def log_patch_function_success(self, args, kwargs):
-        AutologgingEventLogger.get_logger().log_patch_function_success(
-            self._session,
-            self._destination,
-            self._function_name,
-            args,
-            kwargs,
+        self._logger.log_patch_function_success(
+            self._session, self._destination, self._function_name, args, kwargs
         )
 
     @_catch_exception
     def log_patch_function_error(self, args, kwargs, exception):
-        AutologgingEventLogger.get_logger().log_patch_function_error(
-            self._session,
-            self._destination,
-            self._function_name,
-            args,
-            kwargs,
-            exception,
+        self._logger.log_patch_function_error(
+            self._session, self._destination, self._function_name, args, kwargs, exception
         )
 
     @_catch_exception
     def log_original_function_start(self, args, kwargs):
-        AutologgingEventLogger.get_logger().log_original_function_start(
-            self._session,
-            self._destination,
-            self._function_name,
-            args,
-            kwargs,
+        self._logger.log_original_function_start(
+            self._session, self._destination, self._function_name, args, kwargs
         )
 
     @_catch_exception
     def log_original_function_success(self, args, kwargs):
-        AutologgingEventLogger.get_logger().log_original_function_success(
-            self._session,
-            self._destination,
-            self._function_name,
-            args,
-            kwargs,
+        self._logger.log_original_function_success(
+            self._session, self._destination, self._function_name, args, kwargs
         )
 
     @_catch_exception
     def log_original_function_error(self, args, kwargs, exception):
-        AutologgingEventLogger.get_logger().log_original_function_error(
-            self._session,
-            self._destination,
-            self._function_name,
-            args,
-            kwargs,
-            exception,
+        self._logger.log_original_function_error(
+            self._session, self._destination, self._function_name, args, kwargs, exception
         )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14668?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14668/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14668
```

</p>
</details>

### What changes are proposed in this pull request?

***This is a part of `safe_patch` refactoring effort as a preparation for supporting async/stream functions. To support these use cases, the inner function `safe_patch_function` cannot be re-used as is, because we need a different function signature e.g. `async def`. The goal is to simplify the inner function so that we don't need to duplicate hundreds of lines to support new use cases.***

The `AutologgingEventLogger` is an abstraction for logging progress of autogging with a particular logger instance. The interface is a bit rough-hewn that (1) we need to repeatedly pass args like `session`, `destination` while they are unchanged (2) exception handling is done by wrapping every call with another inner function.

This makes the `safe_patch_function` implementation verbose. However, we cannot simply modify `AutologgingEventLogger` because it is used in Databricks as well (it has a custom logger implementation that is set via `set_logger`). To avoid breaking change, this PR adds a wrapper around event logger and resolve above problems.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
