### PR TITLE
Support mysql ssl connections with client certs

### DIFF
--- a/docs/docs/tracking/backend-stores/index.mdx
+++ b/docs/docs/tracking/backend-stores/index.mdx
@@ -95,6 +95,29 @@ You can inject some [SQLAlchemy connection pooling options](https://docs.sqlalch
   </tbody>
 </table>
 
+## MySQL SSL Options
+
+When connecting to a MySQL database that requires SSL certificates, you can set the following environment variables:
+
+```bash
+# Path to SSL CA certificate file
+export MLFLOW_MYSQL_SSL_CA=/path/to/ca.pem
+
+# Path to SSL client certificate file (if needed)
+export MLFLOW_MYSQL_SSL_CERT=/path/to/client-cert.pem
+
+# Path to SSL client key file (if needed)
+export MLFLOW_MYSQL_SSL_KEY=/path/to/client-key.pem
+```
+
+Then start the MLflow server with your MySQL URI:
+
+```bash
+mlflow server --backend-store-uri="mysql+pymysql://username@hostname:port/database" --default-artifact-root=s3://your-bucket --host=0.0.0.0 --port=5000
+```
+
+These environment variables will be used to configure the SSL connection to the MySQL server.
+
 ## File Store Performance
 
 MLflow will automatically try to use [LibYAML](https://pyyaml.org/wiki/LibYAML) bindings if they are already installed.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -722,3 +722,18 @@ MLFLOW_FLASK_SERVER_SECRET_KEY = _EnvironmentVariable("MLFLOW_FLASK_SERVER_SECRE
 MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH = _EnvironmentVariable(
     "MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH", int, 2048
 )
+
+#: Path to SSL CA certificate file for MySQL connections
+#: Used when creating a SQLAlchemy engine for MySQL
+#: (default: ``None``)
+MLFLOW_MYSQL_SSL_CA = _EnvironmentVariable("MLFLOW_MYSQL_SSL_CA", str, None)
+
+#: Path to SSL certificate file for MySQL connections
+#: Used when creating a SQLAlchemy engine for MySQL
+#: (default: ``None``)
+MLFLOW_MYSQL_SSL_CERT = _EnvironmentVariable("MLFLOW_MYSQL_SSL_CERT", str, None)
+
+#: Path to SSL key file for MySQL connections
+#: Used when creating a SQLAlchemy engine for MySQL
+#: (default: ``None``)
+MLFLOW_MYSQL_SSL_KEY = _EnvironmentVariable("MLFLOW_MYSQL_SSL_KEY", str, None)

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -113,6 +113,7 @@ def test_mysql_ssl_params(monkeypatch):
     monkeypatch.setenv("MLFLOW_MYSQL_SSL_CA", "/path/to/ca.pem")
     monkeypatch.setenv("MLFLOW_MYSQL_SSL_CERT", "/path/to/cert.pem")
     monkeypatch.setenv("MLFLOW_MYSQL_SSL_KEY", "/path/to/key.pem")
+    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS", "NullPool")
 
     with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
         utils.create_sqlalchemy_engine("mysql+pymysql://user@host:port/db")
@@ -126,6 +127,7 @@ def test_mysql_ssl_params(monkeypatch):
                 "ssl_cert": "/path/to/cert.pem",
                 "ssl_key": "/path/to/key.pem",
             },
+            poolclass=NullPool,
         )
 
 
@@ -134,6 +136,7 @@ def test_mysql_ssl_params_partial(monkeypatch):
     monkeypatch.setenv("MLFLOW_MYSQL_SSL_CA", "/path/to/ca.pem")
     monkeypatch.delenv("MLFLOW_MYSQL_SSL_CERT", raising=False)
     monkeypatch.delenv("MLFLOW_MYSQL_SSL_KEY", raising=False)
+    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS", "NullPool")
 
     with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
         utils.create_sqlalchemy_engine("mysql+pymysql://user@host:port/db")
@@ -145,6 +148,7 @@ def test_mysql_ssl_params_partial(monkeypatch):
             connect_args={
                 "ssl_ca": "/path/to/ca.pem",
             },
+            poolclass=NullPool,
         )
 
 
@@ -153,6 +157,7 @@ def test_non_mysql_no_ssl_params(monkeypatch):
     monkeypatch.setenv("MLFLOW_MYSQL_SSL_CA", "/path/to/ca.pem")
     monkeypatch.setenv("MLFLOW_MYSQL_SSL_CERT", "/path/to/cert.pem")
     monkeypatch.setenv("MLFLOW_MYSQL_SSL_KEY", "/path/to/key.pem")
+    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS", "NullPool")
 
     with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
         utils.create_sqlalchemy_engine("postgresql://user@host:port/db")
@@ -161,4 +166,5 @@ def test_non_mysql_no_ssl_params(monkeypatch):
         mock_create_engine.assert_called_once_with(
             "postgresql://user@host:port/db",
             pool_pre_ping=True,
+            poolclass=NullPool,
         )

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -91,7 +91,10 @@ def test_create_sqlalchemy_engine_with_retry_success_after_third_call():
 
 def test_create_sqlalchemy_engine_with_retry_fail():
     with (
-        mock.patch("sqlalchemy.inspect", side_effect=[Exception("failed")] * utils.MAX_RETRY_COUNT),
+        mock.patch(
+            "sqlalchemy.inspect",
+            side_effect=[Exception("failed")] * utils.MAX_RETRY_COUNT,
+        ),
         mock.patch(
             "mlflow.store.db.utils.create_sqlalchemy_engine", return_value="Engine"
         ) as mock_create_sqlalchemy_engine,
@@ -102,4 +105,60 @@ def test_create_sqlalchemy_engine_with_retry_fail():
         assert (
             mock_create_sqlalchemy_engine.mock_calls
             == [mock.call("mydb://host:port/")] * utils.MAX_RETRY_COUNT
+        )
+
+
+def test_mysql_ssl_params(monkeypatch):
+    """Test that MySQL SSL certificate params are correctly passed to create_engine."""
+    monkeypatch.setenv("MLFLOW_MYSQL_SSL_CA", "/path/to/ca.pem")
+    monkeypatch.setenv("MLFLOW_MYSQL_SSL_CERT", "/path/to/cert.pem")
+    monkeypatch.setenv("MLFLOW_MYSQL_SSL_KEY", "/path/to/key.pem")
+
+    with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
+        utils.create_sqlalchemy_engine("mysql+pymysql://user@host:port/db")
+
+        # Check that create_engine was called with the right arguments
+        mock_create_engine.assert_called_once_with(
+            "mysql+pymysql://user@host:port/db",
+            pool_pre_ping=True,
+            connect_args={
+                "ssl_ca": "/path/to/ca.pem",
+                "ssl_cert": "/path/to/cert.pem",
+                "ssl_key": "/path/to/key.pem",
+            },
+        )
+
+
+def test_mysql_ssl_params_partial(monkeypatch):
+    """Test that MySQL SSL certificate params work with only CA certificate."""
+    monkeypatch.setenv("MLFLOW_MYSQL_SSL_CA", "/path/to/ca.pem")
+    monkeypatch.delenv("MLFLOW_MYSQL_SSL_CERT", raising=False)
+    monkeypatch.delenv("MLFLOW_MYSQL_SSL_KEY", raising=False)
+
+    with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
+        utils.create_sqlalchemy_engine("mysql+pymysql://user@host:port/db")
+
+        # Check that create_engine was called with the right arguments
+        mock_create_engine.assert_called_once_with(
+            "mysql+pymysql://user@host:port/db",
+            pool_pre_ping=True,
+            connect_args={
+                "ssl_ca": "/path/to/ca.pem",
+            },
+        )
+
+
+def test_non_mysql_no_ssl_params(monkeypatch):
+    """Test that non-MySQL connections don't get SSL params."""
+    monkeypatch.setenv("MLFLOW_MYSQL_SSL_CA", "/path/to/ca.pem")
+    monkeypatch.setenv("MLFLOW_MYSQL_SSL_CERT", "/path/to/cert.pem")
+    monkeypatch.setenv("MLFLOW_MYSQL_SSL_KEY", "/path/to/key.pem")
+
+    with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
+        utils.create_sqlalchemy_engine("postgresql://user@host:port/db")
+
+        # Check that create_engine was called without connect_args
+        mock_create_engine.assert_called_once_with(
+            "postgresql://user@host:port/db",
+            pool_pre_ping=True,
         )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aksylumoed/mlflow/pull/14839?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14839/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 14839
```

</p>
</details>

Signed-off-by: aksylumoed <adityadndkr@gmail.com>

### Related Issues/PRs
https://github.com/mlflow/mlflow/issues/14812

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Added three env vars that can be used to create an sqlalchemy engine via the `connect_args` param:
- MLFLOW_MYSQL_SSL_CA
- MLFLOW_MYSQL_SSL_CERT 
- MLFLOW_MYSQL_SSL_KEY

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [X] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
