### PR TITLE
Use `ModelInfo.model_uri` in `prophet` and `pmdrima` tests

### DIFF
--- a/tests/pmdarima/test_pmdarima_model_export.py
+++ b/tests/pmdarima/test_pmdarima_model_export.py
@@ -195,11 +195,9 @@ def test_pmdarima_log_model(auto_arima_model, tmp_path, should_start_run):
             artifact_path,
             conda_env=str(conda_env),
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-        assert model_info.model_uri == model_uri
-        reloaded_model = mlflow.pmdarima.load_model(model_uri=model_uri)
+        reloaded_model = mlflow.pmdarima.load_model(model_uri=model_info.model_uri)
         np.testing.assert_array_equal(auto_arima_model.predict(20), reloaded_model.predict(20))
-        model_path = Path(_download_artifact_from_uri(artifact_uri=model_uri))
+        model_path = Path(_download_artifact_from_uri(artifact_uri=model_info.model_uri))
         model_config = Model.load(str(model_path.joinpath("MLmodel")))
         assert pyfunc.FLAVOR_NAME in model_config.flavors
         assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
@@ -215,15 +213,16 @@ def test_pmdarima_log_model_calls_register_model(auto_arima_object_model, tmp_pa
     with mlflow.start_run(), register_model_patch:
         conda_env = tmp_path.joinpath("conda_env.yaml")
         _mlflow_conda_env(conda_env, additional_pip_deps=["pmdarima"])
-        mlflow.pmdarima.log_model(
+        model_info = mlflow.pmdarima.log_model(
             auto_arima_object_model,
             artifact_path,
             conda_env=str(conda_env),
             registered_model_name="PmdarimaModel",
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
         assert_register_model_called_with_local_model_path(
-            mlflow.tracking._model_registry.fluent._register_model, model_uri, "PmdarimaModel"
+            mlflow.tracking._model_registry.fluent._register_model,
+            model_info.model_uri,
+            "PmdarimaModel",
         )
 
 
@@ -268,27 +267,27 @@ def test_pmdarima_log_model_with_pip_requirements(auto_arima_object_model, tmp_p
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.pmdarima.log_model(auto_arima_object_model, "model", pip_requirements=str(req_file))
-        _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
+        model_info = mlflow.pmdarima.log_model(
+            auto_arima_object_model, "model", pip_requirements=str(req_file)
         )
+        _assert_pip_requirements(model_info.model_uri, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.pmdarima.log_model(
+        model_info = mlflow.pmdarima.log_model(
             auto_arima_object_model, "model", pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
+            model_info.model_uri, [expected_mlflow_version, "a", "b"], strict=True
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.pmdarima.log_model(
+        model_info = mlflow.pmdarima.log_model(
             auto_arima_object_model, "model", pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "b", "-c constraints.txt"],
             ["a"],
             strict=True,
@@ -303,27 +302,29 @@ def test_pmdarima_log_model_with_extra_pip_requirements(auto_arima_model, tmp_pa
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.pmdarima.log_model(auto_arima_model, "model", extra_pip_requirements=str(req_file))
+        model_info = mlflow.pmdarima.log_model(
+            auto_arima_model, "model", extra_pip_requirements=str(req_file)
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a"]
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.pmdarima.log_model(
+        model_info = mlflow.pmdarima.log_model(
             auto_arima_model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a", "b"]
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.pmdarima.log_model(
+        model_info = mlflow.pmdarima.log_model(
             auto_arima_model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            model_uri=mlflow.get_artifact_uri("model"),
+            model_uri=model_info.model_uri,
             requirements=[expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"],
             constraints=["a"],
             strict=False,
@@ -342,9 +343,8 @@ def test_pmdarima_model_log_without_conda_env_uses_default_env_with_expected_dep
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.pmdarima.log_model(auto_arima_object_model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-    _assert_pip_requirements(model_uri, mlflow.pmdarima.get_default_pip_requirements())
+        model_info = mlflow.pmdarima.log_model(auto_arima_object_model, artifact_path)
+    _assert_pip_requirements(model_info.model_uri, mlflow.pmdarima.get_default_pip_requirements())
 
 
 def test_pmdarima_pyfunc_serve_and_score(auto_arima_model):
@@ -411,10 +411,11 @@ def test_log_model_with_code_paths(auto_arima_model):
         mlflow.start_run(),
         mock.patch("mlflow.pmdarima._add_code_from_conf_to_system_path") as add_mock,
     ):
-        mlflow.pmdarima.log_model(auto_arima_model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.pmdarima.FLAVOR_NAME)
-        mlflow.pmdarima.load_model(model_uri)
+        model_info = mlflow.pmdarima.log_model(
+            auto_arima_model, artifact_path, code_paths=[__file__]
+        )
+        _compare_logged_code_paths(__file__, model_info.model_uri, mlflow.pmdarima.FLAVOR_NAME)
+        mlflow.pmdarima.load_model(model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -439,14 +440,13 @@ def test_model_log_with_metadata(auto_arima_model):
     artifact_path = "model"
 
     with mlflow.start_run():
-        mlflow.pmdarima.log_model(
+        model_info = mlflow.pmdarima.log_model(
             auto_arima_model,
             artifact_path,
             metadata={"metadata_key": "metadata_value"},
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
@@ -455,11 +455,12 @@ def test_model_log_with_signature_inference(auto_arima_model):
     example = pd.DataFrame({"n_periods": 60, "return_conf_int": True, "alpha": 0.1}, index=[0])
 
     with mlflow.start_run():
-        mlflow.pmdarima.log_model(auto_arima_model, artifact_path, input_example=example)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.pmdarima.log_model(
+            auto_arima_model, artifact_path, input_example=example
+        )
 
-    model_info = Model.load(model_uri)
-    assert model_info.signature == ModelSignature(
+    model_info_loaded = Model.load(model_info.model_uri)
+    assert model_info_loaded.signature == ModelSignature(
         inputs=Schema(
             [
                 ColSpec(name="n_periods", type=DataType.long),

--- a/tests/prophet/test_prophet_model_export.py
+++ b/tests/prophet/test_prophet_model_export.py
@@ -225,16 +225,14 @@ def test_prophet_log_model(prophet_model, tmp_path, should_start_run):
         model_info = mlflow.prophet.log_model(
             prophet_model.model, artifact_path, conda_env=str(conda_env)
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
-        assert model_info.model_uri == model_uri
-        reloaded_prophet_model = mlflow.prophet.load_model(model_uri=model_uri)
+        reloaded_prophet_model = mlflow.prophet.load_model(model_uri=model_info.model_uri)
 
         np.testing.assert_array_equal(
             generate_forecast(prophet_model.model, FORECAST_HORIZON),
             generate_forecast(reloaded_prophet_model, FORECAST_HORIZON),
         )
 
-        model_path = Path(_download_artifact_from_uri(artifact_uri=model_uri))
+        model_path = Path(_download_artifact_from_uri(artifact_uri=model_info.model_uri))
         model_config = Model.load(str(model_path.joinpath("MLmodel")))
         assert pyfunc.FLAVOR_NAME in model_config.flavors
         assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
@@ -251,16 +249,15 @@ def test_log_model_calls_register_model(prophet_model, tmp_path):
     with mlflow.start_run(), register_model_patch:
         conda_env = tmp_path.joinpath("conda_env.yaml")
         _mlflow_conda_env(conda_env, additional_pip_deps=["pystan", "prophet"])
-        mlflow.prophet.log_model(
+        model_info = mlflow.prophet.log_model(
             prophet_model.model,
             artifact_path,
             conda_env=str(conda_env),
             registered_model_name="ProphetModel1",
         )
-        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
         assert_register_model_called_with_local_model_path(
             register_model_mock=mlflow.tracking._model_registry.fluent._register_model,
-            model_uri=model_uri,
+            model_uri=model_info.model_uri,
             registered_model_name="ProphetModel1",
         )
 
@@ -308,27 +305,27 @@ def test_log_model_with_pip_requirements(prophet_model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.prophet.log_model(prophet_model.model, "model", pip_requirements=str(req_file))
-        _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
+        model_info = mlflow.prophet.log_model(
+            prophet_model.model, "model", pip_requirements=str(req_file)
         )
+        _assert_pip_requirements(model_info.model_uri, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.prophet.log_model(
+        model_info = mlflow.prophet.log_model(
             prophet_model.model, "model", pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
+            model_info.model_uri, [expected_mlflow_version, "a", "b"], strict=True
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.prophet.log_model(
+        model_info = mlflow.prophet.log_model(
             prophet_model.model, "model", pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "b", "-c constraints.txt"],
             ["a"],
             strict=True,
@@ -343,27 +340,29 @@ def test_log_model_with_extra_pip_requirements(prophet_model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.prophet.log_model(prophet_model.model, "model", extra_pip_requirements=str(req_file))
+        model_info = mlflow.prophet.log_model(
+            prophet_model.model, "model", extra_pip_requirements=str(req_file)
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a"]
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.prophet.log_model(
+        model_info = mlflow.prophet.log_model(
             prophet_model.model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
+            model_info.model_uri, [expected_mlflow_version, *default_reqs, "a", "b"]
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.prophet.log_model(
+        model_info = mlflow.prophet.log_model(
             prophet_model.model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            model_uri=mlflow.get_artifact_uri("model"),
+            model_uri=model_info.model_uri,
             requirements=[expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"],
             constraints=["a"],
             strict=False,
@@ -382,9 +381,8 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.prophet.log_model(prophet_model.model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-    _assert_pip_requirements(model_uri, mlflow.prophet.get_default_pip_requirements())
+        model_info = mlflow.prophet.log_model(prophet_model.model, artifact_path)
+    _assert_pip_requirements(model_info.model_uri, mlflow.prophet.get_default_pip_requirements())
 
 
 def test_pyfunc_serve_and_score(prophet_model):
@@ -433,10 +431,11 @@ def test_log_model_with_code_paths(prophet_model):
         mlflow.start_run(),
         mock.patch("mlflow.prophet._add_code_from_conf_to_system_path") as add_mock,
     ):
-        mlflow.prophet.log_model(prophet_model.model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.prophet.FLAVOR_NAME)
-        mlflow.prophet.load_model(model_uri)
+        model_info = mlflow.prophet.log_model(
+            prophet_model.model, artifact_path, code_paths=[__file__]
+        )
+        _compare_logged_code_paths(__file__, model_info.model_uri, mlflow.prophet.FLAVOR_NAME)
+        mlflow.prophet.load_model(model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -461,14 +460,13 @@ def test_model_log_with_metadata(prophet_model):
     artifact_path = "model"
 
     with mlflow.start_run():
-        mlflow.prophet.log_model(
+        model_info = mlflow.prophet.log_model(
             prophet_model.model,
             artifact_path,
             metadata={"metadata_key": "metadata_value"},
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
@@ -479,8 +477,7 @@ def test_model_log_with_signature_inference(prophet_model):
     signature = infer_signature(horizon_df, model.predict(horizon_df))
 
     with mlflow.start_run():
-        mlflow.prophet.log_model(model, artifact_path, input_example=horizon_df)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.prophet.log_model(model, artifact_path, input_example=horizon_df)
 
-    model_info = Model.load(model_uri)
-    assert model_info.signature == signature
+    loaded_model = Model.load(model_info.model_uri)
+    assert loaded_model.signature == signature


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14673?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14673/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14673
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `ModelInfo.model_uri` in `prophet` and `pmdrima` tests.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
