### PR TITLE
Note about x86_64 reported on Apple Silicon M1

### DIFF
--- a/dev/run-test-container.sh
+++ b/dev/run-test-container.sh
@@ -3,8 +3,14 @@
 set -euo pipefail
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
+
+# When executed on homebrew installed before it got M1/arm64 support
+# uname -m can report x86_64 for Apple Silicon M1 (arm64)
+# Uninstall Homebrew and start over
+# https://github.com/homebrew/install#uninstall-homebrew
 ARCH=$(uname -m)
-echo "Running tests in a Docker container on $ARCH"
+OS_NAME=$(uname -s)
+echo "Running tests in a Docker container on ${OS_NAME} ${ARCH}"
 
 if [ "$ARCH" == "aarch64" ] || [ "$ARCH" == "arm64" ]; then
   MINIFORG_FILENAME="Miniforge3-Linux-aarch64.sh"
@@ -12,8 +18,16 @@ else
   MINIFORG_FILENAME="Miniforge3-Linux-x86_64.sh"
 fi
 
-DOCKER_BUILDKIT=1 docker build -f "${ROOT_DIR}/dev/Dockerfile.test" -t mlflow-test-env "$ROOT_DIR" --build-arg MINIFORG_FILENAME="$MINIFORG_FILENAME"
-docker container rm -f mlflow-test 2>/dev/null
+IMAGE_TAG=mlflow-test-env
+CONTAINER_NAME="mlflow-test"
+
+DOCKER_BUILDKIT=1 \
+docker build \
+  -f "${ROOT_DIR}/dev/Dockerfile.test" \
+  -t ${IMAGE_TAG} \
+  "$ROOT_DIR" \
+  --build-arg MINIFORG_FILENAME="$MINIFORG_FILENAME"
+docker container rm -f ${CONTAINER_NAME} 2>/dev/null
 docker run \
   -v "${ROOT_DIR}"/tests:/app/tests \
   -v "${ROOT_DIR}"/mlflow:/app/mlflow \
@@ -21,7 +35,7 @@ docker run \
   -v "${ROOT_DIR}"/pyproject.toml:/app/pyproject.toml \
   -v "${ROOT_DIR}"/pytest.ini:/app/pytest.ini \
   -v "${ROOT_DIR}"/conftest.py:/app/conftest.py \
-  --name "mlflow-test" \
-  -it mlflow-test-env
+  --name ${CONTAINER_NAME} \
+  -it ${IMAGE_TAG}
 
-docker container rm mlflow-test
+docker container rm ${CONTAINER_NAME}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jaceklaskowski/mlflow/pull/14701?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14701/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14701
```

</p>
</details>

Add a note to `dev/run-test-container.sh` that it can select an incorrect Miniforge3 arch variant when executed on Apple Silicon M1 on homebrew with x86_64 support only (no arm64 support).
