### PR TITLE
Remove pyspark if databricks-connect exists in pip requirements

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -667,16 +667,17 @@ def _deduplicate_requirements(requirements):
     return [str(req) for req in deduped_reqs.values()]
 
 
-def _remove_incompatible_requirements(requirements: list[str]):
-    def fetch_requirement_name(req: str) -> str:
-        try:
-            return Requirement(req).name
-        except Exception:
-            return req
+def _fetch_requirement_name(req: str) -> str:
+    try:
+        return Requirement(req).name
+    except InvalidRequirement:
+        return req
 
-    req_name = {fetch_requirement_name(req) for req in requirements}
-    if "databricks-connect" in req_name and any(
-        x in req_name for x in ["pyspark", "pyspark-connect"]
+
+def _remove_incompatible_requirements(requirements: list[str]) -> list[str]:
+    req_names = {_fetch_requirement_name(req) for req in requirements}
+    if "databricks-connect" in req_names and any(
+        x in req_names for x in ["pyspark", "pyspark-connect"]
     ):
         _logger.debug(
             "Found incompatible requirements: 'databricks-connect' with 'pyspark' or "

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -667,7 +667,7 @@ def _deduplicate_requirements(requirements):
     return [str(req) for req in deduped_reqs.values()]
 
 
-def _fetch_requirement_name(req: str) -> str:
+def _parse_requirement_name(req: str) -> str:
     try:
         return Requirement(req).name
     except InvalidRequirement:
@@ -675,10 +675,8 @@ def _fetch_requirement_name(req: str) -> str:
 
 
 def _remove_incompatible_requirements(requirements: list[str]) -> list[str]:
-    req_names = {_fetch_requirement_name(req) for req in requirements}
-    if "databricks-connect" in req_names and any(
-        x in req_names for x in ["pyspark", "pyspark-connect"]
-    ):
+    req_names = {_parse_requirement_name(req) for req in requirements}
+    if "databricks-connect" in req_names and req_names.intersection({"pyspark", "pyspark-connect"}):
         _logger.debug(
             "Found incompatible requirements: 'databricks-connect' with 'pyspark' or "
             "'pyspark-connect'. Removing 'pyspark' or 'pyspark-connect' from the requirements."
@@ -686,7 +684,7 @@ def _remove_incompatible_requirements(requirements: list[str]) -> list[str]:
         requirements = [
             req
             for req in requirements
-            if Requirement(req).name not in ["pyspark", "pyspark-connect"]
+            if _parse_requirement_name(req) not in ["pyspark", "pyspark-connect"]
         ]
     return requirements
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -668,7 +668,13 @@ def _deduplicate_requirements(requirements):
 
 
 def _remove_incompatible_requirements(requirements: list[str]):
-    req_name = {Requirement(req).name for req in requirements}
+    def fetch_requirement_name(req: str) -> str:
+        try:
+            return Requirement(req).name
+        except Exception:
+            return req
+
+    req_name = {fetch_requirement_name(req) for req in requirements}
     if "databricks-connect" in req_name and any(
         x in req_name for x in ["pyspark", "pyspark-connect"]
     ):

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -567,6 +567,7 @@ def _process_pip_requirements(
         pip_reqs.insert(0, _generate_mlflow_version_pinning())
 
     sanitized_pip_reqs = _deduplicate_requirements(pip_reqs)
+    sanitized_pip_reqs = _remove_incompatible_requirements(sanitized_pip_reqs)
 
     # Check if pip requirements contain incompatible version with the current environment
     warn_dependency_requirement_mismatches(sanitized_pip_reqs)
@@ -664,6 +665,23 @@ def _deduplicate_requirements(requirements):
             if req not in deduped_reqs:
                 deduped_reqs[req] = req
     return [str(req) for req in deduped_reqs.values()]
+
+
+def _remove_incompatible_requirements(requirements: list[str]):
+    req_name = {Requirement(req).name for req in requirements}
+    if "databricks-connect" in req_name and any(
+        x in req_name for x in ["pyspark", "pyspark-connect"]
+    ):
+        _logger.debug(
+            "Found incompatible requirements: 'databricks-connect' with 'pyspark' or "
+            "'pyspark-connect'. Removing 'pyspark' or 'pyspark-connect' from the requirements."
+        )
+        requirements = [
+            req
+            for req in requirements
+            if Requirement(req).name not in ["pyspark", "pyspark-connect"]
+        ]
+    return requirements
 
 
 def _validate_version_constraints(requirements):

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -18,6 +18,7 @@ from mlflow.utils.environment import (
     _parse_pip_requirements,
     _process_conda_env,
     _process_pip_requirements,
+    _remove_incompatible_requirements,
     _validate_env_arguments,
     infer_pip_requirements,
 )
@@ -435,3 +436,20 @@ def test_invalid_requirements_raise(input_requirements):
         MlflowException, match="The specified requirements versions are incompatible"
     ):
         _deduplicate_requirements(input_requirements)
+
+
+@pytest.mark.parametrize(
+    ("input_requirements", "expected"),
+    [
+        (["databricks-connect", "pyspark", "pyspark-connect"], ["databricks-connect"]),
+        (["databricks-connect==1.15.0", "pyspark==3.0.0"], ["databricks-connect==1.15.0"]),
+        (["databricks-connect==1.15.0", "pyspark-connect"], ["databricks-connect==1.15.0"]),
+        (["pyspark==3.0.0", "pyspark-connect"], ["pyspark==3.0.0", "pyspark-connect"]),
+        (
+            ["pyspark==3.0.0", "pyspark-connect==1.0.0"],
+            ["pyspark==3.0.0", "pyspark-connect==1.0.0"],
+        ),
+    ],
+)
+def test_remove_incompatible_requirements(input_requirements, expected):
+    assert _remove_incompatible_requirements(input_requirements) == expected


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/14860?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14860/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14860/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
databricks-connect raises Exception if finding pyspark/pyspark-connect exist in the environment. This PR removes pyspark/pyspark-connect from the pip requirements if databricks-connect exists to avoid meeting such error until execution stage.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
