### PR TITLE
Cast `version` to `int` in `UnityCatalogOssStore`

### DIFF
--- a/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
@@ -297,6 +297,7 @@ class UnityCatalogOssStore(BaseRestStore):
 
     def update_model_version(self, name, version, description):
         full_name = get_full_name_from_sc(name, None)
+        version = int(version)
         req_body = message_to_json(
             UpdateModelVersion(
                 full_name=full_name,
@@ -320,6 +321,7 @@ class UnityCatalogOssStore(BaseRestStore):
 
     def delete_model_version(self, name, version):
         full_name = get_full_name_from_sc(name, None)
+        version = int(version)
         req_body = message_to_json(DeleteModelVersion(full_name=full_name, version=version))
         endpoint, method = _METHOD_TO_INFO[DeleteModelVersion]
         return self._edit_endpoint_and_call(
@@ -335,6 +337,7 @@ class UnityCatalogOssStore(BaseRestStore):
     # which contains the storage location
     def _get_model_version_endpoint_response(self, name, version):
         full_name = get_full_name_from_sc(name, None)
+        version = int(version)
         req_body = message_to_json(GetModelVersion(full_name=full_name, version=version))
         endpoint, method = _METHOD_TO_INFO[GetModelVersion]
         return self._edit_endpoint_and_call(

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_oss_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_oss_rest_store.py
@@ -163,7 +163,7 @@ def test_get_model_version(mock_http, store, creds, version):
         mock_http,
         "models/catalog_1.schema_1.model_1/versions/0",
         "GET",
-        GetModelVersion(full_name=model_name, version=version),
+        GetModelVersion(full_name=model_name, version=int(version)),
     )
 
 
@@ -178,7 +178,7 @@ def test_update_model_version(mock_http, store, creds, version):
         "PATCH",
         UpdateModelVersion(
             full_name=model_name,
-            version=0,
+            version=int(version),
             comment="new description",
         ),
     )
@@ -193,7 +193,7 @@ def test_delete_model_version(mock_http, store, creds, version):
         mock_http,
         "models/catalog_1.schema_1.model_1/versions/0",
         "DELETE",
-        DeleteModelVersion(full_name=model_name, version=version),
+        DeleteModelVersion(full_name=model_name, version=int(version)),
     )
 
 

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_oss_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_oss_rest_store.py
@@ -154,10 +154,10 @@ def test_create_model_version(mock_http, store, creds):
             )
 
 
+@pytest.mark.parametrize("version", [0, "0"])
 @mock_http_200
-def test_get_model_version(mock_http, store, creds):
+def test_get_model_version(mock_http, store, creds, version):
     model_name = "catalog_1.schema_1.model_1"
-    version = 0
     store.get_model_version(name=model_name, version=version)
     _verify_requests(
         mock_http,
@@ -167,10 +167,10 @@ def test_get_model_version(mock_http, store, creds):
     )
 
 
+@pytest.mark.parametrize("version", [0, "0"])
 @mock_http_200
-def test_update_model_version(mock_http, store, creds):
+def test_update_model_version(mock_http, store, creds, version):
     model_name = "catalog_1.schema_1.model_1"
-    version = 0
     store.update_model_version(name=model_name, version=version, description="new description")
     _verify_requests(
         mock_http,
@@ -184,10 +184,10 @@ def test_update_model_version(mock_http, store, creds):
     )
 
 
+@pytest.mark.parametrize("version", [0, "0"])
 @mock_http_200
-def test_delete_model_version(mock_http, store, creds):
+def test_delete_model_version(mock_http, store, creds, version):
     model_name = "catalog_1.schema_1.model_1"
-    version = 0
     store.delete_model_version(name=model_name, version=version)
     _verify_requests(
         mock_http,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14683?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14683/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14683
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

UC rest store expects `version` to be `int`, not string. It's possible that a string is passed as `version`. This PR casts it to `int`.

```python
File /local_disk0/.ephemeral_nfs/envs/pythonEnv-b15e3e44-529f-44c9-9647-db785d7c313a/lib/python3.11/site-packages/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py:342, in UnityCatalogOssStore._get_model_version_endpoint_response(self, name, version)
    340 def _get_model_version_endpoint_response(self, name, version):
    341     full_name = get_full_name_from_sc(name, None)
--> 342     req_body = message_to_json(GetModelVersion(full_name=full_name, version=version))
    343     endpoint, method = _METHOD_TO_INFO[GetModelVersion]
    344     return self._edit_endpoint_and_call(
    345         endpoint=endpoint,
    346         method=method,
   (...)
    350         version=version,
    351     )
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
