### PR TITLE
Use `ModelInfo.model_uri` in shap tests

### DIFF
--- a/mlflow/shap/__init__.py
+++ b/mlflow/shap/__init__.py
@@ -339,7 +339,7 @@ def log_explainer(
         metadata: {{ metadata }}
     """
 
-    Model.log(
+    return Model.log(
         artifact_path=artifact_path,
         flavor=mlflow.shap,
         explainer=explainer,

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -298,27 +298,31 @@ def test_log_model_with_pip_requirements(shap_model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.shap.log_explainer(shap_model, "model", pip_requirements=str(req_file))
+        model_info = mlflow.shap.log_explainer(shap_model, "model", pip_requirements=str(req_file))
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "a", *sklearn_default_reqs],
             strict=False,
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.shap.log_explainer(shap_model, "model", pip_requirements=[f"-r {req_file}", "b"])
+        model_info = mlflow.shap.log_explainer(
+            shap_model, "model", pip_requirements=[f"-r {req_file}", "b"]
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "a", "b", *sklearn_default_reqs],
             strict=False,
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.shap.log_explainer(shap_model, "model", pip_requirements=[f"-c {req_file}", "b"])
+        model_info = mlflow.shap.log_explainer(
+            shap_model, "model", pip_requirements=[f"-c {req_file}", "b"]
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            model_info.model_uri,
             [expected_mlflow_version, "b", "-c constraints.txt", *sklearn_default_reqs],
             ["a"],
             strict=False,
@@ -334,29 +338,31 @@ def test_log_model_with_extra_pip_requirements(shap_model, tmp_path):
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.shap.log_explainer(shap_model, "model", extra_pip_requirements=str(req_file))
+        log_info = mlflow.shap.log_explainer(
+            shap_model, "model", extra_pip_requirements=str(req_file)
+        )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            log_info.model_uri,
             [expected_mlflow_version, *shap_default_reqs, "a", *sklearn_default_reqs],
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.shap.log_explainer(
+        log_info = mlflow.shap.log_explainer(
             shap_model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            log_info.model_uri,
             [expected_mlflow_version, *shap_default_reqs, "a", "b", *sklearn_default_reqs],
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.shap.log_explainer(
+        log_info = mlflow.shap.log_explainer(
             shap_model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
+            log_info.model_uri,
             [
                 expected_mlflow_version,
                 *shap_default_reqs,
@@ -407,11 +413,10 @@ def test_pyfunc_serve_and_score_njit():
     )
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.shap.log_explainer(model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.shap.log_explainer(model, artifact_path)
 
     resp = pyfunc_serve_and_score_model(
-        model_uri,
+        model_info.model_uri,
         data=pd.DataFrame(X[:3]),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
     )
@@ -443,11 +448,10 @@ def test_pyfunc_serve_and_score():
     )
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.shap.log_explainer(model, artifact_path)
-        model_uri = mlflow.get_artifact_uri(artifact_path)
+        model_info = mlflow.shap.log_explainer(model, artifact_path)
 
     resp = pyfunc_serve_and_score_model(
-        model_uri,
+        model_info.model_uri,
         data=pd.DataFrame(X[:3]),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
     )
@@ -462,10 +466,9 @@ def test_log_model_with_code_paths(shap_model):
         mlflow.start_run(),
         mock.patch("mlflow.shap._add_code_from_conf_to_system_path") as add_mock,
     ):
-        mlflow.shap.log_explainer(shap_model, artifact_path, code_paths=[__file__])
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-        _compare_logged_code_paths(__file__, model_uri, mlflow.shap.FLAVOR_NAME)
-        mlflow.shap.load_explainer(model_uri)
+        model_info = mlflow.shap.log_explainer(shap_model, artifact_path, code_paths=[__file__])
+        _compare_logged_code_paths(__file__, model_info.model_uri, mlflow.shap.FLAVOR_NAME)
+        mlflow.shap.load_explainer(model_info.model_uri)
         add_mock.assert_called()
 
 
@@ -483,10 +486,9 @@ def test_model_log_with_metadata(shap_model):
     artifact_path = "model"
 
     with mlflow.start_run():
-        mlflow.shap.log_explainer(
+        model_info = mlflow.shap.log_explainer(
             shap_model, artifact_path=artifact_path, metadata={"metadata_key": "metadata_value"}
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14687?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14687/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14687
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `ModelInfo.model_uri` in shap tests. This is a final PR to update cross-version `models` tests.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
