### PR TITLE
Supports ADLS artifact repo

### DIFF
--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -3,6 +3,7 @@ import warnings
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
+from mlflow.store.artifact.azure_data_lake_artifact_repo import AzureDataLakeArtifactRepository
 from mlflow.store.artifact.dbfs_artifact_repo import dbfs_artifact_repo_factory
 from mlflow.store.artifact.ftp_artifact_repo import FTPArtifactRepository
 from mlflow.store.artifact.gcs_artifact_repo import GCSArtifactRepository
@@ -111,6 +112,7 @@ _artifact_repository_registry.register("models", ModelsArtifactRepository)
 for scheme in ["http", "https"]:
     _artifact_repository_registry.register(scheme, HttpArtifactRepository)
 _artifact_repository_registry.register("mlflow-artifacts", MlflowArtifactsRepository)
+_artifact_repository_registry.register("abfss", AzureDataLakeArtifactRepository)
 
 _artifact_repository_registry.register_entrypoints()
 

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -27,6 +27,7 @@ from mlflow.store.artifact.azure_data_lake_artifact_repo import (
 TEST_ROOT_PATH = "some/path"
 TEST_DATA_LAKE_URI_BASE = "abfss://filesystem@account.dfs.core.windows.net"
 TEST_DATA_LAKE_URI = posixpath.join(TEST_DATA_LAKE_URI_BASE, TEST_ROOT_PATH)
+TEST_CREDENTIAL = mock.Mock()
 
 ADLS_REPOSITORY_PACKAGE = "mlflow.store.artifact.azure_data_lake_artifact_repo"
 ADLS_ARTIFACT_REPOSITORY = f"{ADLS_REPOSITORY_PACKAGE}.AzureDataLakeArtifactRepository"
@@ -73,7 +74,7 @@ def mock_file_client(mock_directory_client):
 
 
 @pytest.mark.parametrize(
-    ("uri", "filesystem", "account", "region_suffix", "path"),
+    ("uri", "filesystem", "account", "region_suffix", "path", "sas_token"),
     [
         (
             "abfss://filesystem@acct.dfs.core.windows.net/path",
@@ -81,12 +82,14 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.windows.net",
             "path",
+            "",
         ),
         (
             "abfss://filesystem@acct.dfs.core.windows.net",
             "filesystem",
             "acct",
             "dfs.core.windows.net",
+            "",
             "",
         ),
         (
@@ -95,6 +98,7 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.windows.net",
             "",
+            "",
         ),
         (
             "abfss://filesystem@acct.dfs.core.windows.net/a/b",
@@ -102,6 +106,7 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.windows.net",
             "a/b",
+            "",
         ),
         (
             "abfss://filesystem@acct.dfs.core.chinacloudapi.cn/a/b",
@@ -109,6 +114,7 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.chinacloudapi.cn",
             "a/b",
+            "",
         ),
         (
             "abfss://filesystem@acct.privatelink.dfs.core.windows.net/a/b",
@@ -116,6 +122,7 @@ def mock_file_client(mock_directory_client):
             "acct",
             "privatelink.dfs.core.windows.net",
             "a/b",
+            "",
         ),
         (
             "abfss://filesystem@acct.dfs.core.usgovcloudapi.net/a/b",
@@ -123,11 +130,20 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.usgovcloudapi.net",
             "a/b",
+            "",
+        ),
+        (
+            "abfss://filesystem@acct.dfs.core.usgovcloudapi.net/a/b?sas_token",
+            "filesystem",
+            "acct",
+            "dfs.core.usgovcloudapi.net",
+            "a/b",
+            "sas_token",
         ),
     ],
 )
-def test_parse_valid_abfss_uri(uri, filesystem, account, region_suffix, path):
-    assert _parse_abfss_uri(uri) == (filesystem, account, region_suffix, path)
+def test_parse_valid_abfss_uri(uri, filesystem, account, region_suffix, path, sas_token):
+    assert _parse_abfss_uri(uri) == (filesystem, account, region_suffix, path, sas_token)
 
 
 @pytest.mark.parametrize(
@@ -149,13 +165,13 @@ def test_parse_invalid_abfss_uri_bad_scheme():
 
 
 def test_list_artifacts_empty(mock_data_lake_client):
-    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, TEST_CREDENTIAL)
     mock_data_lake_client.get_file_system_client.get_paths.return_value = MockPathList([])
     assert repo.list_artifacts() == []
 
 
 def test_list_artifacts_single_file(mock_data_lake_client):
-    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, TEST_CREDENTIAL)
 
     # Evaluate single file
     path_props = PathProperties(name=posixpath.join(TEST_DATA_LAKE_URI, "file"), content_length=42)
@@ -164,7 +180,7 @@ def test_list_artifacts_single_file(mock_data_lake_client):
 
 
 def test_list_artifacts(mock_filesystem_client):
-    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, TEST_CREDENTIAL)
 
     # Create some files to return
     dir_prefix = PathProperties(is_directory=True, name=posixpath.join(TEST_ROOT_PATH, "dir"))
@@ -193,7 +209,7 @@ def test_list_artifacts(mock_filesystem_client):
 )
 def test_log_artifact(mock_filesystem_client, mock_directory_client, tmp_path, contents):
     file_name = "b.txt"
-    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, TEST_CREDENTIAL)
 
     parentd = tmp_path.joinpath("data")
     parentd.mkdir()
@@ -278,7 +294,7 @@ def test_log_artifacts_in_parallel_when_necessary(tmp_path, monkeypatch):
     [(None, False), (100, False), (500 * 1024**2 - 1, False), (500 * 1024**2, True)],
 )
 def test_download_file_in_parallel_when_necessary(file_size, is_parallel_download):
-    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, TEST_CREDENTIAL)
     remote_file_path = "file_1.txt"
     list_artifacts_result = (
         [FileInfo(path=remote_file_path, is_dir=False, file_size=file_size)] if file_size else []
@@ -303,7 +319,7 @@ def test_download_file_in_parallel_when_necessary(file_size, is_parallel_downloa
 
 
 def test_download_file_artifact(mock_directory_client, mock_file_client, tmp_path):
-    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, TEST_CREDENTIAL)
 
     def create_file(file):
         local_path = os.path.basename(file.name)
@@ -317,7 +333,7 @@ def test_download_file_artifact(mock_directory_client, mock_file_client, tmp_pat
 
 
 def test_download_directory_artifact(mock_filesystem_client, mock_file_client, tmp_path):
-    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, TEST_CREDENTIAL)
 
     file_path_1 = "file_1"
     file_path_2 = "file_2"
@@ -404,7 +420,7 @@ def test_refresh_credentials():
 
 
 def test_trace_data(mock_data_lake_client, tmp_path):
-    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, TEST_CREDENTIAL)
     with pytest.raises(MlflowException, match=r"Trace data not found for path="):
         repo.download_trace_data()
     trace_data_path = tmp_path.joinpath("traces.json")

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -74,7 +74,7 @@ def mock_file_client(mock_directory_client):
 
 
 @pytest.mark.parametrize(
-    ("uri", "filesystem", "account", "region_suffix", "path", "sas_token"),
+    ("uri", "filesystem", "account", "region_suffix", "path"),
     [
         (
             "abfss://filesystem@acct.dfs.core.windows.net/path",
@@ -82,14 +82,12 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.windows.net",
             "path",
-            "",
         ),
         (
             "abfss://filesystem@acct.dfs.core.windows.net",
             "filesystem",
             "acct",
             "dfs.core.windows.net",
-            "",
             "",
         ),
         (
@@ -98,7 +96,6 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.windows.net",
             "",
-            "",
         ),
         (
             "abfss://filesystem@acct.dfs.core.windows.net/a/b",
@@ -106,7 +103,6 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.windows.net",
             "a/b",
-            "",
         ),
         (
             "abfss://filesystem@acct.dfs.core.chinacloudapi.cn/a/b",
@@ -114,7 +110,6 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.chinacloudapi.cn",
             "a/b",
-            "",
         ),
         (
             "abfss://filesystem@acct.privatelink.dfs.core.windows.net/a/b",
@@ -122,7 +117,6 @@ def mock_file_client(mock_directory_client):
             "acct",
             "privatelink.dfs.core.windows.net",
             "a/b",
-            "",
         ),
         (
             "abfss://filesystem@acct.dfs.core.usgovcloudapi.net/a/b",
@@ -130,20 +124,11 @@ def mock_file_client(mock_directory_client):
             "acct",
             "dfs.core.usgovcloudapi.net",
             "a/b",
-            "",
-        ),
-        (
-            "abfss://filesystem@acct.dfs.core.usgovcloudapi.net/a/b?sas_token",
-            "filesystem",
-            "acct",
-            "dfs.core.usgovcloudapi.net",
-            "a/b",
-            "sas_token",
         ),
     ],
 )
-def test_parse_valid_abfss_uri(uri, filesystem, account, region_suffix, path, sas_token):
-    assert _parse_abfss_uri(uri) == (filesystem, account, region_suffix, path, sas_token)
+def test_parse_valid_abfss_uri(uri, filesystem, account, region_suffix, path):
+    assert _parse_abfss_uri(uri) == (filesystem, account, region_suffix, path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14723?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14723/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14723
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
With this PR, users can set environment variable `AZURE_STORAGE_SAS_TOKEN` and it will be picked up as the sas_token for uploading/downloading files from ADLS.
If this doesn't exist, DefaultAzureCredential will be used for authentication.

Validated manually.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
