### PR TITLE
Fix test_mlflow_callback_exception with dspy dev

### DIFF
--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import dspy
 import pytest
+from dspy.adapters import JSONAdapter
 from dspy.evaluate import Evaluate
 from dspy.evaluate.metrics import answer_exact_match
 from dspy.predict import Predict
@@ -134,6 +135,9 @@ def test_mlflow_callback_exception():
             model="invalid",
             prompt={"How are you?": {"answer": "test output", "reasoning": "No more responses"}},
         ),
+        # ChatAdapter falls back to JSONAdapter when LLM call fails,
+        # so JSONAdapter is used here for simplicity
+        adapter=JSONAdapter(),
     )
 
     cot = dspy.ChainOfThought("question -> answer", n=3)
@@ -154,7 +158,7 @@ def test_mlflow_callback_exception():
     assert spans[0].status.status_code == "ERROR"
     assert spans[1].name == "Predict.forward"
     assert spans[1].status.status_code == "ERROR"
-    assert spans[2].name == "ChatAdapter.format"
+    assert spans[2].name == "JSONAdapter.format"
     assert spans[2].status.status_code == "OK"
     assert spans[3].name == "ErrorLM.__call__"
     assert spans[3].status.status_code == "ERROR"

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -130,7 +130,9 @@ def test_mlflow_callback_exception():
             time.sleep(0.1)
             raise ValueError("Error")
 
-    dspy.settings.configure(
+    cot = dspy.ChainOfThought("question -> answer", n=3)
+
+    with dspy.context(
         lm=ErrorLM(
             model="invalid",
             prompt={"How are you?": {"answer": "test output", "reasoning": "No more responses"}},
@@ -138,12 +140,9 @@ def test_mlflow_callback_exception():
         # ChatAdapter falls back to JSONAdapter when LLM call fails,
         # so JSONAdapter is used here for simplicity
         adapter=JSONAdapter(),
-    )
-
-    cot = dspy.ChainOfThought("question -> answer", n=3)
-
-    with pytest.raises(ValueError, match="Error"):
-        cot(question="How are you?")
+    ):
+        with pytest.raises(ValueError, match="Error"):
+            cot(question="How are you?")
 
     trace = mlflow.get_last_active_trace()
     assert trace is not None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14850?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14850/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14850/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

This is a fix for DSPy cross version test failure: https://github.com/mlflow-automation/mlflow/actions/runs/13654724171/job/38189580214
Since DSPy ChatAdapter falls back to JSONAdapter (introduced in https://github.com/stanfordnlp/dspy/commit/9f8c26da438e13e71e593cf8eda1231ae4a0d8bb#diff-2c01fd377fe46439e29ea9028bae3151f11eb926014ad8017bc7d031776216ed and the behavior changed a bit recently) for most exceptions, this PR changed the test to let the LM raise ContextWindowExceededError that ChatAdapter does not retry on.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
