### PR TITLE
Support alias for prompt

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -147,11 +147,13 @@ from mlflow.tracing.fluent import (
 )
 from mlflow.tracking._model_registry.fluent import (
     delete_prompt,
+    delete_prompt_alias,
     load_prompt,
     register_model,
     register_prompt,
     search_model_versions,
     search_registered_models,
+    set_prompt_alias,
 )
 from mlflow.tracking.fluent import (
     ActiveRun,
@@ -280,6 +282,8 @@ __all__ = [
     "delete_prompt",
     "load_prompt",
     "register_prompt",
+    "set_prompt_alias",
+    "delete_prompt_alias",
 ]
 
 

--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -55,6 +55,7 @@ class Prompt(ModelVersion):
         description: Optional[str] = None,
         creation_timestamp: Optional[int] = None,
         tags: Optional[dict[str, str]] = None,
+        aliases: Optional[list[str]] = None,
     ):
         # Store template text as a tag
         tags = tags or {}
@@ -67,6 +68,7 @@ class Prompt(ModelVersion):
             creation_timestamp=creation_timestamp,
             description=description,
             tags=[ModelVersionTag(key=key, value=value) for key, value in tags.items()],
+            aliases=aliases,
         )
 
         self._variables = set(_PROMPT_TEMPLATE_VARIABLE_PATTERN.findall(self.template))
@@ -164,4 +166,5 @@ class Prompt(ModelVersion):
             description=model_version.description,
             creation_timestamp=model_version.creation_timestamp,
             tags=model_version.tags,
+            aliases=model_version.aliases,
         )

--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -156,8 +156,15 @@ class Prompt(ModelVersion):
         """
         Create a Prompt object from a ModelVersion object.
         """
+        if IS_PROMPT_TAG_KEY not in model_version.tags:
+            raise MlflowException.invalid_parameter_value(
+                f"Name `{model_version.name}` is registered as a model, not a prompt",
+            )
+
         if PROMPT_TEXT_TAG_KEY not in model_version.tags:
-            raise ValueError("ModelVersion object does not contain prompt text.")
+            raise MlflowException.invalid_parameter_value(
+                f"Prompt `{model_version.name}` does not contain a prompt text"
+            )
 
         return cls(
             name=model_version.name,

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -6,6 +6,8 @@ from typing import Optional
 import mlflow
 from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.store.artifact.utils.models import get_model_name_and_version
 
 
 def add_prompt_filter_string(
@@ -28,10 +30,12 @@ def add_prompt_filter_string(
     return filter_string
 
 
-def parse_prompt_uri(uri: str) -> tuple[str, str]:
+def parse_prompt_uri(mlflow_client, uri: str) -> tuple[str, str]:
     """
     Parse prompt URI into prompt name and prompt version.
-    'prompt:/<name>/<version>' -> ('<name>', '<version>')
+    - 'prompt:/<name>/<version>' -> ('<name>', '<version>')
+    - 'prompt:/<name>' -> ('<name>', '<latest version>')
+    - 'prompt:/<name>@<alias>' -> ('<name>', '<version>')
     """
     parsed = urllib.parse.urlparse(uri)
 
@@ -40,13 +44,11 @@ def parse_prompt_uri(uri: str) -> tuple[str, str]:
             f"Invalid prompt URI: {uri}. Expected schema 'prompts:/<name>/<version>'"
         )
 
-    path = parsed.path
-    if path.count("/") != 2:
-        raise MlflowException.invalid_parameter_value(
-            f"Invalid prompt URI: {uri}. Expected schema 'prompts:/<name>/<version>'"
-        )
-
-    return path.split("/")[1:]
+    # Replace schema to 'models:/' to reuse the model URI parsing logic
+    try:
+        return get_model_name_and_version(mlflow_client, f"models:{parsed.path}")
+    except MlflowException:
+        raise MlflowException(f"Prompt '{uri}' does not exist.", RESOURCE_DOES_NOT_EXIST)
 
 
 def has_prompt_tag(tags: Optional[dict]) -> bool:

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -1,13 +1,10 @@
 import functools
-import urllib.parse
 from textwrap import dedent
 from typing import Optional
 
 import mlflow
 from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
-from mlflow.store.artifact.utils.models import get_model_name_and_version
 
 
 def add_prompt_filter_string(
@@ -28,27 +25,6 @@ def add_prompt_filter_string(
         else:
             filter_string = prompt_filter_query
     return filter_string
-
-
-def parse_prompt_uri(mlflow_client, uri: str) -> tuple[str, str]:
-    """
-    Parse prompt URI into prompt name and prompt version.
-    - 'prompt:/<name>/<version>' -> ('<name>', '<version>')
-    - 'prompt:/<name>' -> ('<name>', '<latest version>')
-    - 'prompt:/<name>@<alias>' -> ('<name>', '<version>')
-    """
-    parsed = urllib.parse.urlparse(uri)
-
-    if parsed.scheme != "prompts":
-        raise MlflowException.invalid_parameter_value(
-            f"Invalid prompt URI: {uri}. Expected schema 'prompts:/<name>/<version>'"
-        )
-
-    # Replace schema to 'models:/' to reuse the model URI parsing logic
-    try:
-        return get_model_name_and_version(mlflow_client, f"models:{parsed.path}")
-    except MlflowException:
-        raise MlflowException(f"Prompt '{uri}' does not exist.", RESOURCE_DOES_NOT_EXIST)
 
 
 def has_prompt_tag(tags: Optional[dict]) -> bool:

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -345,6 +345,18 @@ def register_prompt(
     If there is no registered prompt with the given name, a new prompt will be created.
     Otherwise, a new version of the existing prompt will be created.
 
+
+    Args:
+        name: The name of the prompt.
+        template: The template text of the prompt. It can contain variables enclosed in
+            single curly braces, e.g. {variable}, which will be replaced with actual values
+            by the `format` method.
+        description: The description of the prompt. Optional.
+        tags: A dictionary of tags associated with the prompt. Optional.
+
+    Returns:
+        A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
+
     Example:
 
     .. code-block:: python
@@ -377,17 +389,6 @@ def register_prompt(
             name="my_prompt",
             template="Respond to the user's message as a {style} AI. {greeting}",
         )
-
-    Args:
-        name: The name of the prompt.
-        template: The template text of the prompt. It can contain variables enclosed in
-            single curly braces, e.g. {variable}, which will be replaced with actual values
-            by the `format` method.
-        description: The description of the prompt. Optional.
-        tags: A dictionary of tags associated with the prompt. Optional.
-
-    Returns:
-        A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
     """
     return MlflowClient().register_prompt(
         name=name, template=template, description=description, tags=tags
@@ -401,6 +402,10 @@ def load_prompt(name_or_uri: str, version: Optional[int] = None) -> Prompt:
     Load a :py:class:`Prompt <mlflow.entities.Prompt>` from the MLflow Prompt Registry.
 
     The prompt can be specified by name and version, or by URI.
+
+    Args:
+        name_or_uri: The name of the prompt, or the URI in the format "prompts:/name/version".
+        version: The version of the prompt. If not specified, the latest version will be loaded.
 
     Example:
 
@@ -417,9 +422,9 @@ def load_prompt(name_or_uri: str, version: Optional[int] = None) -> Prompt:
         # Load a specific version of the prompt by URI
         prompt = mlflow.load_prompt(uri="prompts:/my_prompt/1")
 
-    Args:
-        name_or_uri: The name of the prompt, or the URI in the format "prompts:/name/version".
-        version: The version of the prompt. If not specified, the latest version will be loaded.
+        # Load a prompt version with an alias "production"
+        prompt = mlflow.load_prompt("prompts:/my_prompt@production")
+
     """
     return MlflowClient().load_prompt(name_or_uri=name_or_uri, version=version)
 
@@ -435,3 +440,49 @@ def delete_prompt(name: str, version: int) -> Prompt:
         version: The version of the prompt to delete.
     """
     return MlflowClient().delete_prompt(name=name, version=version)
+
+
+@experimental
+@require_prompt_registry
+def set_prompt_alias(name: str, alias: str, version: int) -> Prompt:
+    """
+    Set an alias for a :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
+
+    Args:
+        name: The name of the prompt.
+        alias: The alias to set for the prompt.
+        version: The version of the prompt.
+
+    Example:
+
+    .. code-block:: python
+
+        import mlflow
+
+        # Set an alias for the prompt
+        mlflow.set_prompt_alias(name="my_prompt", version=1, alias="production")
+
+        # Load the prompt by alias (use "@" to specify the alias)
+        prompt = mlflow.load_prompt("prompts:/my_prompt@production")
+
+        # Switch the alias to a new version of the prompt
+        mlflow.set_prompt_alias(name="my_prompt", version=2, alias="production")
+
+        # Delete the alias
+        mlflow.delete_prompt_alias(name="my_prompt", alias="production")
+    """
+
+    return MlflowClient().set_prompt_alias(name=name, version=version, alias=alias)
+
+
+@experimental
+@require_prompt_registry
+def delete_prompt_alias(name: str, alias: str) -> Prompt:
+    """
+    Delete an alias for a :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
+
+    Args:
+        name: The name of the prompt.
+        alias: The alias to delete for the prompt.
+    """
+    return MlflowClient().delete_prompt_alias(name=name, alias=alias)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -538,15 +538,19 @@ class MlflowClient:
             version: The version of the prompt. If not specified, the latest version will be loaded.
         """
         if name_or_uri.startswith("prompts:/"):
-            name, version = parse_prompt_uri(name_or_uri)
+            name, version = parse_prompt_uri(self, name_or_uri)
         else:
             name = name_or_uri
 
         registry_client = self._get_registry_client()
         if version is None:
-            version = registry_client.get_latest_versions(name, stages=ALL_STAGES)[0].version
+            try:
+                version = registry_client.get_latest_versions(name, stages=ALL_STAGES)[0].version
+            except MlflowException as e:
+                if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                    raise MlflowException(f"Prompt '{name}' not found", RESOURCE_DOES_NOT_EXIST)
 
-        mv = registry_client.get_model_version(name, version)
+        mv = self._validate_prompt(name, version)
         return Prompt.from_model_version(mv)
 
     @experimental
@@ -561,13 +565,7 @@ class MlflowClient:
         """
         registry_client = self._get_registry_client()
 
-        mv = registry_client.get_model_version(name, version)
-        if IS_PROMPT_TAG_KEY not in mv.tags:
-            raise MlflowException(
-                f"Model '{name}' with version {version} is not a prompt.",
-                INVALID_PARAMETER_VALUE,
-            )
-
+        self._validate_prompt(name, version)
         registry_client.delete_model_version(name, version)
 
         # If no more versions are left, delete the registered model
@@ -592,7 +590,7 @@ class MlflowClient:
         else:
             run_ids = [run_id]
 
-        name, version = parse_prompt_uri(prompt_uri)
+        name, version = parse_prompt_uri(self, prompt_uri)
         self.set_model_version_tag(
             name, version, PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY, ",".join(run_ids)
         )
@@ -620,7 +618,7 @@ class MlflowClient:
 
         run_ids.remove(run_id)
 
-        name, version = parse_prompt_uri(prompt_uri)
+        name, version = parse_prompt_uri(self, prompt_uri)
         if run_ids:
             self.set_model_version_tag(
                 name, version, PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY, ",".join(run_ids)
@@ -650,6 +648,52 @@ class MlflowClient:
         # NB: We don't support pagination here because the number of prompts associated
         # with a Run is expected to be small.
         return [Prompt.from_model_version(mv) for mv in mvs]
+
+    @experimental
+    @require_prompt_registry
+    def set_prompt_alias(self, name: str, alias: str, version: int) -> None:
+        """
+        Set an alias for a :py:class:`Prompt <mlflow.entities.Prompt>`.
+
+        Args:
+            name: The name of the prompt.
+            alias: The alias to set for the prompt.
+            version: The version of the prompt.
+        """
+        self._validate_prompt(name, version)
+        self.set_registered_model_alias(name, alias, version)
+
+    @experimental
+    @require_prompt_registry
+    def delete_prompt_alias(self, name: str, alias: str) -> None:
+        """
+        Delete an alias for a :py:class:`Prompt <mlflow.entities.Prompt>`.
+
+        Args:
+            name: The name of the prompt.
+            alias: The alias to delete for the prompt.
+        """
+        self.delete_registered_model_alias(name, alias)
+
+    def _validate_prompt(self, name: str, version: int) -> ModelVersion:
+        registry_client = self._get_registry_client()
+
+        try:
+            mv = registry_client.get_model_version(name, version)
+        except MlflowException as e:
+            if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                raise MlflowException(
+                    f"Prompt '{name}' with version {version} not found", RESOURCE_DOES_NOT_EXIST
+                )
+
+        if IS_PROMPT_TAG_KEY not in mv.tags:
+            raise MlflowException(
+                f"Name `{name}` is used for a model, not a prompt. MLflow does not allow "
+                "registering a prompt with the same name as an existing model.",
+                INVALID_PARAMETER_VALUE,
+            )
+
+        return mv
 
     ##### Tracing #####
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -538,6 +538,11 @@ class MlflowClient:
             version: The version of the prompt. If not specified, the latest version will be loaded.
         """
         if name_or_uri.startswith("prompts:/"):
+            if version is not None:
+                raise MlflowException(
+                    "The `version` argument should not be specified when loading a prompt by URI.",
+                    INVALID_PARAMETER_VALUE,
+                )
             name, version = self.parse_prompt_uri(name_or_uri)
         else:
             name = name_or_uri

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1676,7 +1676,7 @@ def test_crud_prompts(tracking_uri):
 
     client.delete_prompt("prompt_1", version=2)
 
-    with pytest.raises(MlflowException, match=r"Model Version (.*) not found"):
+    with pytest.raises(MlflowException, match=r"Prompt (.*) with version 2 not found"):
         client.load_prompt("prompt_1", version=2)
 
     client.delete_prompt("prompt_1", version=1)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14834?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14834/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14834
```

</p>
</details>

### What changes are proposed in this pull request?

Alias is available for prompts off-the-shelf but I forgot to add Python APIs for it. Alias is proven to be useful feature for model registry and most likely for prompt as well.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
