### PR TITLE
Fix `RegressorEvaluator` for a regressor that returns a dataframe with multiple columns

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -61,6 +61,92 @@ def _extract_raw_model(model):
         return model_loader_module, None
 
 
+def _extract_output_and_other_columns(
+    model_predictions: Union[list, dict, pd.DataFrame, pd.Series],
+    output_column_name: Optional[str],
+) -> tuple[pd.Series, Optional[pd.DataFrame], str]:
+    y_pred = None
+    other_output_columns = None
+    ERROR_MISSING_OUTPUT_COLUMN_NAME = (
+        "Output column name is not specified for the multi-output model. "
+        "Please set the correct output column name using the `predictions` parameter."
+    )
+
+    if isinstance(model_predictions, list) and all(isinstance(p, dict) for p in model_predictions):
+        # Extract 'y_pred' and 'other_output_columns' from list of dictionaries
+        if output_column_name in model_predictions[0]:
+            y_pred = pd.Series(
+                [p.get(output_column_name) for p in model_predictions], name=output_column_name
+            )
+            other_output_columns = pd.DataFrame(
+                [{k: v for k, v in p.items() if k != output_column_name} for p in model_predictions]
+            )
+        elif len(model_predictions[0]) == 1:
+            # Set the only key as self.predictions and its value as self.y_pred
+            key, value = list(model_predictions[0].items())[0]
+            y_pred = pd.Series(value, name=key)
+            output_column_name = key
+        elif output_column_name is None:
+            raise MlflowException(
+                ERROR_MISSING_OUTPUT_COLUMN_NAME,
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        else:
+            raise MlflowException(
+                f"Output column name '{output_column_name}' is not found in the model "
+                f"predictions list: {model_predictions}. Please set the correct output column "
+                "name using the `predictions` parameter.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+    elif isinstance(model_predictions, pd.DataFrame):
+        if output_column_name in model_predictions.columns:
+            y_pred = model_predictions[output_column_name]
+            other_output_columns = model_predictions.drop(columns=output_column_name)
+        elif len(model_predictions.columns) == 1:
+            output_column_name = model_predictions.columns[0]
+            y_pred = model_predictions[output_column_name]
+        elif output_column_name is None:
+            raise MlflowException(
+                ERROR_MISSING_OUTPUT_COLUMN_NAME,
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        else:
+            raise MlflowException(
+                f"Output column name '{output_column_name}' is not found in the model "
+                f"predictions dataframe {model_predictions.columns}. Please set the correct "
+                "output column name using the `predictions` parameter.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+    elif isinstance(model_predictions, dict):
+        if output_column_name in model_predictions:
+            y_pred = pd.Series(model_predictions[output_column_name], name=output_column_name)
+            other_output_columns = pd.DataFrame(
+                {k: v for k, v in model_predictions.items() if k != output_column_name}
+            )
+        elif len(model_predictions) == 1:
+            key, value = list(model_predictions.items())[0]
+            y_pred = pd.Series(value, name=key)
+            output_column_name = key
+        elif output_column_name is None:
+            raise MlflowException(
+                ERROR_MISSING_OUTPUT_COLUMN_NAME,
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        else:
+            raise MlflowException(
+                f"Output column name '{output_column_name}' is not found in the "
+                f"model predictions dict {model_predictions}. Please set the correct "
+                "output column name using the `predictions` parameter.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+    return (
+        y_pred if y_pred is not None else model_predictions,
+        other_output_columns,
+        output_column_name,
+    )
+
+
 def _extract_predict_fn(model: Any) -> Optional[Callable]:
     """
     Extracts the predict function from the given model or raw_model.

--- a/mlflow/models/evaluation/evaluators/regressor.py
+++ b/mlflow/models/evaluation/evaluators/regressor.py
@@ -1,13 +1,13 @@
 from typing import Optional
 
 import numpy as np
-import pandas as pd
 from sklearn import metrics as sk_metrics
 
 import mlflow
 from mlflow.models.evaluation.base import EvaluationMetric, EvaluationResult, _ModelType
 from mlflow.models.evaluation.default_evaluator import (
     BuiltInEvaluator,
+    _extract_output_and_other_columns,
     _extract_predict_fn,
     _get_aggregate_metrics_values,
 )
@@ -53,12 +53,8 @@ class RegressorEvaluator(BuiltInEvaluator):
     def _generate_model_predictions(self, model, input_df):
         if predict_fn := _extract_predict_fn(model):
             preds = predict_fn(input_df)
-            if isinstance(preds, pd.DataFrame):
-                if preds.shape[1] != 1:
-                    raise ValueError(f"Predictions must be a 1D array, but got shape {preds.shape}")
-                return preds.iloc[:, 0].values
-            else:
-                return preds
+            y_pred, _, _ = _extract_output_and_other_columns(preds, self.predictions)
+            return y_pred
         else:
             return self.dataset.predictions_data
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -4274,13 +4274,14 @@ def test_evaluate_errors_invalid_pos_label():
 
 
 @pytest.mark.parametrize(
-    "model_output",
+    ("model_output", "predictions"),
     [
-        pd.DataFrame({"output": [0, 1, 2]}),
-        pd.Series([0, 1, 2]),
+        (pd.DataFrame({"output": [0, 1, 2]}), None),
+        (pd.DataFrame({"output_1": [0, 1, 2], "output_2": [4, 5, 6]}), "output_1"),
+        (pd.Series([0, 1, 2]), None),
     ],
 )
-def test_regressor_returning_pandas_object(model_output):
+def test_regressor_returning_pandas_object(model_output, predictions):
     class Model(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input):
             return model_output
@@ -4297,6 +4298,7 @@ def test_regressor_returning_pandas_object(model_output):
             ),
             targets="output",
             model_type="regressor",
+            predictions=predictions,
             evaluators=["regressor"],
         )
         assert result.metrics == {

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -53,6 +53,7 @@ from mlflow.models.evaluation.base import evaluate
 from mlflow.models.evaluation.default_evaluator import (
     _CustomArtifact,
     _evaluate_custom_artifacts,
+    _extract_output_and_other_columns,
     _extract_predict_fn,
     _extract_raw_model,
     _get_aggregate_metrics_values,
@@ -65,7 +66,6 @@ from mlflow.models.evaluation.evaluators.classifier import (
     _get_multiclass_classifier_metrics,
     _infer_model_type_by_labels,
 )
-from mlflow.models.evaluation.evaluators.default import _extract_output_and_other_columns
 from mlflow.models.evaluation.evaluators.regressor import _get_regressor_metrics
 from mlflow.models.evaluation.evaluators.shap import _compute_df_mode_or_mean
 from mlflow.models.evaluation.utils.metric import MetricDefinition


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/JulesLandrySimard/mlflow/pull/14680?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14680/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14680
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

Fix https://github.com/mlflow/mlflow/issues/14376
Follow up on https://github.com/mlflow/mlflow/pull/14388 which itself introduces a regression.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The `mlflow.evaluate` API includes a `predictions` argument that selects the column from the return of `predict_fn` when it is a dataframe. That logic was previously implemented in [`_extract_output_and_other_columns`](https://github.com/mlflow/mlflow/blob/v2.17.2/mlflow/models/evaluation/default_evaluator.py#L525) as part of the default evaluator. 

When https://github.com/mlflow/mlflow/pull/13360 refactors the evaluators into multiple class, that function was omitted from the regressor evaluator. https://github.com/mlflow/mlflow/pull/14388 intended to fix it but simply threw an error if `predict_fn` returns a dataframe.

This PR proposes reusing `_extract_output_and_other_columns` from the default evaluator to handle different format types in the `predict` return type.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```
import mlflow
import numpy as np
import pandas as pd
from sklearn.linear_model import LinearRegression
from sklearn.model_selection import train_test_split
from sklearn.base import BaseEstimator, RegressorMixin

print("MLflow version:", mlflow.__version__)
mlflow.sklearn.autolog()

dataset_url = "http://archive.ics.uci.edu/ml/machine-learning-databases/auto-mpg/auto-mpg.data"
column_names = [
    "MPG", "Cylinders", "Displacement", "Horsepower", "Weight", "Acceleration", "Model Year", "Origin"
]
dataset = pd.read_csv(dataset_url, names=column_names, na_values="?", comment="\t", sep=" ", skipinitialspace=True)
dataset = dataset.dropna(how="any")
dataset["Origin"] = dataset["Origin"].map({1: "USA", 2: "Europe", 3: "Japan"})

X_full = dataset[["Horsepower", "Weight"]]
y = dataset["MPG"]

X_train, X_test, y_train, y_test = train_test_split(X_full, y, test_size=0.2, random_state=0)

class CustomModel(BaseEstimator, RegressorMixin):
    def fit(self, X, y):
        return self

    def predict(self, X):
        return pd.DataFrame({"predicted_MPG": X.iloc[:, 0], "extra_output": X.iloc[:, 1]})

model = CustomModel()

with mlflow.start_run(run_name="sklearn-custom-model") as run:
    model.fit(X_train, y_train)

    # Explicitly log the custom model
    mlflow.sklearn.log_model(model, "model")

run = mlflow.get_run(run_id=run.info.run_id)
model_uri = f"runs:/{run.info.run_id}/model"

eval_data = X_test.assign(MPG= y_test)
eval_data = mlflow.data.from_pandas(eval_data, name="auto_mpg_horsepower", source=dataset_url, targets="MPG")

print(f"Evaluating model from {model_uri}...")
result = mlflow.evaluate(model_uri, eval_data, model_type="regressor", predictions="predicted_MPG")
print(result)

```

### Stack trace

#### On main
```
File ~/mlflow/mlflow/models/evaluation/evaluators/regressor.py:58, in RegressorEvaluator._generate_model_predictions(self, model, input_df)
     56 if isinstance(preds, pd.DataFrame):
     57     if preds.shape[1] != 1:
---> 58         raise ValueError(f"Predictions must be a 1D array, but got shape {preds.shape}")
     59     return preds.iloc[:, 0].values
     60 else:

ValueError: Predictions must be a 1D array, but got shape (79, 2)
```
#### On PR
```
MLflow version: 2.20.3.dev0
2025/02/25 04:33:01 WARNING mlflow.models.model: Model logged without a signature and input example. Please set `input_example` parameter when logging the model to auto infer the model signature.
/home/ubuntu/mlflow/mlflow/data/dataset_source_registry.py:149: UserWarning: Failed to determine whether UCVolumeDatasetSource can resolve source information for 'http://archive.ics.uci.edu/ml/machine-learning-databases/auto-mpg/auto-mpg.data'. Exception: 
  return _dataset_source_registry.resolve(
Evaluating model from runs:/4d153f51f16a45929e5201ed7e7cec0d/model...
2025/02/25 04:33:02 WARNING mlflow.models.evaluation.default_evaluator: Computing sklearn model score failed: ValueError('y_true and y_pred have different number of output (1!=2)'). Set logging level to DEBUG to see the full traceback.
2025/02/25 04:33:02 INFO mlflow.models.evaluation.default_evaluator: Testing metrics on first row...
2025/02/25 04:33:02 WARNING mlflow.models.evaluation.evaluators.shap: SHAP or matplotlib package is not installed, so model explainability insights will not be logged.
<mlflow.models.evaluation.base.EvaluationResult object at 0x7955b10a13d0>
```

#### On 2.17

```
MLflow version: 2.17.0
2025/02/25 04:35:26 WARNING mlflow.utils.requirements_utils: Detected one or more mismatches between the model's dependencies and the current Python environment:
 - mlflow (current: 2.20.3.dev0, required: mlflow==2.17.0)
To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` to fetch the model's environment and install dependencies using the resulting environment file.
2025/02/25 04:35:26 WARNING mlflow.models.model: Model logged without a signature and input example. Please set `input_example` parameter when logging the model to auto infer the model signature.
/home/ubuntu/mlflow/mlflow/data/dataset_source_registry.py:149: UserWarning: Failed to determine whether UCVolumeDatasetSource can resolve source information for 'http://archive.ics.uci.edu/ml/machine-learning-databases/auto-mpg/auto-mpg.data'. Exception: 
  return _dataset_source_registry.resolve(
Evaluating model from runs:/904e49c711ec4bd4a4aae5e74c573ff1/model...
2025/02/25 04:35:27 WARNING mlflow.utils.requirements_utils: Detected one or more mismatches between the model's dependencies and the current Python environment:
 - mlflow (current: 2.20.3.dev0, required: mlflow==2.17.0)
To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` to fetch the model's environment and install dependencies using the resulting environment file.
2025/02/25 04:35:27 INFO mlflow.models.evaluation.default_evaluator: Computing model predictions.
2025/02/25 04:35:27 WARNING mlflow.models.evaluation.default_evaluator: Computing sklearn model score failed: ValueError('y_true and y_pred have different number of output (1!=2)'). Set logging level to DEBUG to see the full traceback.
/home/ubuntu/mlflow/.venvs/mlflow-dev/lib/python3.9/site-packages/sklearn/metrics/_regression.py:492: FutureWarning: 'squared' is deprecated in version 1.4 and will be removed in 1.6. To calculate the root mean squared error, use the function'root_mean_squared_error'.
  warnings.warn(
2025/02/25 04:35:27 INFO mlflow.models.evaluation.default_evaluator: Testing metrics on first row...
2025/02/25 04:35:27 WARNING mlflow.models.evaluation.default_evaluator: SHAP or matplotlib package is not installed, so model explainability insights will not be logged.
<mlflow.models.evaluation.base.EvaluationResult object at 0x72eb7aee1f10>
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
