### PR TITLE
Revert "[Safe-patch] Clean up warning context manager (#14667)"

### DIFF
--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -16,8 +16,8 @@ from mlflow.utils import gorilla, is_iterator
 from mlflow.utils.autologging_utils import _logger
 from mlflow.utils.autologging_utils.events import AutologgingEventLoggerWrapper
 from mlflow.utils.autologging_utils.logging_and_warnings import (
+    set_mlflow_events_and_warnings_behavior_globally,
     set_non_mlflow_warnings_behavior_for_current_thread,
-    set_warning_behavior_during_autologging,
 )
 from mlflow.utils.mlflow_tags import MLFLOW_AUTOLOGGING
 
@@ -255,6 +255,7 @@ def safe_patch(
             `patch_function`.
         extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
     """
+    from mlflow.utils.autologging_utils import autologging_is_disabled, get_autologging_config
 
     if manage_run:
         tags = _resolve_extra_tags(autologging_integration, extra_tags)
@@ -312,12 +313,74 @@ def safe_patch(
         while exceptions thrown from other parts of `patch_function` are caught and logged as
         warnings.
         """
-        if _should_skip_autolog(autologging_integration):
-            return original(*args, **kwargs)
-
-        with set_warning_behavior_during_autologging(autologging_integration):
+        # Reroute warnings encountered during the patch function implementation to an MLflow event
+        # logger, and enforce silent mode if applicable (i.e. if the corresponding autologging
+        # integration was called with `silent=True`), hiding MLflow event logging statements and
+        # hiding all warnings in the autologging preamble and postamble (i.e. the code surrounding
+        # the user's original / underlying ML function). Non-MLflow warnings are enabled during the
+        # execution of the original / underlying ML function
+        #
+        # Note that we've opted *not* to apply this context manager as a decorator on
+        # `safe_patch_function` because the context-manager-as-decorator pattern uses
+        # `contextlib.ContextDecorator`, which creates generator expressions that cannot be pickled
+        # during model serialization by ML frameworks such as scikit-learn
+        is_silent_mode = get_autologging_config(autologging_integration, "silent", False)
+        with (
+            set_mlflow_events_and_warnings_behavior_globally(
+                # MLflow warnings emitted during autologging training sessions are likely not
+                # actionable and result from the autologging implementation invoking another MLflow
+                # API. Accordingly, we reroute these warnings to the MLflow event logger with level
+                # WARNING For reference, see recommended warning and event logging behaviors from
+                # https://docs.python.org/3/howto/logging.html#when-to-use-logging
+                reroute_warnings=True,
+                disable_event_logs=is_silent_mode,
+                disable_warnings=is_silent_mode,
+            ),
+            set_non_mlflow_warnings_behavior_for_current_thread(
+                # non-MLflow Warnings emitted during the autologging preamble (before the original /
+                # underlying ML function is called) and postamble (after the original / underlying
+                # ML function is called) are likely not actionable and result from the autologging
+                # implementation invoking an API from a dependent library. Accordingly, we reroute
+                # these warnings to the MLflow event logger with level WARNING. For reference, see
+                # recommended warning and event logging behaviors from
+                # https://docs.python.org/3/howto/logging.html#when-to-use-logging
+                reroute_warnings=True,
+                disable_warnings=is_silent_mode,
+            ),
+        ):
             if is_testing():
                 preexisting_run_for_testing = mlflow.active_run()
+
+            # Whether or not to exclude autologged content from user-created fluent runs
+            # (i.e. runs created manually via `mlflow.start_run()`)
+            exclusive = get_autologging_config(autologging_integration, "exclusive", False)
+            user_created_fluent_run_is_active = (
+                mlflow.active_run() and not _AutologgingSessionManager.active_session()
+            )
+            active_session_failed = (
+                _AutologgingSessionManager.active_session() is not None
+                and _AutologgingSessionManager.active_session().state == "failed"
+            )
+
+            if (
+                active_session_failed
+                or autologging_is_disabled(autologging_integration)
+                or (user_created_fluent_run_is_active and exclusive)
+                or (
+                    mlflow.utils.autologging_utils._AUTOLOGGING_GLOBALLY_DISABLED
+                    and autologging_integration
+                )
+            ):
+                # If the autologging integration associated with this patch is disabled,
+                # or if the current autologging integration is in exclusive mode and a user-created
+                # fluent run is active, call the original function and return. Restore the original
+                # warning behavior during original function execution, since autologging is being
+                # skipped
+                with set_non_mlflow_warnings_behavior_for_current_thread(
+                    disable_warnings=False,
+                    reroute_warnings=False,
+                ):
+                    return original(*args, **kwargs)
 
             # Whether or not the original / underlying function has been called during the
             # execution of patched code
@@ -503,40 +566,6 @@ def revert_patches(autologging_integration):
         gorilla.revert(patch)
 
     _AUTOLOGGING_PATCHES.pop(autologging_integration, None)
-
-
-def _should_skip_autolog(autologging_integration: str) -> bool:
-    from mlflow.utils.autologging_utils import (
-        _AUTOLOGGING_GLOBALLY_DISABLED,
-        autologging_is_disabled,
-        get_autologging_config,
-    )
-
-    # Autologging is disabled for the specified flavor
-    if autologging_is_disabled(autologging_integration):
-        return True
-
-    # Autologging is globally disabled
-    if _AUTOLOGGING_GLOBALLY_DISABLED and autologging_integration:
-        return True
-
-    # Whether or not to exclude autologged content from user-created fluent runs
-    # (i.e. runs created manually via `mlflow.start_run()`)
-    exclusive = get_autologging_config(autologging_integration, "exclusive", False)
-    user_created_fluent_run_is_active = (
-        mlflow.active_run() and not _AutologgingSessionManager.active_session()
-    )
-    if user_created_fluent_run_is_active and exclusive:
-        return True
-
-    # Failed to start an autologging session
-    if (
-        _AutologgingSessionManager.active_session() is not None
-        and _AutologgingSessionManager.active_session().state == "failed"
-    ):
-        return True
-
-    return False
 
 
 # Represents an active autologging session using two fields:

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -16,7 +16,6 @@ from mlflow.utils.autologging_utils import (
     ExceptionSafeAbstractClass,
     ExceptionSafeClass,
     autologging_integration,
-    disable_autologging,
     is_testing,
     picklable_exception_safe_function,
     safe_patch,
@@ -1438,6 +1437,71 @@ def test_session_manager_terminates_session_when_appropriate():
     assert not _AutologgingSessionManager.active_session()
 
 
+def test_original_fn_runs_if_patch_should_not_be_applied(patch_destination):
+    patch_impl_call_count = 0
+
+    @autologging_integration("test_respects_exclusive")
+    def autolog(disable=False, exclusive=False, silent=False):
+        def patch_impl(original, *args, **kwargs):
+            nonlocal patch_impl_call_count
+            patch_impl_call_count += 1
+            return original(*args, **kwargs)
+
+        safe_patch("test_respects_exclusive", patch_destination, "fn", patch_impl)
+
+    autolog(exclusive=True)
+    with mlflow.start_run():
+        patch_destination.fn()
+    assert patch_impl_call_count == 0
+    assert patch_destination.fn_call_count == 1
+
+
+def test_patch_runs_if_patch_should_be_applied():
+    patch_impl_call_count = 0
+
+    class TestPatchWithNewFnObj:
+        def __init__(self):
+            self.fn_call_count = 0
+
+        def fn(self, *args, **kwargs):
+            self.fn_call_count += 1
+            return PATCH_DESTINATION_FN_DEFAULT_RESULT
+
+        def new_fn(self, *args, **kwargs):
+            with mlflow.start_run():
+                self.fn()
+
+    patch_obj = TestPatchWithNewFnObj()
+
+    @autologging_integration("test_respects_exclusive")
+    def autolog(disable=False, exclusive=False, silent=False):
+        def patch_impl(original, *args, **kwargs):
+            nonlocal patch_impl_call_count
+            patch_impl_call_count += 1
+
+        def new_fn_patch(original, *args, **kwargs):
+            pass
+
+        safe_patch("test_respects_exclusive", patch_obj, "fn", patch_impl)
+        safe_patch("test_respects_exclusive", patch_obj, "new_fn", new_fn_patch)
+
+    # Should patch if no active run
+    autolog()
+    patch_obj.fn()
+    assert patch_impl_call_count == 1
+
+    # Should patch if active run, but not exclusive
+    autolog(exclusive=False)
+    with mlflow.start_run():
+        patch_obj.fn()
+    assert patch_impl_call_count == 2
+
+    # Should patch if active run and exclusive, but active autologging session
+    autolog(exclusive=True)
+    patch_obj.new_fn()
+    assert patch_impl_call_count == 3
+
+
 def test_nested_call_autologging_disabled_when_top_level_call_autologging_failed(patch_destination):
     patch_impl_call_count = 0
 
@@ -1588,53 +1652,3 @@ def test_safe_patch_preserves_original_function_attributes():
     original_predict = Test1.predict
     autolog()
     assert get_func_attrs(Test1.predict) == get_func_attrs(original_predict)
-
-
-def test_should_skip_autolog(patch_destination):
-    patch_impl_call_count = 0
-
-    @autologging_integration("test-flavor")
-    def autolog(disable=False, exclusive=False, silent=False):
-        def patch_impl(original, *args, **kwargs):
-            nonlocal patch_impl_call_count
-            patch_impl_call_count += 1
-            return original(*args, **kwargs)
-
-        safe_patch("test-flavor", patch_destination, "fn", patch_impl)
-
-    # Autologging is enabled -> patch should be applied
-    autolog()
-    patch_destination.fn()
-    assert patch_impl_call_count == 1
-
-    # Autologging is enabled and user-created fluent run
-    with mlflow.start_run():
-        patch_destination.fn()
-    assert patch_impl_call_count == 2
-
-    # Autologging globally disabled via context manager -> patch should not be applied
-    with disable_autologging():
-        patch_destination.fn()
-    assert patch_impl_call_count == 2
-
-    # User-created fluent run exists and "exclusive" is set to True -> patch should not be applied
-    autolog(exclusive=True)
-    with mlflow.start_run():
-        patch_destination.fn()
-    assert patch_impl_call_count == 2
-
-    # Autologging session failed to start -> patch should not be applied
-    with (
-        mock.patch(
-            "mlflow.utils.autologging_utils.safety._AutologgingSessionManager.start_session",
-            side_effect=Exception("Session failed to start"),
-        ),
-        pytest.raises(Exception, match="Session failed to start"),
-    ):
-        patch_destination.fn()
-    assert patch_impl_call_count == 2
-
-    # Autologging is disabled for the flavor -> patch should not be applied
-    autolog(disable=True)
-    patch_destination.fn()
-    assert patch_impl_call_count == 2


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14744?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14744/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14744
```

</p>
</details>

### What changes are proposed in this pull request?
This reverts commit 0c924d4fee3d0770880cb19aa5de755b01ab5680 for 100% safety.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
