### PR TITLE
[Safe-patch 4] Refactor safe patch

### DIFF
--- a/mlflow/keras/autologging.py
+++ b/mlflow/keras/autologging.py
@@ -17,7 +17,6 @@ from mlflow.tracking.context import registry as context_registry
 from mlflow.utils import is_iterator
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
-    PatchFunction,
     autologging_integration,
     get_autologging_config,
     log_fn_args_as_params,
@@ -196,76 +195,73 @@ def autolog(
             model.fit(data, label, batch_size=4, epochs=2)
     """
 
-    class FitPatch(PatchFunction):
-        def __init__(self):
-            pass
+    def _patched_inference(original, inst, *args, **kwargs):
+        unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
-        def _infer_batch_size(self, inst, *args, **kwargs):
-            batch_size = None
-            if "batch_size" in kwargs:
-                batch_size = kwargs["batch_size"]
+        batch_size, args, kwargs = _infer_batch_size(inst, *args, **kwargs)
+
+        if batch_size is not None:
+            mlflow.log_param("batch_size", batch_size)
+            unlogged_params.append("batch_size")
+
+        log_fn_args_as_params(original, [], kwargs, unlogged_params)
+
+        if log_datasets:
+            try:
+                context_tags = context_registry.resolve_tags()
+                source = CodeDatasetSource(tags=context_tags)
+                x, y = _parse_dataset(*args, **kwargs)
+                _log_dataset(x, source, "train", targets=y)
+
+                if "validation_data" in kwargs:
+                    _log_dataset(kwargs["validation_data"], source, "eval")
+
+            except Exception as e:
+                _logger.warning(f"Failed to log dataset information to MLflow. Reason: {e}")
+
+        # Add `MlflowCallback` to the callback list.
+        callbacks = args[5] if len(args) >= 6 else kwargs.get("callbacks", [])
+        mlflow_callback = MlflowCallback(
+            log_every_epoch=log_every_epoch,
+            log_every_n_steps=log_every_n_steps,
+        )
+        _check_existing_mlflow_callback(callbacks)
+        callbacks.append(mlflow_callback)
+        kwargs["callbacks"] = callbacks
+        history = original(inst, *args, **kwargs)
+
+        if log_models:
+            _log_keras_model(inst, save_exported_model, log_model_signatures, save_model_kwargs)
+        return history
+
+    safe_patch(
+        "keras", keras.Model, "fit", _patched_inference, manage_run=True, extra_tags=extra_tags
+    )
+
+
+def _infer_batch_size(inst, *args, **kwargs):
+    batch_size = None
+    if "batch_size" in kwargs:
+        batch_size = kwargs["batch_size"]
+    else:
+        training_data = kwargs["x"] if "x" in kwargs else args[0]
+        if _batch_size := getattr(training_data, "batch_size", None):
+            batch_size = _batch_size
+        elif _batch_size := getattr(training_data, "_batch_size", None):
+            batch_size = _batch_size if isinstance(_batch_size, int) else _batch_size.numpy()
+        elif is_iterator(training_data):
+            is_single_input_model = isinstance(inst.input_shape, tuple)
+            peek = next(training_data)
+            batch_size = len(peek[0]) if is_single_input_model else len(peek[0][0])
+
+            def origin_training_data_generator_fn():
+                yield peek
+                yield from training_data
+
+            origin_training_data = origin_training_data_generator_fn()
+
+            if "x" in kwargs:
+                kwargs["x"] = origin_training_data
             else:
-                training_data = kwargs["x"] if "x" in kwargs else args[0]
-                if _batch_size := getattr(training_data, "batch_size", None):
-                    batch_size = _batch_size
-                elif _batch_size := getattr(training_data, "_batch_size", None):
-                    batch_size = (
-                        _batch_size if isinstance(_batch_size, int) else _batch_size.numpy()
-                    )
-                elif is_iterator(training_data):
-                    is_single_input_model = isinstance(inst.input_shape, tuple)
-                    peek = next(training_data)
-                    batch_size = len(peek[0]) if is_single_input_model else len(peek[0][0])
-
-                    def origin_training_data_generator_fn():
-                        yield peek
-                        yield from training_data
-
-                    origin_training_data = origin_training_data_generator_fn()
-
-                    if "x" in kwargs:
-                        kwargs["x"] = origin_training_data
-                    else:
-                        args = (origin_training_data,) + args[1:]
-            return batch_size, args, kwargs
-
-        def _patch_implementation(self, original, inst, *args, **kwargs):
-            unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
-
-            batch_size, args, kwargs = self._infer_batch_size(inst, *args, **kwargs)
-
-            if batch_size is not None:
-                mlflow.log_param("batch_size", batch_size)
-                unlogged_params.append("batch_size")
-
-            log_fn_args_as_params(original, [], kwargs, unlogged_params)
-
-            if log_datasets:
-                try:
-                    context_tags = context_registry.resolve_tags()
-                    source = CodeDatasetSource(tags=context_tags)
-                    x, y = _parse_dataset(*args, **kwargs)
-                    _log_dataset(x, source, "train", targets=y)
-
-                    if "validation_data" in kwargs:
-                        _log_dataset(kwargs["validation_data"], source, "eval")
-
-                except Exception as e:
-                    _logger.warning(f"Failed to log dataset information to MLflow. Reason: {e}")
-
-            # Add `MlflowCallback` to the callback list.
-            callbacks = args[5] if len(args) >= 6 else kwargs.get("callbacks", [])
-            mlflow_callback = MlflowCallback(
-                log_every_epoch=log_every_epoch,
-                log_every_n_steps=log_every_n_steps,
-            )
-            _check_existing_mlflow_callback(callbacks)
-            callbacks.append(mlflow_callback)
-            kwargs["callbacks"] = callbacks
-            history = original(inst, *args, **kwargs)
-
-            if log_models:
-                _log_keras_model(inst, save_exported_model, log_model_signatures, save_model_kwargs)
-            return history
-
-    safe_patch("keras", keras.Model, "fit", FitPatch, manage_run=True, extra_tags=extra_tags)
+                args = (origin_training_data,) + args[1:]
+    return batch_size, args, kwargs

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -38,7 +38,6 @@ from mlflow.tracking.fluent import _shut_down_async_logging
 from mlflow.types.schema import TensorSpec
 from mlflow.utils import is_iterator
 from mlflow.utils.autologging_utils import (
-    PatchFunction,
     autologging_integration,
     get_autologging_config,
     log_fn_args_as_params,
@@ -1242,11 +1241,9 @@ def autolog(
             keras_model_kwargs=keras_model_kwargs,
         )
 
-    class FitPatch(PatchFunction):
-        def __init__(self):
-            self.log_dir = None
-
-        def _patch_implementation(self, original, inst, *args, **kwargs):
+    def _patched_inference(original, inst, *args, **kwargs):
+        log_dir = None
+        try:
             unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
             batch_size = None
@@ -1298,7 +1295,7 @@ def autolog(
                 # modifying their contents for future training invocations. Introduce
                 # TensorBoard & tf.keras callbacks if necessary
                 callbacks = list(args[5])
-                callbacks, self.log_dir = _setup_callbacks(
+                callbacks, log_dir = _setup_callbacks(
                     callbacks,
                     log_every_epoch=log_every_epoch,
                     log_every_n_steps=log_every_n_steps,
@@ -1311,7 +1308,7 @@ def autolog(
                 # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
                 # & tf.keras callbacks if necessary
                 callbacks = list(kwargs.get("callbacks") or [])
-                kwargs["callbacks"], self.log_dir = _setup_callbacks(
+                kwargs["callbacks"], log_dir = _setup_callbacks(
                     callbacks,
                     log_every_epoch=log_every_epoch,
                     log_every_n_steps=log_every_n_steps,
@@ -1364,27 +1361,30 @@ def autolog(
             _shut_down_async_logging()
 
             mlflow.log_artifacts(
-                local_dir=self.log_dir.location,
+                local_dir=log_dir.location,
                 artifact_path="tensorboard_logs",
             )
-            if self.log_dir.is_temp:
-                shutil.rmtree(self.log_dir.location)
+            if log_dir.is_temp:
+                shutil.rmtree(log_dir.location)
             return history
 
-        def _on_exception(self, exception):
-            if (
-                self.log_dir is not None
-                and self.log_dir.is_temp
-                and os.path.exists(self.log_dir.location)
-            ):
-                shutil.rmtree(self.log_dir.location)
+        except (Exception, KeyboardInterrupt) as e:
+            try:
+                if log_dir is not None and log_dir.is_temp and os.path.exists(log_dir.location):
+                    shutil.rmtree(log_dir.location)
+            finally:
+                # Regardless of what happens during the `_on_exception` callback, reraise
+                # the original implementation exception once the callback completes
+                raise e
 
-    managed = [
-        (tf.keras.Model, "fit", FitPatch),
-    ]
-
-    for p in managed:
-        safe_patch(FLAVOR_NAME, *p, manage_run=True, extra_tags=extra_tags)
+    safe_patch(
+        FLAVOR_NAME,
+        tf.keras.Model,
+        "fit",
+        _patched_inference,
+        manage_run=True,
+        extra_tags=extra_tags,
+    )
 
 
 def _log_tensorflow_dataset(tensorflow_dataset, source, context, name=None, targets=None):

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -31,7 +31,6 @@ from mlflow.utils.autologging_utils.logging_and_warnings import (
 from mlflow.utils.autologging_utils.safety import (  # noqa: F401
     ExceptionSafeAbstractClass,
     ExceptionSafeClass,
-    PatchFunction,
     exception_safe_function_for_class,
     is_testing,
     picklable_exception_safe_function,

--- a/mlflow/utils/autologging_utils/events.py
+++ b/mlflow/utils/autologging_utils/events.py
@@ -1,6 +1,109 @@
 import warnings
+from typing import Any
 
 from mlflow.utils.autologging_utils import _logger
+
+
+class AutologgingRuntimeLogger:
+    """
+    Wrapper class for an `AutologgingEventLogger
+    """
+
+    def __init__(self, session, destinatinon, function_name):
+        self._logger = AutologgingEventLogger.get_logger()
+        self._session = session
+        self._destination = destinatinon
+        self._function_name = function_name
+
+
+def _catch_exception(fn):
+    """A decorator that catches exceptions thrown by the wrapped function and logs them."""
+
+    def wrapper(*args):
+        try:
+            fn(*args)
+        except Exception as e:
+            _logger.debug(f"Failed to log autologging event via '{fn}'. Exception: {e}")
+
+    return wrapper
+
+
+class AutologgingEventLoggerWrapper:
+    """
+    A wrapper around AutologgingEventLogger for DRY:
+      - Store common arguments to avoid passing them to each logger method
+      - Catches exceptions thrown by the logger and logs them
+
+    NB: We could not modify the AutologgingEventLogger class directly because
+        it is used in Databricks code base as well.
+    """
+
+    def __init__(self, session, destination: Any, function_name: str):
+        self._session = session
+        self._destination = destination
+        self._function_name = function_name
+
+    @_catch_exception
+    def log_patch_function_start(self, args, kwargs):
+        AutologgingEventLogger.get_logger().log_patch_function_start(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+        )
+
+    @_catch_exception
+    def log_patch_function_success(self, args, kwargs):
+        AutologgingEventLogger.get_logger().log_patch_function_success(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+        )
+
+    @_catch_exception
+    def log_patch_function_error(self, args, kwargs, exception):
+        AutologgingEventLogger.get_logger().log_patch_function_error(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+            exception,
+        )
+
+    @_catch_exception
+    def log_original_function_start(self, args, kwargs):
+        AutologgingEventLogger.get_logger().log_original_function_start(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+        )
+
+    @_catch_exception
+    def log_original_function_success(self, args, kwargs):
+        AutologgingEventLogger.get_logger().log_original_function_success(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+        )
+
+    @_catch_exception
+    def log_original_function_error(self, args, kwargs, exception):
+        AutologgingEventLogger.get_logger().log_original_function_error(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+            exception,
+        )
 
 
 class AutologgingEventLogger:

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -30,6 +30,9 @@ _AUTOLOGGING_PATCHES = {}
 _ATTRIBUTE_EXCEPTION_SAFE = "exception_safe"
 
 
+_PATCH_RUN_NAME_FOR_TESTING = "MLFLOW_RUN_CREATED_BY_PATCH"
+
+
 def exception_safe_function_for_class(function):
     """
     Wraps the specified function with broad exception handling to guard
@@ -155,7 +158,10 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
     from mlflow.utils.autologging_utils import _has_active_training_session
 
     def create_managed_run():
-        managed_run = mlflow.start_run(tags=tags)
+        # If testing, give a special name to the run to retrieve it later for validation
+        run_name = _PATCH_RUN_NAME_FOR_TESTING if is_testing() else None
+        managed_run = mlflow.start_run(tags=tags, run_name=run_name)
+
         _logger.info(
             "Created MLflow autologging run with ID '%s', which will track hyperparameters,"
             " performance metrics, model artifacts, and lineage information for the"
@@ -294,10 +300,13 @@ def safe_patch(
             # property decorated method.
             bound_delegate_method = original_fn.fget(self)
             return bound_delegate_method(*args, **kwargs)
-
     else:
         original = original_fn
         is_property_method = False
+
+    def _validate_args_if_testing(args, kwargs, og_args, og_kwargs):
+        if is_testing():
+            _validate_args(autologging_integration, function_name, args, kwargs, og_args, og_kwargs)
 
     def safe_patch_function(*args, **kwargs):
         """
@@ -316,139 +325,60 @@ def safe_patch(
             return original(*args, **kwargs)
 
         with set_warning_behavior_during_autologging(autologging_integration):
-            if is_testing():
-                preexisting_run_for_testing = mlflow.active_run()
-
-            # Whether or not the original / underlying function has been called during the
-            # execution of patched code
-            original_has_been_called = False
-            # The value returned by the call to the original / underlying function during
-            # the execution of patched code
-            original_result = None
-            # Whether or not an exception was raised from within the original / underlying function
-            # during the execution of patched code
-            failed_during_original = False
-            # The active MLflow run (if any) associated with patch code execution
-            patch_function_run_for_testing = None
-            # The exception raised during executing patching function
-            patch_function_exception = None
+            # Store the state of the original function execution, including whether or not it has
+            # been called, the (successful) result of the original function, or any exception thrown
+            original_fn_state = FunctionCallState()
+            # The exception raised during executing patch function
+            patch_error = None
 
             with _AutologgingSessionManager.start_session(autologging_integration) as session:
-                event_logger = AutologgingEventLoggerWrapper(
-                    session,
-                    destination,
-                    function_name,
-                )
+                event_logger = AutologgingEventLoggerWrapper(session, destination, function_name)
 
-                def call_original_fn_with_event_logging(original_fn, og_args, og_kwargs):
+                @wraps(original)
+                def _call_original(*og_args, **og_kwargs):
+                    _validate_args_if_testing(args, kwargs, og_args, og_kwargs)
                     try:
                         event_logger.log_original_function_start(og_args, og_kwargs)
+                        original_fn_result = original(*og_args, **og_kwargs)
 
-                        original_fn_result = original_fn(*og_args, **og_kwargs)
+                        with set_non_mlflow_warnings_behavior_for_current_thread(False, False):
+                            original_fn_state.set_result(original_fn_result)
 
                         event_logger.log_original_function_success(og_args, og_kwargs)
                         return original_fn_result
                     except Exception as e:
+                        original_fn_state.set_exception(e)
                         event_logger.log_original_function_error(og_args, og_kwargs, e)
-
-                        nonlocal failed_during_original
-                        failed_during_original = True
                         raise
 
                 try:
-
-                    def call_original(*og_args, **og_kwargs):
-                        def _original_fn(*_og_args, **_og_kwargs):
-                            if is_testing():
-                                _validate_args(
-                                    autologging_integration,
-                                    function_name,
-                                    args,
-                                    kwargs,
-                                    og_args,
-                                    og_kwargs,
-                                )
-                                # By the time `original` is called by the patch implementation, we
-                                # assume that either: 1. the patch implementation has already
-                                # created an MLflow run or 2. the patch code will not create an
-                                # MLflow run during the current execution. Here, we capture a
-                                # reference to the active run, which we will use later on to
-                                # determine whether or not the patch implementation created
-                                # a run and perform validation if necessary
-                                nonlocal patch_function_run_for_testing
-                                patch_function_run_for_testing = mlflow.active_run()
-
-                            nonlocal original_has_been_called
-                            original_has_been_called = True
-
-                            nonlocal original_result
-                            # Show all non-MLflow warnings as normal (i.e. not as event logs)
-                            # during original function execution, even if silent mode is enabled
-                            # (`silent=True`), since these warnings originate from the ML framework
-                            # or one of its dependencies and are likely relevant to the caller
-                            with set_non_mlflow_warnings_behavior_for_current_thread(
-                                disable_warnings=False,
-                                reroute_warnings=False,
-                            ):
-                                original_result = original(*_og_args, **_og_kwargs)
-                                return original_result
-
-                        return call_original_fn_with_event_logging(_original_fn, og_args, og_kwargs)
-
-                    # Apply the name, docstring, and signature of `original` to `call_original`.
-                    # This is important because several autologging patch implementations inspect
-                    # the signature of the `original` argument during execution
-                    call_original = update_wrapper_extended(call_original, original)
-
                     event_logger.log_patch_function_start(args, kwargs)
-
-                    patch_function(call_original, *args, **kwargs)
-
-                    session.state = "succeeded"
+                    patch_function(_call_original, *args, **kwargs)
                     event_logger.log_patch_function_success(args, kwargs)
-
                 except Exception as e:
-                    session.state = "failed"
-                    patch_function_exception = e
+                    session.set_failed()
+                    patch_error = e
                     # Exceptions thrown during execution of the original function should be
                     # propagated to the caller. Additionally, exceptions encountered during test
                     # mode should be reraised to detect bugs in autologging implementations
-                    if failed_during_original or is_testing():
+                    if original_fn_state.exception or is_testing():
                         raise
 
-                if is_testing() and not preexisting_run_for_testing:
-                    # If an MLflow run was created during the execution of patch code, verify that
-                    # it is no longer active and that it contains expected autologging tags
-                    assert not mlflow.active_run(), (
-                        f"Autologging integration {autologging_integration} leaked an active run"
-                    )
-                    if patch_function_run_for_testing:
-                        _validate_autologging_run(
-                            autologging_integration, patch_function_run_for_testing.info.run_id
-                        )
                 try:
-                    if original_has_been_called:
-                        return original_result
+                    if original_fn_state.has_been_called:
+                        return original_fn_state.result
                     else:
-                        return call_original_fn_with_event_logging(original, args, kwargs)
+                        return _call_original(*args, **kwargs)
                 finally:
-                    # If original function succeeds, but `patch_function_exception` exists,
-                    # it represent patching code unexpected failure, so we call
-                    # `log_patch_function_error` in this case.
-                    # If original function failed, we don't call `log_patch_function_error`
-                    # even if `patch_function_exception` exists, because original function failure
-                    # means there's some error in user code (e.g. user provide wrong arguments)
-                    if patch_function_exception is not None and not failed_during_original:
-                        event_logger.log_patch_function_error(
-                            args,
-                            kwargs,
-                            patch_function_exception,
-                        )
-
+                    # If original function succeeds but patch function fails, it indicates patch
+                    # code fault, so we call `log_patch_function_error`. But if the original
+                    # function also fails, there's some error in user code so we don't log it.
+                    if patch_error is not None and original_fn_state.exception is None:
+                        event_logger.log_patch_function_error(args, kwargs, patch_error)
                         _logger.warning(
-                            "Encountered unexpected error during %s autologging: %s",
+                            "Encountered unexpected error during {} autologging: %s",
                             autologging_integration,
-                            patch_function_exception,
+                            patch_error,
                         )
 
     if is_property_method:
@@ -464,12 +394,14 @@ def safe_patch(
         # Suppose `a1` is instance of class A,
         # then `a1.get_bound_safe_patch_fn(*args, **kwargs)` will be equivalent to
         # `bound_safe_patch_fn(*args, **kwargs)`
+        @wraps(original_fn.fget)
         def get_bound_safe_patch_fn(self):
             # This `original_fn.fget` call is for availability check, if it raise error
             # then `hasattr(obj, {func_name})` will return False
             # so it mimic the original property behavior.
             original_fn.fget(self)
 
+            @wraps(original_fn.fget)
             def bound_safe_patch_fn(*args, **kwargs):
                 return safe_patch_function(self, *args, **kwargs)
 
@@ -478,10 +410,9 @@ def safe_patch(
             # method will like `instance.property_decorated_method(...)`, and internally it will
             # call the `bound_safe_patch_fn`, the argument list don't include the `self` argument,
             # so return bound function here.
-            return update_wrapper_extended(bound_safe_patch_fn, original_fn.fget)
+            return bound_safe_patch_fn
 
         # Make unbound method `class.target_method` keep the same doc and signature
-        get_bound_safe_patch_fn = update_wrapper_extended(get_bound_safe_patch_fn, original_fn.fget)
         safe_patch_obj = property(get_bound_safe_patch_fn)
     else:
         safe_patch_obj = update_wrapper_extended(safe_patch_function, original)
@@ -523,19 +454,13 @@ def _should_skip_autolog(autologging_integration: str) -> bool:
     # Whether or not to exclude autologged content from user-created fluent runs
     # (i.e. runs created manually via `mlflow.start_run()`)
     exclusive = get_autologging_config(autologging_integration, "exclusive", False)
-    user_created_fluent_run_is_active = (
-        mlflow.active_run() and not _AutologgingSessionManager.active_session()
-    )
-    if user_created_fluent_run_is_active and exclusive:
+    session = _AutologgingSessionManager.active_session()
+    if mlflow.active_run() and not session and exclusive:
         return True
 
     # Failed to start an autologging session
-    if (
-        _AutologgingSessionManager.active_session() is not None
-        and _AutologgingSessionManager.active_session().state == "failed"
-    ):
+    if session is not None and session.is_failed():
         return True
-
     return False
 
 
@@ -544,10 +469,23 @@ def _should_skip_autolog(autologging_integration: str) -> bool:
 # - id: a unique session identifier (e.g., a UUID)
 # - state: the state of AutologgingSession, will be one of running/succeeded/failed
 class AutologgingSession:
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    RUNNING = "running"
+
     def __init__(self, integration, id_):
         self.integration = integration
         self.id = id_
-        self.state = "running"
+        self.state = self.RUNNING
+
+    def set_succeeded(self):
+        self.state = self.SUCCEEDED
+
+    def set_failed(self):
+        self.state = self.FAILED
+
+    def is_failed(self):
+        return self.state == self.FAILED
 
 
 class _AutologgingSessionManager:
@@ -556,26 +494,45 @@ class _AutologgingSessionManager:
     @classmethod
     @contextmanager
     def start_session(cls, integration):
+        if is_testing():
+            preexisting_run = mlflow.active_run()
+
         try:
             prev_session = cls._session
             if prev_session is None:
                 session_id = uuid.uuid4().hex
                 cls._session = AutologgingSession(integration, session_id)
             yield cls._session
+
+            if cls._session:
+                cls._session.set_succeeded()
+        except Exception as e:
+            if cls._session:
+                cls._session.set_failed()
+            raise e
+
         finally:
             # Only end the session upon termination of the context if we created
             # the session; otherwise, leave the session open for later termination
             # by its creator
             if prev_session is None:
-                cls._end_session()
+                cls._session = None
+
+            if is_testing():
+                _test_only_run_validation(preexisting_run, integration)
 
     @classmethod
     def active_session(cls):
         return cls._session
 
-    @classmethod
-    def _end_session(cls):
-        cls._session = None
+
+def wraps(wrapped):
+    """Extended version of functools.wraps, using update_wrapper_extended"""
+
+    def decorator(wrapper):
+        return update_wrapper_extended(wrapper, wrapped)
+
+    return decorator
 
 
 def update_wrapper_extended(wrapper, wrapped):
@@ -906,3 +863,35 @@ def _validate_args(
                 autologging_call_kwargs[key],
                 user_call_kwargs.get(key, None),
             )
+
+
+def _test_only_run_validation(preexisting_run, flavor):
+    if preexisting_run:
+        # If a run was already active before the patch function, nothing
+        return
+
+    assert not mlflow.active_run(), f"Autologging for {flavor} leaked an active run"
+
+    patch_runs = mlflow.search_runs(
+        filter_string=f"tags.mlflow.runName = '{_PATCH_RUN_NAME_FOR_TESTING}'",
+        max_results=1,
+        output_format="list",
+    )
+
+    if patch_runs:
+        _validate_autologging_run(flavor, patch_runs[0].info.run_id)
+
+
+class FunctionCallState:
+    def __init__(self):
+        self.result = None
+        self.exception = None
+        self.has_been_called = False
+
+    def set_result(self, result):
+        self.result = result
+        self.has_been_called = True
+
+    def set_exception(self, exception):
+        self.exception = exception
+        self.has_been_called = True

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -15,7 +15,7 @@ from mlflow.environment_variables import _MLFLOW_AUTOLOGGING_TESTING
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils import gorilla, is_iterator
 from mlflow.utils.autologging_utils import _logger
-from mlflow.utils.autologging_utils.events import AutologgingEventLogger
+from mlflow.utils.autologging_utils.events import AutologgingEventLoggerWrapper
 from mlflow.utils.autologging_utils.logging_and_warnings import (
     set_non_mlflow_warnings_behavior_for_current_thread,
     set_warning_behavior_during_autologging,
@@ -422,53 +422,28 @@ def safe_patch(
             # The exception raised during executing patching function
             patch_function_exception = None
 
-            def try_log_autologging_event(log_fn, *args):
-                try:
-                    log_fn(*args)
-                except Exception as e:
-                    _logger.debug(
-                        "Failed to log autologging event via '%s'. Exception: %s",
-                        log_fn,
-                        e,
-                    )
-
-            def call_original_fn_with_event_logging(original_fn, og_args, og_kwargs):
-                try:
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_original_function_start,
-                        session,
-                        destination,
-                        function_name,
-                        og_args,
-                        og_kwargs,
-                    )
-                    original_fn_result = original_fn(*og_args, **og_kwargs)
-
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_original_function_success,
-                        session,
-                        destination,
-                        function_name,
-                        og_args,
-                        og_kwargs,
-                    )
-                    return original_fn_result
-                except Exception as original_fn_e:
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_original_function_error,
-                        session,
-                        destination,
-                        function_name,
-                        og_args,
-                        og_kwargs,
-                        original_fn_e,
-                    )
-
-                    nonlocal failed_during_original
-                    failed_during_original = True
-                    raise
-
             with _AutologgingSessionManager.start_session(autologging_integration) as session:
+                event_logger = AutologgingEventLoggerWrapper(
+                    session,
+                    destination,
+                    function_name,
+                )
+
+                def call_original_fn_with_event_logging(original_fn, og_args, og_kwargs):
+                    try:
+                        event_logger.log_original_function_start(og_args, og_kwargs)
+
+                        original_fn_result = original_fn(*og_args, **og_kwargs)
+
+                        event_logger.log_original_function_success(og_args, og_kwargs)
+                        return original_fn_result
+                    except Exception as e:
+                        event_logger.log_original_function_error(og_args, og_kwargs, e)
+
+                        nonlocal failed_during_original
+                        failed_during_original = True
+                        raise
+
                 try:
 
                     def call_original(*og_args, **og_kwargs):
@@ -514,14 +489,7 @@ def safe_patch(
                     # the signature of the `original` argument during execution
                     call_original = update_wrapper_extended(call_original, original)
 
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_patch_function_start,
-                        session,
-                        destination,
-                        function_name,
-                        args,
-                        kwargs,
-                    )
+                    event_logger.log_patch_function_start(args, kwargs)
 
                     if patch_is_class:
                         patch_function.call(call_original, *args, **kwargs)
@@ -529,15 +497,8 @@ def safe_patch(
                         patch_function(call_original, *args, **kwargs)
 
                     session.state = "succeeded"
+                    event_logger.log_patch_function_success(args, kwargs)
 
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_patch_function_success,
-                        session,
-                        destination,
-                        function_name,
-                        args,
-                        kwargs,
-                    )
                 except Exception as e:
                     session.state = "failed"
                     patch_function_exception = e
@@ -570,11 +531,7 @@ def safe_patch(
                     # even if `patch_function_exception` exists, because original function failure
                     # means there's some error in user code (e.g. user provide wrong arguments)
                     if patch_function_exception is not None and not failed_during_original:
-                        try_log_autologging_event(
-                            AutologgingEventLogger.get_logger().log_patch_function_error,
-                            session,
-                            destination,
-                            function_name,
+                        event_logger.log_patch_function_error(
                             args,
                             kwargs,
                             patch_function_exception,

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -23,6 +23,7 @@ from mlflow.utils.autologging_utils import (
     with_managed_run,
 )
 from mlflow.utils.autologging_utils.safety import (
+    _PATCH_RUN_NAME_FOR_TESTING,
     ValidationExemptArgument,
     _AutologgingSessionManager,
     _validate_args,
@@ -403,7 +404,7 @@ def test_safe_patch_validates_autologging_runs_when_necessary_in_test_mode(
     assert autologging_utils.is_testing()
 
     def no_tag_run_patch_impl(original, *args, **kwargs):
-        with mlflow.start_run(nested=True):
+        with mlflow.start_run(nested=True, run_name=_PATCH_RUN_NAME_FOR_TESTING):
             return original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", no_tag_run_patch_impl)
@@ -433,7 +434,7 @@ def test_safe_patch_does_not_validate_autologging_runs_in_standard_mode(
     assert not autologging_utils.is_testing()
 
     def no_tag_run_patch_impl(original, *args, **kwargs):
-        with mlflow.start_run(nested=True):
+        with mlflow.start_run(nested=True, run_name=_PATCH_RUN_NAME_FOR_TESTING):
             return original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", no_tag_run_patch_impl)

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -15,7 +15,6 @@ from mlflow.utils.autologging_utils import (
     AutologgingEventLogger,
     ExceptionSafeAbstractClass,
     ExceptionSafeClass,
-    PatchFunction,
     autologging_integration,
     disable_autologging,
     is_testing,
@@ -184,32 +183,6 @@ def test_safe_patch_forwards_expected_arguments_to_function_based_patch_implemen
     assert bar_val == 11
 
 
-def test_safe_patch_forwards_expected_arguments_to_class_based_patch(
-    patch_destination, test_autologging_integration
-):
-    foo_val = None
-    bar_val = None
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, foo, bar=10):
-            nonlocal foo_val
-            nonlocal bar_val
-            foo_val = foo
-            bar_val = bar
-
-        def _on_exception(self, exception):
-            pass
-
-    safe_patch(test_autologging_integration, patch_destination, "fn", TestPatch)
-    with mock.patch(
-        "mlflow.utils.autologging_utils.PatchFunction.call", wraps=TestPatch.call
-    ) as call_mock:
-        patch_destination.fn(foo=7, bar=11)
-        assert call_mock.call_count == 1
-        assert foo_val == 7
-        assert bar_val == 11
-
-
 def test_safe_patch_provides_expected_original_function(
     patch_destination, test_autologging_integration
 ):
@@ -226,32 +199,6 @@ def test_safe_patch_provides_expected_original_function(
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
     assert patch_destination.fn(1, 2) == {"foo": 2, "bar": 4}
-
-
-def test_safe_patch_provides_expected_original_function_to_class_based_patch(
-    patch_destination, test_autologging_integration
-):
-    def original_fn(foo, bar=10):
-        return {
-            "foo": foo,
-            "bar": bar,
-        }
-
-    patch_destination.fn = original_fn
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, foo, bar=10):
-            return original(foo + 1, bar + 2)
-
-        def _on_exception(self, exception):
-            pass
-
-    safe_patch(test_autologging_integration, patch_destination, "fn", TestPatch)
-    with mock.patch(
-        "mlflow.utils.autologging_utils.PatchFunction.call", wraps=TestPatch.call
-    ) as call_mock:
-        assert patch_destination.fn(1, 2) == {"foo": 2, "bar": 4}
-        assert call_mock.call_count == 1
 
 
 def test_safe_patch_propagates_exceptions_raised_from_original_function(
@@ -906,53 +853,6 @@ def test_exception_safe_class_exhibits_expected_behavior_in_test_mode(baseclass,
     assert exc.value == exc_to_throw
 
 
-def test_patch_function_class_call_invokes_implementation_and_returns_result():
-    class TestPatchFunction(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            return 10
-
-        def _on_exception(self, exception):
-            pass
-
-    assert TestPatchFunction.call("foo", lambda: "foo") == 10
-
-
-@pytest.mark.parametrize("exception_class", [Exception, KeyboardInterrupt])
-def test_patch_function_class_call_handles_exceptions_properly(exception_class):
-    called_on_exception = False
-
-    class TestPatchFunction(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            raise exception_class("implementation exception")
-
-        def _on_exception(self, exception):
-            nonlocal called_on_exception
-            called_on_exception = True
-            raise Exception("on_exception exception")
-
-    # Even if an exception is thrown from `_on_exception`, we expect the original
-    # exception from the implementation to be surfaced to the caller
-    with pytest.raises(exception_class, match="implementation exception"):
-        TestPatchFunction.call("foo", lambda: "foo")
-
-    assert called_on_exception
-
-
-def test_with_managed_runs_yields_functions_and_classes_as_expected():
-    def patch_function(original, *args, **kwargs):
-        pass
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            pass
-
-        def _on_exception(self, exception):
-            pass
-
-    assert callable(with_managed_run("test_integration", patch_function))
-    assert inspect.isclass(with_managed_run("test_integration", TestPatch))
-
-
 def test_with_managed_run_with_non_throwing_function_exhibits_expected_behavior():
     client = MlflowClient()
 
@@ -1000,61 +900,6 @@ def test_with_managed_run_with_throwing_function_exhibits_expected_behavior():
     assert RunStatus.from_string(status2) == RunStatus.FINISHED
 
 
-def test_with_managed_run_with_non_throwing_class_exhibits_expected_behavior():
-    client = MlflowClient()
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            return mlflow.active_run()
-
-        def _on_exception(self, exception):
-            pass
-
-    TestPatch = with_managed_run("test_integration", TestPatch)
-
-    run1 = TestPatch.call(lambda: "foo")
-    run1_status = client.get_run(run1.info.run_id).info.status
-    assert RunStatus.from_string(run1_status) == RunStatus.FINISHED
-
-    with mlflow.start_run() as active_run:
-        run2 = TestPatch.call(lambda: "foo")
-
-    assert run2 == active_run
-    run2_status = client.get_run(run2.info.run_id).info.status
-    assert RunStatus.from_string(run2_status) == RunStatus.FINISHED
-
-
-def test_with_managed_run_with_throwing_class_exhibits_expected_behavior():
-    client = MlflowClient()
-    patch_function_active_run = None
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            nonlocal patch_function_active_run
-            patch_function_active_run = mlflow.active_run()
-            raise Exception("bad implementation")
-
-        def _on_exception(self, exception):
-            pass
-
-    TestPatch = with_managed_run("test_integration", TestPatch)
-
-    with pytest.raises(Exception, match="bad implementation"):
-        TestPatch.call(lambda: "foo")
-
-    assert patch_function_active_run is not None
-    status1 = client.get_run(patch_function_active_run.info.run_id).info.status
-    assert RunStatus.from_string(status1) == RunStatus.FAILED
-
-    with mlflow.start_run() as active_run, pytest.raises(Exception, match="bad implementation"):
-        TestPatch.call(lambda: "foo")
-    assert patch_function_active_run == active_run
-    # `with_managed_run` should not terminate a preexisting MLflow run,
-    # even if the patch function throws
-    status2 = client.get_run(active_run.info.run_id).info.status
-    assert RunStatus.from_string(status2) == RunStatus.FINISHED
-
-
 def test_with_managed_run_sets_specified_run_tags():
     client = MlflowClient()
     tags_to_set = {
@@ -1067,17 +912,6 @@ def test_with_managed_run_sets_specified_run_tags():
     )
     run1 = patch_function_1(lambda: "foo")
     assert tags_to_set.items() <= client.get_run(run1.info.run_id).data.tags.items()
-
-    class PatchFunction2(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            return mlflow.active_run()
-
-        def _on_exception(self, exception):
-            pass
-
-    patch_function_2 = with_managed_run("test_integration", PatchFunction2, tags=tags_to_set)
-    run2 = patch_function_2.call(lambda: "foo")
-    assert tags_to_set.items() <= client.get_run(run2.info.run_id).data.tags.items()
 
 
 @pytest.mark.usefixtures(test_mode_on.__name__)
@@ -1100,22 +934,6 @@ def test_with_managed_run_ends_run_on_keyboard_interrupt():
     assert not mlflow.active_run()
     run_status_1 = client.get_run(run.info.run_id).info.status
     assert RunStatus.from_string(run_status_1) == RunStatus.FAILED
-
-    class PatchFunction2(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            return original(*args, **kwargs)
-
-        def _on_exception(self, exception):
-            pass
-
-    patch_function_2 = with_managed_run("test_integration", PatchFunction2)
-
-    with pytest.raises(KeyboardInterrupt, match=r".*"):
-        patch_function_2.call(original)
-
-    assert not mlflow.active_run()
-    run_status_2 = client.get_run(run.info.run_id).info.status
-    assert RunStatus.from_string(run_status_2) == RunStatus.FAILED
 
 
 @pytest.mark.usefixtures(test_mode_on.__name__)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14724?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14724/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14724
```

</p>
</details>



### What changes are proposed in this pull request?

***This is a part of `safe_patch` refactoring effort as a preparation for supporting async/stream functions. To support these use cases, the inner function `safe_patch_function` cannot be re-used as is, because we need a different function signature e.g. `async def`. The goal is to simplify the inner function so that we don't need to duplicate hundreds of lines to support new use cases.***

This PR depends on https://github.com/mlflow/mlflow/pull/14666 and https://github.com/mlflow/mlflow/pull/14668. The actual diff for this PR is https://github.com/mlflow/mlflow/commit/993676a1854e8010d305b578885c870ff81e8537

Final refactoring for the logic before adding async support. Removing nested inner functions  in `safe_patch_function` and simplifies the logic from 250 lines to 70 lines. Duplicating it for async support is not as painful as before.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
