### PR TITLE
Fix tensorflow autologging tests on mlflow3

### DIFF
--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1240,7 +1240,7 @@ def test_keras_autolog_logs_model_signature_by_default(keras_data_gen_sequence):
     initial_model.fit(keras_data_gen_sequence)
 
     logged_model = mlflow.last_logged_model()
-    mlmodel_path = mlflow.artifacts.download_artifacts(f"{logged_model.artifact_location}/MLmodel")
+    mlmodel_path = f"{logged_model.artifact_location}/MLmodel"
     with open(mlmodel_path) as f:
         mlmodel_contents = yaml.safe_load(f)
     assert "signature" in mlmodel_contents.keys()

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -210,9 +210,9 @@ def test_tf_keras_autolog_log_models_configuration(
 
     client = MlflowClient()
     run_id = client.search_runs(["0"])[0].info.run_id
-    artifacts = client.list_artifacts(run_id)
-    artifacts = (x.path for x in artifacts)
-    assert ("model" in artifacts) == log_models
+    assert (
+        len(mlflow.search_logged_models(filter_string=f"source_run_id='{run_id}'")) == 1
+    ) == log_models
 
 
 @pytest.mark.parametrize("log_datasets", [True, False])
@@ -721,7 +721,7 @@ def test_tf_keras_autolog_model_can_load_from_artifact(tf_keras_random_data_run,
     client = MlflowClient()
     artifacts = client.list_artifacts(run.info.run_id)
     artifacts = (x.path for x in artifacts)
-    assert "model" in artifacts
+    assert len(mlflow.search_logged_models(filter_string=f"source_run_id='{run.info.run_id}'")) == 1
     assert "tensorboard_logs" in artifacts
     model = mlflow.tensorflow.load_model("runs:/" + run.info.run_id + "/model")
     model.predict(random_train_data)
@@ -1061,10 +1061,7 @@ def test_fluent_autolog_with_tf_keras_logs_expected_content(
     run_data = client.get_run(run.info.run_id).data
     assert "accuracy" in run_data.metrics
     assert "epochs" in run_data.params
-
-    artifacts = client.list_artifacts(run.info.run_id)
-    artifacts = (x.path for x in artifacts)
-    assert "model" in artifacts
+    assert len(mlflow.search_logged_models(filter_string=f"source_run_id='{run.info.run_id}'")) == 1
 
 
 def test_callback_is_picklable():
@@ -1099,13 +1096,9 @@ def test_import_tensorflow_with_fluent_autolog_enables_tensorflow_autologging():
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
 
-def _assert_autolog_infers_model_signature_correctly(run, input_sig_spec, output_sig_spec):
-    artifacts_dir = run.info.artifact_uri.replace("file://", "")
-    client = MlflowClient()
-    artifacts = [x.path for x in client.list_artifacts(run.info.run_id, "model")]
-    ml_model_filename = "MLmodel"
-    assert str(os.path.join("model", ml_model_filename)) in artifacts
-    ml_model_path = os.path.join(artifacts_dir, "model", ml_model_filename)
+def _assert_autolog_infers_model_signature_correctly(input_sig_spec, output_sig_spec):
+    logged_model = mlflow.last_logged_model()
+    ml_model_path = os.path.join(logged_model.artifact_location, "MLmodel")
     with open(ml_model_path) as f:
         data = yaml.load(f, Loader=yaml.FullLoader)
         assert data is not None
@@ -1118,12 +1111,12 @@ def _assert_autolog_infers_model_signature_correctly(run, input_sig_spec, output
         assert json.loads(signature["outputs"]) == output_sig_spec
 
 
-def _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, random_train_data):
-    model_path = os.path.join(run.info.artifact_uri, "model")
-    model_conf = Model.load(os.path.join(model_path, "MLmodel"))
-    input_example = _read_example(model_conf, model_path)
+def _assert_keras_autolog_input_example_load_and_predict_with_nparray(random_train_data):
+    logged_model = mlflow.last_logged_model()
+    model_conf = Model.load(logged_model.model_uri)
+    input_example = _read_example(model_conf, logged_model.model_uri)
     np.testing.assert_array_almost_equal(input_example, random_train_data[:5])
-    pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
+    pyfunc_model = mlflow.pyfunc.load_model(logged_model.model_uri)
     pyfunc_model.predict(input_example)
 
 
@@ -1132,9 +1125,9 @@ def test_keras_autolog_input_example_load_and_predict_with_nparray(
 ):
     mlflow.tensorflow.autolog(log_input_examples=True, log_model_signatures=True)
     initial_model = create_tf_keras_model()
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         initial_model.fit(random_train_data, random_one_hot_labels)
-        _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, random_train_data)
+        _assert_keras_autolog_input_example_load_and_predict_with_nparray(random_train_data)
 
 
 def test_keras_autolog_infers_model_signature_correctly_with_nparray(
@@ -1142,10 +1135,9 @@ def test_keras_autolog_infers_model_signature_correctly_with_nparray(
 ):
     mlflow.tensorflow.autolog(log_model_signatures=True)
     initial_model = create_tf_keras_model()
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         initial_model.fit(random_train_data, random_one_hot_labels)
         _assert_autolog_infers_model_signature_correctly(
-            run,
             [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 4]}}],
             [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 3]}}],
         )
@@ -1158,12 +1150,12 @@ def test_keras_autolog_infers_model_signature_correctly_with_nparray(
 def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog(log_input_examples=True, log_model_signatures=True)
     fashion_mnist_model = _create_fashion_mnist_model()
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         fashion_mnist_model.fit(fashion_mnist_tf_dataset)
-        model_path = os.path.join(run.info.artifact_uri, "model")
-        model_conf = Model.load(os.path.join(model_path, "MLmodel"))
-        input_example = _read_example(model_conf, model_path)
-        pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
+        logged_model = mlflow.last_logged_model()
+        model_conf = Model.load(logged_model.model_uri)
+        input_example = _read_example(model_conf, logged_model.model_uri)
+        pyfunc_model = mlflow.pyfunc.load_model(logged_model.model_uri)
         pyfunc_model.predict(input_example)
 
 
@@ -1174,10 +1166,9 @@ def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mn
 def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog(log_model_signatures=True)
     fashion_mnist_model = _create_fashion_mnist_model()
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         fashion_mnist_model.fit(fashion_mnist_tf_dataset)
         _assert_autolog_infers_model_signature_correctly(
-            run,
             [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 28, 28]}}],
             [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 10]}}],
         )
@@ -1188,14 +1179,14 @@ def test_keras_autolog_input_example_load_and_predict_with_dict(
 ):
     mlflow.tensorflow.autolog(log_input_examples=True, log_model_signatures=True)
     model = _create_model_for_dict_mapping()
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         model.fit(random_train_dict_mapping, random_one_hot_labels)
-        model_path = os.path.join(run.info.artifact_uri, "model")
-        model_conf = Model.load(os.path.join(model_path, "MLmodel"))
-        input_example = _read_example(model_conf, model_path)
+        logged_model = mlflow.last_logged_model()
+        model_conf = Model.load(logged_model.model_uri)
+        input_example = _read_example(model_conf, logged_model.model_uri)
         for k, v in random_train_dict_mapping.items():
             np.testing.assert_array_almost_equal(input_example[k], np.take(v, range(0, 5)))
-        pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
+        pyfunc_model = mlflow.pyfunc.load_model(logged_model.model_uri)
         pyfunc_model.predict(input_example)
 
 
@@ -1204,10 +1195,9 @@ def test_keras_autolog_infers_model_signature_correctly_with_dict(
 ):
     mlflow.tensorflow.autolog(log_model_signatures=True)
     model = _create_model_for_dict_mapping()
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         model.fit(random_train_dict_mapping, random_one_hot_labels)
         _assert_autolog_infers_model_signature_correctly(
-            run,
             [
                 {"name": "a", "type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1]}},
                 {"name": "b", "type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1]}},
@@ -1221,10 +1211,10 @@ def test_keras_autolog_infers_model_signature_correctly_with_dict(
 def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_data_gen_sequence):
     mlflow.tensorflow.autolog(log_input_examples=True, log_model_signatures=True)
     model = create_tf_keras_model()
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         model.fit(keras_data_gen_sequence)
         _assert_keras_autolog_input_example_load_and_predict_with_nparray(
-            run, keras_data_gen_sequence[:][0][:5]
+            keras_data_gen_sequence[:][0][:5]
         )
 
 
@@ -1233,10 +1223,9 @@ def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
 ):
     mlflow.tensorflow.autolog(log_model_signatures=True)
     initial_model = create_tf_keras_model()
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         initial_model.fit(keras_data_gen_sequence)
         _assert_autolog_infers_model_signature_correctly(
-            run,
             [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 4]}}],
             [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 3]}}],
         )
@@ -1245,10 +1234,10 @@ def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
 def test_keras_autolog_load_saved_hdf5_model(keras_data_gen_sequence):
     mlflow.tensorflow.autolog(keras_model_kwargs={"save_format": "h5"})
     model = create_tf_keras_model()
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         model.fit(keras_data_gen_sequence)
-        mlflow.tensorflow.load_model(f"runs:/{run.info.run_id}/model")
-        assert Path(run.info.artifact_uri, "model", "data", "model.h5").exists()
+        logged_model = mlflow.last_logged_model()
+        assert Path(logged_model.artifact_location, "data", "model.h5").exists()
 
 
 def test_keras_autolog_logs_model_signature_by_default(keras_data_gen_sequence):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14747?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14747/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14747
```

</p>
</details>

### Related Issues/PRs
N/A

### What changes are proposed in this pull request?

Fix autologging tests for tensorflow on mlflow3.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
