### PR TITLE
Make `preview-docs` fail gracefully

### DIFF
--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -110,13 +110,13 @@ Failed to find a documentation preview for {args.commit_sha}.
             time.sleep(1)
     else:
         upsert_comment(
+            github_session,
+            repo,
+            args.pull_number,
             (
                 f"Failed to find a documentation preview for {args.commit_sha}. "
                 f"See {workflow_run_link} for what went wrong."
             ),
-            repo,
-            args.pull_number,
-            comment_body,
         )
 
     build_doc_job = next(filter(lambda s: s["name"] == build_doc_job_name, workflow["items"]))

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -102,12 +102,14 @@ Failed to find a documentation preview for {args.commit_sha}.
             job_url = job["web_url"]
             workflow_id = job["latest_workflow"]["id"]
             workflow = circle_session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
+            break
         except requests.HTTPError as e:
             print(
                 f"Failed to get CircleCI job info: {e.response.status_code, e.response.text}, "
                 f"retrying..."
             )
             time.sleep(1)
+            continue
     else:
         upsert_comment(
             github_session,
@@ -118,6 +120,7 @@ Failed to find a documentation preview for {args.commit_sha}.
                 f"See {workflow_run_link} for what went wrong."
             ),
         )
+        return
 
     build_doc_job = next(filter(lambda s: s["name"] == build_doc_job_name, workflow["items"]))
     build_doc_job_id = build_doc_job["id"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14804?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14804/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14804
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The preview-docs job sometimes fails with 403 as shown below:

https://github.com/mlflow/mlflow/actions/runs/13621987733/job/38072915983

```
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/dev/preview_docs.py", line 130, in <module>
    main()
  File "/home/runner/work/mlflow/mlflow/dev/preview_docs.py", line 98, in main
    job = circle_session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
  File "/home/runner/work/mlflow/mlflow/dev/preview_docs.py", line 12, in get
    resp.raise_for_status()
  File "/opt/hostedtoolcache/Python/3.9.[18](https://github.com/mlflow/mlflow/actions/runs/13621987733/job/38072915983#step:5:19)/x64/lib/python3.9/site-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://circleci.com/api/v2/project/gh/mlflow/mlflow/job/147573
```

Not sure why a valid token is sometimes rejected. We don't want this job to block PR merge. If it fails with 403, post a message indicating that failed, and mark the job as successful.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
