### PR TITLE
Fix DSPy tracing in serving

### DIFF
--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -7,6 +7,7 @@ from dspy.utils.callback import BaseCallback
 import mlflow
 from mlflow.entities import SpanStatusCode, SpanType
 from mlflow.entities.span_event import SpanEvent
+from mlflow.exceptions import MlflowException
 from mlflow.pyfunc.context import get_prediction_context, maybe_set_prediction_context
 from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
 from mlflow.tracing.utils import (
@@ -27,6 +28,14 @@ class MlflowCallback(BaseCallback):
         self._dependencies_schema = dependencies_schema
         # call_id: (LiveSpan, OTel token)
         self._call_id_to_span: dict[str, SpanWithToken] = {}
+
+    def set_dependencies_schema(self, dependencies_schema: dict[str, Any]):
+        if self._dependencies_schema:
+            raise MlflowException(
+                "Dependencies schema should be set only once to the callback.",
+                error_code=MlflowException.INVALID_PARAMETER_VALUE,
+            )
+        self._dependencies_schema = dependencies_schema
 
     def on_module_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         span_type = self._get_span_type_for_module(instance)

--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -1,4 +1,3 @@
-import logging
 import os
 
 import cloudpickle
@@ -15,28 +14,23 @@ from mlflow.utils.model_utils import (
 
 _DEFAULT_MODEL_PATH = "data/model.pkl"
 
-_logger = logging.getLogger(__name__)
 
-
-def _set_tracer_context(model_path, callbacks):
+def _set_dependency_schema_to_tracer(model_path, callbacks):
     """
-    Set dependency schemas from the saved model metadata to the tracer's prediction context.
+    Set dependency schemas from the saved model metadata to the tracer
+    to propagate it to inference traces.
     """
     from mlflow.dspy.callback import MlflowCallback
 
     tracer = next((cb for cb in callbacks if isinstance(cb, MlflowCallback)), None)
     if tracer is None:
         return
-    context = tracer._prediction_context
 
     model = Model.load(model_path)
-    if schema := _get_dependencies_schema_from_model(model):
-        context.update(**schema)
+    tracer._dependencies_schema = _get_dependencies_schema_from_model(model)
 
 
 def _load_model(model_uri, dst_path=None):
-    import dspy
-
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name="dspy")
 
@@ -45,9 +39,8 @@ def _load_model(model_uri, dst_path=None):
     with open(os.path.join(local_model_path, model_path), "rb") as f:
         loaded_wrapper = cloudpickle.load(f)
 
-    _set_tracer_context(local_model_path, loaded_wrapper.dspy_settings["callbacks"])
-    # Set the global dspy settings and return the dspy wrapper.
-    dspy.settings.configure(**loaded_wrapper.dspy_settings)
+    _set_dependency_schema_to_tracer(local_model_path, loaded_wrapper.dspy_settings["callbacks"])
+
     return loaded_wrapper
 
 

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -16,10 +16,11 @@ from packaging.version import Version
 
 import mlflow
 from mlflow.entities import SpanType
+from mlflow.entities.trace import Trace
 from mlflow.models.dependencies_schemas import DependenciesSchemasType, _clear_retriever_schema
 from mlflow.tracing.constant import SpanAttributeKey
 
-from tests.tracing.helper import get_traces
+from tests.tracing.helper import get_traces, score_in_model_serving
 
 _DSPY_VERSION = Version(importlib.metadata.version("dspy"))
 
@@ -282,7 +283,6 @@ class RAG(dspy.Module):
 
     def forward(self, question):
         # Create a custom span inside the module using fluent API
-        assert mlflow.get_current_active_span() is not None
         with mlflow.start_span(name="retrieve_context", span_type=SpanType.RETRIEVER) as span:
             span.set_inputs(question)
             docs = self.retrieve(question)
@@ -485,3 +485,65 @@ def test_autolog_set_retriever_schema():
             "other_columns": [],
         }
     ]
+
+
+@pytest.mark.parametrize("with_dependencies_schema", [True, False])
+def test_dspy_auto_tracing_in_databricks_model_serving(with_dependencies_schema):
+    mlflow.dspy.autolog()
+
+    dspy.settings.configure(
+        lm=DummyLM(
+            [
+                {
+                    "answer": "test output",
+                    "reasoning": "No more responses",
+                },
+            ]
+        )
+    )
+
+    if with_dependencies_schema:
+        mlflow.models.set_retriever_schema(
+            primary_key="primary-key",
+            text_column="text-column",
+            doc_uri="doc-uri",
+            other_columns=["column1", "column2"],
+        )
+
+    input_example = "What castle did David Gregory inherit?"
+
+    with mlflow.start_run():
+        model_info = mlflow.dspy.log_model(RAG(), "model", input_example=input_example)
+
+    request_id, response, trace_dict = score_in_model_serving(
+        model_info.model_uri,
+        input_example,
+    )
+
+    trace = Trace.from_dict(trace_dict)
+    assert trace.info.request_id == request_id
+    assert trace.info.status == "OK"
+
+    spans = trace.data.spans
+    assert len(spans) == 8
+    assert [span.name for span in spans] == [
+        "RAG.forward",
+        "retrieve_context",
+        "DummyRetriever.forward",
+        "ChainOfThought.forward",
+        "Predict.forward",
+        "ChatAdapter.format",
+        "DummyLM.__call__",
+        "ChatAdapter.parse",
+    ]
+
+    if with_dependencies_schema:
+        assert json.loads(trace.info.tags[DependenciesSchemasType.RETRIEVERS.value]) == [
+            {
+                "name": "retriever",
+                "primary_key": "primary-key",
+                "text_column": "text-column",
+                "doc_uri": "doc-uri",
+                "other_columns": ["column1", "column2"],
+            }
+        ]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14743?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14743/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14743
```

</p>
</details>

### What changes are proposed in this pull request?

When I was adding integ test for DSPy in model serving, I found two issues in current DSPy flavor:

1. In this [PR](https://github.com/mlflow/mlflow/pull/14471), we've moved the setting mutation logic into prediction logic to address thread-safety issue. However, there is a left-over in [load_model](https://github.com/mlflow/mlflow/blob/master/mlflow/dspy/load.py#L49-L50) function. This does not cause real issue in current serving, because the model is loaded in child thread. However, it is unnecessary and also blocks some test scenario.
2. The prediction context is not handled properly. This [maybe_set_prediction_context](https://github.com/mlflow/mlflow/blob/master/mlflow/dspy/callback.py#L187) call inside the callback is intended to propagate dependency schema to the trace. However, this overrides the prediction context passed from the scoring server (that specifies `request_id`). Luckily we haven't seen a real issue from this, because we have fallback logic of fetching `request_id` from Flask context [here](https://github.com/mlflow/mlflow/blob/master/mlflow/tracing/processor/inference_table.py#L65).


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (TODO: test in real serving)

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a bug in DSPy tracing in Databricks model serving.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
