### PR TITLE
Load metric from github if `evaluate.load` fails loading from huggingface hub to stabilize tests

### DIFF
--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -113,7 +113,7 @@ def _cached_evaluate_load(path: str, module_type: str = "metric"):
     import evaluate
 
     try:
-        evaluate.load(path, module_type=module_type)
+        return evaluate.load(path, module_type=module_type)
     except FileNotFoundError:
         if _MLFLOW_TESTING.get():
             # `evaluate.load` is highly unstable and often fails due to a network error or

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -1,9 +1,13 @@
 import functools
 import logging
 import os
+import subprocess
+import tempfile
+from pathlib import Path
 
 import numpy as np
 
+from mlflow.environment_variables import _MLFLOW_TESTING
 from mlflow.metrics.base import MetricValue, standard_aggregations
 
 _logger = logging.getLogger(__name__)
@@ -83,11 +87,41 @@ def _token_count_eval_fn(predictions, targets=None, metrics=None):
     )
 
 
-@functools.lru_cache(maxsize=8)
-def _cached_evaluate_load(path, module_type=None):
+def _load_from_github(path: str, module_type: str = "metric"):
     import evaluate
 
-    return evaluate.load(path, module_type=module_type)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        subprocess.check_call(
+            [
+                "git",
+                "clone",
+                "--filter=blob:none",
+                "--no-checkout",
+                "https://github.com/huggingface/evaluate.git",
+                tmpdir,
+            ]
+        )
+        path = f"{module_type}s/{path}"
+        subprocess.check_call(["git", "sparse-checkout", "set", path], cwd=tmpdir)
+        subprocess.check_call(["git", "checkout"], cwd=tmpdir)
+        return evaluate.load(str(tmpdir / path))
+
+
+@functools.lru_cache(maxsize=8)
+def _cached_evaluate_load(path: str, module_type: str = "metric"):
+    import evaluate
+
+    try:
+        raise FileNotFoundError("test")
+        evaluate.load(path, module_type=module_type)
+    except FileNotFoundError:
+        # `evaluate.load` is highly unstable and often fails due to a network error or huggingface
+        # hub being down. If it fails, attempt to load the metric from the evaluate repository on
+        # GitHub.
+        if _MLFLOW_TESTING.get():
+            return _load_from_github(path, module_type=module_type)
+        raise
 
 
 def _toxicity_eval_fn(predictions, targets=None, metrics=None):

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -116,10 +116,10 @@ def _cached_evaluate_load(path: str, module_type: str = "metric"):
         raise FileNotFoundError("test")
         evaluate.load(path, module_type=module_type)
     except FileNotFoundError:
-        # `evaluate.load` is highly unstable and often fails due to a network error or huggingface
-        # hub being down. If it fails, attempt to load the metric from the evaluate repository on
-        # GitHub.
         if _MLFLOW_TESTING.get():
+            # `evaluate.load` is highly unstable and often fails due to a network error or
+            # huggingface hub being down. In testing, we want to avoid this instability, so we
+            # load the metric from the evaluate repository on GitHub.
             return _load_from_github(path, module_type=module_type)
         raise
 

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -113,7 +113,6 @@ def _cached_evaluate_load(path: str, module_type: str = "metric"):
     import evaluate
 
     try:
-        raise FileNotFoundError("test")
         evaluate.load(path, module_type=module_type)
     except FileNotFoundError:
         if _MLFLOW_TESTING.get():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14731?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14731/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14731
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`evaluate.load` is highly unstable (I saw it fail **_5 or 6 times_** this week, it even fails when huggingface hub is not down) and often fails due to a network error or huggingface hub being down. As a workaround, we fallback to loading from the evaluate repository on GitHub.

Example: https://github.com/mlflow/mlflow/actions/runs/13519943822/job/37779238933?pr=14728

```
_________ test_evaluate_on_completion_model_endpoint[input_data4-None] _________

mock_deploy_client = <MagicMock name='get_deploy_client' id='140477793828672'>
input_data = [{'prompt': 'What is MLflow?'}, {'prompt': 'What is Spark?'}]
feature_names = None

        ...    
        # Validate the evaluation metrics
        expected_metrics_subset = {
            "toxicity/v1/ratio",
            "ari_grade_level/v1/mean",
            "flesch_kincaid_grade_level/v1/mean",
        }
>       assert expected_metrics_subset.issubset(set(eval_result.metrics.keys()))
E       AssertionError: assert False
E        +  where False = <built-in method issubset of set object at 0x7fc38b3d5120>({'ari_grade_level/v1/mean', 'ari_grade_level/v1/p90', 'ari_grade_level/v1/variance', 'flesch_kincaid_grade_level/v1/mean', 'flesch_kincaid_grade_level/v1/p90', 'flesch_kincaid_grade_level/v1/variance'})
E        +    where <built-in method issubset of set object at 0x7fc38b3d5120> = {'ari_grade_level/v1/mean', 'flesch_kincaid_grade_level/v1/mean', 'toxicity/v1/ratio'}.issubset
E        +    and   {'ari_grade_level/v1/mean', 'ari_grade_level/v1/p90', 'ari_grade_level/v1/variance', 'flesch_kincaid_grade_level/v1/mean', 'flesch_kincaid_grade_level/v1/p90', 'flesch_kincaid_grade_level/v1/variance'} = set(dict_keys(['flesch_kincaid_grade_level/v1/mean', 'flesch_kincaid_grade_level/v1/variance', 'flesch_kincaid_grade_level/v1/p90', 'ari_grade_level/v1/mean', 'ari_grade_level/v1/variance', 'ari_grade_level/v1/p90']))
E        +      where dict_keys(['flesch_kincaid_grade_level/v1/mean', 'flesch_kincaid_grade_level/v1/variance', 'flesch_kincaid_grade_level/v1/p90', 'ari_grade_level/v1/mean', 'ari_grade_level/v1/variance', 'ari_grade_level/v1/p90']) = <built-in method keys of dict object at 0x7fc38b3b8440>()
E        +        where <built-in method keys of dict object at 0x7fc38b3b8440> = {'ari_grade_level/v1/mean': -1.9, 'ari_grade_level/v1/p90': -1.9, 'ari_grade_level/v1/variance': 0.0, 'flesch_kincaid_grade_level/v1/mean': 1.3, ...}.keys
E        +          where {'ari_grade_level/v1/mean': -1.9, 'ari_grade_level/v1/p90': -1.9, 'ari_grade_level/v1/variance': 0.0, 'flesch_kincaid_grade_level/v1/mean': 1.3, ...} = <mlflow.models.evaluation.base.EvaluationResult object at 0x7fc407acc190>.metrics

call_args_list = [call(endpoint='completions', inputs={'prompt': 'What is MLflow?', 'max_tokens': 10}),
 call(endpoint='completions', inputs={'prompt': 'What is Spark?', 'max_tokens': 10})]
eval_result = <mlflow.models.evaluation.base.EvaluationResult object at 0x7fc407acc190>
expected_calls = [call(endpoint='completions', inputs={'prompt': 'What is MLflow?', 'max_tokens': 10}), call(endpoint='completions', inputs={'prompt': 'What is Spark?', 'max_tokens': 10})]
expected_metrics_subset = {'ari_grade_level/v1/mean', 'flesch_kincaid_grade_level/v1/mean', 'toxicity/v1/ratio'}
feature_names = None
input_data = [{'prompt': 'What is MLflow?'}, {'prompt': 'What is Spark?'}]
mock_deploy_client = <MagicMock name='get_deploy_client' id='140477793828672'>

tests/evaluate/test_evaluation.py:1922: AssertionError
----------------------------- Captured stderr call -----------------------------
...
2025/02/25 12:19:44 INFO mlflow.models.evaluation.evaluators.default: Computing model predictions.
2025/02/25 12:19:44 INFO mlflow.models.evaluation.default_evaluator: Testing metrics on first row...
2025/02/25 12:19:44 WARNING mlflow.metrics.metric_definitions: Failed to load 'toxicity' metric (error: FileNotFoundError("Couldn't find a module script at /home/runner/work/mlflow/mlflow/toxicity/toxicity.py. Module 'toxicity' doesn't exist on the Hugging Face Hub either.")), skipping metric logging.
2025/02/25 12:19:44 WARNING mlflow.models.evaluation.utils.metric: Did not log metric 'toxicity' at index 1 in the `extra_metrics` parameter because it returned None.
2025/02/25 12:19:45 WARNING mlflow.metrics.metric_definitions: Failed to load 'toxicity' metric (error: FileNotFoundError("Couldn't find a module script at /home/runner/work/mlflow/mlflow/toxicity/toxicity.py. Module 'toxicity' doesn't exist on the Hugging Face Hub either.")), skipping metric logging.
2025/02/25 12:19:45 WARNING mlflow.models.evaluation.utils.metric: Did not log metric 'toxicity' at index 1 in the `extra_metrics` parameter because it returned None.
2025/02/25 12:19:45 WARNING mlflow.utils.autologging_utils: MLflow xgboost autologging is known to be compatible with 1.4.2 <= xgboost <= 2.1.3, but the installed version is 2.1.4. If you encounter errors during autologging, try upgrading / downgrading xgboost to a compatible version, or try upgrading MLflow.
=============================== warnings summary ===============================
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
