### PR TITLE
Draft: Add 0.0.0.0 host binding for gunicorn in generated Dockerfiles

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -44,7 +44,7 @@ WORKDIR /opt/mlflow
 
 ENV MLFLOW_DISABLE_ENV_CREATION={disable_env_creation}
 ENV ENABLE_MLSERVER={enable_mlserver}
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_conda
+++ b/tests/resources/dockerfile/Dockerfile_conda
@@ -31,7 +31,7 @@ RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps(
 
 ENV MLFLOW_DISABLE_ENV_CREATION=True
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_custom_scipy
+++ b/tests/resources/dockerfile/Dockerfile_custom_scipy
@@ -16,7 +16,7 @@ RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps(
 
 ENV MLFLOW_DISABLE_ENV_CREATION=True
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_default
+++ b/tests/resources/dockerfile/Dockerfile_default
@@ -16,7 +16,7 @@ RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps(
 
 ENV MLFLOW_DISABLE_ENV_CREATION=True
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_enable_mlserver
+++ b/tests/resources/dockerfile/Dockerfile_enable_mlserver
@@ -16,7 +16,7 @@ RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps(
 
 ENV MLFLOW_DISABLE_ENV_CREATION=True
 ENV ENABLE_MLSERVER=True
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow
@@ -16,7 +16,7 @@ RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps(
 
 ENV MLFLOW_DISABLE_ENV_CREATION=True
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -42,7 +42,7 @@ RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps(
 
 ENV MLFLOW_DISABLE_ENV_CREATION=True
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -42,7 +42,7 @@ RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps(
 
 ENV MLFLOW_DISABLE_ENV_CREATION=True
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -40,7 +40,7 @@ RUN cd /opt/java && mvn --batch-mode dependency:copy-dependencies -DoutputDirect
 
 ENV MLFLOW_DISABLE_ENV_CREATION=True
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_conda
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_conda
@@ -28,7 +28,7 @@ RUN python -c "from mlflow.models.container import _install_pyfunc_deps;_install
 
 ENV MLFLOW_DISABLE_ENV_CREATION=False
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -39,7 +39,7 @@ RUN python -c "from mlflow.models.container import _install_pyfunc_deps;_install
 
 ENV MLFLOW_DISABLE_ENV_CREATION=False
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints

--- a/tests/resources/dockerfile/Dockerfile_with_mlflow_home
+++ b/tests/resources/dockerfile/Dockerfile_with_mlflow_home
@@ -17,7 +17,7 @@ RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps(
 
 ENV MLFLOW_DISABLE_ENV_CREATION=True
 ENV ENABLE_MLSERVER=False
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent -b 0.0.0.0"
 
 # granting read/write access and conditional execution authority to all child directories
 # and files to allow for deployment to AWS Sagemaker Serverless Endpoints


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/robbertvdg/mlflow/pull/14730?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14730/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14730
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #14365

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes
`mlflow models generate-dockerfile` will create a Dockerfile that by default expose the gunicorn API so that it is reachable for external traffic.

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
