### PR TITLE
Fix TS types

### DIFF
--- a/mlflow/server/js/src/common/components/DesignSystemContainer.tsx
+++ b/mlflow/server/js/src/common/components/DesignSystemContainer.tsx
@@ -1,15 +1,9 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
-import React, { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { DesignSystemProvider, DesignSystemThemeProvider } from '@databricks/design-system';
 import { ColorsPaletteDatalist } from './ColorsPaletteDatalist';
 
-const isInsideShadowDOM = (element: any) => element instanceof window.Node && element.getRootNode() !== document;
+const isInsideShadowDOM = (element: HTMLDivElement | null): boolean =>
+  element instanceof window.Node && element.getRootNode() !== document;
 
 type DesignSystemContainerProps = {
   isDarkTheme?: boolean;
@@ -17,7 +11,6 @@ type DesignSystemContainerProps = {
 };
 
 const ThemeProvider = ({ children, isDarkTheme }: { children?: React.ReactNode; isDarkTheme?: boolean }) => {
-  // eslint-disable-next-line react/forbid-elements
   return <DesignSystemThemeProvider isDarkMode={isDarkTheme}>{children}</DesignSystemThemeProvider>;
 };
 
@@ -27,22 +20,21 @@ const ThemeProvider = ({ children, isDarkTheme }: { children?: React.ReactNode; 
  * DOM element for the purpose of housing modals/popups there.
  */
 export const DesignSystemContainer = (props: DesignSystemContainerProps) => {
-  const modalContainerElement = useRef();
+  const modalContainerElement = useRef<HTMLDivElement | null>(null);
   const { isDarkTheme = false, children } = props;
 
   const getPopupContainer = useCallback(() => {
-    if (isInsideShadowDOM(modalContainerElement.current)) {
-      return modalContainerElement.current;
+    const modelContainerEle = modalContainerElement.current;
+    if (modelContainerEle !== null && isInsideShadowDOM(modelContainerEle)) {
+      return modelContainerEle;
     }
     return document.body;
   }, []);
 
   return (
     <ThemeProvider isDarkTheme={isDarkTheme}>
-      {/* @ts-expect-error TS(2322): Type '() => HTMLElement | undefined' is not assign... Remove this comment to see the full error message */}
-      <DesignSystemProvider getPopupContainer={getPopupContainer} isCompact {...props}>
+      <DesignSystemProvider getPopupContainer={getPopupContainer} {...props}>
         {children}
-        {/* @ts-expect-error TS(2322): Type 'MutableRefObject<undefined>' is not assignab... Remove this comment to see the full error message */}
         <div ref={modalContainerElement} />
       </DesignSystemProvider>
       <ColorsPaletteDatalist />

--- a/mlflow/server/js/src/common/components/ErrorView.tsx
+++ b/mlflow/server/js/src/common/components/ErrorView.tsx
@@ -1,19 +1,12 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
-import React, { Component } from 'react';
+import { Component } from 'react';
 import errorDefaultImg from '../static/default-error.svg';
 import error404Img from '../static/404-overflow.svg';
 import Routes from '../../experiment-tracking/routes';
 import { Link } from '../utils/RoutingUtils';
 import { FormattedMessage } from 'react-intl';
-import { WithDesignSystemThemeHoc } from '@databricks/design-system';
+import { DesignSystemThemeInterface, WithDesignSystemThemeHoc } from '@databricks/design-system';
 
-const altMessages = {
+const altMessages: Record<number, string> = {
   400: '400 Bad Request',
   401: '401 Unauthorized',
   404: '404 Not Found',
@@ -29,7 +22,6 @@ type ErrorImageProps = {
 
 function ErrorImage(props: ErrorImageProps) {
   const { statusCode } = props;
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const alt = altMessages[statusCode] || statusCode.toString();
 
   switch (props.statusCode) {
@@ -54,24 +46,24 @@ type ErrorViewImplProps = {
   statusCode: number;
   subMessage?: string;
   fallbackHomePageReactRoute?: string;
-  designSystemThemeApi?: any;
+  designSystemThemeApi?: DesignSystemThemeInterface;
 };
 
 class ErrorViewImpl extends Component<ErrorViewImplProps> {
-  static centerMessages = {
+  static centerMessages: Record<number, string> = {
     400: 'Bad Request',
     404: 'Page Not Found',
     409: 'Resource Conflict',
   };
 
-  renderErrorMessage(subMessage: any, fallbackHomePageReactRoute: any) {
+  renderErrorMessage(subMessage?: string, fallbackHomePageReactRoute?: string) {
     if (subMessage) {
       return (
         <FormattedMessage
           defaultMessage="{subMessage}, go back to <link>the home page.</link>"
           description="Default error message for error views in MLflow"
           values={{
-            link: (chunks: any) => (
+            link: (chunks) => (
               <Link data-testid="error-view-link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
                 {chunks}
               </Link>
@@ -86,7 +78,7 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
           defaultMessage="Go back to <link>the home page.</link>"
           description="Default error message for error views in MLflow"
           values={{
-            link: (chunks: any) => (
+            link: (chunks) => (
               <Link data-testid="error-view-link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
                 {chunks}
               </Link>
@@ -99,15 +91,13 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
 
   render() {
     const { statusCode, subMessage, fallbackHomePageReactRoute, designSystemThemeApi } = this.props;
-    const { theme } = designSystemThemeApi;
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     const centerMessage = ErrorViewImpl.centerMessages[statusCode] || 'HTTP Request Error';
 
     return (
       <div className="center">
         <ErrorImage statusCode={statusCode} />
         <h1 style={{ paddingTop: '10px' }}>{centerMessage}</h1>
-        <h2 style={{ color: theme.colors.textSecondary }}>
+        <h2 style={{ color: designSystemThemeApi?.theme.colors.textSecondary }}>
           {this.renderErrorMessage(subMessage, fallbackHomePageReactRoute)}
         </h2>
       </div>

--- a/mlflow/server/js/src/common/components/ErrorView.tsx
+++ b/mlflow/server/js/src/common/components/ErrorView.tsx
@@ -4,7 +4,7 @@ import error404Img from '../static/404-overflow.svg';
 import Routes from '../../experiment-tracking/routes';
 import { Link } from '../utils/RoutingUtils';
 import { FormattedMessage } from 'react-intl';
-import { DesignSystemThemeInterface, WithDesignSystemThemeHoc } from '@databricks/design-system';
+import { DesignSystemHocProps, WithDesignSystemThemeHoc } from '@databricks/design-system';
 
 const altMessages: Record<number, string> = {
   400: '400 Bad Request',
@@ -42,11 +42,10 @@ function ErrorImage(props: ErrorImageProps) {
   }
 }
 
-type ErrorViewImplProps = {
+type ErrorViewImplProps = DesignSystemHocProps & {
   statusCode: number;
   subMessage?: string;
   fallbackHomePageReactRoute?: string;
-  designSystemThemeApi?: DesignSystemThemeInterface;
 };
 
 class ErrorViewImpl extends Component<ErrorViewImplProps> {
@@ -97,7 +96,7 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
       <div className="center">
         <ErrorImage statusCode={statusCode} />
         <h1 style={{ paddingTop: '10px' }}>{centerMessage}</h1>
-        <h2 style={{ color: designSystemThemeApi?.theme.colors.textSecondary }}>
+        <h2 style={{ color: designSystemThemeApi.theme.colors.textSecondary }}>
           {this.renderErrorMessage(subMessage, fallbackHomePageReactRoute)}
         </h2>
       </div>
@@ -105,5 +104,4 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
   }
 }
 
-// @ts-expect-error TS(2345): Argument of type 'typeof ErrorViewImpl' is not ass... Remove this comment to see the full error message
 export const ErrorView = WithDesignSystemThemeHoc(ErrorViewImpl);

--- a/mlflow/server/js/src/common/components/IconButton.tsx
+++ b/mlflow/server/js/src/common/components/IconButton.tsx
@@ -1,18 +1,11 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import React from 'react';
 import { Button } from '@databricks/design-system';
 
 type Props = {
   icon: React.ReactNode;
-  style?: any;
+  style?: React.CSSProperties;
   className?: string;
-  restProps?: any;
+  restProps?: unknown;
 };
 
 export const IconButton = ({ icon, className, style, ...restProps }: Props) => {

--- a/mlflow/server/js/src/common/components/TrimmedText.tsx
+++ b/mlflow/server/js/src/common/components/TrimmedText.tsx
@@ -1,10 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import React, { useState } from 'react';
 import { Button } from '@databricks/design-system';
 

--- a/mlflow/server/js/src/common/utils/ErrorWrapper.test.ts
+++ b/mlflow/server/js/src/common/utils/ErrorWrapper.test.ts
@@ -1,10 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import { ErrorWrapper } from './ErrorWrapper';
 
 describe('ErrorWrapper', () => {
@@ -27,8 +20,7 @@ describe('ErrorWrapper', () => {
   });
 
   it('renderHttpError works weird stuff', () => {
-    // @ts-expect-error TS(2345): Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
-    const error = new ErrorWrapper('{}', '500').renderHttpError();
+    const error = new ErrorWrapper('{}', 500).renderHttpError();
     expect(error).toEqual('Request Failed');
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotControls.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotControls.enzyme.test.tsx
@@ -1,11 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
-import React from 'react';
 import { shallowWithInjectIntl } from '@mlflow/mlflow/src/common/utils/TestUtils.enzyme';
 import { MetricsPlotControls, X_AXIS_RELATIVE } from './MetricsPlotControls';
 import { CHART_TYPE_BAR, CHART_TYPE_LINE } from './MetricsPlotPanel';

--- a/mlflow/server/js/src/experiment-tracking/components/PermissionDeniedView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/PermissionDeniedView.tsx
@@ -1,10 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import React from 'react';
 import permissionDeniedLock from '../../common/static/permission-denied-lock.svg';
 import { useDesignSystemTheme } from '@databricks/design-system';

--- a/mlflow/server/js/src/experiment-tracking/components/RunNotFoundView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/RunNotFoundView.tsx
@@ -1,10 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import React, { Component } from 'react';
 import Routes from '../routes';
 import { ErrorView } from '../../common/components/ErrorView';

--- a/mlflow/server/js/src/experiment-tracking/utils/NoteUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/NoteUtils.ts
@@ -1,11 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import { MLFLOW_INTERNAL_PREFIX } from '../../common/utils/TagUtils';
-import { KeyValueEntity } from '../types';
 
 export const NOTE_CONTENT_TAG = MLFLOW_INTERNAL_PREFIX + 'note.content';

--- a/mlflow/server/js/src/experiment-tracking/utils/test-utils/Fixtures.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/test-utils/Fixtures.ts
@@ -1,10 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import { ExperimentEntity, RunInfoEntity } from '../../types';
 
 const createExperiment = ({

--- a/mlflow/server/js/src/experiment-tracking/utils/test-utils/ReduxStoreFixtures.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/test-utils/ReduxStoreFixtures.ts
@@ -1,18 +1,9 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
-import { RunTag, Metric } from '../../sdk/MlflowMessages';
-
-export const mockExperiment = (eid: any, name: any) => {
+export const mockExperiment = (eid: string, name: string) => {
   return { experimentId: eid, name: name, allowedActions: [] };
 };
 
 export const mockRunInfo = (
-  run_id: any,
+  run_id: string,
   experiment_id = undefined,
   artifact_uri = undefined,
   lifecycle_stage = undefined,

--- a/mlflow/server/js/src/index.tsx
+++ b/mlflow/server/js/src/index.tsx
@@ -1,18 +1,9 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
-import React from 'react';
 import ReactDOM from 'react-dom';
-import { I18nUtils } from './i18n/I18nUtils';
 import { MLFlowRoot } from './app';
 
 ReactDOM.render(<MLFlowRoot />, document.getElementById('root'));
 
-const windowOnError = (message: any, source: any, lineno: any, colno: any, error: any) => {
+const windowOnError = (message: Event | string, source?: string, lineno?: number, colno?: number, error?: Error) => {
   // eslint-disable-next-line no-console -- TODO(FEINF-3587)
   console.error(error, message);
   // returning false allows the default handler to fire as well

--- a/mlflow/server/js/src/model-registry/components/CreateModelButton.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/CreateModelButton.test.tsx
@@ -1,11 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
-import React from 'react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import promiseMiddleware from 'redux-promise-middleware';

--- a/mlflow/server/js/src/model-registry/components/CreateModelButton.tsx
+++ b/mlflow/server/js/src/model-registry/components/CreateModelButton.tsx
@@ -1,10 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import React from 'react';
 import { Button } from '@databricks/design-system';
 import { CreateModelModal } from './CreateModelModal';
@@ -15,7 +8,9 @@ type Props = {
   buttonText?: React.ReactNode;
 };
 
-type State = any;
+type State = {
+  modalVisible: boolean;
+};
 
 export class CreateModelButton extends React.Component<Props, State> {
   state = {
@@ -56,7 +51,7 @@ export class CreateModelButton extends React.Component<Props, State> {
 }
 
 const styles = {
-  getButtonSize: (buttonType: any) =>
+  getButtonSize: (buttonType: string) =>
     buttonType === 'primary'
       ? {
           height: '40px',

--- a/mlflow/server/js/src/model-registry/components/ModelStageTransitionDropdown.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelStageTransitionDropdown.tsx
@@ -1,10 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import React from 'react';
 import { Dropdown, Menu, ChevronDownIcon, ArrowRightIcon } from '@databricks/design-system';
 import {
@@ -68,7 +61,7 @@ export class ModelStageTransitionDropdown extends React.Component<
     this.setState({ confirmModalVisible: false });
   };
 
-  getNoneCurrentStages = (currentStage: any) => {
+  getNoneCurrentStages = (currentStage?: string) => {
     const stages = Object.values(Stages);
     _.remove(stages, (s) => s === currentStage);
     return stages;

--- a/mlflow/server/js/src/model-registry/utils/SearchUtils.test.ts
+++ b/mlflow/server/js/src/model-registry/utils/SearchUtils.test.ts
@@ -1,10 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import { getModelNameFilter, getCombinedSearchFilter, constructSearchInputFromURLState } from './SearchUtils';
 
 describe('getModelNameFilter', () => {

--- a/mlflow/server/js/src/shared/building_blocks/CopyBox.tsx
+++ b/mlflow/server/js/src/shared/building_blocks/CopyBox.tsx
@@ -1,11 +1,3 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
-import React from 'react';
 import { Input } from '@databricks/design-system';
 import { CopyButton } from './CopyButton';
 

--- a/mlflow/server/js/src/shared/building_blocks/Spacer.tsx
+++ b/mlflow/server/js/src/shared/building_blocks/Spacer.tsx
@@ -1,15 +1,8 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
 import React from 'react';
 
 const spacingSizes = [4, 8, 16, 24, 32, 40];
 
-const getMarginSize = (size: any) => {
+const getMarginSize = (size: SpacerProps['size']): number => {
   switch (size) {
     case 'small':
       return 4;
@@ -24,13 +17,13 @@ const getMarginSize = (size: any) => {
 };
 
 type SpacerProps = {
-  size?: any; // TODO: PropTypes.oneOf([undefined, 'small', 'medium', 'large', 0, 1, 2, 3, 4, 5])
-  direction?: string;
+  size?: 'small' | 'medium' | 'large' | 0 | 1 | 2 | 3 | 4 | 5;
+  direction?: 'horizontal' | 'vertical';
 };
 
 /**
  * Spaces its children according to the direction and size specified.
- * @param props size: One of "small", "medium" or "large". Default small.
+ * @param props size: One of "small", "medium", "large", 0, 1, 2, 3, 4, or 5. Default small.
  * @param props direction: One of "horizontal" or "vertical". Default vertical.
  */
 export class Spacer extends React.Component<SpacerProps> {
@@ -42,7 +35,7 @@ export class Spacer extends React.Component<SpacerProps> {
   }
 }
 
-const styles = (marginSize: any, direction: any) =>
+const styles = (marginSize: number, direction: Exclude<SpacerProps['direction'], undefined>) =>
   direction === 'horizontal'
     ? {
         display: 'flex',


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Gumichocopengin8/mlflow/pull/14788?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14788/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14788
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fixed some files with the following comment by annotating the proper types instead of using `any` or `@ts-expect-error`.
I didn't fix all files because I didn't have enough confidence in some files.

```
/**
 * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
 * may contain multiple `any` type annotations and `@ts-expect-error` directives.
 * If possible, please improve types while making changes to this file. If the type
 * annotations are already looking good, please remove this comment.
 */
```

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
