### PR TITLE
Deprecate `MLserver` integration

### DIFF
--- a/docs/docs/deployment/deploy-model-locally/index.mdx
+++ b/docs/docs/deployment/deploy-model-locally/index.mdx
@@ -280,7 +280,7 @@ auto scaling out of the box.
     <tr>
       <td>**Use Case**</td>
       <td>Standard usecases including local testing.</td>
-      <td>High-scale production environment.</td>
+      <td>[DEPRECATED] High-scale production environment.</td>
     </tr>
     <tr>
       <td>**Set Up**</td>

--- a/docs/docs/deployment/deploy-model-locally/index.mdx
+++ b/docs/docs/deployment/deploy-model-locally/index.mdx
@@ -252,6 +252,10 @@ curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '[
 
 ## Serving Frameworks
 
+:::warning
+MLServer integration is deprecated and will be removed in MLflow 3.0.
+:::
+
 By default, MLflow uses [FastAPI](https://fastapi.tiangolo.com/), a modern ASGI web application framework for Python, to serve the inference endpoint. 
 FastAPI handles requests asynchronously and is recognized as one of the fastest Python frameworks. This production-ready framework works well for most use cases.
 Additionally, MLflow also integrates with [MLServer](https://mlserver.readthedocs.io/en/latest) as an alternative serving engine. MLServer achieves
@@ -280,7 +284,7 @@ auto scaling out of the box.
     <tr>
       <td>**Use Case**</td>
       <td>Standard usecases including local testing.</td>
-      <td>[DEPRECATED] High-scale production environment.</td>
+      <td>High-scale production environment.</td>
     </tr>
     <tr>
       <td>**Set Up**</td>

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 import click
 
@@ -97,6 +98,9 @@ def serve(
         }'
 
     """
+    if enable_mlserver:
+        warnings.warn("MLServer integration is deprecated and will be removed in MLflow 3.0.")
+
     env_manager = _EnvManager.LOCAL if no_conda else env_manager
 
     return get_flavor_backend(

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -99,7 +99,9 @@ def serve(
 
     """
     if enable_mlserver:
-        warnings.warn("MLServer integration is deprecated and will be removed in MLflow 3.0.")
+        warnings.warn(
+            "MLServer integration is deprecated and will be removed in MLflow 3.0.", FutureWarning
+        )
 
     env_manager = _EnvManager.LOCAL if no_conda else env_manager
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14726?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14726/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14726
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

<img width="946" alt="image" src="https://github.com/user-attachments/assets/5bd496bc-0260-4518-9ffc-64ec59a8ec45" />


Deprecate `MLserver` integration.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```
> mlflow models serve -m my_model --enable-mlserver
/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/recipes/__init__.py:32: FutureWarning: MLServer integration is deprecated and will be removed in a future release.
...
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
