### PR TITLE
Fix spark exception during evaluation in shared cluster

### DIFF
--- a/mlflow/models/evaluation/utils/trace.py
+++ b/mlflow/models/evaluation/utils/trace.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 import inspect
 import logging
 from typing import Any, Callable
@@ -57,12 +58,16 @@ def configure_autologging_for_evaluation(enable_tracing: bool = True):
         # because the evaluation code usually only uses a subset of the supported flavors,
         # hence we want to avoid unnecessary overhead of configuring all flavors.
         @autologging_conf_lock
-        def _setup_autolog(module):
+        def _setup_autolog(autologging_integration: str, module: str):
             try:
-                autolog = get_autolog_function(flavor)
+                # NB: Use function argument to pass the flavor name to the hook function, rather
+                # than using the closure variable `flavor` to avoid late binding issue.
+                autolog = get_autolog_function(autologging_integration)
 
                 # If tracing is supported and not explicitly disabled, enable it.
-                if enable_tracing and _should_enable_tracing(flavor, global_config_snapshot):
+                if enable_tracing and _should_enable_tracing(
+                    autologging_integration, global_config_snapshot
+                ):
                     new_config = {
                         k: False if k.startswith("log_") else v for k, v in original_config.items()
                     }
@@ -81,13 +86,17 @@ def configure_autologging_for_evaluation(enable_tracing: bool = True):
                     autolog(disable=True)
 
             except Exception:
-                _logger.debug(f"Failed to update autologging config for {flavor}.", exc_info=True)
+                _logger.debug(
+                    f"Failed to update autologging config for {autologging_integration}.",
+                    exc_info=True,
+                )
 
         module = FLAVOR_TO_MODULE_NAME[flavor]
         try:
             original_import_hooks[module] = get_post_import_hooks(module)
-            new_import_hooks[module] = _setup_autolog
-            register_post_import_hook(_setup_autolog, module, overwrite=True)
+            hook = functools.partial(_setup_autolog, flavor)
+            new_import_hooks[module] = hook
+            register_post_import_hook(hook, module, overwrite=True)
         except Exception:
             _logger.debug(f"Failed to register post-import hook for {flavor}.", exc_info=True)
 
@@ -131,6 +140,8 @@ def configure_autologging_for_evaluation(enable_tracing: bool = True):
                         _logger.warning(
                             f"Exception raised while calling autologging for {flavor}: {e}"
                         )
+                    else:
+                        _logger.debug(f"Failed to restore autologging for {flavor}.", exc_info=True)
 
 
 def _should_enable_tracing(flavor: str, autologging_config: dict[str, Any]) -> bool:

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -360,36 +360,6 @@ def test_mlflow_evaluate_logs_traces():
     assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
 
 
-def test_pyfunc_evaluate_logs_traces():
-    class Model(mlflow.pyfunc.PythonModel):
-        @mlflow.trace()
-        def predict(self, context, model_input):
-            return self.add(model_input, model_input)
-
-        @mlflow.trace()
-        def add(self, x, y):
-            return x + y
-
-    eval_data = pd.DataFrame(
-        {
-            "inputs": [1, 2, 4],
-            "ground_truth": [2, 4, 8],
-        }
-    )
-
-    with mlflow.start_run() as run:
-        model_info = mlflow.pyfunc.log_model("model", python_model=Model())
-        evaluate(
-            model_info.model_uri,
-            eval_data,
-            targets="ground_truth",
-            extra_metrics=[mlflow.metrics.exact_match()],
-        )
-    assert len(get_traces()) == 1
-    assert len(get_traces()[0].data.spans) == 2
-    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
-
-
 # Patching for counting calls but not actually mocking out the function
 @mock.patch(
     "mlflow.models.evaluation.utils.trace._kwargs_safe_invoke",
@@ -483,6 +453,36 @@ def test_evaluate_auto_enables_tracing_thread_safe(mock_autolog_invoke):
     assert not get_autologging_config("openai", "log_traces")
     # Disable should be reset to None
     assert not get_autologging_config("sklearn", "disable")
+
+
+def test_pyfunc_evaluate_logs_traces():
+    class Model(mlflow.pyfunc.PythonModel):
+        @mlflow.trace()
+        def predict(self, context, model_input):
+            return self.add(model_input, model_input)
+
+        @mlflow.trace()
+        def add(self, x, y):
+            return x + y
+
+    eval_data = pd.DataFrame(
+        {
+            "inputs": [1, 2, 4],
+            "ground_truth": [2, 4, 8],
+        }
+    )
+
+    with mlflow.start_run() as run:
+        model_info = mlflow.pyfunc.log_model("model", python_model=Model())
+        evaluate(
+            model_info.model_uri,
+            eval_data,
+            targets="ground_truth",
+            extra_metrics=[mlflow.metrics.exact_match()],
+        )
+    assert len(get_traces()) == 1
+    assert len(get_traces()[0].data.spans) == 2
+    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
 
 
 def test_classifier_evaluate(multiclass_logistic_regressor_model_uri, iris_dataset):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14771?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14771/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14771
```

</p>
</details>

### What changes are proposed in this pull request?

During evaluation, we disable all autologging, and [here](https://github.com/mlflow/mlflow/blob/e56f3d7f16ba6d65a669971eb0feef5fa2de1a07/mlflow/models/evaluation/utils/trace.py#L118) we reset the state for each flavor afterward.

However, in DB shared cluster, calling `mlflow.spark.autolog()` raises the following error:

> [[JVM_ATTRIBUTE_NOT_SUPPORTED](https://docs.databricks.com/error-messages/error-classes.html#jvm_attribute_not_supported)] Directly accessing the underlying Spark driver JVM using the attribute 'sparkContext' is not supported on shared clusters. If you require direct access to these fields, consider using a single-user cluster. For more details on compatibility and limitations, check: https://docs.databricks.com/compute/access-mode-limitations.html#shared-access-mode-limitations-on-unity-catalog
raises an exception 

We only try-catch `ImportError` right now in the clean-up block, but we should catch any kind of errors like this.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
