### PR TITLE
Remove `run.info.artifact_uri` in sklearn autolog tests

### DIFF
--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -118,6 +118,9 @@ def fit_func_name(request):
 
 
 def _get_model_uri(name: str = MODEL_DIR) -> str:
+    """
+    Get the model URI for the last active run.
+    """
     last_active_run = mlflow.last_active_run()
     return f"runs:/{last_active_run.info.run_id}/{name}"
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -3,7 +3,6 @@ import doctest
 import functools
 import inspect
 import json
-import os
 import pickle
 import re
 from unittest import mock
@@ -94,11 +93,6 @@ def load_model_by_run_id(run_id):
     return mlflow.sklearn.load_model(f"runs:/{run_id}/{MODEL_DIR}")
 
 
-def get_model_conf(artifact_uri, model_subpath=MODEL_DIR):
-    model_conf_path = os.path.join(artifact_uri, model_subpath, "MLmodel")
-    return Model.load(model_conf_path)
-
-
 def stringify_dict_values(d):
     return {k: str(v) for k, v in d.items()}
 
@@ -121,6 +115,11 @@ def assert_predict_equal(left, right, X):
 @pytest.fixture(params=FIT_FUNC_NAMES)
 def fit_func_name(request):
     return request.param
+
+
+def _get_model_uri(name: str = MODEL_DIR) -> str:
+    last_active_run = mlflow.last_active_run()
+    return f"runs:/{last_active_run.info.run_id}/{name}"
 
 
 def test_autolog_preserves_original_function_attributes():
@@ -819,11 +818,11 @@ def test_parameter_search_estimators_produce_expected_outputs(
     assert isinstance(cv_model, cv_class)
 
     # Ensure that a signature and input example are produced for the best estimator
-    best_estimator_conf = get_model_conf(run.info.artifact_uri, "best_estimator")
+    model_uri = _get_model_uri(name="best_estimator")
+    best_estimator_conf = Model.load(model_uri)
     assert best_estimator_conf.signature == infer_signature(X, best_estimator.predict(X[:5]))
 
-    best_estimator_path = os.path.join(run.info.artifact_uri, "best_estimator")
-    input_example = _read_example(best_estimator_conf, best_estimator_path)
+    input_example = _read_example(best_estimator_conf, model_uri)
     best_estimator.predict(input_example)  # Ensure that input example evaluation succeeds
 
     client = MlflowClient()
@@ -913,13 +912,13 @@ def test_autolog_logs_signature_and_input_example(data_type):
     y = np.array(y) if data_type in [csr_matrix, csc_matrix] else data_type(y)
     model = sklearn.linear_model.LinearRegression()
 
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         model.fit(X, y)
-        model_path = os.path.join(run.info.artifact_uri, MODEL_DIR)
 
-    model_conf = get_model_conf(run.info.artifact_uri)
-    input_example = _read_example(model_conf, model_path)
-    pyfunc_model = mlflow.pyfunc.load_model(model_path)
+    model_uri = _get_model_uri()
+    model_conf = Model.load(model_uri)
+    input_example = _read_example(model_conf, model_uri)
+    pyfunc_model = mlflow.pyfunc.load_model(model_uri)
 
     assert model_conf.signature == infer_signature(X, model.predict(X[:5]))
 
@@ -976,11 +975,9 @@ def test_autolog_metrics_input_example_and_signature_do_not_reflect_training_mut
     )
     sk_pipeline.fit(X_train, y_train)
 
-    run_artifact_uri = mlflow.last_active_run().info.artifact_uri
-    model_conf = get_model_conf(run_artifact_uri)
-    input_example = pd.read_json(
-        os.path.join(run_artifact_uri, "model", "input_example.json"), orient="split"
-    )
+    model_uri = _get_model_uri()
+    model_conf = Model.load(model_uri)
+    input_example = _read_example(model_conf, model_uri)
     model_signature_input_names = [inp.name for inp in model_conf.signature.inputs.inputs]
     assert "XLarge Bags" in model_signature_input_names
     assert "XLarge Bags" in input_example.columns
@@ -1012,11 +1009,10 @@ def test_autolog_does_not_throw_when_failing_to_sample_X():
     mlflow.sklearn.autolog()
     model = sklearn.linear_model.LinearRegression()
 
-    with mlflow.start_run() as run, mock.patch("mlflow.sklearn._logger.warning") as mock_warning:
+    with mlflow.start_run(), mock.patch("mlflow.sklearn._logger.warning") as mock_warning:
         model.fit(throwing_X, y)
 
-    model_conf = get_model_conf(run.info.artifact_uri)
-
+    model_conf = Model.load(_get_model_uri())
     assert mock_warning.call_count == 2
     mock_warning.call_args[0][0].endswith("DO NOT SLICE ME")
     assert "signature" not in model_conf.to_dict()
@@ -1032,10 +1028,10 @@ def test_autolog_logs_signature_only_when_estimator_defines_predict():
     model = AgglomerativeClustering()
     assert not hasattr(model, "predict")
 
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         model.fit(X, y)
 
-    model_conf = get_model_conf(run.info.artifact_uri)
+    model_conf = Model.load(_get_model_uri())
     assert "signature" not in model_conf.to_dict()
 
 
@@ -1046,7 +1042,7 @@ def test_autolog_does_not_throw_when_predict_fails():
 
     # Note that `mock_warning` will be called twice because if `predict` throws, `score` also throws
     with (
-        mlflow.start_run() as run,
+        mlflow.start_run(),
         mock.patch(
             "sklearn.linear_model.LinearRegression.predict", side_effect=Exception("Failed")
         ),
@@ -1056,7 +1052,7 @@ def test_autolog_does_not_throw_when_predict_fails():
         model.fit(X, y)
 
     mock_warning.assert_called_with("Failed to infer model signature: Failed")
-    model_conf = get_model_conf(run.info.artifact_uri)
+    model_conf = Model.load(_get_model_uri())
     assert "signature" not in model_conf.to_dict()
 
 
@@ -1064,7 +1060,7 @@ def test_autolog_does_not_throw_when_infer_signature_fails():
     X, y = get_iris()
 
     with (
-        mlflow.start_run() as run,
+        mlflow.start_run(),
         mock.patch("mlflow.models.infer_signature", side_effect=Exception("Failed")),
         mock.patch("mlflow.sklearn._logger.warning") as mock_warning,
     ):
@@ -1073,7 +1069,7 @@ def test_autolog_does_not_throw_when_infer_signature_fails():
         model.fit(X, y)
 
     mock_warning.assert_called_once_with("Failed to infer model signature: Failed")
-    model_conf = get_model_conf(run.info.artifact_uri)
+    model_conf = Model.load(_get_model_uri())
     assert "signature" not in model_conf.to_dict()
 
 
@@ -1081,7 +1077,7 @@ def test_autolog_does_not_warn_when_model_has_transform_function():
     X, y = get_iris()
 
     mlflow.sklearn.autolog(log_input_examples=True, log_model_signatures=True)
-    with mlflow.start_run() as run, mock.patch("mlflow.sklearn._logger.warning") as mock_warning:
+    with mlflow.start_run(), mock.patch("mlflow.sklearn._logger.warning") as mock_warning:
         estimators = [
             ("std_scaler", sklearn.preprocessing.StandardScaler()),
         ]
@@ -1092,7 +1088,7 @@ def test_autolog_does_not_warn_when_model_has_transform_function():
     msg = "Failed to infer model signature:"
     assert all(msg not in c[0] for c in mock_warning.call_args_list)
 
-    model_conf = get_model_conf(run.info.artifact_uri)
+    model_conf = Model.load(_get_model_uri())
     assert "signature" in model_conf.to_dict()
 
 
@@ -1101,13 +1097,13 @@ def test_autolog_does_not_warn_when_model_has_transform_function():
 def test_autolog_configuration_options(log_input_examples, log_model_signatures):
     X, y = get_iris()
 
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         mlflow.sklearn.autolog(
             log_input_examples=log_input_examples, log_model_signatures=log_model_signatures
         )
         model = sklearn.linear_model.LinearRegression()
         model.fit(X, y)
-    model_conf = get_model_conf(run.info.artifact_uri)
+    model_conf = Model.load(_get_model_uri())
     assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_examples
     assert ("signature" in model_conf.to_dict()) == log_model_signatures
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14728?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14728/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14728
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

On the `mlflow-3` feature branch, attempting to load a model using `run.info.artifact_uri` fails. This PR replaces them with `runs:/<run_id>/model`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
