### PR TITLE
Expand safe patch to the accept async function

### DIFF
--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -21,8 +21,8 @@ from mlflow.ml_package_versions import _ML_PACKAGE_VERSIONS, FLAVOR_TO_MODULE_NA
 from mlflow.utils.autologging_utils.client import MlflowAutologgingQueueingClient  # noqa: F401
 from mlflow.utils.autologging_utils.events import AutologgingEventLogger
 from mlflow.utils.autologging_utils.logging_and_warnings import (
-    set_mlflow_events_and_warnings_behavior_globally,
-    set_non_mlflow_warnings_behavior_for_current_thread,
+    MlflowEventsAndWarningsBehaviorGlobally,
+    NonMlflowWarningsBehaviorForCurrentThread,
 )
 
 # Wildcard import other autologging utilities (e.g. safety utilities, event logging utilities) used
@@ -448,7 +448,7 @@ def autologging_integration(name):
             # MLflow event logger, and enforce silent mode if applicable (i.e. if the corresponding
             # autologging integration was called with `silent=True`)
             with (
-                set_mlflow_events_and_warnings_behavior_globally(
+                MlflowEventsAndWarningsBehaviorGlobally(
                     # MLflow warnings emitted during autologging setup / enablement are likely
                     # actionable and relevant to the user, so they should be emitted as normal
                     # when `silent=False`. For reference, see recommended warning and event logging
@@ -457,7 +457,7 @@ def autologging_integration(name):
                     disable_event_logs=is_silent_mode,
                     disable_warnings=is_silent_mode,
                 ),
-                set_non_mlflow_warnings_behavior_for_current_thread(
+                NonMlflowWarningsBehaviorForCurrentThread(
                     # non-MLflow warnings emitted during autologging setup / enablement are not
                     # actionable for the user, as they are a byproduct of the autologging
                     # implementation. Accordingly, they should be rerouted to `logger.warning()`.

--- a/mlflow/utils/autologging_utils/logging_and_warnings.py
+++ b/mlflow/utils/autologging_utils/logging_and_warnings.py
@@ -1,6 +1,5 @@
 import os
 import warnings
-from contextlib import contextmanager
 from pathlib import Path
 from threading import RLock
 from threading import get_ident as get_current_thread_id
@@ -178,8 +177,7 @@ class _WarningsController:
 _WARNINGS_CONTROLLER = _WarningsController()
 
 
-@contextmanager
-def set_non_mlflow_warnings_behavior_for_current_thread(disable_warnings, reroute_warnings):
+class NonMlflowWarningsBehaviorForCurrentThread:
     """
     Context manager that modifies the behavior of non-MLflow warnings upon entry, according to the
     specified parameters.
@@ -190,32 +188,56 @@ def set_non_mlflow_warnings_behavior_for_current_thread(disable_warnings, rerout
         reroute_warnings: If `True`, reroute non-MLflow warnings to an MLflow event logger with
             level WARNING. If `False`, do not reroute non-MLflow warnings.
     """
-    prev_disablement_state = (
-        _WARNINGS_CONTROLLER.get_warnings_disablement_state_for_current_thread()
-    )
-    prev_rerouting_state = _WARNINGS_CONTROLLER.get_warnings_rerouting_state_for_current_thread()
-    try:
+
+    def __init__(self, disable_warnings, reroute_warnings):
+        self._disable_warnings = disable_warnings
+        self._reroute_warnings = reroute_warnings
+        self._prev_disablement_state = None
+        self._prev_rerouting_state = None
+
+    def __enter__(self):
+        self._enter_impl()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+
+    async def __aenter__(self):
+        self._enter_impl()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+
+    def _enter_impl(self):
+        self._prev_disablement_state = (
+            _WARNINGS_CONTROLLER.get_warnings_disablement_state_for_current_thread()
+        )
+        self._prev_rerouting_state = (
+            _WARNINGS_CONTROLLER.get_warnings_rerouting_state_for_current_thread()
+        )
+        try:
+            _WARNINGS_CONTROLLER.set_non_mlflow_warnings_disablement_state_for_current_thread(
+                disabled=self._disable_warnings
+            )
+            _WARNINGS_CONTROLLER.set_non_mlflow_warnings_rerouting_state_for_current_thread(
+                rerouted=self._reroute_warnings
+            )
+        except Exception:
+            pass
+
+    def _exit_impl(self, *args, **kwargs):
         _WARNINGS_CONTROLLER.set_non_mlflow_warnings_disablement_state_for_current_thread(
-            disabled=disable_warnings
+            disabled=self._prev_disablement_state
         )
         _WARNINGS_CONTROLLER.set_non_mlflow_warnings_rerouting_state_for_current_thread(
-            rerouted=reroute_warnings
-        )
-        yield
-    finally:
-        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_disablement_state_for_current_thread(
-            disabled=prev_disablement_state
-        )
-        _WARNINGS_CONTROLLER.set_non_mlflow_warnings_rerouting_state_for_current_thread(
-            rerouted=prev_rerouting_state
+            rerouted=self._prev_rerouting_state
         )
 
 
-@contextmanager
-def set_mlflow_events_and_warnings_behavior_globally(
-    disable_event_logs, disable_warnings, reroute_warnings
-):
-    """Threadsafe context manager that modifies the behavior of MLflow event logging statements
+class MlflowEventsAndWarningsBehaviorGlobally:
+    """
+    Threadsafe context manager that modifies the behavior of MLflow event logging statements
     and MLflow warnings upon entry, according to the specified parameters. Modifications are
     applied globally across all threads and are not reverted until all threads that have made
     a particular modification have exited the context.
@@ -230,13 +252,6 @@ def set_mlflow_events_and_warnings_behavior_globally(
 
     """
 
-    with _SetMlflowEventsAndWarningsBehaviorGlobally(
-        disable_event_logs, disable_warnings, reroute_warnings
-    ):
-        yield
-
-
-class _SetMlflowEventsAndWarningsBehaviorGlobally:
     _lock = RLock()
     _disable_event_logs_count = 0
     _disable_warnings_count = 0
@@ -248,46 +263,60 @@ class _SetMlflowEventsAndWarningsBehaviorGlobally:
         self._reroute_warnings = reroute_warnings
 
     def __enter__(self):
+        self._enter_impl()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+
+    async def __aenter__(self):
+        self._enter_impl()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+
+    def _enter_impl(self):
         try:
-            with _SetMlflowEventsAndWarningsBehaviorGlobally._lock:
+            with MlflowEventsAndWarningsBehaviorGlobally._lock:
                 if self._disable_event_logs:
-                    if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
+                    if MlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
                         logging_utils.disable_logging()
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count += 1
+                    MlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count += 1
 
                 if self._disable_warnings:
-                    if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
+                    if MlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
                         _WARNINGS_CONTROLLER.set_mlflow_warnings_disablement_state_globally(
                             disabled=True
                         )
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count += 1
+                    MlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count += 1
 
                 if self._reroute_warnings:
-                    if _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
+                    if MlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
                         _WARNINGS_CONTROLLER.set_mlflow_warnings_rerouting_state_globally(
                             rerouted=True
                         )
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count += 1
+                    MlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count += 1
         except Exception:
             pass
 
-    def __exit__(self, *args, **kwargs):
+    def _exit_impl(self, *args, **kwargs):
         try:
-            with _SetMlflowEventsAndWarningsBehaviorGlobally._lock:
+            with MlflowEventsAndWarningsBehaviorGlobally._lock:
                 if self._disable_event_logs:
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count -= 1
+                    MlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count -= 1
                 if self._disable_warnings:
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count -= 1
+                    MlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count -= 1
                 if self._reroute_warnings:
-                    _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count -= 1
+                    MlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count -= 1
 
-                if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
+                if MlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
                     logging_utils.enable_logging()
-                if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
+                if MlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
                     _WARNINGS_CONTROLLER.set_mlflow_warnings_disablement_state_globally(
                         disabled=False
                     )
-                if _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
+                if MlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
                     _WARNINGS_CONTROLLER.set_mlflow_warnings_rerouting_state_globally(
                         rerouted=False
                     )

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -268,9 +268,7 @@ def safe_patch(
 
     if manage_run:
         if is_async_function:
-            raise MlflowException(
-                "The `manage_run` parameter is not supported for async functions."
-            )
+            raise MlflowException("manage_run parameter is not supported for async functions.")
 
         tags = _resolve_extra_tags(autologging_integration, extra_tags)
         patch_function = with_managed_run(
@@ -329,6 +327,10 @@ def safe_patch(
         Exceptions thrown from the underlying / original function are propagated to the caller,
         while exceptions thrown from other parts of `patch_function` are caught and logged as
         warnings.
+
+        NB: PLEASE BE SUPER CAREFUL WHEN MODIFYING THIS FUNCTION. IT IS USED IN A WIDE VARIETY
+        OF CONTEXTX AND CRITICAL PATH IN DBR/MLR BY DEFAULT. ANY BUG HERE CAN BREAK USERS'
+        WORKLOAD WITHOUT THEM TAKING ANY ACTION.
         """
         # Reroute warnings encountered during the patch function implementation to an MLflow event
         # logger, and enforce silent mode if applicable (i.e. if the corresponding autologging

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -536,8 +536,15 @@ def safe_patch(
         """
         is_silent_mode = get_autologging_config(autologging_integration, "silent", False)
         async with (
-            MlflowEventsAndWarningsBehaviorGlobally(True, is_silent_mode, is_silent_mode),
-            NonMlflowWarningsBehaviorForCurrentThread(True, is_silent_mode),
+            MlflowEventsAndWarningsBehaviorGlobally(
+                reroute_warnings=True,
+                disable_event_logs=is_silent_mode,
+                disable_warnings=is_silent_mode,
+            ),
+            NonMlflowWarningsBehaviorForCurrentThread(
+                disable_warnings=is_silent_mode,
+                reroute_warnings=True,
+            ),
         ):
             if is_testing():
                 preexisting_run_for_testing = mlflow.active_run()

--- a/tests/autologging/async_helper.py
+++ b/tests/autologging/async_helper.py
@@ -36,7 +36,7 @@ def asyncify(is_async):
     return decorator
 
 
-def run_sync_or_sync(fn, *args, **kwargs):
+def run_sync_or_async(fn, *args, **kwargs):
     """Convenience function that runs a function synchronously regardless of whether it is async."""
     if inspect.iscoroutinefunction(fn):
         return asyncio.run(fn(*args, **kwargs))

--- a/tests/autologging/async_helper.py
+++ b/tests/autologging/async_helper.py
@@ -1,0 +1,44 @@
+import asyncio
+import inspect
+from concurrent.futures import ThreadPoolExecutor
+
+from mlflow.utils.autologging_utils.safety import update_wrapper_extended
+
+
+def asyncify(is_async):
+    """
+    Decorator that converts a function to an async function if `is_async` is True. This is useful
+    for testing purposes, where we want to test both synchronous and asynchronous code paths.
+    """
+
+    def decorator(fn):
+        if is_async:
+
+            async def async_fn(*args, **kwargs):
+                if args and inspect.iscoroutinefunction(args[0]):
+                    original = args[0]
+
+                    def wrapped_original(*og_args, **og_kwargs):
+                        # Run the original async function in a separate thread. This is a workaround
+                        # for the fact that we cannot use asyncio.run here because an event loop is
+                        # already running in the main thread.
+                        with ThreadPoolExecutor() as executor:
+                            future = executor.submit(asyncio.run, original(*og_args, **og_kwargs))
+                            return future.result()
+
+                    args = (update_wrapper_extended(wrapped_original, original), *args[1:])
+                return fn(*args, **kwargs)
+
+            return update_wrapper_extended(async_fn, fn)
+        else:
+            return fn
+
+    return decorator
+
+
+def run_sync_or_sync(fn, *args, **kwargs):
+    """Convenience function that runs a function synchronously regardless of whether it is async."""
+    if inspect.iscoroutinefunction(fn):
+        return asyncio.run(fn(*args, **kwargs))
+    else:
+        return fn(*args, **kwargs)

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -10,28 +10,60 @@ from mlflow.utils.autologging_utils import is_testing
 PATCH_DESTINATION_FN_DEFAULT_RESULT = "original_result"
 
 
-@pytest.fixture
-def patch_destination():
-    class PatchObj:
-        def __init__(self):
-            self.fn_call_count = 0
-            self.recurse_fn_call_count = 0
+# Fixture to run the test case with and without async logging enabled
+@pytest.fixture(params=[True, False], ids=["sync", "async"])
+def patch_destination(request):
+    if request.param:
 
-        def fn(self, *args, **kwargs):
-            self.fn_call_count += 1
-            return PATCH_DESTINATION_FN_DEFAULT_RESULT
+        class Destination:
+            def __init__(self):
+                self.fn_call_count = 0
+                self.recurse_fn_call_count = 0
 
-        def recursive_fn(self, level, max_depth):
-            self.recurse_fn_call_count += 1
-            if level == max_depth:
+            def fn(self, *args, **kwargs):
+                self.fn_call_count += 1
                 return PATCH_DESTINATION_FN_DEFAULT_RESULT
-            else:
-                return self.recursive_fn(level + 1, max_depth)
 
-        def throw_error_fn(self, error_to_raise):
-            raise error_to_raise
+            def recursive_fn(self, level, max_depth):
+                self.recurse_fn_call_count += 1
+                if level == max_depth:
+                    return PATCH_DESTINATION_FN_DEFAULT_RESULT
+                else:
+                    return self.recursive_fn(level + 1, max_depth)
 
-    return PatchObj()
+            def throw_error_fn(self, error_to_raise):
+                raise error_to_raise
+
+            @property
+            def is_async(self):
+                return False
+
+    else:
+
+        class Destination:
+            def __init__(self):
+                self.fn_call_count = 0
+                self.recurse_fn_call_count = 0
+
+            async def fn(self, *args, **kwargs):
+                self.fn_call_count += 1
+                return PATCH_DESTINATION_FN_DEFAULT_RESULT
+
+            async def recursive_fn(self, level, max_depth):
+                self.recurse_fn_call_count += 1
+                if level == max_depth:
+                    return PATCH_DESTINATION_FN_DEFAULT_RESULT
+                else:
+                    return await self.recursive_fn(level + 1, max_depth)
+
+            async def throw_error_fn(self, error_to_raise):
+                raise error_to_raise
+
+            @property
+            def is_async(self):
+                return True
+
+    return Destination()
 
 
 @pytest.fixture

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -24,6 +24,9 @@ def patch_destination(request):
                 self.fn_call_count += 1
                 return PATCH_DESTINATION_FN_DEFAULT_RESULT
 
+            def fn2(self, *args, **kwargs):
+                return "f2"
+
             def recursive_fn(self, level, max_depth):
                 self.recurse_fn_call_count += 1
                 if level == max_depth:
@@ -48,6 +51,9 @@ def patch_destination(request):
             async def fn(self, *args, **kwargs):
                 self.fn_call_count += 1
                 return PATCH_DESTINATION_FN_DEFAULT_RESULT
+
+            async def fn2(self, *args, **kwargs):
+                return "f2"
 
             async def recursive_fn(self, level, max_depth):
                 self.recurse_fn_call_count += 1

--- a/tests/autologging/test_autologging_behaviors_unit.py
+++ b/tests/autologging/test_autologging_behaviors_unit.py
@@ -13,6 +13,7 @@ import mlflow
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 from mlflow.utils.logging_utils import eprint
 
+from tests.autologging.async_helper import asyncify, run_sync_or_sync
 from tests.autologging.fixtures import (
     patch_destination,
     reset_stderr,  # noqa: F401
@@ -243,8 +244,7 @@ def test_silent_mode_operates_independently_across_integrations(patch_destinatio
     stream = StringIO()
     sys.stderr = stream
 
-    patch_destination.fn2 = lambda *args, **kwargs: "fn2"
-
+    @asyncify(patch_destination.is_async)
     def patch_impl1(original):
         warnings.warn("patchimpl1")
         original()
@@ -254,6 +254,7 @@ def test_silent_mode_operates_independently_across_integrations(patch_destinatio
         logger.info("autolog1")
         safe_patch("integration1", patch_destination, "fn", patch_impl1)
 
+    @asyncify(patch_destination.is_async)
     def patch_impl2(original):
         logger.info("patchimpl2")
         original()
@@ -270,8 +271,8 @@ def test_silent_mode_operates_independently_across_integrations(patch_destinatio
         autolog1(silent=True)
         autolog2(silent=False)
 
-        patch_destination.fn()
-        patch_destination.fn2()
+        run_sync_or_sync(patch_destination.fn)
+        run_sync_or_sync(patch_destination.fn2)
 
     warning_messages = [str(w.message) for w in warnings_record]
     assert warning_messages == ["warn_autolog2"]

--- a/tests/autologging/test_autologging_behaviors_unit.py
+++ b/tests/autologging/test_autologging_behaviors_unit.py
@@ -13,7 +13,7 @@ import mlflow
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 from mlflow.utils.logging_utils import eprint
 
-from tests.autologging.async_helper import asyncify, run_sync_or_sync
+from tests.autologging.async_helper import asyncify, run_sync_or_async
 from tests.autologging.fixtures import (
     patch_destination,
     reset_stderr,  # noqa: F401
@@ -271,8 +271,8 @@ def test_silent_mode_operates_independently_across_integrations(patch_destinatio
         autolog1(silent=True)
         autolog2(silent=False)
 
-        run_sync_or_sync(patch_destination.fn)
-        run_sync_or_sync(patch_destination.fn2)
+        run_sync_or_async(patch_destination.fn)
+        run_sync_or_async(patch_destination.fn2)
 
     warning_messages = [str(w.message) for w in warnings_record]
     assert warning_messages == ["warn_autolog2"]

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1,9 +1,7 @@
 import abc
-import asyncio
 import copy
 import inspect
 from collections import namedtuple
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
@@ -28,10 +26,10 @@ from mlflow.utils.autologging_utils.safety import (
     _AutologgingSessionManager,
     _validate_args,
     _validate_autologging_run,
-    update_wrapper_extended,
 )
 from mlflow.utils.mlflow_tags import MLFLOW_AUTOLOGGING
 
+from tests.autologging.async_helper import asyncify, run_sync_or_sync
 from tests.autologging.fixtures import (
     patch_destination,  # noqa: F401
     test_mode_off,
@@ -167,51 +165,13 @@ def test_is_testing_respects_environment_variable(monkeypatch):
     assert is_testing()
 
 
-def _test_async(is_async):
-    """
-    Decorator that converts a function to an async function if `is_async` is True. This is useful
-    for testing purposes, where we want to test both synchronous and asynchronous code paths.
-    """
-
-    def decorator(fn):
-        if is_async:
-
-            async def async_fn(*args, **kwargs):
-                if args and inspect.iscoroutinefunction(args[0]):
-                    original = args[0]
-
-                    def wrapped_original(*og_args, **og_kwargs):
-                        # Run the original async function in a separate thread. This is a workaround
-                        # for the fact that we cannot use asyncio.run here because an event loop is
-                        # already running in the main thread.
-                        with ThreadPoolExecutor() as executor:
-                            future = executor.submit(asyncio.run, original(*og_args, **og_kwargs))
-                            return future.result()
-
-                    args = (update_wrapper_extended(wrapped_original, original), *args[1:])
-                return fn(*args, **kwargs)
-
-            return update_wrapper_extended(async_fn, fn)
-        else:
-            return fn
-
-    return decorator
-
-
-def _run_sync_or_sync(fn, *args, **kwargs):
-    if inspect.iscoroutinefunction(fn):
-        return asyncio.run(fn(*args, **kwargs))
-    else:
-        return fn(*args, **kwargs)
-
-
 def test_safe_patch_forwards_expected_arguments_to_function_based_patch_implementation(
     patch_destination, test_autologging_integration
 ):
     foo_val = None
     bar_val = None
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, foo, bar=10):
         nonlocal foo_val
         nonlocal bar_val
@@ -219,7 +179,7 @@ def test_safe_patch_forwards_expected_arguments_to_function_based_patch_implemen
         bar_val = bar
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    _run_sync_or_sync(patch_destination.fn, 7, bar=11)
+    run_sync_or_sync(patch_destination.fn, 7, bar=11)
     assert foo_val == 7
     assert bar_val == 11
 
@@ -227,7 +187,7 @@ def test_safe_patch_forwards_expected_arguments_to_function_based_patch_implemen
 def test_safe_patch_provides_expected_original_function(
     test_autologging_integration, patch_destination
 ):
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def original_fn(foo, bar=10):
         return {
             "foo": foo,
@@ -236,13 +196,13 @@ def test_safe_patch_provides_expected_original_function(
 
     patch_destination.fn = original_fn
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, foo, bar):
         return original(foo + 1, bar + 2)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
 
-    assert _run_sync_or_sync(patch_destination.fn, 1, 2) == {"foo": 2, "bar": 4}
+    assert run_sync_or_sync(patch_destination.fn, 1, 2) == {"foo": 2, "bar": 4}
 
 
 def test_safe_patch_propagates_exceptions_raised_from_original_function(
@@ -250,7 +210,7 @@ def test_safe_patch_propagates_exceptions_raised_from_original_function(
 ):
     exc_to_throw = Exception("Bad original function")
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def original(*args, **kwargs):
         raise exc_to_throw
 
@@ -258,7 +218,7 @@ def test_safe_patch_propagates_exceptions_raised_from_original_function(
 
     patch_impl_called = False
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
@@ -267,7 +227,7 @@ def test_safe_patch_propagates_exceptions_raised_from_original_function(
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
 
     with pytest.raises(Exception, match=str(exc_to_throw)) as exc:
-        _run_sync_or_sync(patch_destination.fn)
+        run_sync_or_sync(patch_destination.fn)
 
     assert exc.value == exc_to_throw
     assert patch_impl_called
@@ -278,15 +238,15 @@ def test_safe_patch_logs_exceptions_raised_outside_of_original_function_as_warni
 ):
     exc_to_throw = Exception("Bad patch implementation")
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         raise exc_to_throw
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
     with mock.patch("mlflow.utils.autologging_utils._logger.warning") as logger_mock:
-        assert _run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
+        assert run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
         assert logger_mock.call_count == 1
-        expected_warning = "Encountered unexpected error during {} autologging {}".format(
+        expected_warning = "Encountered unexpected error during {} autologging: {}".format(
             test_autologging_integration, exc_to_throw
         )
         assert logger_mock.call_args[0][0] == expected_warning
@@ -298,13 +258,13 @@ def test_safe_patch_propagates_exceptions_raised_outside_of_original_function_in
 ):
     exc_to_throw = Exception("Bad patch implementation")
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         raise exc_to_throw
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
     with pytest.raises(Exception, match=str(exc_to_throw)) as exc:
-        _run_sync_or_sync(patch_destination.fn)
+        run_sync_or_sync(patch_destination.fn)
 
     assert exc.value == exc_to_throw
 
@@ -314,14 +274,14 @@ def test_safe_patch_calls_original_function_when_patch_preamble_throws(
 ):
     patch_impl_called = False
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
         raise Exception("Bad patch preamble")
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    assert _run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
+    assert run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
     assert patch_destination.fn_call_count == 1
     assert patch_impl_called
 
@@ -331,7 +291,7 @@ def test_safe_patch_returns_original_result_without_second_call_when_patch_posta
 ):
     patch_impl_called = False
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
@@ -339,7 +299,7 @@ def test_safe_patch_returns_original_result_without_second_call_when_patch_posta
         raise Exception("Bad patch postamble")
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    assert _run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
+    assert run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
     assert patch_destination.fn_call_count == 1
     assert patch_impl_called
 
@@ -349,7 +309,7 @@ def test_safe_patch_respects_disable_flag(patch_destination):
 
     @autologging_integration("test_respects_disable")
     def autolog(disable=False, silent=False):
-        @_test_async(patch_destination.is_async)
+        @asyncify(patch_destination.is_async)
         def patch_impl(original, *args, **kwargs):
             nonlocal patch_impl_call_count
             patch_impl_call_count += 1
@@ -358,11 +318,11 @@ def test_safe_patch_respects_disable_flag(patch_destination):
         safe_patch("test_respects_disable", patch_destination, "fn", patch_impl)
 
     autolog(disable=False)
-    _run_sync_or_sync(patch_destination.fn)
+    run_sync_or_sync(patch_destination.fn)
     assert patch_impl_call_count == 1
 
     autolog(disable=True)
-    _run_sync_or_sync(patch_destination.fn)
+    run_sync_or_sync(patch_destination.fn)
     assert patch_impl_call_count == 1
 
 
@@ -371,14 +331,14 @@ def test_safe_patch_returns_original_result_and_ignores_patch_return_value(
 ):
     patch_impl_called = False
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
         return 10
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    assert _run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
+    assert run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
     assert patch_destination.fn_call_count == 1
     assert patch_impl_called
 
@@ -387,7 +347,7 @@ def test_safe_patch_returns_original_result_and_ignores_patch_return_value(
 def test_safe_patch_validates_arguments_to_original_function_in_test_mode(
     patch_destination, test_autologging_integration
 ):
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         return original("1", "2", "3")
 
@@ -400,7 +360,7 @@ def test_safe_patch_validates_arguments_to_original_function_in_test_mode(
             wraps=autologging_utils.safety._validate_args,
         ) as validate_mock,
     ):
-        _run_sync_or_sync(patch_destination.fn, "a", "b", "c")
+        run_sync_or_sync(patch_destination.fn, "a", "b", "c")
 
     assert validate_mock.call_count == 1
 
@@ -411,13 +371,13 @@ def test_safe_patch_throws_when_autologging_runs_are_leaked_in_test_mode(
 ):
     assert autologging_utils.is_testing()
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def leak_run_patch_impl(original, *args, **kwargs):
         mlflow.start_run(nested=True)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", leak_run_patch_impl)
     with pytest.raises(AssertionError, match="leaked an active run"):
-        _run_sync_or_sync(patch_destination.fn)
+        run_sync_or_sync(patch_destination.fn)
 
     # End the leaked run
     mlflow.end_run()
@@ -437,12 +397,12 @@ def test_safe_patch_does_not_throw_when_autologging_runs_are_leaked_in_standard_
 ):
     assert not autologging_utils.is_testing()
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def leak_run_patch_impl(original, *args, **kwargs):
         mlflow.start_run(nested=True)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", leak_run_patch_impl)
-    _run_sync_or_sync(patch_destination.fn)
+    run_sync_or_sync(patch_destination.fn)
     assert mlflow.active_run()
 
     # End the leaked run
@@ -477,7 +437,7 @@ def test_safe_patch_validates_autologging_runs_when_necessary_in_test_mode(
         with pytest.raises(
             AssertionError, match="failed to set autologging tag with expected value"
         ):
-            _run_sync_or_sync(patch_destination.fn)
+            run_sync_or_sync(patch_destination.fn)
         assert validate_run_mock.call_count == 1
 
         validate_run_mock.reset_mock()
@@ -485,7 +445,7 @@ def test_safe_patch_validates_autologging_runs_when_necessary_in_test_mode(
         with mlflow.start_run(nested=True):
             # If a user-generated run existed prior to the autologged training session, we expect
             # that safe patch will not attempt to validate it
-            _run_sync_or_sync(patch_destination.fn)
+            run_sync_or_sync(patch_destination.fn)
         assert not validate_run_mock.called
 
 
@@ -494,7 +454,7 @@ def test_safe_patch_does_not_validate_autologging_runs_in_standard_mode(
 ):
     assert not autologging_utils.is_testing()
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def no_tag_run_patch_impl(original, *args, **kwargs):
         with mlflow.start_run(nested=True):
             return original(*args, **kwargs)
@@ -505,12 +465,12 @@ def test_safe_patch_does_not_validate_autologging_runs_in_standard_mode(
         "mlflow.utils.autologging_utils.safety._validate_autologging_run",
         wraps=_validate_autologging_run,
     ) as validate_run_mock:
-        _run_sync_or_sync(patch_destination.fn)
+        run_sync_or_sync(patch_destination.fn)
 
         with mlflow.start_run(nested=True):
             # If a user-generated run existed prior to the autologged training session, we expect
             # that safe patch will not attempt to validate it
-            _run_sync_or_sync(patch_destination.fn)
+            run_sync_or_sync(patch_destination.fn)
 
         assert not validate_run_mock.called
 
@@ -521,7 +481,7 @@ def test_safe_patch_manages_run_if_specified_and_sets_expected_run_tags(
     client = MlflowClient()
     active_run = None
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal active_run
         active_run = mlflow.active_run()
@@ -541,7 +501,7 @@ def test_safe_patch_manages_run_if_specified_and_sets_expected_run_tags(
             test_autologging_integration, patch_destination, "fn", patch_impl, manage_run=True
         )
 
-    _run_sync_or_sync(patch_destination.fn)
+    run_sync_or_sync(patch_destination.fn)
     assert managed_run_mock.call_count == 1
     assert active_run is not None
     assert active_run.info.run_id is not None
@@ -555,7 +515,7 @@ def test_safe_patch_does_not_manage_run_if_unspecified(
 ):
     active_run = None
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal active_run
         active_run = mlflow.active_run()
@@ -567,7 +527,7 @@ def test_safe_patch_does_not_manage_run_if_unspecified(
         safe_patch(
             test_autologging_integration, patch_destination, "fn", patch_impl, manage_run=False
         )
-        _run_sync_or_sync(patch_destination.fn)
+        run_sync_or_sync(patch_destination.fn)
         assert managed_run_mock.call_count == 0
         assert active_run is None
 
@@ -575,7 +535,7 @@ def test_safe_patch_does_not_manage_run_if_unspecified(
 def test_safe_patch_preserves_signature_of_patched_function(
     patch_destination, test_autologging_integration
 ):
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def original(a, b, c=10, *, d=11):
         return 10
 
@@ -583,14 +543,14 @@ def test_safe_patch_preserves_signature_of_patched_function(
 
     patch_impl_called = False
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_impl_called
         patch_impl_called = True
         return original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    _run_sync_or_sync(patch_destination.fn, 1, 2)
+    run_sync_or_sync(patch_destination.fn, 1, 2)
     assert patch_impl_called
     assert inspect.signature(patch_destination.fn) == inspect.signature(original)
 
@@ -598,7 +558,7 @@ def test_safe_patch_preserves_signature_of_patched_function(
 def test_safe_patch_provides_original_function_with_expected_signature(
     patch_destination, test_autologging_integration
 ):
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def original(a, b, c=10, *, d=11):
         return 10
 
@@ -606,14 +566,14 @@ def test_safe_patch_provides_original_function_with_expected_signature(
 
     original_signature = False
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal original_signature
         original_signature = inspect.signature(original)
         return original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    _run_sync_or_sync(patch_destination.fn, 1, 2)
+    run_sync_or_sync(patch_destination.fn, 1, 2)
     assert original_signature == inspect.signature(original)
 
 
@@ -625,7 +585,7 @@ def test_safe_patch_makes_expected_event_logging_calls_for_successful_patch_invo
     patch_session = None
     og_call_kwargs = {}
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal og_call_kwargs
         kwargs.update({"extra_func": picklable_exception_safe_function(lambda k: "foo")})
@@ -638,7 +598,7 @@ def test_safe_patch_makes_expected_event_logging_calls_for_successful_patch_invo
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
 
-    _run_sync_or_sync(patch_destination.fn, "a", 1, b=2)
+    run_sync_or_sync(patch_destination.fn, "a", 1, b=2)
     expected_order = ["patch_start", "original_start", "original_success", "patch_success"]
     assert [call.method for call in mock_event_logger.calls] == expected_order
     assert all(call.session == patch_session for call in mock_event_logger.calls)
@@ -662,7 +622,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_an
 
     throw_location = None
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal throw_location
 
@@ -685,7 +645,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_an
 
     for throw_location in ["before", "after"]:
         mock_event_logger.reset()
-        _run_sync_or_sync(patch_destination.fn)
+        run_sync_or_sync(patch_destination.fn)
         assert [call.method for call in mock_event_logger.calls] == expected_order
         patch_start, original_start, original_success, patch_error = mock_event_logger.calls
         assert patch_start.exception is None
@@ -704,7 +664,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_an
 
     throw_location = None
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal throw_location
 
@@ -723,7 +683,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_an
     for throw_location in ["before", "after"]:
         mock_event_logger.reset()
         with pytest.raises(Exception, match="throw from original"):
-            _run_sync_or_sync(patch_destination.throw_error_fn, original_err_to_raise)
+            run_sync_or_sync(patch_destination.throw_error_fn, original_err_to_raise)
         assert [call.method for call in mock_event_logger.calls] == expected_order
         patch_start, original_start, original_error = mock_event_logger.calls
         assert patch_start.exception is None
@@ -738,20 +698,20 @@ def test_safe_patch_makes_expected_event_logging_calls_when_original_function_th
 ):
     exc_to_raise = Exception("thrown from patch")
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def original(*args, **kwargs):
         raise exc_to_raise
 
     patch_destination.fn = original
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         original(*args, **kwargs)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
 
     with pytest.raises(Exception, match="thrown from patch"):
-        _run_sync_or_sync(patch_destination.fn)
+        run_sync_or_sync(patch_destination.fn)
     expected_order = ["patch_start", "original_start", "original_error"]
     assert [call.method for call in mock_event_logger.calls] == expected_order
     patch_start, original_start, original_error = mock_event_logger.calls
@@ -767,7 +727,7 @@ def test_safe_patch_succeeds_when_event_logging_throws_in_standard_mode(
     patch_preamble_called = False
     patch_postamble_called = False
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_preamble_called
         patch_preamble_called = True
@@ -828,7 +788,7 @@ def test_safe_patch_succeeds_when_event_logging_throws_in_standard_mode(
 
     logger = ThrowingLogger()
     AutologgingEventLogger.set_logger(logger)
-    assert _run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
+    assert run_sync_or_sync(patch_destination.fn) == PATCH_DESTINATION_FN_DEFAULT_RESULT
     assert patch_preamble_called
     assert patch_postamble_called
     expected_calls = ["patch_start", "original_start", "original_success", "patch_success"]
@@ -1474,25 +1434,25 @@ def test_session_manager_creates_session_before_patch_executes(
 ):
     is_session_active = None
 
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def check_session_manager_status(original):
         nonlocal is_session_active
         is_session_active = _AutologgingSessionManager.active_session()
 
     safe_patch(test_autologging_integration, patch_destination, "fn", check_session_manager_status)
-    _run_sync_or_sync(patch_destination.fn)
+    run_sync_or_sync(patch_destination.fn)
     assert is_session_active is not None
 
 
 def test_session_manager_exits_session_after_patch_executes(
     patch_destination, test_autologging_integration
 ):
-    @_test_async(patch_destination.is_async)
+    @asyncify(patch_destination.is_async)
     def patch_fn(original):
         assert _AutologgingSessionManager.active_session() is not None
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_fn)
-    _run_sync_or_sync(patch_destination.fn)
+    run_sync_or_sync(patch_destination.fn)
     assert _AutologgingSessionManager.active_session() is None
 
 
@@ -1513,7 +1473,7 @@ def test_original_fn_runs_if_patch_should_not_be_applied(patch_destination):
 
     @autologging_integration("test_respects_exclusive")
     def autolog(disable=False, exclusive=False, silent=False):
-        @_test_async(patch_destination.is_async)
+        @asyncify(patch_destination.is_async)
         def patch_impl(original, *args, **kwargs):
             nonlocal patch_impl_call_count
             patch_impl_call_count += 1
@@ -1523,7 +1483,7 @@ def test_original_fn_runs_if_patch_should_not_be_applied(patch_destination):
 
     autolog(exclusive=True)
     with mlflow.start_run():
-        _run_sync_or_sync(patch_destination.fn)
+        run_sync_or_sync(patch_destination.fn)
     assert patch_impl_call_count == 0
     assert patch_destination.fn_call_count == 1
 
@@ -1581,7 +1541,7 @@ def test_nested_call_autologging_disabled_when_top_level_call_autologging_failed
         "test_nested_call_autologging_disabled_when_top_level_call_autologging_failed"
     )
     def autolog(disable=False, exclusive=False, silent=False):
-        @_test_async(patch_destination.is_async)
+        @asyncify(patch_destination.is_async)
         def patch_impl(original, *args, **kwargs):
             nonlocal patch_impl_call_count
             patch_impl_call_count += 1
@@ -1605,7 +1565,7 @@ def test_nested_call_autologging_disabled_when_top_level_call_autologging_failed
         patch_impl_call_count = 0
         patch_destination.recurse_fn_call_count = 0
         with mlflow.start_run():
-            _run_sync_or_sync(patch_destination.recursive_fn, level=0, max_depth=max_depth)
+            run_sync_or_sync(patch_destination.recursive_fn, level=0, max_depth=max_depth)
         assert patch_impl_call_count == 1
         assert patch_destination.recurse_fn_call_count == max_depth + 1
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14748?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14748/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14748
```

</p>
</details>

### What changes are proposed in this pull request?

Expand the `safe_patch` function to handle async function as well.

*Note: We decided not to [refactor](https://github.com/mlflow/mlflow/pull/14724) the existing safe patch implementation, to minimize the risk of regression. The risk is higher than I thought given that we automatically enables it in many DB workspaces, such that we can break users' workload silently. Hence, this PR goes with pretty conservative approach where it just copies the existing `safe_patch_function` implementation into async function. *

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
