### PR TITLE
[Safe-patch 5] Async Support

### DIFF
--- a/mlflow/keras/autologging.py
+++ b/mlflow/keras/autologging.py
@@ -17,7 +17,6 @@ from mlflow.tracking.context import registry as context_registry
 from mlflow.utils import is_iterator
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
-    PatchFunction,
     autologging_integration,
     get_autologging_config,
     log_fn_args_as_params,
@@ -196,76 +195,73 @@ def autolog(
             model.fit(data, label, batch_size=4, epochs=2)
     """
 
-    class FitPatch(PatchFunction):
-        def __init__(self):
-            pass
+    def _patched_inference(original, inst, *args, **kwargs):
+        unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
-        def _infer_batch_size(self, inst, *args, **kwargs):
-            batch_size = None
-            if "batch_size" in kwargs:
-                batch_size = kwargs["batch_size"]
+        batch_size, args, kwargs = _infer_batch_size(inst, *args, **kwargs)
+
+        if batch_size is not None:
+            mlflow.log_param("batch_size", batch_size)
+            unlogged_params.append("batch_size")
+
+        log_fn_args_as_params(original, [], kwargs, unlogged_params)
+
+        if log_datasets:
+            try:
+                context_tags = context_registry.resolve_tags()
+                source = CodeDatasetSource(tags=context_tags)
+                x, y = _parse_dataset(*args, **kwargs)
+                _log_dataset(x, source, "train", targets=y)
+
+                if "validation_data" in kwargs:
+                    _log_dataset(kwargs["validation_data"], source, "eval")
+
+            except Exception as e:
+                _logger.warning(f"Failed to log dataset information to MLflow. Reason: {e}")
+
+        # Add `MlflowCallback` to the callback list.
+        callbacks = args[5] if len(args) >= 6 else kwargs.get("callbacks", [])
+        mlflow_callback = MlflowCallback(
+            log_every_epoch=log_every_epoch,
+            log_every_n_steps=log_every_n_steps,
+        )
+        _check_existing_mlflow_callback(callbacks)
+        callbacks.append(mlflow_callback)
+        kwargs["callbacks"] = callbacks
+        history = original(inst, *args, **kwargs)
+
+        if log_models:
+            _log_keras_model(inst, save_exported_model, log_model_signatures, save_model_kwargs)
+        return history
+
+    safe_patch(
+        "keras", keras.Model, "fit", _patched_inference, manage_run=True, extra_tags=extra_tags
+    )
+
+
+def _infer_batch_size(inst, *args, **kwargs):
+    batch_size = None
+    if "batch_size" in kwargs:
+        batch_size = kwargs["batch_size"]
+    else:
+        training_data = kwargs["x"] if "x" in kwargs else args[0]
+        if _batch_size := getattr(training_data, "batch_size", None):
+            batch_size = _batch_size
+        elif _batch_size := getattr(training_data, "_batch_size", None):
+            batch_size = _batch_size if isinstance(_batch_size, int) else _batch_size.numpy()
+        elif is_iterator(training_data):
+            is_single_input_model = isinstance(inst.input_shape, tuple)
+            peek = next(training_data)
+            batch_size = len(peek[0]) if is_single_input_model else len(peek[0][0])
+
+            def origin_training_data_generator_fn():
+                yield peek
+                yield from training_data
+
+            origin_training_data = origin_training_data_generator_fn()
+
+            if "x" in kwargs:
+                kwargs["x"] = origin_training_data
             else:
-                training_data = kwargs["x"] if "x" in kwargs else args[0]
-                if _batch_size := getattr(training_data, "batch_size", None):
-                    batch_size = _batch_size
-                elif _batch_size := getattr(training_data, "_batch_size", None):
-                    batch_size = (
-                        _batch_size if isinstance(_batch_size, int) else _batch_size.numpy()
-                    )
-                elif is_iterator(training_data):
-                    is_single_input_model = isinstance(inst.input_shape, tuple)
-                    peek = next(training_data)
-                    batch_size = len(peek[0]) if is_single_input_model else len(peek[0][0])
-
-                    def origin_training_data_generator_fn():
-                        yield peek
-                        yield from training_data
-
-                    origin_training_data = origin_training_data_generator_fn()
-
-                    if "x" in kwargs:
-                        kwargs["x"] = origin_training_data
-                    else:
-                        args = (origin_training_data,) + args[1:]
-            return batch_size, args, kwargs
-
-        def _patch_implementation(self, original, inst, *args, **kwargs):
-            unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
-
-            batch_size, args, kwargs = self._infer_batch_size(inst, *args, **kwargs)
-
-            if batch_size is not None:
-                mlflow.log_param("batch_size", batch_size)
-                unlogged_params.append("batch_size")
-
-            log_fn_args_as_params(original, [], kwargs, unlogged_params)
-
-            if log_datasets:
-                try:
-                    context_tags = context_registry.resolve_tags()
-                    source = CodeDatasetSource(tags=context_tags)
-                    x, y = _parse_dataset(*args, **kwargs)
-                    _log_dataset(x, source, "train", targets=y)
-
-                    if "validation_data" in kwargs:
-                        _log_dataset(kwargs["validation_data"], source, "eval")
-
-                except Exception as e:
-                    _logger.warning(f"Failed to log dataset information to MLflow. Reason: {e}")
-
-            # Add `MlflowCallback` to the callback list.
-            callbacks = args[5] if len(args) >= 6 else kwargs.get("callbacks", [])
-            mlflow_callback = MlflowCallback(
-                log_every_epoch=log_every_epoch,
-                log_every_n_steps=log_every_n_steps,
-            )
-            _check_existing_mlflow_callback(callbacks)
-            callbacks.append(mlflow_callback)
-            kwargs["callbacks"] = callbacks
-            history = original(inst, *args, **kwargs)
-
-            if log_models:
-                _log_keras_model(inst, save_exported_model, log_model_signatures, save_model_kwargs)
-            return history
-
-    safe_patch("keras", keras.Model, "fit", FitPatch, manage_run=True, extra_tags=extra_tags)
+                args = (origin_training_data,) + args[1:]
+    return batch_size, args, kwargs

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -38,7 +38,6 @@ from mlflow.tracking.fluent import _shut_down_async_logging
 from mlflow.types.schema import TensorSpec
 from mlflow.utils import is_iterator
 from mlflow.utils.autologging_utils import (
-    PatchFunction,
     autologging_integration,
     get_autologging_config,
     log_fn_args_as_params,
@@ -1242,11 +1241,9 @@ def autolog(
             keras_model_kwargs=keras_model_kwargs,
         )
 
-    class FitPatch(PatchFunction):
-        def __init__(self):
-            self.log_dir = None
-
-        def _patch_implementation(self, original, inst, *args, **kwargs):
+    def _patched_inference(original, inst, *args, **kwargs):
+        log_dir = None
+        try:
             unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
             batch_size = None
@@ -1298,7 +1295,7 @@ def autolog(
                 # modifying their contents for future training invocations. Introduce
                 # TensorBoard & tf.keras callbacks if necessary
                 callbacks = list(args[5])
-                callbacks, self.log_dir = _setup_callbacks(
+                callbacks, log_dir = _setup_callbacks(
                     callbacks,
                     log_every_epoch=log_every_epoch,
                     log_every_n_steps=log_every_n_steps,
@@ -1311,7 +1308,7 @@ def autolog(
                 # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
                 # & tf.keras callbacks if necessary
                 callbacks = list(kwargs.get("callbacks") or [])
-                kwargs["callbacks"], self.log_dir = _setup_callbacks(
+                kwargs["callbacks"], log_dir = _setup_callbacks(
                     callbacks,
                     log_every_epoch=log_every_epoch,
                     log_every_n_steps=log_every_n_steps,
@@ -1364,27 +1361,30 @@ def autolog(
             _shut_down_async_logging()
 
             mlflow.log_artifacts(
-                local_dir=self.log_dir.location,
+                local_dir=log_dir.location,
                 artifact_path="tensorboard_logs",
             )
-            if self.log_dir.is_temp:
-                shutil.rmtree(self.log_dir.location)
+            if log_dir.is_temp:
+                shutil.rmtree(log_dir.location)
             return history
 
-        def _on_exception(self, exception):
-            if (
-                self.log_dir is not None
-                and self.log_dir.is_temp
-                and os.path.exists(self.log_dir.location)
-            ):
-                shutil.rmtree(self.log_dir.location)
+        except (Exception, KeyboardInterrupt) as e:
+            try:
+                if log_dir is not None and log_dir.is_temp and os.path.exists(log_dir.location):
+                    shutil.rmtree(log_dir.location)
+            finally:
+                # Regardless of what happens during the `_on_exception` callback, reraise
+                # the original implementation exception once the callback completes
+                raise e
 
-    managed = [
-        (tf.keras.Model, "fit", FitPatch),
-    ]
-
-    for p in managed:
-        safe_patch(FLAVOR_NAME, *p, manage_run=True, extra_tags=extra_tags)
+    safe_patch(
+        FLAVOR_NAME,
+        tf.keras.Model,
+        "fit",
+        _patched_inference,
+        manage_run=True,
+        extra_tags=extra_tags,
+    )
 
 
 def _log_tensorflow_dataset(tensorflow_dataset, source, context, name=None, targets=None):

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -31,7 +31,6 @@ from mlflow.utils.autologging_utils.logging_and_warnings import (
 from mlflow.utils.autologging_utils.safety import (  # noqa: F401
     ExceptionSafeAbstractClass,
     ExceptionSafeClass,
-    PatchFunction,
     exception_safe_function_for_class,
     is_testing,
     picklable_exception_safe_function,

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -21,8 +21,8 @@ from mlflow.ml_package_versions import _ML_PACKAGE_VERSIONS, FLAVOR_TO_MODULE_NA
 from mlflow.utils.autologging_utils.client import MlflowAutologgingQueueingClient  # noqa: F401
 from mlflow.utils.autologging_utils.events import AutologgingEventLogger
 from mlflow.utils.autologging_utils.logging_and_warnings import (
-    set_mlflow_events_and_warnings_behavior_globally,
-    set_non_mlflow_warnings_behavior_for_current_thread,
+    MlflowEventsAndWarningsBehavior,
+    NonMlflowWarningsBehaviorForCurrentThread,
 )
 
 # Wildcard import other autologging utilities (e.g. safety utilities, event logging utilities) used
@@ -448,7 +448,7 @@ def autologging_integration(name):
             # MLflow event logger, and enforce silent mode if applicable (i.e. if the corresponding
             # autologging integration was called with `silent=True`)
             with (
-                set_mlflow_events_and_warnings_behavior_globally(
+                MlflowEventsAndWarningsBehavior(
                     # MLflow warnings emitted during autologging setup / enablement are likely
                     # actionable and relevant to the user, so they should be emitted as normal
                     # when `silent=False`. For reference, see recommended warning and event logging
@@ -457,7 +457,7 @@ def autologging_integration(name):
                     disable_event_logs=is_silent_mode,
                     disable_warnings=is_silent_mode,
                 ),
-                set_non_mlflow_warnings_behavior_for_current_thread(
+                NonMlflowWarningsBehaviorForCurrentThread(
                     # non-MLflow warnings emitted during autologging setup / enablement are not
                     # actionable for the user, as they are a byproduct of the autologging
                     # implementation. Accordingly, they should be rerouted to `logger.warning()`.

--- a/mlflow/utils/autologging_utils/events.py
+++ b/mlflow/utils/autologging_utils/events.py
@@ -1,6 +1,109 @@
 import warnings
+from typing import Any
 
 from mlflow.utils.autologging_utils import _logger
+
+
+class AutologgingRuntimeLogger:
+    """
+    Wrapper class for an `AutologgingEventLogger
+    """
+
+    def __init__(self, session, destinatinon, function_name):
+        self._logger = AutologgingEventLogger.get_logger()
+        self._session = session
+        self._destination = destinatinon
+        self._function_name = function_name
+
+
+def _catch_exception(fn):
+    """A decorator that catches exceptions thrown by the wrapped function and logs them."""
+
+    def wrapper(*args):
+        try:
+            fn(*args)
+        except Exception as e:
+            _logger.debug(f"Failed to log autologging event via '{fn}'. Exception: {e}")
+
+    return wrapper
+
+
+class AutologgingEventLoggerWrapper:
+    """
+    A wrapper around AutologgingEventLogger for DRY:
+      - Store common arguments to avoid passing them to each logger method
+      - Catches exceptions thrown by the logger and logs them
+
+    NB: We could not modify the AutologgingEventLogger class directly because
+        it is used in Databricks code base as well.
+    """
+
+    def __init__(self, session, destination: Any, function_name: str):
+        self._session = session
+        self._destination = destination
+        self._function_name = function_name
+
+    @_catch_exception
+    def log_patch_function_start(self, args, kwargs):
+        AutologgingEventLogger.get_logger().log_patch_function_start(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+        )
+
+    @_catch_exception
+    def log_patch_function_success(self, args, kwargs):
+        AutologgingEventLogger.get_logger().log_patch_function_success(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+        )
+
+    @_catch_exception
+    def log_patch_function_error(self, args, kwargs, exception):
+        AutologgingEventLogger.get_logger().log_patch_function_error(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+            exception,
+        )
+
+    @_catch_exception
+    def log_original_function_start(self, args, kwargs):
+        AutologgingEventLogger.get_logger().log_original_function_start(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+        )
+
+    @_catch_exception
+    def log_original_function_success(self, args, kwargs):
+        AutologgingEventLogger.get_logger().log_original_function_success(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+        )
+
+    @_catch_exception
+    def log_original_function_error(self, args, kwargs, exception):
+        AutologgingEventLogger.get_logger().log_original_function_error(
+            self._session,
+            self._destination,
+            self._function_name,
+            args,
+            kwargs,
+            exception,
+        )
 
 
 class AutologgingEventLogger:

--- a/mlflow/utils/autologging_utils/logging_and_warnings.py
+++ b/mlflow/utils/autologging_utils/logging_and_warnings.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from threading import RLock
 from threading import get_ident as get_current_thread_id
@@ -28,7 +28,7 @@ def set_warning_behavior_during_autologging(autologging_integration: str):
 
     is_silent_mode = get_autologging_config(autologging_integration, "silent", False)
     with (
-        set_mlflow_events_and_warnings_behavior_globally(
+        MlflowEventsAndWarningsBehavior(
             # MLflow warnings emitted during autologging training sessions are likely not
             # actionable and result from the autologging implementation invoking another MLflow
             # API. Accordingly, we reroute these warnings to the MLflow event logger with level
@@ -38,7 +38,7 @@ def set_warning_behavior_during_autologging(autologging_integration: str):
             disable_event_logs=is_silent_mode,
             disable_warnings=is_silent_mode,
         ),
-        set_non_mlflow_warnings_behavior_for_current_thread(
+        NonMlflowWarningsBehaviorForCurrentThread(
             # non-MLflow Warnings emitted during the autologging preamble (before the original /
             # underlying ML function is called) and postamble (after the original / underlying
             # ML function is called) are likely not actionable and result from the autologging
@@ -46,6 +46,27 @@ def set_warning_behavior_during_autologging(autologging_integration: str):
             # these warnings to the MLflow event logger with level WARNING. For reference, see
             # recommended warning and event logging behaviors from
             # https://docs.python.org/3/howto/logging.html#when-to-use-logging
+            reroute_warnings=True,
+            disable_warnings=is_silent_mode,
+        ),
+    ):
+        yield
+
+@asynccontextmanager
+async def async_set_warning_behavior_during_autologging(autologging_integration: str):
+    """
+    Async version of `set_warning_behavior_during_autologging`
+    """
+    from mlflow.utils.autologging_utils import get_autologging_config
+
+    is_silent_mode = get_autologging_config(autologging_integration, "silent", False)
+    async with (
+        MlflowEventsAndWarningsBehavior(
+            reroute_warnings=True,
+            disable_event_logs=is_silent_mode,
+            disable_warnings=is_silent_mode,
+        ),
+        NonMlflowWarningsBehaviorForCurrentThread(
             reroute_warnings=True,
             disable_warnings=is_silent_mode,
         ),
@@ -222,8 +243,7 @@ class _WarningsController:
 _WARNINGS_CONTROLLER = _WarningsController()
 
 
-@contextmanager
-def set_non_mlflow_warnings_behavior_for_current_thread(disable_warnings, reroute_warnings):
+class NonMlflowWarningsBehaviorForCurrentThread:
     """
     Context manager that modifies the behavior of non-MLflow warnings upon entry, according to the
     specified parameters.
@@ -234,32 +254,60 @@ def set_non_mlflow_warnings_behavior_for_current_thread(disable_warnings, rerout
         reroute_warnings: If `True`, reroute non-MLflow warnings to an MLflow event logger with
             level WARNING. If `False`, do not reroute non-MLflow warnings.
     """
-    prev_disablement_state = (
-        _WARNINGS_CONTROLLER.get_warnings_disablement_state_for_current_thread()
-    )
-    prev_rerouting_state = _WARNINGS_CONTROLLER.get_warnings_rerouting_state_for_current_thread()
-    try:
-        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_disablement_state_for_current_thread(
-            disabled=disable_warnings
+    def __init__(self, disable_warnings, reroute_warnings):
+        """
+        Args:
+            disable_warnings: If `True`, disable (mutate & discard) non-MLflow warnings.
+            reroute_warnings: If `True`, reroute non-MLflow warnings to an MLflow event logger.
+        """
+        self._disable_warnings = disable_warnings
+        self._reroute_warnings = reroute_warnings
+        self._prev_disablement_state = None
+        self._prev_rerouting_state = None
+
+    def _enter_impl(self):
+        self._prev_disablement_state = (
+            _WARNINGS_CONTROLLER.get_warnings_disablement_state_for_current_thread()
         )
-        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_rerouting_state_for_current_thread(
-            rerouted=reroute_warnings
-        )
-        yield
-    finally:
-        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_disablement_state_for_current_thread(
-            disabled=prev_disablement_state
-        )
-        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_rerouting_state_for_current_thread(
-            rerouted=prev_rerouting_state
+        self._prev_rerouting_state = (
+            _WARNINGS_CONTROLLER.get_warnings_rerouting_state_for_current_thread()
         )
 
+        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_disablement_state_for_current_thread(
+            disabled=self._disable_warnings
+        )
+        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_rerouting_state_for_current_thread(
+            rerouted=self._reroute_warnings
+        )
 
-@contextmanager
-def set_mlflow_events_and_warnings_behavior_globally(
-    disable_event_logs, disable_warnings, reroute_warnings
-):
-    """Threadsafe context manager that modifies the behavior of MLflow event logging statements
+    def _exit_impl(self, *args, **kwargs):
+        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_disablement_state_for_current_thread(
+            disabled=self._prev_disablement_state
+        )
+        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_rerouting_state_for_current_thread(
+            rerouted=self._prev_rerouting_state
+        )
+
+    def __enter__(self):
+        self._enter_impl()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+        return None
+
+    async def __aenter__(self):
+        self._enter_impl()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+        return None
+
+
+class MlflowEventsAndWarningsBehavior:
+    """
+    Threadsafe context manager that modifies the behavior of MLflow event logging statements
     and MLflow warnings upon entry, according to the specified parameters. Modifications are
     applied globally across all threads and are not reverted until all threads that have made
     a particular modification have exited the context.
@@ -271,16 +319,7 @@ def set_mlflow_events_and_warnings_behavior_globally(
             do not disable MLflow warnings.
         reroute_warnings: If `True`, reroute MLflow warnings to an MLflow event logger with
             level WARNING. If `False`, do not reroute MLflow warnings.
-
     """
-
-    with _SetMlflowEventsAndWarningsBehaviorGlobally(
-        disable_event_logs, disable_warnings, reroute_warnings
-    ):
-        yield
-
-
-class _SetMlflowEventsAndWarningsBehaviorGlobally:
     _lock = RLock()
     _disable_event_logs_count = 0
     _disable_warnings_count = 0
@@ -291,49 +330,65 @@ class _SetMlflowEventsAndWarningsBehaviorGlobally:
         self._disable_warnings = disable_warnings
         self._reroute_warnings = reroute_warnings
 
-    def __enter__(self):
+    def _enter_impl(self):
         try:
-            with _SetMlflowEventsAndWarningsBehaviorGlobally._lock:
+            with self._lock:
                 if self._disable_event_logs:
-                    if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
+                    if self._disable_event_logs_count <= 0:
                         logging_utils.disable_logging()
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count += 1
+                    self._disable_event_logs_count += 1
 
                 if self._disable_warnings:
-                    if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
+                    if self._disable_warnings_count <= 0:
                         _WARNINGS_CONTROLLER.set_mlflow_warnings_disablement_state_globally(
                             disabled=True
                         )
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count += 1
+                    self._disable_warnings_count += 1
 
                 if self._reroute_warnings:
-                    if _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
+                    if self._reroute_warnings_count <= 0:
                         _WARNINGS_CONTROLLER.set_mlflow_warnings_rerouting_state_globally(
                             rerouted=True
                         )
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count += 1
+                    self._reroute_warnings_count += 1
         except Exception:
             pass
 
-    def __exit__(self, *args, **kwargs):
+    def _exit_impl(self, *args, **kwargs):
         try:
-            with _SetMlflowEventsAndWarningsBehaviorGlobally._lock:
+            with self._lock:
                 if self._disable_event_logs:
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count -= 1
+                    self._disable_event_logs_count -= 1
                 if self._disable_warnings:
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count -= 1
+                    self._disable_warnings_count -= 1
                 if self._reroute_warnings:
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count -= 1
+                    self._reroute_warnings_count -= 1
 
-                if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
+                if self._disable_event_logs_count <= 0:
                     logging_utils.enable_logging()
-                if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
+                if self._disable_warnings_count <= 0:
                     _WARNINGS_CONTROLLER.set_mlflow_warnings_disablement_state_globally(
                         disabled=False
                     )
-                if _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
+                if self._reroute_warnings_count <= 0:
                     _WARNINGS_CONTROLLER.set_mlflow_warnings_rerouting_state_globally(
                         rerouted=False
                     )
         except Exception:
             pass
+
+    def __enter__(self):
+        self._enter_impl()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+        return None
+
+    async def __aenter__(self):
+        self._enter_impl()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+        return None

--- a/mlflow/utils/autologging_utils/logging_and_warnings.py
+++ b/mlflow/utils/autologging_utils/logging_and_warnings.py
@@ -52,6 +52,7 @@ def set_warning_behavior_during_autologging(autologging_integration: str):
     ):
         yield
 
+
 @asynccontextmanager
 async def async_set_warning_behavior_during_autologging(autologging_integration: str):
     """
@@ -254,6 +255,7 @@ class NonMlflowWarningsBehaviorForCurrentThread:
         reroute_warnings: If `True`, reroute non-MLflow warnings to an MLflow event logger with
             level WARNING. If `False`, do not reroute non-MLflow warnings.
     """
+
     def __init__(self, disable_warnings, reroute_warnings):
         """
         Args:
@@ -320,6 +322,7 @@ class MlflowEventsAndWarningsBehavior:
         reroute_warnings: If `True`, reroute MLflow warnings to an MLflow event logger with
             level WARNING. If `False`, do not reroute MLflow warnings.
     """
+
     _lock = RLock()
     _disable_event_logs_count = 0
     _disable_warnings_count = 0

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -593,9 +593,11 @@ class _AutologgingSessionManager:
                 cls._session = AutologgingSession(integration, session_id)
             yield cls._session
 
-            cls._session.set_succeeded()
+            if cls._session:
+                cls._session.set_succeeded()
         except Exception as e:
-            cls._session.set_failed()
+            if cls._session:
+                cls._session.set_failed()
             raise e
 
         finally:

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -15,7 +15,7 @@ from mlflow.environment_variables import _MLFLOW_AUTOLOGGING_TESTING
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils import gorilla, is_iterator
 from mlflow.utils.autologging_utils import _logger
-from mlflow.utils.autologging_utils.events import AutologgingEventLogger
+from mlflow.utils.autologging_utils.events import AutologgingEventLoggerWrapper
 from mlflow.utils.autologging_utils.logging_and_warnings import (
     set_non_mlflow_warnings_behavior_for_current_thread,
     set_warning_behavior_during_autologging,
@@ -422,53 +422,28 @@ def safe_patch(
             # The exception raised during executing patching function
             patch_function_exception = None
 
-            def try_log_autologging_event(log_fn, *args):
-                try:
-                    log_fn(*args)
-                except Exception as e:
-                    _logger.debug(
-                        "Failed to log autologging event via '%s'. Exception: %s",
-                        log_fn,
-                        e,
-                    )
-
-            def call_original_fn_with_event_logging(original_fn, og_args, og_kwargs):
-                try:
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_original_function_start,
-                        session,
-                        destination,
-                        function_name,
-                        og_args,
-                        og_kwargs,
-                    )
-                    original_fn_result = original_fn(*og_args, **og_kwargs)
-
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_original_function_success,
-                        session,
-                        destination,
-                        function_name,
-                        og_args,
-                        og_kwargs,
-                    )
-                    return original_fn_result
-                except Exception as original_fn_e:
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_original_function_error,
-                        session,
-                        destination,
-                        function_name,
-                        og_args,
-                        og_kwargs,
-                        original_fn_e,
-                    )
-
-                    nonlocal failed_during_original
-                    failed_during_original = True
-                    raise
-
             with _AutologgingSessionManager.start_session(autologging_integration) as session:
+                event_logger = AutologgingEventLoggerWrapper(
+                    session,
+                    destination,
+                    function_name,
+                )
+
+                def call_original_fn_with_event_logging(original_fn, og_args, og_kwargs):
+                    try:
+                        event_logger.log_original_function_start(og_args, og_kwargs)
+
+                        original_fn_result = original_fn(*og_args, **og_kwargs)
+
+                        event_logger.log_original_function_success(og_args, og_kwargs)
+                        return original_fn_result
+                    except Exception as e:
+                        event_logger.log_original_function_error(og_args, og_kwargs, e)
+
+                        nonlocal failed_during_original
+                        failed_during_original = True
+                        raise
+
                 try:
 
                     def call_original(*og_args, **og_kwargs):
@@ -514,14 +489,7 @@ def safe_patch(
                     # the signature of the `original` argument during execution
                     call_original = update_wrapper_extended(call_original, original)
 
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_patch_function_start,
-                        session,
-                        destination,
-                        function_name,
-                        args,
-                        kwargs,
-                    )
+                    event_logger.log_patch_function_start(args, kwargs)
 
                     if patch_is_class:
                         patch_function.call(call_original, *args, **kwargs)
@@ -529,15 +497,8 @@ def safe_patch(
                         patch_function(call_original, *args, **kwargs)
 
                     session.state = "succeeded"
+                    event_logger.log_patch_function_success(args, kwargs)
 
-                    try_log_autologging_event(
-                        AutologgingEventLogger.get_logger().log_patch_function_success,
-                        session,
-                        destination,
-                        function_name,
-                        args,
-                        kwargs,
-                    )
                 except Exception as e:
                     session.state = "failed"
                     patch_function_exception = e
@@ -570,11 +531,7 @@ def safe_patch(
                     # even if `patch_function_exception` exists, because original function failure
                     # means there's some error in user code (e.g. user provide wrong arguments)
                     if patch_function_exception is not None and not failed_during_original:
-                        try_log_autologging_event(
-                            AutologgingEventLogger.get_logger().log_patch_function_error,
-                            session,
-                            destination,
-                            function_name,
+                        event_logger.log_patch_function_error(
                             args,
                             kwargs,
                             patch_function_exception,

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -14,6 +14,7 @@ PATCH_DESTINATION_FN_DEFAULT_RESULT = "original_result"
 @pytest.fixture(params=[False, True], ids=["sync", "async"])
 def patch_destination(request):
     if not request.param:
+
         class Destination:
             def __init__(self):
                 self.fn_call_count = 0
@@ -38,6 +39,7 @@ def patch_destination(request):
                 return False
 
     else:
+
         class Destination:
             def __init__(self):
                 self.fn_call_count = 0

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -10,28 +10,58 @@ from mlflow.utils.autologging_utils import is_testing
 PATCH_DESTINATION_FN_DEFAULT_RESULT = "original_result"
 
 
-@pytest.fixture
-def patch_destination():
-    class PatchObj:
-        def __init__(self):
-            self.fn_call_count = 0
-            self.recurse_fn_call_count = 0
+# Fixture to run the test case with and without async logging enabled
+@pytest.fixture(params=[False, True], ids=["sync", "async"])
+def patch_destination(request):
+    if not request.param:
+        class Destination:
+            def __init__(self):
+                self.fn_call_count = 0
+                self.recurse_fn_call_count = 0
 
-        def fn(self, *args, **kwargs):
-            self.fn_call_count += 1
-            return PATCH_DESTINATION_FN_DEFAULT_RESULT
-
-        def recursive_fn(self, level, max_depth):
-            self.recurse_fn_call_count += 1
-            if level == max_depth:
+            def fn(self, *args, **kwargs):
+                self.fn_call_count += 1
                 return PATCH_DESTINATION_FN_DEFAULT_RESULT
-            else:
-                return self.recursive_fn(level + 1, max_depth)
 
-        def throw_error_fn(self, error_to_raise):
-            raise error_to_raise
+            def recursive_fn(self, level, max_depth):
+                self.recurse_fn_call_count += 1
+                if level == max_depth:
+                    return PATCH_DESTINATION_FN_DEFAULT_RESULT
+                else:
+                    return self.recursive_fn(level + 1, max_depth)
 
-    return PatchObj()
+            def throw_error_fn(self, error_to_raise):
+                raise error_to_raise
+
+            @property
+            def is_async(self):
+                return False
+
+    else:
+        class Destination:
+            def __init__(self):
+                self.fn_call_count = 0
+                self.recurse_fn_call_count = 0
+
+            async def fn(self, *args, **kwargs):
+                self.fn_call_count += 1
+                return PATCH_DESTINATION_FN_DEFAULT_RESULT
+
+            async def recursive_fn(self, level, max_depth):
+                self.recurse_fn_call_count += 1
+                if level == max_depth:
+                    return PATCH_DESTINATION_FN_DEFAULT_RESULT
+                else:
+                    return await self.recursive_fn(level + 1, max_depth)
+
+            async def throw_error_fn(self, error_to_raise):
+                raise error_to_raise
+
+            @property
+            def is_async(self):
+                return True
+
+    return Destination()
 
 
 @pytest.fixture

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -23,6 +23,7 @@ from mlflow.utils.autologging_utils import (
     with_managed_run,
 )
 from mlflow.utils.autologging_utils.safety import (
+    _PATCH_RUN_NAME_FOR_TESTING,
     ValidationExemptArgument,
     _AutologgingSessionManager,
     _validate_args,
@@ -403,7 +404,7 @@ def test_safe_patch_validates_autologging_runs_when_necessary_in_test_mode(
     assert autologging_utils.is_testing()
 
     def no_tag_run_patch_impl(original, *args, **kwargs):
-        with mlflow.start_run(nested=True):
+        with mlflow.start_run(nested=True, run_name=_PATCH_RUN_NAME_FOR_TESTING):
             return original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", no_tag_run_patch_impl)
@@ -433,7 +434,7 @@ def test_safe_patch_does_not_validate_autologging_runs_in_standard_mode(
     assert not autologging_utils.is_testing()
 
     def no_tag_run_patch_impl(original, *args, **kwargs):
-        with mlflow.start_run(nested=True):
+        with mlflow.start_run(nested=True, run_name=_PATCH_RUN_NAME_FOR_TESTING):
             return original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", no_tag_run_patch_impl)

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -15,7 +15,6 @@ from mlflow.utils.autologging_utils import (
     AutologgingEventLogger,
     ExceptionSafeAbstractClass,
     ExceptionSafeClass,
-    PatchFunction,
     autologging_integration,
     disable_autologging,
     is_testing,
@@ -184,32 +183,6 @@ def test_safe_patch_forwards_expected_arguments_to_function_based_patch_implemen
     assert bar_val == 11
 
 
-def test_safe_patch_forwards_expected_arguments_to_class_based_patch(
-    patch_destination, test_autologging_integration
-):
-    foo_val = None
-    bar_val = None
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, foo, bar=10):
-            nonlocal foo_val
-            nonlocal bar_val
-            foo_val = foo
-            bar_val = bar
-
-        def _on_exception(self, exception):
-            pass
-
-    safe_patch(test_autologging_integration, patch_destination, "fn", TestPatch)
-    with mock.patch(
-        "mlflow.utils.autologging_utils.PatchFunction.call", wraps=TestPatch.call
-    ) as call_mock:
-        patch_destination.fn(foo=7, bar=11)
-        assert call_mock.call_count == 1
-        assert foo_val == 7
-        assert bar_val == 11
-
-
 def test_safe_patch_provides_expected_original_function(
     patch_destination, test_autologging_integration
 ):
@@ -226,32 +199,6 @@ def test_safe_patch_provides_expected_original_function(
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
     assert patch_destination.fn(1, 2) == {"foo": 2, "bar": 4}
-
-
-def test_safe_patch_provides_expected_original_function_to_class_based_patch(
-    patch_destination, test_autologging_integration
-):
-    def original_fn(foo, bar=10):
-        return {
-            "foo": foo,
-            "bar": bar,
-        }
-
-    patch_destination.fn = original_fn
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, foo, bar=10):
-            return original(foo + 1, bar + 2)
-
-        def _on_exception(self, exception):
-            pass
-
-    safe_patch(test_autologging_integration, patch_destination, "fn", TestPatch)
-    with mock.patch(
-        "mlflow.utils.autologging_utils.PatchFunction.call", wraps=TestPatch.call
-    ) as call_mock:
-        assert patch_destination.fn(1, 2) == {"foo": 2, "bar": 4}
-        assert call_mock.call_count == 1
 
 
 def test_safe_patch_propagates_exceptions_raised_from_original_function(
@@ -906,53 +853,6 @@ def test_exception_safe_class_exhibits_expected_behavior_in_test_mode(baseclass,
     assert exc.value == exc_to_throw
 
 
-def test_patch_function_class_call_invokes_implementation_and_returns_result():
-    class TestPatchFunction(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            return 10
-
-        def _on_exception(self, exception):
-            pass
-
-    assert TestPatchFunction.call("foo", lambda: "foo") == 10
-
-
-@pytest.mark.parametrize("exception_class", [Exception, KeyboardInterrupt])
-def test_patch_function_class_call_handles_exceptions_properly(exception_class):
-    called_on_exception = False
-
-    class TestPatchFunction(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            raise exception_class("implementation exception")
-
-        def _on_exception(self, exception):
-            nonlocal called_on_exception
-            called_on_exception = True
-            raise Exception("on_exception exception")
-
-    # Even if an exception is thrown from `_on_exception`, we expect the original
-    # exception from the implementation to be surfaced to the caller
-    with pytest.raises(exception_class, match="implementation exception"):
-        TestPatchFunction.call("foo", lambda: "foo")
-
-    assert called_on_exception
-
-
-def test_with_managed_runs_yields_functions_and_classes_as_expected():
-    def patch_function(original, *args, **kwargs):
-        pass
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            pass
-
-        def _on_exception(self, exception):
-            pass
-
-    assert callable(with_managed_run("test_integration", patch_function))
-    assert inspect.isclass(with_managed_run("test_integration", TestPatch))
-
-
 def test_with_managed_run_with_non_throwing_function_exhibits_expected_behavior():
     client = MlflowClient()
 
@@ -1000,61 +900,6 @@ def test_with_managed_run_with_throwing_function_exhibits_expected_behavior():
     assert RunStatus.from_string(status2) == RunStatus.FINISHED
 
 
-def test_with_managed_run_with_non_throwing_class_exhibits_expected_behavior():
-    client = MlflowClient()
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            return mlflow.active_run()
-
-        def _on_exception(self, exception):
-            pass
-
-    TestPatch = with_managed_run("test_integration", TestPatch)
-
-    run1 = TestPatch.call(lambda: "foo")
-    run1_status = client.get_run(run1.info.run_id).info.status
-    assert RunStatus.from_string(run1_status) == RunStatus.FINISHED
-
-    with mlflow.start_run() as active_run:
-        run2 = TestPatch.call(lambda: "foo")
-
-    assert run2 == active_run
-    run2_status = client.get_run(run2.info.run_id).info.status
-    assert RunStatus.from_string(run2_status) == RunStatus.FINISHED
-
-
-def test_with_managed_run_with_throwing_class_exhibits_expected_behavior():
-    client = MlflowClient()
-    patch_function_active_run = None
-
-    class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            nonlocal patch_function_active_run
-            patch_function_active_run = mlflow.active_run()
-            raise Exception("bad implementation")
-
-        def _on_exception(self, exception):
-            pass
-
-    TestPatch = with_managed_run("test_integration", TestPatch)
-
-    with pytest.raises(Exception, match="bad implementation"):
-        TestPatch.call(lambda: "foo")
-
-    assert patch_function_active_run is not None
-    status1 = client.get_run(patch_function_active_run.info.run_id).info.status
-    assert RunStatus.from_string(status1) == RunStatus.FAILED
-
-    with mlflow.start_run() as active_run, pytest.raises(Exception, match="bad implementation"):
-        TestPatch.call(lambda: "foo")
-    assert patch_function_active_run == active_run
-    # `with_managed_run` should not terminate a preexisting MLflow run,
-    # even if the patch function throws
-    status2 = client.get_run(active_run.info.run_id).info.status
-    assert RunStatus.from_string(status2) == RunStatus.FINISHED
-
-
 def test_with_managed_run_sets_specified_run_tags():
     client = MlflowClient()
     tags_to_set = {
@@ -1067,17 +912,6 @@ def test_with_managed_run_sets_specified_run_tags():
     )
     run1 = patch_function_1(lambda: "foo")
     assert tags_to_set.items() <= client.get_run(run1.info.run_id).data.tags.items()
-
-    class PatchFunction2(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            return mlflow.active_run()
-
-        def _on_exception(self, exception):
-            pass
-
-    patch_function_2 = with_managed_run("test_integration", PatchFunction2, tags=tags_to_set)
-    run2 = patch_function_2.call(lambda: "foo")
-    assert tags_to_set.items() <= client.get_run(run2.info.run_id).data.tags.items()
 
 
 @pytest.mark.usefixtures(test_mode_on.__name__)
@@ -1100,22 +934,6 @@ def test_with_managed_run_ends_run_on_keyboard_interrupt():
     assert not mlflow.active_run()
     run_status_1 = client.get_run(run.info.run_id).info.status
     assert RunStatus.from_string(run_status_1) == RunStatus.FAILED
-
-    class PatchFunction2(PatchFunction):
-        def _patch_implementation(self, original, *args, **kwargs):
-            return original(*args, **kwargs)
-
-        def _on_exception(self, exception):
-            pass
-
-    patch_function_2 = with_managed_run("test_integration", PatchFunction2)
-
-    with pytest.raises(KeyboardInterrupt, match=r".*"):
-        patch_function_2.call(original)
-
-    assert not mlflow.active_run()
-    run_status_2 = client.get_run(run.info.run_id).info.status
-    assert RunStatus.from_string(run_status_2) == RunStatus.FAILED
 
 
 @pytest.mark.usefixtures(test_mode_on.__name__)

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1,8 +1,11 @@
 import abc
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import copy
 import inspect
 from collections import namedtuple
 from contextlib import nullcontext as does_not_raise
+from threading import Thread
 from unittest import mock
 
 import pytest
@@ -28,6 +31,7 @@ from mlflow.utils.autologging_utils.safety import (
     _AutologgingSessionManager,
     _validate_args,
     _validate_autologging_run,
+    wraps,
 )
 from mlflow.utils.mlflow_tags import MLFLOW_AUTOLOGGING
 
@@ -166,12 +170,51 @@ def test_is_testing_respects_environment_variable(monkeypatch):
     assert is_testing()
 
 
+def _test_async(is_async):
+    """
+    Decorator that converts a function to an async function if `is_async` is True. This is useful
+    for testing purposes, where we want to test both synchronous and asynchronous code paths.
+    """
+    def decorator(fn):
+        if is_async:
+
+            @wraps(fn)
+            async def async_fn(*args, **kwargs):
+
+                if args and inspect.iscoroutinefunction(args[0]):
+                    original = args[0]
+                    @wraps(original)
+                    def wrapped_original(*og_args, **og_kwargs):
+                        # Run the original async function in a separate thread. This is a workaround
+                        # for the fact that we cannot use asyncio.run here because an event loop is
+                        # already running in the main thread.
+                        with ThreadPoolExecutor() as executor:
+                            future = executor.submit(asyncio.run, original(*og_args, **og_kwargs))
+                            return future.result()
+                    args = (wrapped_original, *args[1:])
+
+                return fn(*args, **kwargs)
+            return async_fn
+        else:
+            return fn
+
+    return decorator
+
+
+def _call_sync_or_async(fn, *args, **kwargs):
+    if inspect.iscoroutinefunction(fn):
+        return asyncio.run(fn(*args, **kwargs))
+    else:
+        return fn(*args, **kwargs)
+
+
 def test_safe_patch_forwards_expected_arguments_to_function_based_patch_implementation(
     patch_destination, test_autologging_integration
 ):
     foo_val = None
     bar_val = None
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, foo, bar=10):
         nonlocal foo_val
         nonlocal bar_val
@@ -179,14 +222,13 @@ def test_safe_patch_forwards_expected_arguments_to_function_based_patch_implemen
         bar_val = bar
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    patch_destination.fn(foo=7, bar=11)
+    _call_sync_or_async(patch_destination.fn, 7, bar=11)
     assert foo_val == 7
     assert bar_val == 11
 
 
-def test_safe_patch_provides_expected_original_function(
-    patch_destination, test_autologging_integration
-):
+def test_safe_patch_provides_expected_original_function(test_autologging_integration, patch_destination):
+    @_test_async(patch_destination.is_async)
     def original_fn(foo, bar=10):
         return {
             "foo": foo,
@@ -195,11 +237,13 @@ def test_safe_patch_provides_expected_original_function(
 
     patch_destination.fn = original_fn
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, foo, bar):
         return original(foo + 1, bar + 2)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    assert patch_destination.fn(1, 2) == {"foo": 2, "bar": 4}
+
+    assert _call_sync_or_async(patch_destination.fn, 1, 2) == {"foo": 2, "bar": 4}
 
 
 def test_safe_patch_propagates_exceptions_raised_from_original_function(
@@ -207,6 +251,7 @@ def test_safe_patch_propagates_exceptions_raised_from_original_function(
 ):
     exc_to_throw = Exception("Bad original function")
 
+    @_test_async(patch_destination.is_async)
     def original(*args, **kwargs):
         raise exc_to_throw
 
@@ -214,6 +259,7 @@ def test_safe_patch_propagates_exceptions_raised_from_original_function(
 
     patch_impl_called = False
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
@@ -222,7 +268,7 @@ def test_safe_patch_propagates_exceptions_raised_from_original_function(
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
 
     with pytest.raises(Exception, match=str(exc_to_throw)) as exc:
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
 
     assert exc.value == exc_to_throw
     assert patch_impl_called
@@ -233,12 +279,13 @@ def test_safe_patch_logs_exceptions_raised_outside_of_original_function_as_warni
 ):
     exc_to_throw = Exception("Bad patch implementation")
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         raise exc_to_throw
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
     with mock.patch("mlflow.utils.autologging_utils._logger.warning") as logger_mock:
-        assert patch_destination.fn() == PATCH_DESTINATION_FN_DEFAULT_RESULT
+        assert _call_sync_or_async(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
         assert logger_mock.call_count == 1
         message, formatting_arg1, formatting_arg2 = logger_mock.call_args[0]
         assert "Encountered unexpected error" in message
@@ -252,12 +299,13 @@ def test_safe_patch_propagates_exceptions_raised_outside_of_original_function_in
 ):
     exc_to_throw = Exception("Bad patch implementation")
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         raise exc_to_throw
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
     with pytest.raises(Exception, match=str(exc_to_throw)) as exc:
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
 
     assert exc.value == exc_to_throw
 
@@ -267,13 +315,14 @@ def test_safe_patch_calls_original_function_when_patch_preamble_throws(
 ):
     patch_impl_called = False
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
         raise Exception("Bad patch preamble")
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    assert patch_destination.fn() == PATCH_DESTINATION_FN_DEFAULT_RESULT
+    assert _call_sync_or_async(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
     assert patch_destination.fn_call_count == 1
     assert patch_impl_called
 
@@ -283,6 +332,7 @@ def test_safe_patch_returns_original_result_without_second_call_when_patch_posta
 ):
     patch_impl_called = False
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
@@ -290,7 +340,7 @@ def test_safe_patch_returns_original_result_without_second_call_when_patch_posta
         raise Exception("Bad patch postamble")
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    assert patch_destination.fn() == PATCH_DESTINATION_FN_DEFAULT_RESULT
+    assert _call_sync_or_async(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
     assert patch_destination.fn_call_count == 1
     assert patch_impl_called
 
@@ -300,6 +350,7 @@ def test_safe_patch_respects_disable_flag(patch_destination):
 
     @autologging_integration("test_respects_disable")
     def autolog(disable=False, silent=False):
+        @_test_async(patch_destination.is_async)
         def patch_impl(original, *args, **kwargs):
             nonlocal patch_impl_call_count
             patch_impl_call_count += 1
@@ -308,11 +359,11 @@ def test_safe_patch_respects_disable_flag(patch_destination):
         safe_patch("test_respects_disable", patch_destination, "fn", patch_impl)
 
     autolog(disable=False)
-    patch_destination.fn()
+    _call_sync_or_async(patch_destination.fn)
     assert patch_impl_call_count == 1
 
     autolog(disable=True)
-    patch_destination.fn()
+    _call_sync_or_async(patch_destination.fn)
     assert patch_impl_call_count == 1
 
 
@@ -321,13 +372,14 @@ def test_safe_patch_returns_original_result_and_ignores_patch_return_value(
 ):
     patch_impl_called = False
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
         return 10
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    assert patch_destination.fn() == PATCH_DESTINATION_FN_DEFAULT_RESULT
+    assert _call_sync_or_async(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
     assert patch_destination.fn_call_count == 1
     assert patch_impl_called
 
@@ -336,6 +388,7 @@ def test_safe_patch_returns_original_result_and_ignores_patch_return_value(
 def test_safe_patch_validates_arguments_to_original_function_in_test_mode(
     patch_destination, test_autologging_integration
 ):
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         return original("1", "2", "3")
 
@@ -348,7 +401,7 @@ def test_safe_patch_validates_arguments_to_original_function_in_test_mode(
             wraps=autologging_utils.safety._validate_args,
         ) as validate_mock,
     ):
-        patch_destination.fn("a", "b", "c")
+        _call_sync_or_async(patch_destination.fn, "a", "b", "c")
 
     assert validate_mock.call_count == 1
 
@@ -359,12 +412,13 @@ def test_safe_patch_throws_when_autologging_runs_are_leaked_in_test_mode(
 ):
     assert autologging_utils.is_testing()
 
+    @_test_async(patch_destination.is_async)
     def leak_run_patch_impl(original, *args, **kwargs):
         mlflow.start_run(nested=True)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", leak_run_patch_impl)
     with pytest.raises(AssertionError, match="leaked an active run"):
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
 
     # End the leaked run
     mlflow.end_run()
@@ -372,7 +426,7 @@ def test_safe_patch_throws_when_autologging_runs_are_leaked_in_test_mode(
     with mlflow.start_run():
         # If a user-generated run existed prior to the autologged training session, we expect
         # that safe patch will not throw a leaked run exception
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
         # End the leaked nested run
         mlflow.end_run()
 
@@ -384,11 +438,12 @@ def test_safe_patch_does_not_throw_when_autologging_runs_are_leaked_in_standard_
 ):
     assert not autologging_utils.is_testing()
 
+    @_test_async(patch_destination.is_async)
     def leak_run_patch_impl(original, *args, **kwargs):
         mlflow.start_run(nested=True)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", leak_run_patch_impl)
-    patch_destination.fn()
+    _call_sync_or_async(patch_destination.fn)
     assert mlflow.active_run()
 
     # End the leaked run
@@ -403,6 +458,7 @@ def test_safe_patch_validates_autologging_runs_when_necessary_in_test_mode(
 ):
     assert autologging_utils.is_testing()
 
+    @_test_async(patch_destination.is_async)
     def no_tag_run_patch_impl(original, *args, **kwargs):
         with mlflow.start_run(nested=True, run_name=_PATCH_RUN_NAME_FOR_TESTING):
             return original(*args, **kwargs)
@@ -416,7 +472,7 @@ def test_safe_patch_validates_autologging_runs_when_necessary_in_test_mode(
         with pytest.raises(
             AssertionError, match="failed to set autologging tag with expected value"
         ):
-            patch_destination.fn()
+            _call_sync_or_async(patch_destination.fn)
         assert validate_run_mock.call_count == 1
 
         validate_run_mock.reset_mock()
@@ -424,7 +480,7 @@ def test_safe_patch_validates_autologging_runs_when_necessary_in_test_mode(
         with mlflow.start_run(nested=True):
             # If a user-generated run existed prior to the autologged training session, we expect
             # that safe patch will not attempt to validate it
-            patch_destination.fn()
+            _call_sync_or_async(patch_destination.fn)
         assert not validate_run_mock.called
 
 
@@ -433,6 +489,7 @@ def test_safe_patch_does_not_validate_autologging_runs_in_standard_mode(
 ):
     assert not autologging_utils.is_testing()
 
+    @_test_async(patch_destination.is_async)
     def no_tag_run_patch_impl(original, *args, **kwargs):
         with mlflow.start_run(nested=True, run_name=_PATCH_RUN_NAME_FOR_TESTING):
             return original(*args, **kwargs)
@@ -443,12 +500,12 @@ def test_safe_patch_does_not_validate_autologging_runs_in_standard_mode(
         "mlflow.utils.autologging_utils.safety._validate_autologging_run",
         wraps=_validate_autologging_run,
     ) as validate_run_mock:
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
 
         with mlflow.start_run(nested=True):
             # If a user-generated run existed prior to the autologged training session, we expect
             # that safe patch will not attempt to validate it
-            patch_destination.fn()
+            _call_sync_or_async(patch_destination.fn)
 
         assert not validate_run_mock.called
 
@@ -459,25 +516,31 @@ def test_safe_patch_manages_run_if_specified_and_sets_expected_run_tags(
     client = MlflowClient()
     active_run = None
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal active_run
         active_run = mlflow.active_run()
         return original(*args, **kwargs)
 
+
+    if patch_destination.is_async:
+        with pytest.raises(Exception, match="Managed run is not supported for"):
+            safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl, manage_run=True)
+        return
+
     with mock.patch(
         "mlflow.utils.autologging_utils.safety.with_managed_run", wraps=with_managed_run
     ) as managed_run_mock:
-        safe_patch(
-            test_autologging_integration, patch_destination, "fn", patch_impl, manage_run=True
-        )
-        patch_destination.fn()
-        assert managed_run_mock.call_count == 1
-        assert active_run is not None
-        assert active_run.info.run_id is not None
-        assert (
-            client.get_run(active_run.info.run_id).data.tags[MLFLOW_AUTOLOGGING]
-            == "test_integration"
-        )
+        safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl, manage_run=True)
+
+    _call_sync_or_async(patch_destination.fn)
+    assert managed_run_mock.call_count == 1
+    assert active_run is not None
+    assert active_run.info.run_id is not None
+    assert (
+        client.get_run(active_run.info.run_id).data.tags[MLFLOW_AUTOLOGGING]
+        == "test_integration"
+    )
 
 
 def test_safe_patch_does_not_manage_run_if_unspecified(
@@ -485,6 +548,7 @@ def test_safe_patch_does_not_manage_run_if_unspecified(
 ):
     active_run = None
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal active_run
         active_run = mlflow.active_run()
@@ -496,7 +560,7 @@ def test_safe_patch_does_not_manage_run_if_unspecified(
         safe_patch(
             test_autologging_integration, patch_destination, "fn", patch_impl, manage_run=False
         )
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
         assert managed_run_mock.call_count == 0
         assert active_run is None
 
@@ -504,6 +568,7 @@ def test_safe_patch_does_not_manage_run_if_unspecified(
 def test_safe_patch_preserves_signature_of_patched_function(
     patch_destination, test_autologging_integration
 ):
+    @_test_async(patch_destination.is_async)
     def original(a, b, c=10, *, d=11):
         return 10
 
@@ -511,13 +576,14 @@ def test_safe_patch_preserves_signature_of_patched_function(
 
     patch_impl_called = False
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
         return original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    patch_destination.fn(1, 2)
+    _call_sync_or_async(patch_destination.fn, 1, 2)
     assert patch_impl_called
     assert inspect.signature(patch_destination.fn) == inspect.signature(original)
 
@@ -525,6 +591,7 @@ def test_safe_patch_preserves_signature_of_patched_function(
 def test_safe_patch_provides_original_function_with_expected_signature(
     patch_destination, test_autologging_integration
 ):
+    @_test_async(patch_destination.is_async)
     def original(a, b, c=10, *, d=11):
         return 10
 
@@ -532,13 +599,14 @@ def test_safe_patch_provides_original_function_with_expected_signature(
 
     original_signature = False
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal original_signature
         original_signature = inspect.signature(original)
         return original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    patch_destination.fn(1, 2)
+    _call_sync_or_async(patch_destination.fn, 1, 2)
     assert original_signature == inspect.signature(original)
 
 
@@ -550,6 +618,7 @@ def test_safe_patch_makes_expected_event_logging_calls_for_successful_patch_invo
     patch_session = None
     og_call_kwargs = {}
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal og_call_kwargs
         kwargs.update({"extra_func": picklable_exception_safe_function(lambda k: "foo")})
@@ -562,7 +631,7 @@ def test_safe_patch_makes_expected_event_logging_calls_for_successful_patch_invo
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
 
-    patch_destination.fn("a", 1, b=2)
+    _call_sync_or_async(patch_destination.fn, "a", 1, b=2)
     expected_order = ["patch_start", "original_start", "original_success", "patch_success"]
     assert [call.method for call in mock_event_logger.calls] == expected_order
     assert all(call.session == patch_session for call in mock_event_logger.calls)
@@ -586,6 +655,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_an
 
     throw_location = None
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal throw_location
 
@@ -608,7 +678,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_an
 
     for throw_location in ["before", "after"]:
         mock_event_logger.reset()
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
         assert [call.method for call in mock_event_logger.calls] == expected_order
         patch_start, original_start, original_success, patch_error = mock_event_logger.calls
         assert patch_start.exception is None
@@ -627,6 +697,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_an
 
     throw_location = None
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal throw_location
 
@@ -645,7 +716,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_an
     for throw_location in ["before", "after"]:
         mock_event_logger.reset()
         with pytest.raises(Exception, match="throw from original"):
-            patch_destination.throw_error_fn(original_err_to_raise)
+            _call_sync_or_async(patch_destination.throw_error_fn, original_err_to_raise)
         assert [call.method for call in mock_event_logger.calls] == expected_order
         patch_start, original_start, original_error = mock_event_logger.calls
         assert patch_start.exception is None
@@ -660,18 +731,20 @@ def test_safe_patch_makes_expected_event_logging_calls_when_original_function_th
 ):
     exc_to_raise = Exception("thrown from patch")
 
+    @_test_async(patch_destination.is_async)
     def original(*args, **kwargs):
         raise exc_to_raise
 
     patch_destination.fn = original
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
 
     with pytest.raises(Exception, match="thrown from patch"):
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
     expected_order = ["patch_start", "original_start", "original_error"]
     assert [call.method for call in mock_event_logger.calls] == expected_order
     patch_start, original_start, original_error = mock_event_logger.calls
@@ -687,6 +760,7 @@ def test_safe_patch_succeeds_when_event_logging_throws_in_standard_mode(
     patch_preamble_called = False
     patch_postamble_called = False
 
+    @_test_async(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_preamble_called
         patch_preamble_called = True
@@ -747,7 +821,7 @@ def test_safe_patch_succeeds_when_event_logging_throws_in_standard_mode(
 
     logger = ThrowingLogger()
     AutologgingEventLogger.set_logger(logger)
-    assert patch_destination.fn() == PATCH_DESTINATION_FN_DEFAULT_RESULT
+    assert _call_sync_or_async(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
     assert patch_preamble_called
     assert patch_postamble_called
     expected_calls = ["patch_start", "original_start", "original_success", "patch_success"]
@@ -1393,36 +1467,39 @@ def test_session_manager_creates_session_before_patch_executes(
 ):
     is_session_active = None
 
+    @_test_async(patch_destination.is_async)
     def check_session_manager_status(original):
         nonlocal is_session_active
         is_session_active = _AutologgingSessionManager.active_session()
 
     safe_patch(test_autologging_integration, patch_destination, "fn", check_session_manager_status)
-    patch_destination.fn()
+    _call_sync_or_async(patch_destination.fn)
     assert is_session_active is not None
 
 
 def test_session_manager_exits_session_after_patch_executes(
     patch_destination, test_autologging_integration
 ):
+    @_test_async(patch_destination.is_async)
     def patch_fn(original):
         assert _AutologgingSessionManager.active_session() is not None
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_fn)
-    patch_destination.fn()
+    _call_sync_or_async(patch_destination.fn)
     assert _AutologgingSessionManager.active_session() is None
 
 
 def test_session_manager_exits_session_if_error_in_patch(
     patch_destination, test_autologging_integration
 ):
+    @_test_async(patch_destination.is_async)
     def patch_fn(original):
         raise Exception("Exception that should stop autologging session")
 
     # If use safe_patch to patch, exception would not come from original fn and so would be logged
     patch_destination.fn = patch_fn
     with pytest.raises(Exception, match="Exception that should stop autologging session"):
-        patch_destination.fn(lambda: None)
+        _call_sync_or_async(patch_destination.fn, lambda: None)
 
     assert _AutologgingSessionManager.active_session() is None
 
@@ -1446,11 +1523,13 @@ def test_nested_call_autologging_disabled_when_top_level_call_autologging_failed
         "test_nested_call_autologging_disabled_when_top_level_call_autologging_failed"
     )
     def autolog(disable=False, exclusive=False, silent=False):
+        @_test_async(patch_destination.is_async)
         def patch_impl(original, *args, **kwargs):
             nonlocal patch_impl_call_count
             patch_impl_call_count += 1
 
             level = kwargs["level"]
+            print(f"level: {level}")
 
             if level == 0:
                 raise RuntimeError("analog top level call autologging failure.")
@@ -1469,7 +1548,7 @@ def test_nested_call_autologging_disabled_when_top_level_call_autologging_failed
         patch_impl_call_count = 0
         patch_destination.recurse_fn_call_count = 0
         with mlflow.start_run():
-            patch_destination.recursive_fn(level=0, max_depth=max_depth)
+            _call_sync_or_async(patch_destination.recursive_fn, level=0, max_depth=max_depth)
         assert patch_impl_call_count == 1
         assert patch_destination.recurse_fn_call_count == max_depth + 1
 
@@ -1596,6 +1675,7 @@ def test_should_skip_autolog(patch_destination):
 
     @autologging_integration("test-flavor")
     def autolog(disable=False, exclusive=False, silent=False):
+        @_test_async(patch_destination.is_async)
         def patch_impl(original, *args, **kwargs):
             nonlocal patch_impl_call_count
             patch_impl_call_count += 1
@@ -1605,37 +1685,38 @@ def test_should_skip_autolog(patch_destination):
 
     # Autologging is enabled -> patch should be applied
     autolog()
-    patch_destination.fn()
+    _call_sync_or_async(patch_destination.fn)
     assert patch_impl_call_count == 1
 
     # Autologging is enabled and user-created fluent run
     with mlflow.start_run():
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
     assert patch_impl_call_count == 2
 
     # Autologging globally disabled via context manager -> patch should not be applied
     with disable_autologging():
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
     assert patch_impl_call_count == 2
 
     # User-created fluent run exists and "exclusive" is set to True -> patch should not be applied
     autolog(exclusive=True)
     with mlflow.start_run():
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
     assert patch_impl_call_count == 2
 
     # Autologging session failed to start -> patch should not be applied
+    patch_target = "async_start_session" if patch_destination.is_async else "start_session"
     with (
         mock.patch(
-            "mlflow.utils.autologging_utils.safety._AutologgingSessionManager.start_session",
+            f"mlflow.utils.autologging_utils.safety._AutologgingSessionManager.{patch_target}",
             side_effect=Exception("Session failed to start"),
         ),
         pytest.raises(Exception, match="Session failed to start"),
     ):
-        patch_destination.fn()
+        _call_sync_or_async(patch_destination.fn)
     assert patch_impl_call_count == 2
 
     # Autologging is disabled for the flavor -> patch should not be applied
     autolog(disable=True)
-    patch_destination.fn()
+    _call_sync_or_async(patch_destination.fn)
     assert patch_impl_call_count == 2


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14725?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14725/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14725
```

</p>
</details>

### What changes are proposed in this pull request?

This PR depends on https://github.com/mlflow/mlflow/pull/14724. Actually diff can be found at https://github.com/mlflow/mlflow/compare/3dae55712b7c0f2beeee02a99a44e6dd8332a31a...c190f5713594d6e7ea9a631b838f93cf0757beb8

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
