### PR TITLE
Pin reticulate to 1.41.0

### DIFF
--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -14,4 +14,5 @@ devtools::install_git("https://github.com/smurching/Rd2md", ref = "mlflow-patche
 devtools::install_version("roxygen2", "7.1.2")
 # The latest version of git2r (0.35.0) doesn't work with the rocker/r-ver:4.2.1 docker image
 devtools::install_version("git2r", "0.33.0")
+devtools::install_version("reticulate", "1.40.0")
 install.packages("rmarkdown", repos = "https://cloud.r-project.org")

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -14,5 +14,7 @@ devtools::install_git("https://github.com/smurching/Rd2md", ref = "mlflow-patche
 devtools::install_version("roxygen2", "7.1.2")
 # The latest version of git2r (0.35.0) doesn't work with the rocker/r-ver:4.2.1 docker image
 devtools::install_version("git2r", "0.33.0")
+# In reticulate 1.41.0, `py_module_import` doesn't work.
+# See https://github.com/mlflow/mlflow/pull/14734 for the full traceback.
 devtools::install_version("reticulate", "1.40.0")
 install.packages("rmarkdown", repos = "https://cloud.r-project.org")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14734?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14734/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14734
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow/mlflow/actions/runs/13533111120/job/37819525261.

```
── Failed tests ────────────────────────────────────────────────────────────────
/usr/bin/xdg-open: 882: www-browser: not found
/usr/bin/xdg-open: 882: links2: not found
/usr/bin/xdg-open: 882: elinks: not found
/usr/bin/xdg-open: 882: links: not found
/usr/bin/xdg-open: 882: lynx: not found
/usr/bin/xdg-open: 882: w3m: not found
xdg-open: no method available for opening 'http://127.0.0.1:5965/'
Error ('test-keras-model.R:14:3'): mlflow can save keras model 
Error: Error: Valid installation of TensorFlow not found.

Python environments searched for 'tensorflow' package:
 /home/runner/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/bin/python3.11

Python exception encountered:
 Traceback (most recent call last):
  File "/home/runner/work/_temp/Library/reticulate/python/rpytools/loader.py", line 122, in _find_and_load_hook
    return _run_hook(name, _hook)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/_temp/Library/reticulate/python/rpytools/loader.py", line 96, in _run_hook
    module = hook()
             ^^^^^^
  File "/home/runner/work/_temp/Library/reticulate/python/rpytools/loader.py", line 120, in _hook
    return _find_and_load(name, import_)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'tensorflow'


You can install TensorFlow using the install_tensorflow() function.

Backtrace:
    ▆
 1. ├─... %>% layer_dense(units = 3, activation = "softmax") at test-keras-model.R:14:3
 2. ├─keras::layer_dense(., units = 3, activation = "softmax")
 3. │ ├─keras::create_layer(...)
 4. │ ├─keras$layers
 5. │ └─reticulate:::`$.python.builtin.module`(keras, "layers")
 6. │   └─reticulate::py_get_attr(x, name, TRUE)
 7. └─reticulate (local) `<fn>`(`<python.builtin.module>`)
 8.   └─keras (local) on_error(result)

Error ('test-model-h2o.R:43:3'): can load and predict with python pyfunct and h2o backend
<python.builtin.ModuleNotFoundError/python.builtin.ImportError/python.builtin.Exception/python.builtin.BaseException/python.builtin.object/error/condition>
Error in `py_module_import(module, convert = convert)`: ModuleNotFoundError: No module named 'mlflow'
Run `reticulate::py_last_error()` for details.
Backtrace:
    ▆
 1. └─reticulate::import("mlflow.pyfunc") at test-model-h2o.R:43:3
 2.   └─reticulate:::py_module_import(module, convert = convert)

Error ('test-model-xgboost.R:43:3'): can load and predict with python pyfunct and xgboost backend
<python.builtin.ModuleNotFoundError/python.builtin.ImportError/python.builtin.Exception/python.builtin.BaseException/python.builtin.object/error/condition>
Error in `py_module_import(module, convert = convert)`: ModuleNotFoundError: No module named 'mlflow'
Run `reticulate::py_last_error()` for details.
Backtrace:
    ▆
 1. └─reticulate::import("mlflow.pyfunc") at test-model-xgboost.R:43:3
 2.   └─reticulate:::py_module_import(module, convert = convert)

[ FAIL 3 | WARN 30 | SKIP 2 | PASS 395 ]
```

No idea what changed in `reticulate`, but 1.40.0 seems to work fine. 1.41.0 was released a few days ago: https://cran.r-project.org/web/packages/reticulate/index.html.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
