### PR TITLE
Avoid `dspy` 2.6.9

### DIFF
--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -76,7 +76,9 @@ anthropic
 # Required by mlflow.autogen
 autogen
 # Required by mlflow.dspy
-dspy
+# In dspy 2.6.9, `dspy.__name__` is not 'dspy', but 'dspy.__metadata__',
+# which causes auto-logging tests to fail.
+dspy!=2.6.9
 # Required by mlflow.litellm
 litellm
 # Required by mlflow.gemini


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14814?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14814/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14814
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Avoid `dspy==2.6.9` to fix the following error:

https://github.com/mlflow/mlflow/actions/runs/13643921776/job/38139218209?pr=14813

```
2025-03-04T01:20:14.0952209Z ________________ ERROR at setup of test_autolog_obeys_disabled _________________
2025-03-04T01:20:14.0952214Z 
2025-03-04T01:20:14.0952446Z     @pytest.fixture(autouse=True)
2025-03-04T01:20:14.0952690Z     def reset_global_states():
2025-03-04T01:20:14.0953347Z         from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
2025-03-04T01:20:14.0953444Z     
2025-03-04T01:20:14.0953722Z         for value in AUTOLOGGING_INTEGRATIONS.values():
2025-03-04T01:20:14.0953849Z             value.clear()
2025-03-04T01:20:14.0953943Z     
2025-03-04T01:20:14.0954224Z         for integration_name in library_to_mlflow_module:
2025-03-04T01:20:14.0954397Z             try:
2025-03-04T01:20:14.0954804Z                 del mlflow.utils.import_hooks._post_import_hooks[integration_name.__name__]
2025-03-04T01:20:14.0955141Z             except Exception:
2025-03-04T01:20:14.0955273Z                 pass
2025-03-04T01:20:14.0955371Z     
2025-03-04T01:20:14.0955844Z         assert all(v == {} for v in AUTOLOGGING_INTEGRATIONS.values())
2025-03-04T01:20:14.0956127Z >       assert mlflow.utils.import_hooks._post_import_hooks == {}
2025-03-04T01:20:14.0956356Z E       AssertionError: assert {'dspy': [<fu...efb45db2c10>]} == {}
2025-03-04T01:20:14.0956453Z E         
2025-03-04T01:20:14.0956593Z E         Left contains 1 more item:
2025-03-04T01:20:14.0957106Z E         {'dspy': [<function autolog.<locals>.setup_autologging at 0x7efb45db2c10>]}
2025-03-04T01:20:14.0957212Z E         
2025-03-04T01:20:14.0957321Z E         Full diff:
2025-03-04T01:20:14.0957480Z E         - {}
2025-03-04T01:20:14.0957622Z E         + {
2025-03-04T01:20:14.0957788Z E         +     'dspy': [
2025-03-04T01:20:14.0958146Z E         +         <function autolog.<locals>.setup_autologging at 0x7efb45db2c10>,
2025-03-04T01:20:14.0958296Z E         +     ],
2025-03-04T01:20:14.0958441Z E         + }%  
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
