### PR TITLE
Fix keras test

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1134,6 +1134,7 @@ def get_model_info(model_uri: str) -> ModelInfo:
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``
             - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            - ``models:/<model_id>``
             - ``models:/<model_name>/<model_version>``
             - ``models:/<model_name>/<stage>``
             - ``mlflow-artifacts:/path/to/model``

--- a/tests/keras/test_autolog.py
+++ b/tests/keras/test_autolog.py
@@ -102,8 +102,8 @@ def test_default_autolog_behavior():
 
     # Test the loaded pyfunc model produces the same output for the same input as the model.
     test_input = np.random.uniform(size=[2, 28, 28, 3]).astype(np.float32)
-    logged_model = f"runs:/{run.info.run_id}/model"
-    loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model)
+    logged_model = mlflow.last_logged_model()
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model.model_uri)
     np.testing.assert_allclose(
         keras.ops.convert_to_numpy(model(test_input)),
         loaded_pyfunc_model.predict(test_input),
@@ -112,7 +112,9 @@ def test_default_autolog_behavior():
     # Test the signature is logged.
     input_schema = Schema([TensorSpec(np.dtype(np.float32), (-1, 28, 28, 3))])
     output_schema = Schema([TensorSpec(np.dtype(np.float32), (-1, 2))])
-    _check_logged_model_signature_is_expected(run, input_schema, output_schema)
+    model_info = mlflow.models.get_model_info(logged_model.model_uri)
+    assert model_info.signature.inputs == input_schema
+    assert model_info.signature.outputs == output_schema
 
 
 @pytest.mark.parametrize(

--- a/tests/keras/test_autolog.py
+++ b/tests/keras/test_autolog.py
@@ -1,14 +1,11 @@
 import json
 import math
-import os
 
 import keras
 import numpy as np
 import pytest
-import yaml
 
 import mlflow
-from mlflow import MlflowClient
 from mlflow.tracking.fluent import flush_async_logging
 from mlflow.types import Schema, TensorSpec
 from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
@@ -35,25 +32,6 @@ def _create_keras_model():
         metrics=[keras.metrics.SparseCategoricalAccuracy()],
     )
     return model
-
-
-def _check_logged_model_signature_is_expected(run, input_schema, output_schema):
-    artifacts_dir = run.info.artifact_uri.replace("file://", "")
-    client = MlflowClient()
-    artifacts = [x.path for x in client.list_artifacts(run.info.run_id, "model")]
-    ml_model_filename = "MLmodel"
-    assert str(os.path.join("model", ml_model_filename)) in artifacts
-    ml_model_path = os.path.join(artifacts_dir, "model", ml_model_filename)
-    with open(ml_model_path) as f:
-        model_config = yaml.load(f, Loader=yaml.FullLoader)
-        assert model_config is not None
-        assert "signature" in model_config
-        signature = model_config["signature"]
-        assert signature is not None
-        assert "inputs" in signature
-        assert "outputs" in signature
-        assert signature["inputs"] == input_schema.to_json()
-        assert signature["outputs"] == output_schema.to_json()
 
 
 def test_default_autolog_behavior():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14761?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14761/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14761
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
