### PR TITLE
Fix `_get_installed_version` to return correct mlflow version

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -267,11 +267,14 @@ def _run_command(cmd, timeout_seconds, env=None):
             timer.cancel()
 
 
-def _get_installed_version(package, module=None):
+def _get_installed_version(package: str, module: Optional[str] = None) -> str:
     """
     Obtains the installed package version using `importlib_metadata.version`. If it fails, use
     `__import__(module or package).__version__`.
     """
+    if package == "mlflow":
+        return mlflow.__version__
+
     try:
         version = importlib_metadata.version(package)
     except importlib_metadata.PackageNotFoundError:
@@ -672,7 +675,11 @@ def _check_requirement_satisfied(requirement_str):
                 requirement=requirement_str,
             )
 
-    if pkg_name == "mlflow" and Version(installed_version).is_devrelease:
+    if (
+        pkg_name == "mlflow"
+        and installed_version == mlflow.__version__
+        and Version(installed_version).is_devrelease
+    ):
         return None
 
     if len(req.specifier) > 0 and not req.specifier.contains(installed_version):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -677,11 +677,7 @@ def _check_requirement_satisfied(requirement_str):
                 requirement=requirement_str,
             )
 
-    if (
-        pkg_name == "mlflow"
-        and installed_version == mlflow.__version__
-        and Version(installed_version).is_devrelease
-    ):
+    if pkg_name == "mlflow" and Version(installed_version).is_devrelease:
         return None
 
     if len(req.specifier) > 0 and not req.specifier.contains(installed_version):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -672,11 +672,7 @@ def _check_requirement_satisfied(requirement_str):
                 requirement=requirement_str,
             )
 
-    if (
-        pkg_name == "mlflow"
-        and installed_version == mlflow.__version__
-        and Version(installed_version).is_devrelease
-    ):
+    if pkg_name == "mlflow" and Version(installed_version).is_devrelease:
         return None
 
     if len(req.specifier) > 0 and not req.specifier.contains(installed_version):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -273,6 +273,8 @@ def _get_installed_version(package: str, module: Optional[str] = None) -> str:
     `__import__(module or package).__version__`.
     """
     if package == "mlflow":
+        # `importlib_metadata.version` returns a wrong version for MLflow when it's installed
+        # in editable mode (e.g. `pip install -e .`).
         return mlflow.__version__
 
     try:

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -273,8 +273,8 @@ def _get_installed_version(package: str, module: Optional[str] = None) -> str:
     `__import__(module or package).__version__`.
     """
     if package == "mlflow":
-        # `importlib_metadata.version` returns a wrong version for MLflow when it's installed
-        # in editable mode (e.g. `pip install -e .`).
+        # `importlib.metadata.version` may return an incorrect version of MLflow when it's
+        # installed in editable mode (e.g. `pip install -e .`).
         return mlflow.__version__
 
     try:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14822?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14822/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14822
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`_get_installed_version` may return an incorrect version of mlflow when it's installed in editable mode. This PR fixes it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
