### PR TITLE
Fix mlflow3 XGB autolog

### DIFF
--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -30,11 +30,6 @@ def get_latest_run():
     return client.get_run(client.search_runs(["0"])[0].info.run_id)
 
 
-def get_model_conf(artifact_uri, model_subpath="model"):
-    model_conf_path = os.path.join(artifact_uri, model_subpath, "MLmodel")
-    return Model.load(model_conf_path)
-
-
 @pytest.fixture(scope="module")
 def bst_params():
     return {
@@ -192,14 +187,13 @@ def test_xgb_autolog_sklearn():
 
     with mlflow.start_run() as run:
         model.fit(X, y)
-        model_uri = mlflow.get_artifact_uri("model")
 
     client = MlflowClient()
     run = client.get_run(run.info.run_id)
     assert run.data.metrics.items() <= params.items()
     artifacts = {x.path for x in client.list_artifacts(run.info.run_id)}
     assert artifacts >= {"feature_importance_weight.png", "feature_importance_weight.json"}
-    loaded_model = mlflow.xgboost.load_model(model_uri)
+    loaded_model = mlflow.xgboost.load_model(f"runs:/{run.info.run_id}/model")
     np.testing.assert_allclose(loaded_model.predict(X), model.predict(X))
 
 
@@ -264,10 +258,10 @@ def test_xgb_autolog_with_sklearn_outputs_do_not_reflect_training_dataset_mutati
         model = xgb.XGBRegressor(**params)
         model.fit(X, y)
 
-        run_artifact_uri = mlflow.last_active_run().info.artifact_uri
-        model_conf = get_model_conf(run_artifact_uri)
+        model = mlflow.last_logged_model()
+        model_conf = Model.load(model.model_uri)
         input_example = pd.read_json(
-            os.path.join(run_artifact_uri, "model", "input_example.json"), orient="split"
+            os.path.join(model.artifact_location, "input_example.json"), orient="split"
         )
         model_signature_input_names = [inp.name for inp in model_conf.signature.inputs.inputs]
         assert "XLarge Bags" in model_signature_input_names
@@ -510,16 +504,14 @@ def test_xgb_autolog_gets_input_example(bst_params):
     dataset = xgb.DMatrix(X, y)
 
     xgb.train(bst_params, dataset)
-    run = get_latest_run()
 
-    model_path = os.path.join(run.info.artifact_uri, "model")
-    model_conf = Model.load(os.path.join(model_path, "MLmodel"))
-
-    input_example = _read_example(model_conf, model_path)
+    model = mlflow.last_logged_model()
+    model_conf = Model.load(model.model_uri)
+    input_example = _read_example(model_conf, model.model_uri)
 
     pd.testing.assert_frame_equal(input_example, X[:5])
 
-    pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
+    pyfunc_model = mlflow.pyfunc.load_model(model.model_uri)
 
     # make sure reloading the input_example and predicting on it does not error
     pyfunc_model.predict(input_example)
@@ -536,15 +528,9 @@ def test_xgb_autolog_infers_model_signature_correctly(bst_params):
     dataset = xgb.DMatrix(X, y)
 
     xgb.train(bst_params, dataset)
-    run = get_latest_run()
-    run_id = run.info.run_id
-    artifacts_dir = run.info.artifact_uri.replace("file://", "")
-    client = MlflowClient()
-    artifacts = [x.path for x in client.list_artifacts(run_id, "model")]
+    model = mlflow.last_logged_model()
 
-    ml_model_filename = "MLmodel"
-    assert str(os.path.join("model", ml_model_filename)) in artifacts
-    ml_model_path = os.path.join(artifacts_dir, "model", ml_model_filename)
+    ml_model_path = os.path.join(model.artifact_location, "MLmodel")
 
     data = None
     with open(ml_model_path) as f:
@@ -599,15 +585,9 @@ def test_xgb_autolog_continues_logging_even_if_signature_inference_fails(bst_par
     dataset = xgb.DMatrix(f"{tmp_csv}?format=csv&label_column=0")
 
     xgb.train(bst_params, dataset)
-    run = get_latest_run()
-    run_id = run.info.run_id
-    artifacts_dir = run.info.artifact_uri.replace("file://", "")
-    client = MlflowClient()
-    artifacts = [x.path for x in client.list_artifacts(run_id, "model")]
+    model = mlflow.last_logged_model()
 
-    ml_model_filename = "MLmodel"
-    assert os.path.join("model", ml_model_filename) in artifacts
-    ml_model_path = os.path.join(artifacts_dir, "model", ml_model_filename)
+    ml_model_path = os.path.join(model.artifact_location, "MLmodel")
 
     data = None
     with open(ml_model_path) as f:
@@ -647,7 +627,8 @@ def test_xgb_autolog_configuration_options(bst_params, log_input_examples, log_m
         )
         dataset = xgb.DMatrix(X, y)
         xgb.train(bst_params, dataset)
-    model_conf = get_model_conf(run.info.artifact_uri)
+
+    model_conf = Model.load(f"runs:/{run.info.run_id}/model")
     assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_examples
     assert ("signature" in model_conf.to_dict()) == log_model_signatures
 
@@ -658,15 +639,12 @@ def test_xgb_autolog_log_models_configuration(bst_params, log_models):
     X = pd.DataFrame(iris.data[:, :2], columns=iris.feature_names[:2])
     y = iris.target
 
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         mlflow.xgboost.autolog(log_models=log_models)
         dataset = xgb.DMatrix(X, y)
         xgb.train(bst_params, dataset)
 
-    run_id = run.info.run_id
-    client = MlflowClient()
-    artifacts = [f.path for f in client.list_artifacts(run_id)]
-    assert ("model" in artifacts) == log_models
+    assert (mlflow.last_logged_model() is not None) == log_models
 
 
 @pytest.mark.skipif(
@@ -730,12 +708,11 @@ def test_xgb_api_autolog_registering_model(bst_params, dtrain):
 @pytest.mark.parametrize("model_format", ["xgb", "json", "ubj"])
 def test_xgb_autolog_with_model_format(bst_params, dtrain, model_format):
     mlflow.xgboost.autolog(log_models=True, model_format=model_format)
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         xgb.train(bst_params, dtrain)
-    run_id = run.info.run_id
-    client = MlflowClient()
-    artifacts = [f.path for f in client.list_artifacts(run_id, "model")]
-    assert f"model/model.{model_format}" in artifacts
+    model = mlflow.last_logged_model()
+    artifacts = [f.path for f in mlflow.artifacts.list_artifacts(model.model_uri)]
+    assert f"model.{model_format}" in artifacts
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14742?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14742/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14742
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Fix mlflow3 XGB autolog tests

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
