### PR TITLE
Fix `_is_logged_model_uri` to avoid error when `uri` is a `Path` object

### DIFF
--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import urllib.parse
+from pathlib import Path
+from typing import Union
 
 import mlflow
 from mlflow.exceptions import MlflowException
@@ -102,7 +104,7 @@ class ModelsArtifactRepository(ArtifactRepository):
         return uri, ""
 
     @staticmethod
-    def _is_logged_model_uri(uri: str) -> bool:
+    def _is_logged_model_uri(uri: Union[str, Path]) -> bool:
         """
         Returns True if the URI is a logged model URI (e.g. 'models:/<model_id>'), False otherwise.
         """

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -108,6 +108,7 @@ class ModelsArtifactRepository(ArtifactRepository):
         """
         Returns True if the URI is a logged model URI (e.g. 'models:/<model_id>'), False otherwise.
         """
+        uri = str(uri)
         return is_models_uri(uri) and _parse_model_uri(uri).model_id is not None
 
     @staticmethod

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -27,6 +28,7 @@ from tests.store.artifact.constants import (
         ("models:/123", True),
         ("models:/name/1", False),
         ("/path/to/model", False),
+        (Path("path/to/model"), False),
         ("s3://bucket/path/to/model", False),
     ],
 )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14777?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14777/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14777
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow/mlflow/actions/runs/13583983681/job/37974980295?pr=13211

```
mlflow/models/utils.py:633: in _read_example
    input_example = _get_mlflow_model_input_example_dict(mlflow_model, uri_or_path)
        mlflow_model = <mlflow.models.model.Model object at 0x7fd61d5ce730>
        uri_or_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_diviner_signature_and_exa1/model')
mlflow/models/utils.py:556: in _get_mlflow_model_input_example_dict
    _read_file_content(uri_or_path, mlflow_model.saved_input_example_info[INPUT_EXAMPLE_PATH])
        example_type = 'dataframe'
        mlflow_model = <mlflow.models.model.Model object at 0x7fd61d5ce730>
        uri_or_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_diviner_signature_and_exa1/model')
mlflow/models/utils.py:604: in _read_file_content
    if ModelsArtifactRepository._is_logged_model_uri(uri_or_path):
        ModelsArtifactRepository = <class 'mlflow.store.artifact.models_artifact_repo.ModelsArtifactRepository'>
        file_name  = 'input_example.json'
        uri_or_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_diviner_signature_and_exa1/model')
mlflow/store/artifact/models_artifact_repo.py:109: in _is_logged_model_uri
    return is_models_uri(uri) and _parse_model_uri(uri).model_id is not None
        uri        = PosixPath('/tmp/pytest-of-runner/pytest-0/test_diviner_signature_and_exa1/model')
mlflow/utils/uri.py:551: in is_models_uri
    parsed = urllib.parse.urlparse(uri)
        uri        = PosixPath('/tmp/pytest-of-runner/pytest-0/test_diviner_signature_and_exa1/model')
/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/urllib/parse.py:400: in urlparse
    url, scheme, _coerce_result = _coerce_args(url, scheme)
        allow_fragments = True
        scheme     = ''
        url        = PosixPath('/tmp/pytest-of-runner/pytest-0/test_diviner_signature_and_exa1/model')
/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/urllib/parse.py:136: in _coerce_args
    return _decode_args(args) + (_encode_result,)
        arg        = ''
        args       = (PosixPath('/tmp/pytest-of-runner/pytest-0/test_diviner_signature_and_exa1/model'), '')
        str_input  = False
/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/urllib/parse.py:120: in _decode_args
    return tuple(x.decode(encoding, errors) if x else '' for x in args)
        args       = (PosixPath('/tmp/pytest-of-runner/pytest-0/test_diviner_signature_and_exa1/model'), '')
        encoding   = 'ascii'
        errors     = 'strict'
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <tuple_iterator object at 0x7fd61d5ced60>

>   return tuple(x.decode(encoding, errors) if x else '' for x in args)
E   AttributeError: 'PosixPath' object has no attribute 'decode'
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
