### PR TITLE
Add autologging for txtai

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -202,6 +202,7 @@ def pytest_ignore_collect(collection_path, config):
             "tests/statsmodels",
             "tests/tensorflow",
             "tests/transformers",
+            "tests/txtai",
             "tests/xgboost",
             # Lazy loading test.
             "tests/test_mlflow_lazily_imports_ml_packages.py",

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -100,6 +100,7 @@ spark = LazyLoader("mlflow.spark", globals(), "mlflow.spark")
 statsmodels = LazyLoader("mlflow.statsmodels", globals(), "mlflow.statsmodels")
 tensorflow = LazyLoader("mlflow.tensorflow", globals(), "mlflow.tensorflow")
 transformers = LazyLoader("mlflow.transformers", globals(), "mlflow.transformers")
+txtai = LazyLoader("mlflow.txtai", globals(), "mlflow.txtai")
 xgboost = LazyLoader("mlflow.xgboost", globals(), "mlflow.xgboost")
 
 if MLFLOW_CONFIGURE_LOGGING.get() is True:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -980,3 +980,15 @@ bedrock:
     minimum: "1.33.0"
     maximum: "1.35.97"
     run: pytest tests/bedrock
+
+txtai:
+  package_info:
+    pip_release: "txtai"
+    module_name: "txtai"
+    install_dev: |
+      pip install git+https://github.com/neuml/txtai
+  autologging:
+    minimum: "8.0.0"
+    maximum: "8.3.1"
+    requirements:
+    run: pytest tests/txtai

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -393,6 +393,16 @@ _ML_PACKAGE_VERSIONS = {
             "minimum": "1.33.0",
             "maximum": "1.35.97"
         }
+    },
+    "txtai": {
+        "package_info": {
+            "pip_release": "txtai",
+            "module_name": "txtai"
+        },
+        "autologging": {
+            "minimum": "8.0.0",
+            "maximum": "8.3.1"
+        }
     }
 }
 
@@ -424,5 +434,6 @@ FLAVOR_TO_MODULE_NAME = {
     "litellm": "litellm",
     "groq": "groq",
     "bedrock": "boto3",
+    "txtai": "txtai",
     "pyspark.ml": "pyspark"
 }

--- a/mlflow/txtai/__init__.py
+++ b/mlflow/txtai/__init__.py
@@ -1,0 +1,147 @@
+"""
+The ``mlflow.txtai`` module provides an API for tracing txtai methods.
+"""
+
+import collections
+import inspect
+
+from mlflow.txtai.autolog import patch_class_call, patch_generator
+from mlflow.utils.annotations import experimental
+from mlflow.utils.autologging_utils import autologging_integration, safe_patch
+
+FLAVOR_NAME = "txtai"
+
+
+@experimental
+def autolog(
+    log_traces: bool = True,
+    disable: bool = False,
+    silent: bool = False,
+):
+    """
+    Enables (or disables) and configures autologging from txtai to MLflow. Currently, MLflow
+    only supports autologging for tracing.
+
+    Args:
+        log_traces: If ``True``, traces are logged for txtai calls. If ``False``,
+            no traces are collected during inference. Default to ``True``.
+        disable: If ``True``, disables the txtai autologging integration. If ``False``,
+            enables the txtai autologging integration.
+        silent: If ``True``, suppress all event logs and warnings from MLflow during txtai
+            autologging. If ``False``, show all events and warnings.
+    """
+
+    # This needs to be called before doing any safe-patching (otherwise safe-patch will be no-op).
+    _autolog(log_traces, disable, silent)
+
+    # pylint: disable=C0415
+    import txtai
+
+    # Base mappings
+    mappings = {
+        txtai.archive.Archive: ["load", "save"],
+        txtai.Agent: ["__call__"],
+        txtai.cloud.Cloud: ["load", "save"],
+        txtai.Embeddings: ["batchsearch", "delete", "index", "load", "save", "upsert"],
+        txtai.LLM: ["__call__"],
+        txtai.RAG: ["__call__"],
+        txtai.workflow.Task: ["__call__"],
+        txtai.Workflow: ["__call__"],
+        txtai.vectors.Vectors: ["vectorize"],
+    }
+
+    # Add component mappings
+    _components(mappings)
+
+    # Add autologging
+    for target, methods in mappings.items():
+        for method in methods:
+            function = getattr(target, method)
+
+            # Separate path for patching generator methods vs standard methods
+            if inspect.isgeneratorfunction(function):
+                patch_generator(target, method, function)
+            else:
+                safe_patch(FLAVOR_NAME, target, method, patch_class_call)
+
+
+# pylint: disable=W0613
+# The @autologging_integration annotation must be applied here, and the callback injection
+# needs to happen outside the annotated function. This is because the annotated function is NOT
+# executed when disable=True is passed. This prevents us from removing our callback and patching
+# when autologging is turned off.
+@autologging_integration(FLAVOR_NAME)
+def _autolog(
+    log_traces: bool,
+    disable: bool = False,
+    silent: bool = False,
+):
+    pass
+
+
+def _components(mappings):
+    """
+    Add mappings for txtai components.
+
+    Args:
+        mappings: where to add mappings
+    """
+
+    # pylint: disable=C0415
+    import txtai
+
+    # ANN
+    for target in vars(txtai.ann).values():
+        if _is_subclass(target, txtai.ann.ANN):
+            mappings[target] = ["append", "delete", "index", "load", "save", "search"]
+
+    # Database, Graph, Scoring
+    for module, clss in [
+        (txtai.database, txtai.database.Database),
+        (txtai.graph, txtai.graph.Graph),
+        (txtai.scoring, txtai.scoring.Scoring),
+    ]:
+        for target in vars(module).values():
+            if _is_subclass(target, clss):
+                mappings[target] = ["delete", "insert", "load", "save", "search"]
+
+                if hasattr(target, "index"):
+                    mappings[target] += ["index", "upsert"]
+
+    # Pipelines
+    for target in vars(txtai.pipeline).values():
+        if (
+            _is_subclass(target, txtai.pipeline.Pipeline)
+            and _is_callable(target)
+            and target not in mappings
+        ):
+            mappings[target] = ["__call__"]
+
+
+def _is_callable(target):
+    """
+    Checks if target is a callable method.
+
+    Args:
+        target: method to check
+
+    Returns:
+        True if target is callable
+    """
+
+    return issubclass(target, collections.abc.Callable)
+
+
+def _is_subclass(target, check):
+    """
+    Checks if target is a subclass of check.
+
+    Args:
+        target: class to check
+        check: validation check class
+
+    Returns:
+        True if target is a subclass of check
+    """
+
+    return inspect.isclass(target) and issubclass(target, check) and target != check

--- a/mlflow/txtai/autolog.py
+++ b/mlflow/txtai/autolog.py
@@ -1,0 +1,286 @@
+"""
+Autolog patch methods for ``mlflow.txtai``
+"""
+
+import inspect
+import json
+import warnings
+
+import mlflow
+from mlflow import MlflowClient, start_span
+from mlflow.entities import SpanType
+from mlflow.entities.span_event import SpanEvent
+from mlflow.entities.span_status import SpanStatusCode
+from mlflow.tracing.constant import STREAM_CHUNK_EVENT_NAME_FORMAT, STREAM_CHUNK_EVENT_VALUE_KEY
+from mlflow.tracing.fluent import get_current_active_span
+from mlflow.tracing.provider import safe_set_span_in_context
+from mlflow.tracing.utils import (
+    TraceJSONEncoder,
+    end_client_span_or_trace,
+    start_client_span_or_trace,
+)
+from mlflow.utils.autologging_utils.config import AutoLoggingConfig
+
+
+def patch_generator(target, method, function):
+    """
+    Patches a generator method with trace logging.
+
+    Args:
+        target: target class
+        method: target method
+        function: target.method function
+    """
+
+    def fn(self, *args, **kwargs):
+        return _patch_class_generator(function, self, *args, **kwargs)
+
+    # Add original function as attribute
+    setattr(fn, "__wrapped__", function)
+    setattr(target, method, fn)
+
+
+def patch_class_call(original, self, *args, **kwargs):
+    """
+    Patches a method with trace logging.
+
+    Args:
+        original: original method
+        self: object instance
+        args: arguments
+        kwargs: keyword arguments
+
+    Returns:
+        self.original result
+    """
+
+    config = AutoLoggingConfig.init(flavor_name=mlflow.txtai.FLAVOR_NAME)
+
+    if config.log_traces:
+        with start_span(
+            name=_get_span_name(original, self), span_type=_get_span_type(self)
+        ) as span:
+            # Set attributes
+            for attribute, value in vars(self).items():
+                span.set_attribute(attribute, value)
+
+            # Set inputs
+            inputs = _construct_full_inputs(original, self, *args, **kwargs)
+            span.set_inputs(inputs)
+
+            # Run method
+            results = original(self, *args, **kwargs)
+
+            # Set outputs
+            outputs = results.__dict__ if hasattr(results, "__dict__") else results
+            span.set_outputs(outputs)
+
+            return results
+
+    return None
+
+
+def _patch_class_generator(original, self, *args, **kwargs):
+    """
+    Patches a generator method with trace logging.
+
+    Args:
+        original: generator method
+        self: object instance
+        args: arguments
+        kwargs: keyword arguments
+
+    Returns:
+        self.original result
+    """
+
+    config = AutoLoggingConfig.init(flavor_name=mlflow.txtai.FLAVOR_NAME)
+
+    if config.log_traces:
+        span = _start_stream_span(original, self, *args, **kwargs)
+
+        # Start generator
+        generator = original(self, *args, **kwargs)
+
+        index, outputs = 0, []
+        while True:
+            try:
+                # Set the span to active only when the generator is running
+                with safe_set_span_in_context(span):
+                    value = next(generator)
+            except StopIteration:
+                break
+            except Exception as e:
+                _end_stream_span(span, error=e)
+                raise e
+            else:
+                outputs.append(value)
+                _stream_span_chunk(span, value, index)
+                yield value
+                index += 1
+
+        _end_stream_span(span, outputs)
+
+
+def _start_stream_span(original, self, *args, **kwargs):
+    """
+    Starts a span.
+
+    Args:
+        original: original method
+        self: object instance
+        args: arguments
+        kwargs: keyword arguments
+
+    Returns:
+        span
+    """
+
+    # Start span
+    return start_client_span_or_trace(
+        client=MlflowClient(),
+        name=_get_span_name(original, self),
+        parent_span=get_current_active_span(),
+        span_type=_get_span_type(self),
+        attributes=vars(self),
+        inputs=_construct_full_inputs(original, self, *args, **kwargs),
+    )
+
+
+def _stream_span_chunk(span, chunk, index):
+    """
+    Adds a span event with a chunk of data.
+
+    Args:
+        span: span instance
+        chunk: data chunk
+        index: data chunk index
+    """
+
+    event = SpanEvent(
+        name=STREAM_CHUNK_EVENT_NAME_FORMAT.format(index=index),
+        attributes={STREAM_CHUNK_EVENT_VALUE_KEY: json.dumps(chunk, cls=TraceJSONEncoder)},
+    )
+    span.add_event(event)
+
+
+def _end_stream_span(span, outputs=None, error=None):
+    """
+    Ends a span.
+
+    Args:
+        span: span to end
+        outputs: optional outputs to log
+        error: error to log, if any
+    """
+
+    client = MlflowClient()
+    if error:
+        span.add_event(SpanEvent.from_exception(error))
+        end_client_span_or_trace(client, span, status=SpanStatusCode.ERROR)
+        return
+
+    end_client_span_or_trace(client, span, outputs=outputs)
+
+
+def _get_span_name(original, self):
+    """
+    Creates a span name for inputs.
+
+    Args:
+        original: original method
+        self: object instance
+
+    Returns:
+        span name
+    """
+
+    name = self.__class__.__name__
+    if not original.__name__.startswith("__"):
+        name += f".{original.__name__}"
+
+    return name
+
+
+def _get_span_type(instance):
+    """
+    Maps txtai objects to MLflow span types.
+
+    Args:
+        instance: txtai object instance
+
+    Returns:
+        SpanType
+    """
+
+    # pylint: disable=C0415
+    import txtai
+
+    if isinstance(instance, txtai.Agent):
+        return SpanType.AGENT
+
+    if isinstance(instance, txtai.Embeddings):
+        return SpanType.RETRIEVER
+
+    if isinstance(instance, txtai.LLM):
+        return SpanType.LLM
+
+    if isinstance(instance, (txtai.pipeline.Pipeline, txtai.workflow.Task)):
+        return SpanType.PARSER
+
+    if isinstance(instance, (txtai.RAG, txtai.Workflow)):
+        return SpanType.CHAIN
+
+    if isinstance(instance, txtai.vectors.Vectors):
+        return SpanType.EMBEDDING
+
+    # Default to RETRIEVER
+    return SpanType.RETRIEVER
+
+
+def _construct_full_inputs(func, *args, **kwargs):
+    """
+    Constructs function inputs as a dictionary.
+
+    Args:
+        func: function
+        args: arguments
+        kwargs: keyword arguments
+
+    Returns:
+        dictionary of function inputs
+    """
+
+    # Get function arguments
+    signature = inspect.signature(func)
+    arguments = signature.bind_partial(*args, **kwargs).arguments
+
+    if "self" in arguments:
+        arguments.pop("self")
+
+    # Avoid non serializable objects and circular references
+    return {
+        k: v.__dict__ if hasattr(v, "__dict__") else v
+        for k, v in arguments.items()
+        if v is not None and _is_serializable(v)
+    }
+
+
+def _is_serializable(value):
+    """
+    Checks if a value is serializable.
+
+    Args:
+        value: value to check
+
+    Returns:
+        True if the value is serializable, False otherwise
+    """
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            json.dumps(value, cls=TraceJSONEncoder, ensure_ascii=False)
+        return True
+    except (TypeError, ValueError):
+        return False

--- a/tests/txtai/test_txtai_autolog.py
+++ b/tests/txtai/test_txtai_autolog.py
@@ -1,0 +1,221 @@
+from unittest.mock import Mock, patch
+
+import numpy as np
+import txtai
+
+import mlflow
+from mlflow.entities import SpanType
+
+from tests.tracing.helper import get_traces
+
+
+def _agent(self, *args, **kwargs):
+    def run(s, *a, **kw):
+        return "The Roman Empire ruled the Mediterranean and much of Europe"
+
+    self.process = Mock()
+    self.process.run = run
+
+
+def _embeddings_batchsearch(self, *args, **kwargs):
+    return [[{"id": 0, "text": "text search result", "score": 1.0}]]
+
+
+def _llm(self, *args, **kwargs):
+    def generator(s, *a, **kw):
+        return "The Roman Empire ruled the Mediterranean and much of Europe"
+
+    self.generator = generator
+
+
+def _vectors(self, *args, **kwargs):
+    return np.random.rand(1, 10)
+
+
+def test_enable_disable_autolog():
+    with patch("txtai.Embeddings.batchsearch", _embeddings_batchsearch):
+        mlflow.txtai.autolog()
+
+        embeddings = txtai.Embeddings()
+        embeddings.search("test query")
+
+        traces = get_traces()
+        assert len(traces) == 1
+
+        mlflow.txtai.autolog(disable=True)
+        embeddings.search("test query")
+
+        # New trace should not be created
+        traces = get_traces()
+        assert len(traces) == 1
+
+
+def test_agent():
+    with patch("txtai.Agent.__init__", _agent):
+        mlflow.txtai.autolog()
+
+        agent = txtai.Agent()
+        response = agent("Tell me about the Roman Empire")
+
+        trace = get_traces()[0]
+        assert trace is not None
+        assert trace.info.status == "OK"
+        assert len(trace.data.spans) == 1
+
+        span = trace.data.spans[0]
+        assert span.span_type == SpanType.AGENT
+        assert span.inputs == {"text": "Tell me about the Roman Empire"}
+        assert span.outputs == response
+
+
+def test_ann():
+    mlflow.txtai.autolog()
+
+    ann = txtai.ann.NumPy({})
+    ann.backend = np.random.rand(1, 10)
+
+    results = ann.search(np.random.rand(1, 10), 1)
+
+    trace = get_traces()[0]
+    assert trace is not None
+    assert trace.info.status == "OK"
+    assert len(trace.data.spans) == 1
+
+    span = trace.data.spans[0]
+    assert span.span_type == SpanType.RETRIEVER
+    assert span.inputs["limit"] == 1
+    assert np.allclose(span.outputs[0], results)
+
+
+def test_database():
+    mlflow.txtai.autolog()
+
+    database = txtai.database.SQLite({"content": True})
+    database.insert([(0, "test", None)])
+    results = database.search("select id, text from txtai")
+
+    trace = get_traces()[0]
+    assert trace is not None
+    assert trace.info.status == "OK"
+    assert len(trace.data.spans) == 1
+
+    span = trace.data.spans[0]
+    assert span.span_type == SpanType.RETRIEVER
+    assert span.inputs == {"query": "select id, text from txtai"}
+    assert span.outputs == results
+
+
+def test_embeddings():
+    with patch("txtai.Embeddings.batchsearch", _embeddings_batchsearch):
+        mlflow.txtai.autolog()
+
+        embeddings = txtai.Embeddings()
+        results = embeddings.batchsearch("apple")
+
+        trace = get_traces()[0]
+        assert trace is not None
+        assert trace.info.status == "OK"
+        assert len(trace.data.spans) == 1
+
+        span = trace.data.spans[0]
+        assert span.span_type == SpanType.RETRIEVER
+        assert span.inputs == {"args": ["apple"]}
+        assert span.outputs == results
+
+
+def test_llm():
+    with patch("txtai.LLM.__init__", _llm):
+        mlflow.txtai.autolog()
+
+        llm = txtai.LLM()
+        response = llm("Tell me about the Roman Empire")
+
+        trace = get_traces()[0]
+        assert trace is not None
+        assert trace.info.status == "OK"
+        assert len(trace.data.spans) == 1
+
+        span = trace.data.spans[0]
+        assert span.span_type == SpanType.LLM
+        assert span.inputs == {"text": "Tell me about the Roman Empire"}
+        assert span.outputs == response
+
+
+def test_pipeline():
+    mlflow.txtai.autolog()
+
+    segment = txtai.pipeline.Segmentation(lines=True)
+    results = segment("abc\ndef")
+
+    trace = get_traces()[0]
+    assert trace is not None
+    assert trace.info.status == "OK"
+    assert len(trace.data.spans) == 1
+
+    span = trace.data.spans[0]
+    assert span.span_type == SpanType.PARSER
+    assert span.inputs == {"text": "abc\ndef"}
+    assert span.outputs == results
+
+
+def test_scoring():
+    mlflow.txtai.autolog()
+
+    scoring = txtai.scoring.BM25({"terms": True})
+    scoring.index(documents=[(0, "test", None)])
+    results = scoring.search("test", 1)
+
+    trace = get_traces()[0]
+    assert trace is not None
+    assert trace.info.status == "OK"
+    assert len(trace.data.spans) == 2
+
+    span = trace.data.spans[0]
+    assert span.span_type == SpanType.RETRIEVER
+    assert span.inputs == {"limit": 1, "query": "test"}
+    assert np.allclose(span.outputs, results)
+
+
+def test_vectors():
+    with patch("txtai.vectors.Vectors.encode", _vectors):
+        mlflow.txtai.autolog()
+
+        vectors = txtai.vectors.Vectors({}, None, None)
+        vectors.dimensionality, vectors.qbits = None, None
+
+        results = vectors.vectorize(["test"])
+
+        trace = get_traces()[0]
+        assert trace is not None
+        assert trace.info.status == "OK"
+        assert len(trace.data.spans) == 1
+
+        span = trace.data.spans[0]
+        assert span.span_type == SpanType.EMBEDDING
+        assert span.inputs == {"data": ["test"]}
+        assert str(span.outputs) == str(results)
+
+
+def test_workflow():
+    mlflow.txtai.autolog()
+
+    # No-op workflow that returns inputs
+    workflow = txtai.Workflow(tasks=[txtai.workflow.Task()])
+    results = list(workflow(["workflow input"]))
+
+    trace = get_traces()[0]
+    assert trace is not None
+    assert trace.info.status == "OK"
+    assert len(trace.data.spans) == 2
+
+    # Check workflow
+    span = trace.data.spans[0]
+    assert span.span_type == SpanType.CHAIN
+    assert span.inputs == {"elements": results}
+    assert span.outputs == results
+
+    # Check task
+    span = trace.data.spans[1]
+    assert span.span_type == SpanType.PARSER
+    assert span.inputs["elements"] == results
+    assert span.outputs == results


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/davidmezzetti/mlflow/pull/14697?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14697/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14697
```

</p>
</details>

This PR proposes adding autologging for [txtai](https://github.com/neuml/txtai).

Someone recently opened an issue with txtai to [Enhance observability and tracing capabilities](https://github.com/neuml/txtai/issues/869) and suggested MLflow. 

`txtai` is an all-in-one embeddings database for semantic search, LLM orchestration and language model workflows. It has over 10K stars on GitHub. It's often compared to LangChain / LlamaIndex / Haystack.

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Autologging for txtai via `mlflow.txtai.autolog()`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

This change adds autologging to txtai. The following code snippet shows an example.

```python
import mlflow

from txtai import Embeddings, RAG

with mlflow.start_run():
    wiki = Embeddings()
    wiki.load(provider="huggingface-hub", container="neuml/txtai-wikipedia-slim")

    # Define prompt template
    template = """
    Answer the following question using only the context below. Only include information
    specifically discussed.

    question: {question}
    context: {context} """

    # Create RAG pipeline
    rag = RAG(
        wiki,
        "hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4",
        system="You are a friendly assistant. You answer questions from users.",
        template=template,
        context=10
    )

    rag("Tell me about the Roman Empire", maxlength=2048)
```

Results in the following trace.

![rag](https://github.com/user-attachments/assets/7c0e47b6-2dda-4711-9e7f-b5eee758ed20)

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
