### PR TITLE
Add calibration metrics and plot to classification evaluator

### DIFF
--- a/mlflow/models/evaluation/calibration_curve.py
+++ b/mlflow/models/evaluation/calibration_curve.py
@@ -6,7 +6,7 @@ from sklearn.calibration import CalibrationDisplay, calibration_curve
 def make_multi_class_calibration_plot(
     n_classes, y_true, y_probs, calibration_config, label_list
 ) -> Figure:
-    """generate one calibration plot for a classes for a multi-class classifier
+    """Generate one calibration plot for all classes of a multi-class classifier
 
     Args:
         n_classes (int): number of classes in multi-class prediction
@@ -19,7 +19,7 @@ def make_multi_class_calibration_plot(
         label_list (array-like): list of label names for each class
 
     Returns:
-        Figure: Multi-Class Calibartion Plot
+        Figure: Multi-Class Calibration Plot
     """
     fig, ax = plt.subplots()
     # add calibration line for each class
@@ -55,7 +55,7 @@ def make_multi_class_calibration_plot(
     return fig
 
 
-def plot_calibration_curve(y_true, y_probs, pos_label, calibration_config, **kwargs) -> Figure:
+def plot_calibration_curve(y_true, y_probs, pos_label, calibration_config, label_list) -> Figure:
     """Generate a calibration curve for a trained classifier
 
     Args:
@@ -69,14 +69,15 @@ def plot_calibration_curve(y_true, y_probs, pos_label, calibration_config, **kwa
 
         calibration_config (dict[str, Union[str, int]]):
             Additional parameters for sklearn.CalibrationDisplay
-        **kwargs: Additional arguments passed to plotting functions.
+
+        label_list: List of class names
 
     Raises:
         TypeError: if calibration_config["calibration_classifier_name"] is not str
         TypeError: if calibration_config["calibration_n_bins"] is not int
 
     Returns:
-        Axes: Calibration Curve for Evaluated Classifier
+        Figure: Calibration Curve for Evaluated Classifier
     """
     # get number of classes
     n_classes = y_probs.shape[-1]
@@ -104,5 +105,5 @@ def plot_calibration_curve(y_true, y_probs, pos_label, calibration_config, **kwa
     # evaluating a multi-class classifier, create a calibration curve for each class
 
     return make_multi_class_calibration_plot(
-        n_classes, y_true, y_probs, calibration_config, label_list=kwargs["label_list"]
+        n_classes, y_true, y_probs, calibration_config, label_list
     )

--- a/mlflow/models/evaluation/calibration_curve.py
+++ b/mlflow/models/evaluation/calibration_curve.py
@@ -1,0 +1,51 @@
+from matplotlib.axes import Axes
+from sklearn.calibration import CalibrationDisplay
+
+
+def plot_calibration_curve(
+    y_true,
+    y_probs,
+    pos_label,
+    calibration_config,
+) -> Axes:
+    """Generate a calibration curve for a trained classifier
+
+    Args:
+        y_true (array-like, shape (n_samples)):
+            Ground truth (correct) target values.
+
+        y_probs (array-like, shape (n_samples, n_classes)):
+            Prediction probabilities for each class returned by a classifier.
+
+        pos_label (str): Label for the positive class.
+
+        calibration_config (dict[str, Union[str, int]]):
+            Additional parameters for sklearn.CalibrationDisplay
+
+    Raises:
+        TypeError: if calibration_config["calibration_classifier_name"] is not str
+        TypeError: if calibration_config["calibration_n_bins"] is not int
+
+    Returns:
+        Axes: Calibration Curve for Evaluated Classifier
+    """
+
+    # check that types are appropriate
+    if calibration_config:
+        # check that name provided for classifier is of proper type
+        if not isinstance(
+            calibration_config.get("calibration_classifier_name", ""), str
+        ):
+            raise TypeError("calibration_classifier_name should be of type string")
+
+        # check that name provided for calibration n_bins is of proper type
+        if not isinstance(calibration_config.get("calibration_n_bins", ""), int):
+            raise TypeError("calibration_n_bins should be of type int")
+
+    return CalibrationDisplay.from_predictions(
+        y_true,
+        y_prob=y_probs[:, 1],
+        pos_label=pos_label,
+        name=calibration_config.get("calibration_classifier_name", None),  # type: ignore
+        n_bins=calibration_config.get("calibration_n_bins", 10),  # type: ignore
+    ).ax_

--- a/mlflow/models/evaluation/calibration_curve.py
+++ b/mlflow/models/evaluation/calibration_curve.py
@@ -1,13 +1,61 @@
-from matplotlib.axes import Axes
-from sklearn.calibration import CalibrationDisplay
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+from sklearn.calibration import CalibrationDisplay, calibration_curve
 
 
-def plot_calibration_curve(
-    y_true,
-    y_probs,
-    pos_label,
-    calibration_config,
-) -> Axes:
+def make_multi_class_calibration_plot(
+    n_classes, y_true, y_probs, calibration_config, label_list
+) -> Figure:
+    """generate one calibration plot for a classes for a multi-class classifier
+
+    Args:
+        n_classes (int): number of classes in multi-class prediction
+        y_true (array-like, shape (n_samples)):
+            Ground truth (correct) target values.
+        y_probs (array-like, shape (n_samples, n_classes)):
+            Prediction probabilities for each class returned by a classifier.
+        calibration_config (dict[str, Union[str, int]]):
+            Additional parameters for sklearn.CalibrationDisplay
+        label_list (array-like): list of label names for each class
+
+    Returns:
+        Figure: Multi-Class Calibartion Plot
+    """
+    fig, ax = plt.subplots()
+    # add calibration line for each class
+    for _class in range(n_classes):
+        curves = calibration_curve(
+            y_true=[v == _class for v in y_true],
+            y_prob=y_probs[:, _class],
+            n_bins=calibration_config.get("calibration_n_bins", 10),
+        )
+        plt.plot(
+            curves[0],
+            curves[1],
+            marker="o",
+            markersize=3,
+            label=f"Class {label_list[_class]}",
+        )
+    # plot perfect calibration line
+    plt.plot([0, 1], [0, 1], linestyle="dotted", label="Perfect Calibration", color="black")
+    # add legend to plot
+    plt.legend(
+        loc="upper center",
+        bbox_to_anchor=(0.5, -0.25),
+        ncol=n_classes // 3,
+    )
+    # set figure title
+    ax.set_title(
+        f"{calibration_config.get('calibration_classifier_name', 'Classifier')} Calibration",
+        fontsize=12,
+    )
+    # set figure axis labels
+    ax.set_xlabel("Mean Predicted Probability", fontsize=10)
+    ax.set_ylabel("Fraction of True Positives", fontsize=10)
+    return fig
+
+
+def plot_calibration_curve(y_true, y_probs, pos_label, calibration_config, **kwargs) -> Figure:
     """Generate a calibration curve for a trained classifier
 
     Args:
@@ -21,6 +69,7 @@ def plot_calibration_curve(
 
         calibration_config (dict[str, Union[str, int]]):
             Additional parameters for sklearn.CalibrationDisplay
+        **kwargs: Additional arguments passed to plotting functions.
 
     Raises:
         TypeError: if calibration_config["calibration_classifier_name"] is not str
@@ -29,23 +78,31 @@ def plot_calibration_curve(
     Returns:
         Axes: Calibration Curve for Evaluated Classifier
     """
+    # get number of classes
+    n_classes = y_probs.shape[-1]
 
     # check that types are appropriate
     if calibration_config:
         # check that name provided for classifier is of proper type
-        if not isinstance(
-            calibration_config.get("calibration_classifier_name", ""), str
-        ):
+        if not isinstance(calibration_config.get("calibration_classifier_name", ""), str):
             raise TypeError("calibration_classifier_name should be of type string")
 
         # check that name provided for calibration n_bins is of proper type
-        if not isinstance(calibration_config.get("calibration_n_bins", ""), int):
+        if not isinstance(calibration_config.get("calibration_n_bins", 10), int):
             raise TypeError("calibration_n_bins should be of type int")
 
-    return CalibrationDisplay.from_predictions(
-        y_true,
-        y_prob=y_probs[:, 1],
-        pos_label=pos_label,
-        name=calibration_config.get("calibration_classifier_name", None),  # type: ignore
-        n_bins=calibration_config.get("calibration_n_bins", 10),  # type: ignore
-    ).ax_
+    # if we are evaluating a binary classifier assume positive class is at column index 1
+    if n_classes == 2:
+        return CalibrationDisplay.from_predictions(
+            y_true,
+            y_prob=y_probs[:, 1],
+            pos_label=pos_label,
+            name=calibration_config.get("calibration_classifier_name", None),  # type: ignore
+            n_bins=calibration_config.get("calibration_n_bins", 10),  # type: ignore
+        ).figure_
+
+    # evaluating a multi-class classifier, create a calibration curve for each class
+
+    return make_multi_class_calibration_plot(
+        n_classes, y_true, y_probs, calibration_config, label_list=kwargs["label_list"]
+    )

--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -293,10 +293,12 @@ class ClassifierEvaluator(BuiltInEvaluator):
 
         def _plot_calibration_curve():
             return plot_calibration_curve(
-                self.y_true,
-                self.y_probs,
-                self.pos_label,
-                {k: v for k, v in self.evaluator_config.items() if k.startswith("calibration_")},
+                y_true=self.y_true,
+                y_probs=self.y_probs,
+                pos_label=self.pos_label,
+                calibration_config={
+                    k: v for k, v in self.evaluator_config.items() if k.startswith("calibration_")
+                },
                 label_list=self.label_list,
             )
 

--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -93,9 +93,7 @@ class ClassifierEvaluator(BuiltInEvaluator):
     def _generate_model_predictions(self, model, input_df):
         predict_fn, predict_proba_fn = _extract_predict_fn_and_prodict_proba_fn(model)
         # Classifier model is guaranteed to output single column of predictions
-        y_pred = (
-            self.dataset.predictions_data if model is None else predict_fn(input_df)
-        )
+        y_pred = self.dataset.predictions_data if model is None else predict_fn(input_df)
 
         # Predict class probabilities if the model supports it
         y_probs = predict_proba_fn(input_df) if predict_proba_fn is not None else None
@@ -140,9 +138,7 @@ class ClassifierEvaluator(BuiltInEvaluator):
             )
 
     def _compute_builtin_metrics(self, model):
-        self._evaluate_sklearn_model_score_if_scorable(
-            model, self.y_true, self.sample_weights
-        )
+        self._evaluate_sklearn_model_score_if_scorable(model, self.y_true, self.sample_weights)
 
         if len(self.label_list) <= 2:
             metrics = _get_binary_classifier_metrics(
@@ -197,9 +193,7 @@ class ClassifierEvaluator(BuiltInEvaluator):
                 )
 
                 self.metrics_values.update(
-                    _get_aggregate_metrics_values(
-                        {"precision_recall_auc": self.pr_curve.auc}
-                    )
+                    _get_aggregate_metrics_values({"precision_recall_auc": self.pr_curve.auc})
                 )
 
     def _log_pandas_df_artifact(self, pandas_df, artifact_name):
@@ -215,17 +209,18 @@ class ClassifierEvaluator(BuiltInEvaluator):
         self.artifacts[artifact_name] = artifact
 
     def _log_multiclass_classifier_artifacts(self):
-        per_class_metrics_collection_df = (
-            _get_classifier_per_class_metrics_collection_df(
-                y=self.y_true,
-                y_pred=self.y_pred,
-                labels=self.label_list,
-                sample_weights=self.sample_weights,
-            )
+        per_class_metrics_collection_df = _get_classifier_per_class_metrics_collection_df(
+            y=self.y_true,
+            y_pred=self.y_pred,
+            labels=self.label_list,
+            sample_weights=self.sample_weights,
         )
 
         log_roc_pr_curve = False
         if self.y_probs is not None:
+            with _suppress_class_imbalance_errors(TypeError, log_warning=False):
+                self._log_calibration_curve()
+
             max_classes_for_multiclass_roc_pr = self.evaluator_config.get(
                 "max_classes_for_multiclass_roc_pr", 10
             )
@@ -271,9 +266,7 @@ class ClassifierEvaluator(BuiltInEvaluator):
             self._log_image_artifact(plot_pr_curve, "precision_recall_curve_plot")
             per_class_metrics_collection_df["precision_recall_auc"] = pr_curve.auc
 
-        self._log_pandas_df_artifact(
-            per_class_metrics_collection_df, "per_class_metrics"
-        )
+        self._log_pandas_df_artifact(per_class_metrics_collection_df, "per_class_metrics")
 
     def _log_roc_curve(self):
         def _plot_roc_curve():
@@ -303,11 +296,8 @@ class ClassifierEvaluator(BuiltInEvaluator):
                 self.y_true,
                 self.y_probs,
                 self.pos_label,
-                {
-                    k: v
-                    for k, v in self.evaluator_config.items()
-                    if k.startswith("calibration_")
-                },
+                {k: v for k, v in self.evaluator_config.items() if k.startswith("calibration_")},
+                label_list=self.label_list,
             )
 
         self._log_image_artifact(_plot_calibration_curve, "calibration_curve_plot")
@@ -408,9 +398,7 @@ def _extract_predict_fn_and_prodict_proba_fn(model):
 
             # Because shap evaluation will pass evaluation data in ndarray format
             # (without feature names), if set validate_features=True it will raise error.
-            predict_fn = _wrapped_xgboost_model_predict_fn(
-                raw_model, validate_features=False
-            )
+            predict_fn = _wrapped_xgboost_model_predict_fn(raw_model, validate_features=False)
             predict_proba_fn = _wrapped_xgboost_model_predict_proba_fn(
                 raw_model, validate_features=False
             )
@@ -448,9 +436,7 @@ def _suppress_class_imbalance_errors(exception_type=Exception, log_warning=True)
             raise e
 
 
-def _get_binary_sum_up_label_pred_prob(
-    positive_class_index, positive_class, y, y_pred, y_probs
-):
+def _get_binary_sum_up_label_pred_prob(positive_class_index, positive_class, y, y_pred, y_probs):
     y = np.array(y)
     y_bin = np.where(y == positive_class, 1, 0)
     y_pred_bin = None
@@ -471,9 +457,7 @@ def _get_common_classifier_metrics(
 ):
     metrics = {
         "example_count": len(y_true),
-        "accuracy_score": sk_metrics.accuracy_score(
-            y_true, y_pred, sample_weight=sample_weights
-        ),
+        "accuracy_score": sk_metrics.accuracy_score(y_true, y_pred, sample_weight=sample_weights),
         "recall_score": sk_metrics.recall_score(
             y_true,
             y_pred,
@@ -623,9 +607,7 @@ def _gen_classifier_curve(
                 pos_label=_pos_label if _pos_label == pos_label else None,
             )
 
-            auc = sk_metrics.roc_auc_score(
-                y_true=_y, y_score=_y_prob, sample_weight=sample_weights
-            )
+            auc = sk_metrics.roc_auc_score(y_true=_y, y_score=_y_prob, sample_weight=sample_weights)
             return fpr, tpr, f"AUC={auc:.3f}", auc
 
         xlabel = "False Positive Rate"
@@ -649,10 +631,7 @@ def _gen_classifier_curve(
             # NB: We return average precision score (AP) instead of AUC because AP is more
             # appropriate for summarizing a precision-recall curve
             ap = sk_metrics.average_precision_score(
-                y_true=_y,
-                y_score=_y_prob,
-                pos_label=_pos_label,
-                sample_weight=sample_weights,
+                y_true=_y, y_score=_y_prob, pos_label=_pos_label, sample_weight=sample_weights
             )
             return recall, precision, f"AP={ap:.3f}", ap
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -282,6 +282,7 @@ def test_multi_classifier_evaluation(
         "explainer",
         "confusion_matrix.png",
         "shap_summary_plot.png",
+        "calibration_curve_plot.png",
     }
     assert result.artifacts.keys() == {
         "per_class_metrics",
@@ -291,6 +292,7 @@ def test_multi_classifier_evaluation(
         "shap_beeswarm_plot",
         "shap_summary_plot",
         "shap_feature_importance_plot",
+        "calibration_curve_plot",
     }
 
 
@@ -376,6 +378,7 @@ def test_bin_classifier_evaluation(
         "confusion_matrix.png",
         "shap_summary_plot.png",
         "roc_curve_plot.png",
+        "calibration_curve_plot.png",
     }
     assert result.artifacts.keys() == {
         "roc_curve_plot",
@@ -385,6 +388,7 @@ def test_bin_classifier_evaluation(
         "shap_beeswarm_plot",
         "shap_summary_plot",
         "shap_feature_importance_plot",
+        "calibration_curve_plot",
     }
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/singh-kristian/mlflow/pull/14702?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14702/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14702
```

</p>
</details>

### Related Issues/PRs
None
<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve -->

### What changes are proposed in this pull request?

Currently during evaluation of binary and multi-class classifiers there is no support for providing charts relating to the [calibration](https://en.wikipedia.org/wiki/Probabilistic_classification#Probability_calibration) of the classifier. This pr introduces the functionality to produce calibration plots for both binary and multi-class classifiers. A new plotting function is introduced in`calibration_curve.py` that creates the calibration plots either using [sklearn's Calibration Display](https://scikit-learn.org/stable/modules/generated/sklearn.calibration.CalibrationDisplay.html) for binary classifiers, and matplotlib directly for multi-class classifiers. Currently all calibration curves are plotted on one plot for the multi-class case (as opposed to subplots or multiple artifacts). 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested Binary Classifier using modified example from `/examples`:
<img width="713" alt="Screen Shot 2025-02-22 at 4 33 17 PM" src="https://github.com/user-attachments/assets/c812c18b-e0ca-4df1-9594-745f970eb86c" />

Resulting output in local mlruns folder:
<img width="1624" alt="Screen Shot 2025-02-22 at 4 32 45 PM" src="https://github.com/user-attachments/assets/6dcc78e0-bdd0-4afa-a55f-757847120ae6" />

Tested Multi-Class Classifier using modified example from `/examples`:
<img width="1112" alt="Screen Shot 2025-02-22 at 4 34 27 PM" src="https://github.com/user-attachments/assets/38e10436-05eb-4909-8257-e63a173f4855" />

Resulting output in local mlruns folder:
<img width="1624" alt="Screen Shot 2025-02-22 at 4 34 13 PM" src="https://github.com/user-attachments/assets/104a0b49-a3e8-45f8-926a-72d2154f239d" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds Calibration Plots for Binary and Multi-Class Classifiers During Evaluation

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
