### PR TITLE
Only emit recipes deprecation warning when recipes is used

### DIFF
--- a/mlflow/recipes/__init__.py
+++ b/mlflow/recipes/__init__.py
@@ -25,13 +25,6 @@ them to production. Compared to ad-hoc ML workflows, MLflow Recipes offers sever
 For more information, see the `MLflow Recipes overview <../../recipes/index.html>`_.
 """
 
-import warnings
-
 from mlflow.recipes.recipe import Recipe
-
-warnings.warn(
-    "MLflow Recipes is deprecated and will be removed in a future release.",
-    FutureWarning,
-)
 
 __all__ = ["Recipe"]

--- a/mlflow/recipes/cli.py
+++ b/mlflow/recipes/cli.py
@@ -21,6 +21,8 @@ _CLI_ARG_RECIPE_PROFILE = click.option(
 @click.group("recipes")
 def commands():
     """
+    MLflow Recipes is deprecated and will be removed in MLflow 3.0.
+
     Run MLflow Recipes and inspect recipe results.
     """
 

--- a/mlflow/recipes/recipe.py
+++ b/mlflow/recipes/recipe.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 import os
+import warnings
 from typing import Optional
 
 from mlflow.exceptions import MlflowException
@@ -395,6 +396,10 @@ class Recipe:
             regression_recipe = Recipe(profile="local")
             regression_recipe.run(step="train")
         """
+        warnings.warn(
+            "MLflow Recipes is deprecated and will be removed in MLflow 3.0.",
+            FutureWarning,
+        )
         if not profile:
             raise MlflowException(
                 "A profile name must be provided to construct a valid Recipe object.",

--- a/tests/recipes/test_deprecation_warning.py
+++ b/tests/recipes/test_deprecation_warning.py
@@ -8,7 +8,7 @@ from mlflow.recipes import Recipe
 WARNING_MESSAGE = "MLflow Recipes is deprecated"
 
 
-def test_no_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_no_warns() -> None:
     stdout = subprocess.check_output(
         [sys.executable, "-c", "import mlflow"], stderr=subprocess.STDOUT, text=True
     )

--- a/tests/recipes/test_deprecation_warning.py
+++ b/tests/recipes/test_deprecation_warning.py
@@ -3,6 +3,8 @@ import sys
 
 import pytest
 
+from mlflow.recipes import Recipe
+
 WARNING_MESSAGE = "MLflow Recipes is deprecated"
 
 
@@ -17,6 +19,7 @@ def test_no_warns(monkeypatch: pytest.MonkeyPatch) -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        # As there is no model 'foo', the command will fail.
         check=False,
     )
     assert WARNING_MESSAGE not in prc.stdout
@@ -25,9 +28,7 @@ def test_no_warns(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_warns(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir("examples/recipes/regression")
 
-    from mlflow.recipes import Recipe
-
-    with pytest.warns(FutureWarning, match=r"MLflow Recipes is deprecated"):
+    with pytest.warns(FutureWarning, match=WARNING_MESSAGE):
         Recipe(profile="local")
 
     stdout = subprocess.check_output(
@@ -40,4 +41,4 @@ def test_warns(monkeypatch: pytest.MonkeyPatch) -> None:
         stderr=subprocess.STDOUT,
         text=True,
     )
-    assert WARNING_MESSAGE in stdout, stdout
+    assert WARNING_MESSAGE in stdout

--- a/tests/recipes/test_deprecation_warning.py
+++ b/tests/recipes/test_deprecation_warning.py
@@ -3,17 +3,41 @@ import sys
 
 import pytest
 
+WARNING_MESSAGE = "MLflow Recipes is deprecated"
 
-@pytest.mark.parametrize(
-    ("code", "should_warn"),
-    [
-        ("import mlflow.recipes", True),
-        ("from mlflow.recipes import Recipe", True),
-        ("import mlflow", False),
-    ],
-)
-def test_deprecation_warning(code: str, should_warn: bool) -> None:
+
+def test_no_warns(monkeypatch: pytest.MonkeyPatch) -> None:
     stdout = subprocess.check_output(
-        [sys.executable, "-c", code], stderr=subprocess.STDOUT, text=True
+        [sys.executable, "-c", "import mlflow"], stderr=subprocess.STDOUT, text=True
     )
-    assert ("FutureWarning: MLflow Recipes is deprecated" in stdout) is should_warn
+    assert WARNING_MESSAGE not in stdout
+
+    prc = subprocess.run(
+        [sys.executable, "-m", "mlflow", "models", "serve", "-m", "foo"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    assert WARNING_MESSAGE not in prc.stdout
+
+
+def test_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir("examples/recipes/regression")
+
+    from mlflow.recipes import Recipe
+
+    with pytest.warns(FutureWarning, match=r"MLflow Recipes is deprecated"):
+        Recipe(profile="local")
+
+    stdout = subprocess.check_output(
+        [sys.executable, "-m", "mlflow", "recipes", "--help"], stderr=subprocess.STDOUT, text=True
+    )
+    assert WARNING_MESSAGE in stdout
+
+    stdout = subprocess.check_output(
+        [sys.executable, "-m", "mlflow", "recipes", "clean", "--profile", "local"],
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    assert WARNING_MESSAGE in stdout, stdout


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14727?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14727/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14727
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Follow-up for #14690. Currently, `mlflow models serve` emits the recipes deprecation warning but it shouldn't (discovered in #14726). This PR fixes that.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
