### PR TITLE
Fix Langchain autologging on mlflow3

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -924,6 +924,10 @@ class _LoadedModelTracker:
     def last_model_id(self, model_id: Optional[str]) -> None:
         self._last_model_id = model_id
 
+    def clear(self):
+        self.model_ids.clear()
+        self._last_model_id = None
+
 
 _LOADED_MODEL_TRACKER = _LoadedModelTracker()
 

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -71,7 +71,7 @@ def patched_inference(func_name, original, self, *args, **kwargs):
     if mid := _LOADED_MODEL_TRACKER.last_model_id:
         model_id = mid
     elif config.log_models:
-        logged_model = mlflow.create_logged_model()
+        logged_model = mlflow.create_logged_model(name="model")
         model_id = logged_model.model_id
         _LOADED_MODEL_TRACKER.last_model_id = model_id
     else:
@@ -102,9 +102,10 @@ def _setup_autolog_run(config, model):
 
     Returns: yields the run IDs
     """
-    if propagated_run_id := getattr(model, "run_id", None):
-        # When model has "run_id" attribute, it means the model is already invoked once with autolog
-        # enabled and the run_id is propagated from the previous call, so we don't create a new run.
+    if propagated_run_id := getattr(model, "source_run_id", None):
+        # When model has "source_run_id" attribute, it means the model is already invoked
+        # once with autolog enabled and the source_run_id is propagated from the previous call,
+        # so we don't create a new run.
         run_id = propagated_run_id
         # The run should be already terminated at the end of the previous call.
         should_terminate_run = False
@@ -279,7 +280,7 @@ def _log_optional_artifacts(
                 with disable_patching():
                     mlflow.langchain.log_model(
                         self,
-                        "model",
+                        name="model",
                         input_example=input_example,
                         registered_model_name=registered_model_name,
                         run_id=run_id,

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -102,10 +102,9 @@ def _setup_autolog_run(config, model):
 
     Returns: yields the run IDs
     """
-    if propagated_run_id := getattr(model, "source_run_id", None):
-        # When model has "source_run_id" attribute, it means the model is already invoked
-        # once with autolog enabled and the source_run_id is propagated from the previous call,
-        # so we don't create a new run.
+    if propagated_run_id := getattr(model, "run_id", None):
+        # When model has "run_id" attribute, it means the model is already invoked once with autolog
+        # enabled and the run_id is propagated from the previous call, so we don't create a new run.
         run_id = propagated_run_id
         # The run should be already terminated at the end of the previous call.
         should_terminate_run = False

--- a/tests/langchain/conftest.py
+++ b/tests/langchain/conftest.py
@@ -6,6 +6,8 @@ import pytest
 from langchain.embeddings.base import Embeddings
 from pydantic import BaseModel
 
+from mlflow.langchain import _LOADED_MODEL_TRACKER
+
 from tests.helper_functions import start_mock_openai_server
 from tests.tracing.helper import reset_autolog_state  # noqa: F401
 
@@ -31,6 +33,12 @@ def mock_openai():
 @pytest.fixture(autouse=True)
 def reset_autolog(reset_autolog_state):
     # Apply the reset_autolog_state fixture to all tests for LangChain
+    return
+
+
+@pytest.fixture(autouse=True)
+def reset_loaded_model_tracker():
+    _LOADED_MODEL_TRACKER.clear()
     return
 
 

--- a/tests/langchain/conftest.py
+++ b/tests/langchain/conftest.py
@@ -39,7 +39,6 @@ def reset_autolog(reset_autolog_state):
 @pytest.fixture(autouse=True)
 def reset_loaded_model_tracker():
     _LOADED_MODEL_TRACKER.clear()
-    return
 
 
 # Define a special embedding for testing

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -579,9 +579,9 @@ def test_loaded_runnable_sequence_autolog():
         assert loaded_model.invoke(input_example) == TEST_CONTENT
         log_model_mock.assert_not_called()
 
-        mlflow_model = get_mlflow_model(run.info.artifact_uri)
-        model_path = os.path.join(run.info.artifact_uri, MODEL_DIR)
-        saved_example = _read_example(mlflow_model, model_path)
+        logged_model = mlflow.last_logged_model()
+        mlflow_model = get_mlflow_model(logged_model.artifact_location, "")
+        saved_example = _read_example(mlflow_model, logged_model.model_uri)
         assert saved_example == input_example
 
         pyfunc_model = mlflow.pyfunc.load_model(f"runs:/{run.info.run_id}/model")

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -1,4 +1,3 @@
-import os
 import random
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -73,11 +72,6 @@ MODEL_DIR = "model"
 # The mock OpenAI endpoint simply echos the prompt back as the completion.
 # So the expected output will be the prompt itself.
 TEST_CONTENT = "What is MLflow?"
-
-
-def get_mlflow_model(artifact_uri, model_subpath=MODEL_DIR):
-    model_conf_path = os.path.join(artifact_uri, model_subpath, "MLmodel")
-    return Model.load(model_conf_path)
 
 
 def create_openai_llmchain():
@@ -359,9 +353,9 @@ def test_loaded_llmchain_autolog():
         assert loaded_model.invoke(question) == answer
         log_model_mock.assert_not_called()
 
-        mlflow_model = get_mlflow_model(run.info.artifact_uri)
-        model_path = os.path.join(run.info.artifact_uri, MODEL_DIR)
-        input_example = _read_example(mlflow_model, model_path)
+        logged_model = mlflow.last_logged_model()
+        mlflow_model = Model.load(logged_model.model_uri)
+        input_example = _read_example(mlflow_model, logged_model.model_uri)
         assert input_example == question
 
         pyfunc_model = mlflow.pyfunc.load_model(f"runs:/{run.info.run_id}/model")

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -580,7 +580,7 @@ def test_loaded_runnable_sequence_autolog():
         log_model_mock.assert_not_called()
 
         logged_model = mlflow.last_logged_model()
-        mlflow_model = get_mlflow_model(logged_model.artifact_location, "")
+        mlflow_model = Model.load(logged_model.model_uri)
         saved_example = _read_example(mlflow_model, logged_model.model_uri)
         assert saved_example == input_example
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14717?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14717/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14717
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Fix Langchain autologging on mlflow3

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
