### PR TITLE
Fix `last_logged_model` example

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2073,8 +2073,6 @@ def last_logged_model() -> Optional[LoggedModel]:
 
         import mlflow
 
-        assert mlflow.last_logged_model() is None
-
         model = mlflow.create_logged_model()
         last_model = mlflow.last_logged_model()
         assert last_model.model_id == model.model_id


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix `last_logged_model` example. It's possible that a model is created in other examples. This PR should fix the `build-doc` error.

https://app.circleci.com/pipelines/github/mlflow/mlflow/46789/workflows/fb60c219-2289-49ba-87e0-e9828e83ac14/jobs/146096

```
        import mlflow
    
>       assert mlflow.last_logged_model() is None

_          = ' mlflow/tracking/fluent.py:2071 '
mlflow     = <module 'mlflow' from '/home/circleci/project/mlflow/__init__.py'>

.examples/test_mlflow_tracking_fluent_last_logged_model_9.py:9: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../mlflow/tracking/fluent.py:2084: in last_logged_model
    return get_logged_model(id)
        id         = '24d816b2-ab1a-4f1e-9eac-2551fd87a87e'
../../mlflow/tracking/fluent.py:2057: in get_logged_model
    return MlflowClient().get_logged_model(model_id)
        model_id   = '24d816b2-ab1a-4f1e-9eac-2551fd87a87e'
../../mlflow/tracking/client.py:4860: in get_logged_model
    return self._tracking_client.get_logged_model(model_id)
        model_id   = '24d816b2-ab1a-4f1e-9eac-2551fd87a87e'
        self       = <mlflow.tracking.client.MlflowClient object at 0x7f69edb17f40>
../../mlflow/tracking/_tracking_service/client.py:1112: in get_logged_model
    return self.store.get_logged_model(model_id)
        model_id   = '24d816b2-ab1a-4f1e-9eac-2551fd87a87e'
        self       = <mlflow.tracking._tracking_service.client.TrackingServiceClient object at 0x7f69edb17ee0>
../../mlflow/store/tracking/sqlalchemy_store.py:1695: in get_logged_model
    self._raise_model_not_found(model_id)
        logged_model = None
        model_id   = '24d816b2-ab1a-4f1e-9eac-2551fd87a87e'
        self       = <mlflow.store.tracking.sqlalchemy_store.SqlAlchemyStore object at 0x7f69edb17a30>
        session    = <sqlalchemy.orm.session.Session object at 0x7f69eda56220>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <mlflow.store.tracking.sqlalchemy_store.SqlAlchemyStore object at 0x7f69edb17a30>
model_id = '24d816b2-ab1a-4f1e-9eac-2551fd87a87e'

    def _raise_model_not_found(self, model_id: str):
>       raise MlflowException(
            f"Logged model with ID '{model_id}' not found.",
            RESOURCE_DOES_NOT_EXIST,
        )
E       mlflow.exceptions.MlflowException: Logged model with ID '24d816b2-ab1a-4f1e-9eac-2551fd87a87e' not found.
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
