### PR TITLE
Fix: `pyfunc.load_model()` followed by `predict()` does not log trace associated with the model

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -824,6 +824,9 @@ class PyFuncModel:
         with set_prediction_context(context):
             if schema := _get_dependencies_schema_from_model(self._model_meta):
                 context.update(**schema)
+
+            if self.model_id:
+                context.update(model_id=self.model_id)
             return self._predict(data, params)
 
     def _predict(self, data: PyFuncInput, params: Optional[dict[str, Any]] = None) -> PyFuncOutput:
@@ -886,6 +889,9 @@ class PyFuncModel:
 
         if schema := _get_dependencies_schema_from_model(self._model_meta):
             context.update(**schema)
+
+        if self.model_id:
+            context.update(model_id=self.model_id)
 
         # NB: The prediction context must be applied during iterating over the stream,
         # hence, simply wrapping the self._predict_stream call with the context manager

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -18,6 +18,8 @@ class Context:
     is_evaluate: bool = False
     # The schema of the dependencies to be added into the tag of trace info.
     dependencies_schemas: Optional[dict] = None
+    # The model ID associated with the current prediction request
+    model_id: Optional[str] = None
 
     def update(self, **kwargs):
         for key, value in kwargs.items():

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -18,7 +18,7 @@ class Context:
     is_evaluate: bool = False
     # The schema of the dependencies to be added into the tag of trace info.
     dependencies_schemas: Optional[dict] = None
-    # The model ID associated with the current prediction request
+    # The logged model ID associated with the current prediction request
     model_id: Optional[str] = None
 
     def update(self, **kwargs):

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -24,7 +24,7 @@ from mlflow.tracing.utils import (
     deduplicate_span_names_in_place,
     get_otel_attribute,
     maybe_get_dependencies_schemas,
-    maybe_get_model_id,
+    maybe_get_logged_model_id,
     maybe_get_request_id,
 )
 from mlflow.tracking.client import MlflowClient
@@ -115,7 +115,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         if run := _get_latest_active_run():
             metadata[TraceMetadataKey.SOURCE_RUN] = run.info.run_id
 
-        if model_id := maybe_get_model_id():
+        if model_id := maybe_get_logged_model_id():
             metadata[TraceMetadataKey.MODEL_ID] = model_id
 
         experiment_id = self._get_experiment_id_for_trace(span)

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -24,6 +24,7 @@ from mlflow.tracing.utils import (
     deduplicate_span_names_in_place,
     get_otel_attribute,
     maybe_get_dependencies_schemas,
+    maybe_get_model_id,
     maybe_get_request_id,
 )
 from mlflow.tracking.client import MlflowClient
@@ -113,6 +114,9 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         # all threads and set it as the tracing source run.
         if run := _get_latest_active_run():
             metadata[TraceMetadataKey.SOURCE_RUN] = run.info.run_id
+
+        if model_id := maybe_get_model_id():
+            metadata[TraceMetadataKey.MODEL_ID] = model_id
 
         experiment_id = self._get_experiment_id_for_trace(span)
         if experiment_id == DEFAULT_EXPERIMENT_ID and not self._issued_default_exp_warning:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -234,6 +234,11 @@ def maybe_get_dependencies_schemas() -> Optional[dict]:
         return context.dependencies_schemas
 
 
+def maybe_get_model_id() -> Optional[str]:
+    if context := _try_get_prediction_context():
+        return context.model_id
+
+
 def exclude_immutable_tags(tags: dict[str, str]) -> dict[str, str]:
     """Exclude immutable tags e.g. "mlflow.user" from the given tags."""
     return {k: v for k, v in tags.items() if k not in IMMUTABLE_TAGS}

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -234,7 +234,10 @@ def maybe_get_dependencies_schemas() -> Optional[dict]:
         return context.dependencies_schemas
 
 
-def maybe_get_model_id() -> Optional[str]:
+def maybe_get_logged_model_id() -> Optional[str]:
+    """
+    Get the logged model ID associated with the current prediction context.
+    """
     if context := _try_get_prediction_context():
         return context.model_id
 

--- a/tests/pyfunc/test_logged_models.py
+++ b/tests/pyfunc/test_logged_models.py
@@ -2,22 +2,32 @@ import mlflow
 from mlflow.tracing.constant import TraceMetadataKey
 
 
-def test_model_id_tracking():
-    class TraceModel(mlflow.pyfunc.PythonModel):
-        @mlflow.trace
-        def predict(self, model_input: list[int]) -> list[int]:
-            return model_input
+class TraceModel(mlflow.pyfunc.PythonModel):
+    @mlflow.trace
+    def predict(self, model_input):
+        return len(model_input) * [0]
 
+
+def test_model_id_tracking():
     model = TraceModel()
-    assert model.predict([1, 2, 3]) == [1, 2, 3]
+    model.predict([1, 2, 3])
     trace = mlflow.get_last_active_trace()
     assert TraceMetadataKey.MODEL_ID not in trace.info.request_metadata
 
     with mlflow.start_run():
-        info = mlflow.pyfunc.log_model("my_model", python_model=TraceModel())
+        info = mlflow.pyfunc.log_model("my_model", python_model=model)
 
     model = mlflow.pyfunc.load_model(info.model_uri)
-    assert model.predict([4, 5, 6]) == [4, 5, 6]
+    model.predict([4, 5, 6])
 
     trace = mlflow.get_last_active_trace()
-    assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == model.model_id
+    assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == info.model_id
+
+
+def test_model_id_tracking_evaluate():
+    with mlflow.start_run():
+        info = mlflow.pyfunc.log_model("my_model", python_model=TraceModel())
+
+    mlflow.evaluate(model=info.model_uri, data=[[1, 2, 3]], model_type="regressor", targets=[1])
+    trace = mlflow.get_last_active_trace()
+    assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == info.model_id

--- a/tests/pyfunc/test_logged_models.py
+++ b/tests/pyfunc/test_logged_models.py
@@ -16,6 +16,8 @@ def test_model_id_tracking():
 
     with mlflow.start_run():
         info = mlflow.pyfunc.log_model("my_model", python_model=model)
+        # Log another model to ensure that the model ID is correctly associated with the first model
+        mlflow.pyfunc.log_model("another_model", python_model=model)
 
     model = mlflow.pyfunc.load_model(info.model_uri)
     model.predict([4, 5, 6])

--- a/tests/pyfunc/test_logged_models.py
+++ b/tests/pyfunc/test_logged_models.py
@@ -1,0 +1,23 @@
+import mlflow
+from mlflow.tracing.constant import TraceMetadataKey
+
+
+def test_model_id_tracking():
+    class TraceModel(mlflow.pyfunc.PythonModel):
+        @mlflow.trace
+        def predict(self, model_input: list[int]) -> list[int]:
+            return model_input
+
+    model = TraceModel()
+    assert model.predict([1, 2, 3]) == [1, 2, 3]
+    trace = mlflow.get_last_active_trace()
+    assert TraceMetadataKey.MODEL_ID not in trace.info.request_metadata
+
+    with mlflow.start_run():
+        info = mlflow.pyfunc.log_model("my_model", python_model=TraceModel())
+
+    model = mlflow.pyfunc.load_model(info.model_uri)
+    assert model.predict([4, 5, 6]) == [4, 5, 6]
+
+    trace = mlflow.get_last_active_trace()
+    assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == model.model_id

--- a/tests/pyfunc/test_logged_models.py
+++ b/tests/pyfunc/test_logged_models.py
@@ -21,6 +21,7 @@ def test_model_id_tracking():
     model.predict([4, 5, 6])
 
     trace = mlflow.get_last_active_trace()
+    assert trace is not None
     assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == info.model_id
 
 
@@ -30,4 +31,5 @@ def test_model_id_tracking_evaluate():
 
     mlflow.evaluate(model=info.model_uri, data=[[1, 2, 3]], model_type="regressor", targets=[1])
     trace = mlflow.get_last_active_trace()
+    assert trace is not None
     assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == info.model_id


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14797?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14797/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14797
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for `pyfunc.load_model()` followed by `predict()` does not log trace associated with the model.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
