### PR TITLE
Improve `_enforce_array` efficiency

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1376,7 +1376,9 @@ def _enforce_array(data: Any, arr: Array, required: bool = True):
         # TODO: this is still significantly slower than direct np.asarray dtype conversion
         # pd.Series conversion can be removed once we support direct validation on the numpy array
         data_enforced = (
-            _enforce_mlflow_datatype("", pd.Series(data), arr.dtype).to_numpy()
+            _enforce_mlflow_datatype("", pd.Series(data), arr.dtype).to_numpy(
+                dtype=arr.dtype.to_numpy()
+            )
             if len(data) > 0
             else data
         )

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1372,10 +1372,16 @@ def _enforce_array(data: Any, arr: Array, required: bool = True):
     if not isinstance(data, (list, np.ndarray)):
         raise MlflowException(f"Expected data to be list or numpy array, got {type(data).__name__}")
 
-    data_enforced = [_enforce_type(x, arr.dtype, required=required) for x in data]
+    if isinstance(arr.dtype, DataType):
+        # TODO: this is still significantly slower than direct np.asarray dtype conversion
+        # pd.Series conversion can be removed once we support direct validation on the numpy array
+        data_enforced = _enforce_mlflow_datatype("", pd.Series(data), arr.dtype).to_numpy()
+    else:
+        data_enforced = [_enforce_type(x, arr.dtype, required=required) for x in data]
 
-    # Keep input data type
-    if isinstance(data, np.ndarray):
+    if isinstance(data, list) and isinstance(data_enforced, np.ndarray):
+        data_enforced = data_enforced.tolist()
+    elif isinstance(data, np.ndarray) and isinstance(data_enforced, list):
         data_enforced = np.array(data_enforced)
 
     return data_enforced

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1375,7 +1375,11 @@ def _enforce_array(data: Any, arr: Array, required: bool = True):
     if isinstance(arr.dtype, DataType):
         # TODO: this is still significantly slower than direct np.asarray dtype conversion
         # pd.Series conversion can be removed once we support direct validation on the numpy array
-        data_enforced = _enforce_mlflow_datatype("", pd.Series(data), arr.dtype).to_numpy()
+        data_enforced = (
+            _enforce_mlflow_datatype("", pd.Series(data), arr.dtype).to_numpy()
+            if len(data) > 0
+            else data
+        )
     else:
         data_enforced = [_enforce_type(x, arr.dtype, required=required) for x in data]
 

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -396,15 +396,11 @@ def test_enforce_array_with_errors():
     with pytest.raises(MlflowException, match=r"Expected data to be list or numpy array, got str"):
         _enforce_array("abc", Array(DataType.string))
 
-    with pytest.raises(
-        MlflowException, match=r"Failed to enforce schema of data `123` with dtype `string`"
-    ):
+    with pytest.raises(MlflowException, match=r"Incompatible input types"):
         _enforce_array([123, 456, 789], Array(DataType.string))
 
     # Nested array with mixed type elements
-    with pytest.raises(
-        MlflowException, match=r"Failed to enforce schema of data `1` with dtype `string`"
-    ):
+    with pytest.raises(MlflowException, match=r"Incompatible input types"):
         _enforce_array([["a", "b"], [1, 2]], Array(Array(DataType.string)))
 
     # Nested array with different nest level

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -270,7 +270,7 @@ def test_enforce_property():
     assert _enforce_property(data, prop) == data
 
     prop = Property("a", Array(DataType.binary))
-    assert _enforce_property(data, prop) == data
+    assert _enforce_property(data, prop) == [b"some_sentence1", b"some_sentence2"]
 
     data = np.array([np.int32(1), np.int32(2)])
     prop = Property("a", Array(DataType.integer))


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
The current implementation of _enforce_array is super slow on nested arrays, this PR improve the speed of Array(Array(double)) type data from 7seconds to 0.1 second.
The implementation can be further improved by using numpy data conversion without pandas Series, but it can be a follow-up.
Benchmark code:
```
from mlflow.types.schema import *
from mlflow.models.utils import _enforce_schema
import pandas as pd
import numpy as np
import datetime

schema = Schema([ColSpec(Array(Array("double")), "embeddings")])
pdf = pd.DataFrame({"embeddings": [np.random.random_sample((50, 50))] * 180})

timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
print(timestamp)
_enforce_schema(pdf, schema)
timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
print(timestamp)
```

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
