### PR TITLE
ChatAgent Updates

### DIFF
--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -38,6 +38,10 @@ from mlflow.utils.annotations import experimental
 
 
 def _add_agent_messages(left: list[dict], right: list[dict]):
+    if not isinstance(left, list):
+        left = [left]
+    if not isinstance(right, list):
+        right = [right]
     # assign missing ids
     for i, m in enumerate(left):
         if isinstance(m, BaseMessage):

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -1,7 +1,7 @@
 import importlib.metadata
 import json
-import uuid
 from typing import Annotated, Any, Optional, TypedDict, Union
+from uuid import uuid4
 
 from packaging.version import Version
 
@@ -18,7 +18,7 @@ try:
         # show a friendlier error message
         if Version(importlib.metadata("langgraph").version) >= Version("0.3.0"):
             raise ImportError(
-                "Please install `langgraph-prebuilt>=0.3.0` to use MLflow LangGraph ChatAgent "
+                "Please install `langgraph-prebuilt>=0.1.2` to use MLflow LangGraph ChatAgent "
                 "helpers with LangGraph 0.3.x."
             ) from e
 
@@ -47,13 +47,13 @@ def _add_agent_messages(left: Union[dict, list[dict]], right: Union[dict, list[d
         if isinstance(m, BaseMessage):
             left[i] = parse_message(m)
         if left[i].get("id") is None:
-            left[i]["id"] = str(uuid.uuid4())
+            left[i]["id"] = str(uuid4())
 
     for i, m in enumerate(right):
         if isinstance(m, BaseMessage):
             right[i] = parse_message(m)
         if right[i].get("id") is None:
-            right[i]["id"] = str(uuid.uuid4())
+            right[i]["id"] = str(uuid4())
 
     # merge
     left_idx_by_id = {m.get("id"): i for i, m in enumerate(left)}
@@ -326,6 +326,8 @@ class ChatAgentToolNode(ToolNode):
                         pass
                 if "custom_outputs" in return_obj:
                     custom_outputs = return_obj["custom_outputs"]
+                if m.id is None:
+                    m.id = str(uuid4())
                 messages.append(parse_message(m, attachments=return_obj.get("attachments")))
             except Exception:
                 messages.append(parse_message(m))

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -19,7 +19,10 @@ try:
         if Version(importlib.metadata("langgraph").version) >= Version("0.3.0"):
             raise ImportError(
                 "Please install `langgraph-prebuilt>=0.1.2` to use MLflow LangGraph ChatAgent "
-                "helpers with LangGraph 0.3.x."
+                "helpers with LangGraph 0.3.x.\n"
+                "If you already have the proper versions installed, please try running "
+                "`pip install --force-reinstall langgraph`. This is a known issue. See: "
+                "https://github.com/langchain-ai/langgraph/issues/3662"
             ) from e
 
         # LangGraph < 0.3

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -1,7 +1,7 @@
 import importlib.metadata
 import json
 import uuid
-from typing import Annotated, Any, Optional, TypedDict
+from typing import Annotated, Any, Optional, TypedDict, Union
 
 from packaging.version import Version
 
@@ -37,7 +37,7 @@ from mlflow.types.agent import ChatAgentMessage
 from mlflow.utils.annotations import experimental
 
 
-def _add_agent_messages(left: list[dict], right: list[dict]):
+def _add_agent_messages(left: Union[dict, list[dict]], right: Union[dict, list[dict]]):
     if not isinstance(left, list):
         left = [left]
     if not isinstance(right, list):

--- a/mlflow/langchain/output_parsers.py
+++ b/mlflow/langchain/output_parsers.py
@@ -1,5 +1,6 @@
 from dataclasses import asdict
 from typing import Any, Iterator
+from uuid import uuid4
 
 from langchain_core.messages.base import BaseMessage
 from langchain_core.output_parsers.transform import BaseTransformOutputParser
@@ -126,7 +127,7 @@ class ChatAgentOutputParser(BaseTransformOutputParser[str]):
         :py:class:`ChatAgentResponse <mlflow.types.agent.ChatAgentResponse>`.
         """
         return ChatAgentResponse(
-            messages=[ChatAgentMessage(content=text, role="assistant")]
+            messages=[ChatAgentMessage(content=text, role="assistant", id=str(uuid4()))]
         ).model_dump_compat(exclude_none=True)
 
     def transform(self, input: Iterator[BaseMessage], config, **kwargs) -> Iterator[dict[str, Any]]:

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -19,12 +19,6 @@ from mlflow.types.schema import (
 )
 from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER, model_validator
 
-if not IS_PYDANTIC_V2_OR_NEWER:
-    raise ImportError(
-        "mlflow.types.agent is only supported with Pydantic v2 or newer. "
-        "Please upgrade Pydantic to use this feature."
-    )
-
 
 class ChatAgentMessage(BaseModel):
     """
@@ -58,8 +52,12 @@ class ChatAgentMessage(BaseModel):
         """
         Ensure at least one of 'content' or 'tool_calls' is set.
         """
-        content = values.content
-        tool_calls = values.tool_calls
+        if IS_PYDANTIC_V2_OR_NEWER:
+            content = values.content
+            tool_calls = values.tool_calls
+        else:
+            content = values.get("content")
+            tool_calls = values.get("tool_calls")
 
         if not content and not tool_calls:
             raise ValueError("Either 'content' or 'tool_calls' must be provided.")
@@ -70,9 +68,14 @@ class ChatAgentMessage(BaseModel):
         """
         Ensure that the 'name' and 'tool_call_id' fields are set for tool messages.
         """
-        name = values.name
-        role = values.role
-        tool_call_id = values.tool_call_id
+        if IS_PYDANTIC_V2_OR_NEWER:
+            name = values.name
+            role = values.role
+            tool_call_id = values.tool_call_id
+        else:
+            name = values.get("name")
+            role = values.get("role")
+            tool_call_id = values.get("tool_call_id")
 
         if role == "tool" and (not name or not tool_call_id):
             raise ValueError("Both 'name' and 'tool_call_id' must be provided for tool messages.")
@@ -127,7 +130,12 @@ class ChatAgentResponse(BaseModel):
             **Optional**, defaults to None
     """
 
-    model_config = ConfigDict(validate_assignment=True)
+    if not IS_PYDANTIC_V2_OR_NEWER:
+        model_config = ConfigDict(validate_assignment=True)
+    else:
+
+        class Config:
+            validate_assignment = True
 
     messages: list[ChatAgentMessage]
     finish_reason: Optional[str] = None
@@ -140,7 +148,10 @@ class ChatAgentResponse(BaseModel):
         """
         Ensure that all messages have an ID and it is unique.
         """
-        message_ids = [msg.id for msg in values.messages]
+        if IS_PYDANTIC_V2_OR_NEWER:
+            message_ids = [msg.id for msg in values.messages]
+        else:
+            message_ids = [msg.get("id") for msg in values.get("messages")]
 
         if any(msg_id is None for msg_id in message_ids):
             raise ValueError("All ChatAgentMessage objects in field `messages` must have an ID.")
@@ -169,7 +180,12 @@ class ChatAgentChunk(BaseModel):
             **Optional**, defaults to None
     """
 
-    model_config = ConfigDict(validate_assignment=True)
+    if not IS_PYDANTIC_V2_OR_NEWER:
+        model_config = ConfigDict(validate_assignment=True)
+    else:
+
+        class Config:
+            validate_assignment = True
 
     delta: ChatAgentMessage
     finish_reason: Optional[str] = None
@@ -182,7 +198,7 @@ class ChatAgentChunk(BaseModel):
         """
         Ensure that the message ID is unique.
         """
-        message_id = values.delta.id
+        message_id = values.delta.id if IS_PYDANTIC_V2_OR_NEWER else values.get("delta").get("id")
 
         if message_id is None:
             raise ValueError(

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional
-from uuid import uuid4
 
-from pydantic import Field
+from pydantic import ConfigDict
 
 from mlflow.types.chat import BaseModel, ChatUsage, ToolCall
 from mlflow.types.llm import (
@@ -42,7 +41,7 @@ class ChatAgentMessage(BaseModel):
     role: str
     content: Optional[str] = None
     name: Optional[str] = None
-    id: Optional[str] = Field(default_factory=lambda: str(uuid4()))
+    id: Optional[str] = None
     tool_calls: Optional[list[ToolCall]] = None
     tool_call_id: Optional[str] = None
     # TODO make this a pydantic class with subtypes once we have more details on usage
@@ -131,11 +130,36 @@ class ChatAgentResponse(BaseModel):
             **Optional**, defaults to None
     """
 
+    if not IS_PYDANTIC_V2_OR_NEWER:
+        model_config = ConfigDict(validate_assignment=True)
+    else:
+
+        class Config:
+            validate_assignment = True
+
     messages: list[ChatAgentMessage]
     finish_reason: Optional[str] = None
     # TODO: add finish_reason_metadata once we have a plan for usage
     custom_outputs: Optional[dict[str, Any]] = None
     usage: Optional[ChatUsage] = None
+
+    @model_validator(mode="after")
+    def check_message_ids(cls, values):
+        """
+        Ensure that all messages have an ID and it is unique.
+        """
+        if IS_PYDANTIC_V2_OR_NEWER:
+            message_ids = [msg.id for msg in values.messages]
+        else:
+            message_ids = [msg.get("id") for msg in values.get("messages")]
+
+        if any(msg_id is None for msg_id in message_ids):
+            raise ValueError("All ChatAgentMessage objects in field `messages` must have an ID.")
+        if len(message_ids) != len(set(message_ids)):
+            raise ValueError(
+                "All ChatAgentMessage objects in field `messages` must have unique IDs."
+            )
+        return values
 
 
 class ChatAgentChunk(BaseModel):
@@ -156,11 +180,35 @@ class ChatAgentChunk(BaseModel):
             **Optional**, defaults to None
     """
 
+    if not IS_PYDANTIC_V2_OR_NEWER:
+        model_config = ConfigDict(validate_assignment=True)
+    else:
+
+        class Config:
+            validate_assignment = True
+
     delta: ChatAgentMessage
     finish_reason: Optional[str] = None
     # TODO: add finish_reason_metadata once we have a plan for usage
     custom_outputs: Optional[dict[str, Any]] = None
     usage: Optional[ChatUsage] = None
+
+    @model_validator(mode="after")
+    def check_message_id(cls, values):
+        """
+        Ensure that the message ID is unique.
+        """
+        message_id = values.delta.id if IS_PYDANTIC_V2_OR_NEWER else values.get("delta").get("id")
+
+        if message_id is None:
+            raise ValueError(
+                "The field `delta` of ChatAgentChunk must contain a ChatAgentMessage object with an"
+                " ID. If this chunk contains partial content, it should have the same ID as other "
+                " chunks in the same message. See "
+                "https://mlflow.org/docs/latest/api_reference/python_api/mlflow.pyfunc.html#mlflow.pyfunc.ChatAgent.predict_stream"
+                " for more details."
+            )
+        return values
 
 
 # fmt: off

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -19,6 +19,12 @@ from mlflow.types.schema import (
 )
 from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER, model_validator
 
+if not IS_PYDANTIC_V2_OR_NEWER:
+    raise ImportError(
+        "mlflow.types.agent is only supported with Pydantic v2 or newer. "
+        "Please upgrade Pydantic to use this feature."
+    )
+
 
 class ChatAgentMessage(BaseModel):
     """
@@ -52,12 +58,8 @@ class ChatAgentMessage(BaseModel):
         """
         Ensure at least one of 'content' or 'tool_calls' is set.
         """
-        if IS_PYDANTIC_V2_OR_NEWER:
-            content = values.content
-            tool_calls = values.tool_calls
-        else:
-            content = values.get("content")
-            tool_calls = values.get("tool_calls")
+        content = values.content
+        tool_calls = values.tool_calls
 
         if not content and not tool_calls:
             raise ValueError("Either 'content' or 'tool_calls' must be provided.")
@@ -68,14 +70,9 @@ class ChatAgentMessage(BaseModel):
         """
         Ensure that the 'name' and 'tool_call_id' fields are set for tool messages.
         """
-        if IS_PYDANTIC_V2_OR_NEWER:
-            name = values.name
-            role = values.role
-            tool_call_id = values.tool_call_id
-        else:
-            name = values.get("name")
-            role = values.get("role")
-            tool_call_id = values.get("tool_call_id")
+        name = values.name
+        role = values.role
+        tool_call_id = values.tool_call_id
 
         if role == "tool" and (not name or not tool_call_id):
             raise ValueError("Both 'name' and 'tool_call_id' must be provided for tool messages.")
@@ -130,12 +127,7 @@ class ChatAgentResponse(BaseModel):
             **Optional**, defaults to None
     """
 
-    if not IS_PYDANTIC_V2_OR_NEWER:
-        model_config = ConfigDict(validate_assignment=True)
-    else:
-
-        class Config:
-            validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
     messages: list[ChatAgentMessage]
     finish_reason: Optional[str] = None
@@ -148,10 +140,7 @@ class ChatAgentResponse(BaseModel):
         """
         Ensure that all messages have an ID and it is unique.
         """
-        if IS_PYDANTIC_V2_OR_NEWER:
-            message_ids = [msg.id for msg in values.messages]
-        else:
-            message_ids = [msg.get("id") for msg in values.get("messages")]
+        message_ids = [msg.id for msg in values.messages]
 
         if any(msg_id is None for msg_id in message_ids):
             raise ValueError("All ChatAgentMessage objects in field `messages` must have an ID.")
@@ -180,12 +169,7 @@ class ChatAgentChunk(BaseModel):
             **Optional**, defaults to None
     """
 
-    if not IS_PYDANTIC_V2_OR_NEWER:
-        model_config = ConfigDict(validate_assignment=True)
-    else:
-
-        class Config:
-            validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
     delta: ChatAgentMessage
     finish_reason: Optional[str] = None
@@ -198,7 +182,7 @@ class ChatAgentChunk(BaseModel):
         """
         Ensure that the message ID is unique.
         """
-        message_id = values.delta.id if IS_PYDANTIC_V2_OR_NEWER else values.get("delta").get("id")
+        message_id = values.delta.id
 
         if message_id is None:
             raise ValueError(

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -157,12 +157,12 @@ class ChatAgentResponse(BaseModel):
         if any(msg_id is None for msg_id in message_ids):
             raise ValueError(
                 "All ChatAgentMessage objects in field `messages` must have an ID. You can use "
-                "`uuid.uuid4()` to generate a unique ID."
+                "`str(uuid.uuid4())` to generate a unique ID."
             )
         if len(message_ids) != len(set(message_ids)):
             raise ValueError(
                 "All ChatAgentMessage objects in field `messages` must have unique IDs. "
-                "You can use `uuid.uuid4()` to generate a unique ID."
+                "You can use `str(uuid.uuid4())` to generate a unique ID."
             )
         return values
 
@@ -211,7 +211,7 @@ class ChatAgentChunk(BaseModel):
                 " ID. If this chunk contains partial content, it should have the same ID as other "
                 " chunks in the same message. See "
                 "https://mlflow.org/docs/latest/api_reference/python_api/mlflow.pyfunc.html#mlflow.pyfunc.ChatAgent.predict_stream"
-                " for more details. You can use `uuid.uuid4()` to generate a unique ID."
+                " for more details. You can use `str(uuid.uuid4())` to generate a unique ID."
             )
         return values
 

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -131,7 +131,7 @@ class ChatAgentResponse(BaseModel):
             **Optional**, defaults to None
     """
 
-    if not IS_PYDANTIC_V2_OR_NEWER:
+    if IS_PYDANTIC_V2_OR_NEWER:
         model_config = ConfigDict(validate_assignment=True)
     else:
 
@@ -181,7 +181,7 @@ class ChatAgentChunk(BaseModel):
             **Optional**, defaults to None
     """
 
-    if not IS_PYDANTIC_V2_OR_NEWER:
+    if IS_PYDANTIC_V2_OR_NEWER:
         model_config = ConfigDict(validate_assignment=True)
     else:
 

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -211,7 +211,7 @@ class ChatAgentChunk(BaseModel):
                 " ID. If this chunk contains partial content, it should have the same ID as other "
                 " chunks in the same message. See "
                 "https://mlflow.org/docs/latest/api_reference/python_api/mlflow.pyfunc.html#mlflow.pyfunc.ChatAgent.predict_stream"
-                " for more details."
+                " for more details. You can use `uuid.uuid4()` to generate a unique ID."
             )
         return values
 

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -155,10 +155,14 @@ class ChatAgentResponse(BaseModel):
             message_ids = [msg.get("id") for msg in values.get("messages")]
 
         if any(msg_id is None for msg_id in message_ids):
-            raise ValueError("All ChatAgentMessage objects in field `messages` must have an ID.")
+            raise ValueError(
+                "All ChatAgentMessage objects in field `messages` must have an ID. You can use "
+                "`uuid.uuid4()` to generate a unique ID."
+            )
         if len(message_ids) != len(set(message_ids)):
             raise ValueError(
-                "All ChatAgentMessage objects in field `messages` must have unique IDs."
+                "All ChatAgentMessage objects in field `messages` must have unique IDs. "
+                "You can use `uuid.uuid4()` to generate a unique ID."
             )
         return values
 

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -30,7 +30,8 @@ class ChatAgentMessage(BaseModel):
         content (str): The content of the message.
             **Optional** Can be ``None`` if tool_calls is provided.
         name (str): The name of the entity that sent the message. **Optional** defaults to ``None``
-        id (str): The ID of the message. **Optional** defaults to a random UUID
+        id (str): The ID of the message. Required when it is either part of a
+            :py:class:`ChatAgentResponse` or :py:class:`ChatAgentChunk`.
         tool_calls (List[:py:class:`mlflow.types.chat.ToolCall`]): A list of tool calls made by the
             model. **Optional** defaults to ``None``
         tool_call_id (str): The ID of the tool call that this message is a response to.

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -130,36 +130,11 @@ class ChatAgentResponse(BaseModel):
             **Optional**, defaults to None
     """
 
-    if not IS_PYDANTIC_V2_OR_NEWER:
-        model_config = ConfigDict(validate_assignment=True)
-    else:
-
-        class Config:
-            validate_assignment = True
-
     messages: list[ChatAgentMessage]
     finish_reason: Optional[str] = None
     # TODO: add finish_reason_metadata once we have a plan for usage
     custom_outputs: Optional[dict[str, Any]] = None
     usage: Optional[ChatUsage] = None
-
-    @model_validator(mode="after")
-    def check_message_ids(cls, values):
-        """
-        Ensure that all messages have an ID and it is unique.
-        """
-        if IS_PYDANTIC_V2_OR_NEWER:
-            message_ids = [msg.id for msg in values.messages]
-        else:
-            message_ids = [msg.get("id") for msg in values.get("messages")]
-
-        if any(msg_id is None for msg_id in message_ids):
-            raise ValueError("All ChatAgentMessage objects in field `messages` must have an ID.")
-        if len(message_ids) != len(set(message_ids)):
-            raise ValueError(
-                "All ChatAgentMessage objects in field `messages` must have unique IDs."
-            )
-        return values
 
 
 class ChatAgentChunk(BaseModel):

--- a/tests/langchain/test_langchain_output_parsers.py
+++ b/tests/langchain/test_langchain_output_parsers.py
@@ -88,6 +88,8 @@ def test_chat_agent_output_parser_parse_response():
     message = "The weather today is"
 
     parsed_response = parser.parse(message)
+    assert parsed_response["messages"][0]["id"] is not None
+    del parsed_response["messages"][0]["id"]
     assert parsed_response == {
         "messages": [{"content": "The weather today is", "role": "assistant"}],
     }

--- a/tests/langchain/test_langchain_output_parsers.py
+++ b/tests/langchain/test_langchain_output_parsers.py
@@ -88,15 +88,14 @@ def test_chat_agent_output_parser_parse_response():
     message = "The weather today is"
 
     parsed_response = parser.parse(message)
-    for msg in parsed_response["messages"]:
-        assert isinstance(msg["id"], str)
-        del msg["id"]
     assert parsed_response == {
         "messages": [{"content": "The weather today is", "role": "assistant"}],
     }
 
     streaming_messages = ["The ", "weather ", "today ", "is"]
-    base_messages = [BaseMessage(content=m, type="test") for m in streaming_messages]
+    base_messages = [BaseMessage(content=m, type="test", id="1") for m in streaming_messages]
     streaming_chunks = parser.transform(base_messages, RunnableConfig())
     for i, chunk in enumerate(streaming_chunks):
-        assert chunk == {"delta": {"content": streaming_messages[i], "role": "assistant"}}
+        assert chunk == {
+            "delta": {"content": streaming_messages[i], "role": "assistant", "id": "1"}
+        }

--- a/tests/langgraph/sample_code/langgraph_chat_agent.py
+++ b/tests/langgraph/sample_code/langgraph_chat_agent.py
@@ -38,7 +38,7 @@ class FakeOpenAI(ChatOpenAI, extra="allow"):
                     content="",
                     tool_calls=[ToolCall(name="lc_tool_format", args={}, id="456")],
                 ),
-                AIMessage(content="Successfully generated"),
+                AIMessage(content="Successfully generated", id="789"),
             ]
         )
 

--- a/tests/langgraph/sample_code/langgraph_chat_agent_custom_inputs.py
+++ b/tests/langgraph/sample_code/langgraph_chat_agent_custom_inputs.py
@@ -38,7 +38,7 @@ class FakeOpenAI(ChatOpenAI, extra="allow"):
                     content="",
                     tool_calls=[ToolCall(name="lc_tool_format", args={}, id="456")],
                 ),
-                AIMessage(content="Successfully generated"),
+                AIMessage(content="Successfully generated", id="789"),
             ]
         )
 

--- a/tests/langgraph/sample_code/langgraph_chat_agent_custom_inputs.py
+++ b/tests/langgraph/sample_code/langgraph_chat_agent_custom_inputs.py
@@ -1,6 +1,7 @@
 import json
 import os
 from typing import Any, Generator, Optional, Sequence, Union
+from uuid import uuid4
 
 from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import AIMessage, ToolCall
@@ -102,7 +103,9 @@ def create_tool_calling_agent(
     def add_custom_outputs(state: ChatAgentState):
         custom_outputs = (state.get("custom_outputs") or {}) | (state.get("custom_inputs") or {})
         return {
-            "messages": [{"role": "assistant", "content": "adding custom outputs"}],
+            "messages": [
+                {"role": "assistant", "content": "adding custom outputs", "id": str(uuid4())}
+            ],
             "custom_outputs": custom_outputs,
         }
 

--- a/tests/langgraph/test_chat_agent_langgraph.py
+++ b/tests/langgraph/test_chat_agent_langgraph.py
@@ -7,8 +7,6 @@ import mlflow
 from mlflow.langchain.chat_agent_langgraph import parse_message
 from mlflow.types.agent import ChatAgentMessage
 
-from tests.tracing.helper import get_traces
-
 LC_TOOL_CALL_MSG = AIMessage(
     **{
         "content": "",
@@ -169,34 +167,6 @@ def test_langgraph_chat_agent_save_as_code():
     for event, (role, expected_content) in zip(response, expected_messages):
         assert event["delta"]["content"] == expected_content
         assert event["delta"]["role"] == role
-
-
-def test_langgraph_chat_agent_trace():
-    input_example = {"messages": [{"role": "user", "content": "hi"}]}
-
-    with mlflow.start_run():
-        model_info = mlflow.pyfunc.log_model(
-            "agent",
-            python_model="tests/langgraph/sample_code/langgraph_chat_agent.py",
-        )
-    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    # No trace should be created for loading it in
-    assert mlflow.get_last_active_trace() is None
-
-    loaded_model.predict(input_example)
-    traces = get_traces()
-    assert len(traces) == 1
-    assert traces[0].info.status == "OK"
-    assert traces[0].data.spans[0].name == "LangGraph"
-    assert traces[0].data.spans[0].inputs == input_example
-
-    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    list(loaded_model.predict_stream(input_example))
-    traces = get_traces()
-    assert len(traces) == 2
-    assert traces[0].info.status == "OK"
-    assert traces[0].data.spans[0].name == "LangGraph"
-    assert traces[0].data.spans[0].inputs == input_example
 
 
 def test_langgraph_chat_agent_custom_inputs():

--- a/tests/langgraph/test_chat_agent_langgraph.py
+++ b/tests/langgraph/test_chat_agent_langgraph.py
@@ -7,6 +7,8 @@ import mlflow
 from mlflow.langchain.chat_agent_langgraph import parse_message
 from mlflow.types.agent import ChatAgentMessage
 
+from tests.tracing.helper import get_traces
+
 LC_TOOL_CALL_MSG = AIMessage(
     **{
         "content": "",
@@ -167,6 +169,34 @@ def test_langgraph_chat_agent_save_as_code():
     for event, (role, expected_content) in zip(response, expected_messages):
         assert event["delta"]["content"] == expected_content
         assert event["delta"]["role"] == role
+
+
+def test_langgraph_chat_agent_trace():
+    input_example = {"messages": [{"role": "user", "content": "hi"}]}
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "agent",
+            python_model="tests/langchain/sample_code/langgraph_chat_agent.py",
+        )
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    # No trace should be created for loading it in
+    assert mlflow.get_last_active_trace() is None
+
+    loaded_model.predict(input_example)
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    assert traces[0].data.spans[0].name == "LangGraph"
+    assert traces[0].data.spans[0].inputs == input_example
+
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    list(loaded_model.predict_stream(input_example))
+    traces = get_traces()
+    assert len(traces) == 2
+    assert traces[0].info.status == "OK"
+    assert traces[0].data.spans[0].name == "LangGraph"
+    assert traces[0].data.spans[0].inputs == input_example
 
 
 def test_langgraph_chat_agent_custom_inputs():

--- a/tests/langgraph/test_chat_agent_langgraph.py
+++ b/tests/langgraph/test_chat_agent_langgraph.py
@@ -177,7 +177,7 @@ def test_langgraph_chat_agent_trace():
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(
             "agent",
-            python_model="tests/langchain/sample_code/langgraph_chat_agent.py",
+            python_model="tests/langgraph/sample_code/langgraph_chat_agent.py",
         )
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     # No trace should be created for loading it in

--- a/tests/langgraph/test_langgraph_autolog.py
+++ b/tests/langgraph/test_langgraph_autolog.py
@@ -192,8 +192,6 @@ def test_langgraph_chat_agent_trace():
     assert len(traces) == 1
     assert traces[0].info.status == "OK"
     assert traces[0].data.spans[0].name == "LangGraph"
-    # delete the generated uuid
-    del traces[0].data.spans[0].inputs["messages"][0]["id"]
     assert traces[0].data.spans[0].inputs == input_example
 
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -202,6 +200,4 @@ def test_langgraph_chat_agent_trace():
     assert len(traces) == 2
     assert traces[0].info.status == "OK"
     assert traces[0].data.spans[0].name == "LangGraph"
-    # delete the generated uuid
-    del traces[0].data.spans[0].inputs["messages"][0]["id"]
     assert traces[0].data.spans[0].inputs == input_example

--- a/tests/pyfunc/test_chat_agent_validation.py
+++ b/tests/pyfunc/test_chat_agent_validation.py
@@ -1,9 +1,9 @@
 import pytest
 
-from mlflow.types.agent import ChatAgentMessage
+from mlflow.types.agent import ChatAgentChunk, ChatAgentMessage, ChatAgentResponse
 
 
-def test_chat_message_throws_on_invalid_data():
+def test_chat_agent_message_throws_on_invalid_data():
     # Missing 'content' or 'tool_calls'
     data = {"role": "user", "name": "test_user"}
     with pytest.raises(ValueError, match="Either 'content' or 'tool_calls'"):
@@ -23,3 +23,48 @@ def test_chat_message_throws_on_invalid_data():
     data = {"role": "tool", "content": "test_content"}
     with pytest.raises(ValueError, match="Both 'name' and 'tool_call_id'."):
         ChatAgentMessage(**data)
+
+
+def test_chat_agent_response_throws_on_missing_id():
+    data = {"messages": [{"role": "user", "content": "a"}]}
+    with pytest.raises(ValueError, match="All ChatAgentMessage objects in field `messages`"):
+        ChatAgentResponse(**data)
+
+
+def test_chat_agent_response_throws_on_duplicate_ids():
+    data = {
+        "messages": [
+            {"role": "user", "content": "a", "id": "1"},
+            {"role": "user", "content": "b", "id": "1"},
+        ]
+    }
+    with pytest.raises(ValueError, match="unique IDs"):
+        ChatAgentResponse(**data)
+
+
+def test_chat_agent_response_throws_on_updated_id():
+    data = {
+        "messages": [
+            {"role": "user", "content": "a", "id": "1"},
+        ]
+    }
+    # shouldn't raise an error
+    response = ChatAgentResponse(**data)
+    with pytest.raises(ValueError, match="unique IDs"):
+        response.messages = [
+            ChatAgentMessage(**{"role": "user", "content": "b", "id": "1"}),
+            ChatAgentMessage(**{"role": "user", "content": "a", "id": "1"}),
+        ]
+
+
+def test_chat_agent_chunk_throws_on_missing_id():
+    data = {"delta": {"role": "user", "content": "a"}}
+    with pytest.raises(ValueError, match="The field `delta` of ChatAgentChunk"):
+        ChatAgentChunk(**data)
+
+
+def test_chat_agent_chunk_throws_on_updated_id():
+    data = {"delta": {"role": "user", "content": "a", "id": "1"}}
+    chunk = ChatAgentChunk(**data)
+    with pytest.raises(ValueError, match="The field `delta` of ChatAgentChunk"):
+        chunk.delta = ChatAgentMessage(**{"role": "user", "content": "b"})

--- a/tests/pyfunc/test_chat_agent_validation.py
+++ b/tests/pyfunc/test_chat_agent_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mlflow.types.agent import ChatAgentChunk, ChatAgentMessage, ChatAgentResponse
+from mlflow.types.agent import ChatAgentChunk, ChatAgentMessage
 
 
 def test_chat_agent_message_throws_on_invalid_data():
@@ -23,38 +23,6 @@ def test_chat_agent_message_throws_on_invalid_data():
     data = {"role": "tool", "content": "test_content"}
     with pytest.raises(ValueError, match="Both 'name' and 'tool_call_id'."):
         ChatAgentMessage(**data)
-
-
-def test_chat_agent_response_throws_on_missing_id():
-    data = {"messages": [{"role": "user", "content": "a"}]}
-    with pytest.raises(ValueError, match="All ChatAgentMessage objects in field `messages`"):
-        ChatAgentResponse(**data)
-
-
-def test_chat_agent_response_throws_on_duplicate_ids():
-    data = {
-        "messages": [
-            {"role": "user", "content": "a", "id": "1"},
-            {"role": "user", "content": "b", "id": "1"},
-        ]
-    }
-    with pytest.raises(ValueError, match="unique IDs"):
-        ChatAgentResponse(**data)
-
-
-def test_chat_agent_response_throws_on_updated_id():
-    data = {
-        "messages": [
-            {"role": "user", "content": "a", "id": "1"},
-        ]
-    }
-    # shouldn't raise an error
-    response = ChatAgentResponse(**data)
-    with pytest.raises(ValueError, match="unique IDs"):
-        response.messages = [
-            ChatAgentMessage(**{"role": "user", "content": "b", "id": "1"}),
-            ChatAgentMessage(**{"role": "user", "content": "a", "id": "1"}),
-        ]
 
 
 def test_chat_agent_chunk_throws_on_missing_id():

--- a/tests/pyfunc/test_chat_agent_validation.py
+++ b/tests/pyfunc/test_chat_agent_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mlflow.types.agent import ChatAgentChunk, ChatAgentMessage
+from mlflow.types.agent import ChatAgentChunk, ChatAgentMessage, ChatAgentResponse
 
 
 def test_chat_agent_message_throws_on_invalid_data():
@@ -23,6 +23,38 @@ def test_chat_agent_message_throws_on_invalid_data():
     data = {"role": "tool", "content": "test_content"}
     with pytest.raises(ValueError, match="Both 'name' and 'tool_call_id'."):
         ChatAgentMessage(**data)
+
+
+def test_chat_agent_response_throws_on_missing_id():
+    data = {"messages": [{"role": "user", "content": "a"}]}
+    with pytest.raises(ValueError, match="All ChatAgentMessage objects in field `messages`"):
+        ChatAgentResponse(**data)
+
+
+def test_chat_agent_response_throws_on_duplicate_ids():
+    data = {
+        "messages": [
+            {"role": "user", "content": "a", "id": "1"},
+            {"role": "user", "content": "b", "id": "1"},
+        ]
+    }
+    with pytest.raises(ValueError, match="unique IDs"):
+        ChatAgentResponse(**data)
+
+
+def test_chat_agent_response_throws_on_updated_id():
+    data = {
+        "messages": [
+            {"role": "user", "content": "a", "id": "1"},
+        ]
+    }
+    # shouldn't raise an error
+    response = ChatAgentResponse(**data)
+    with pytest.raises(ValueError, match="unique IDs"):
+        response.messages = [
+            ChatAgentMessage(**{"role": "user", "content": "b", "id": "1"}),
+            ChatAgentMessage(**{"role": "user", "content": "a", "id": "1"}),
+        ]
 
 
 def test_chat_agent_chunk_throws_on_missing_id():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bbqiu/mlflow/pull/14755?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14755/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14755
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- revise LangGraph add_agent_messages function
- do not set ID automatically. throw an error when constructing a `ChatAgentChunk` or `ChatAgentResponse`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
