### PR TITLE
Import lazily-loaded modules in `TYPE_CHECKING` block for code completion to work in IDEs

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -189,7 +189,7 @@ class Linter(ast.NodeVisitor):
         self.violations: list[Violation] = []
         self.in_type_annotation = False
         self.in_TYPE_CHECKING = False
-        self.is_mlflow_init_py = path == Path("mlflow/__init__.py")
+        self.is_mlflow_init_py = path == Path("mlflow", "__init__.py")
         self.imported_modules: set[str] = set()
         self.lazy_modules: set[str] = set()
 

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -188,6 +188,10 @@ class Linter(ast.NodeVisitor):
         self.cell = cell
         self.violations: list[Violation] = []
         self.in_type_annotation = False
+        self.in_TYPE_CHECKING = False
+        self.is_mlflow_init_py = path == Path("mlflow/__init__.py")
+        self.imported_modules: set[str] = set()
+        self.lazy_modules: set[str] = set()
 
     def _check(self, loc: Location, rule: rules.Rule) -> None:
         if (lines := self.ignore.get(rule.name)) and loc.lineno in lines:
@@ -390,6 +394,10 @@ class Linter(ast.NodeVisitor):
         if self._is_in_function() and root_module in BUILTIN_MODULES:
             self._check(Location.from_node(node), rules.LazyBuiltinImport())
 
+        if self.in_TYPE_CHECKING and self.is_mlflow_init_py:
+            for alias in node.names:
+                self.imported_modules.add(f"{node.module}.{alias.name}")
+
         if root_module == "typing_extensions":
             for alias in node.names:
                 full_name = f"{node.module}.{alias.name}"
@@ -418,6 +426,19 @@ class Linter(ast.NodeVisitor):
                 )
 
     def visit_Call(self, node: ast.Call) -> None:
+        if (
+            self.is_mlflow_init_py
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "LazyLoader"
+        ):
+            last_arg = node.args[-1]
+            if (
+                isinstance(last_arg, ast.Constant)
+                and isinstance(last_arg.value, str)
+                and last_arg.value.startswith("mlflow.")
+            ):
+                self.lazy_modules.add(last_arg.value)
+
         if (
             self.path.parts[0] in ["tests", "mlflow"]
             and _is_log_model(node.func)
@@ -475,6 +496,16 @@ class Linter(ast.NodeVisitor):
         self.visit(node)
         self.in_type_annotation = False
 
+    def visit_If(self, node: ast.If) -> None:
+        if isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING":
+            self.in_TYPE_CHECKING = True
+        self.generic_visit(node)
+        self.in_TYPE_CHECKING = False
+
+    def post_visit(self) -> None:
+        if self.is_mlflow_init_py and (diff := self.lazy_modules - self.imported_modules):
+            self.violations.append(Violation(rules.LazyModule(diff), self.path, 0, 0))
+
 
 def _lint_cell(path: Path, config: Config, cell: dict[str, Any], index: int) -> list[Violation]:
     type_ = cell.get("cell_type")
@@ -508,4 +539,5 @@ def lint_file(path: Path, config: Config) -> list[Violation]:
     else:
         linter = Linter(path=path, config=config, ignore=ignore_map(code))
         linter.visit(ast.parse(code))
+        linter.post_visit()
         return linter.violations

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -504,7 +504,7 @@ class Linter(ast.NodeVisitor):
 
     def post_visit(self) -> None:
         if self.is_mlflow_init_py and (diff := self.lazy_modules - self.imported_modules):
-            self.violations.append(Violation(rules.LazyModule(diff), self.path, 0, 0))
+            self._check(Location(1, 1), rules.LazyModule(diff))
 
 
 def _lint_cell(path: Path, config: Config, cell: dict[str, Any], index: int) -> list[Violation]:

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -341,6 +341,6 @@ class LazyModule(Rule):
 
     def _message(self) -> str:
         return (
-            "Module loaded by `LazyLoader` must be imported in `TYPE_CHECKING:` block: "
+            "Module loaded by `LazyLoader` must be imported in `TYPE_CHECKING` block: "
             f"{self.modules}"
         )

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -333,14 +333,8 @@ class MarkdownLink(Rule):
 
 
 class LazyModule(Rule):
-    def __init__(self, modules: set[str]) -> None:
-        self.modules = modules
-
     def _id(self) -> str:
         return "MLF0019"
 
     def _message(self) -> str:
-        return (
-            "Module loaded by `LazyLoader` must be imported in `TYPE_CHECKING` block: "
-            f"{self.modules}"
-        )
+        return "Module loaded by `LazyLoader` must be imported in `TYPE_CHECKING` block."

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -330,3 +330,17 @@ class MarkdownLink(Rule):
             "Markdown link is not supported in docstring. "
             "Use reST link instead (e.g., `Link text <link URL>`_)."
         )
+
+
+class LazyModule(Rule):
+    def __init__(self, modules: set[str]) -> None:
+        self.modules = modules
+
+    def _id(self) -> str:
+        return "MLF0019"
+
+    def _message(self) -> str:
+        return (
+            "Module loaded by `LazyLoader` must be imported in `TYPE_CHECKING:` block: "
+            f"{self.modules}"
+        )

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -28,6 +28,7 @@ For a lower level API, see the :py:mod:`mlflow.client` module.
 """
 
 import contextlib
+from typing import TYPE_CHECKING
 
 from mlflow.version import VERSION
 
@@ -102,6 +103,52 @@ tensorflow = LazyLoader("mlflow.tensorflow", globals(), "mlflow.tensorflow")
 txtai = LazyLoader("mlflow.txtai", globals(), "mlflow_txtai")
 transformers = LazyLoader("mlflow.transformers", globals(), "mlflow.transformers")
 xgboost = LazyLoader("mlflow.xgboost", globals(), "mlflow.xgboost")
+
+if TYPE_CHECKING:
+    # Do not move this block above the lazy-loaded modules above.
+    # All the lazy-loaded modules above must be imported here for code completion to work in IDEs.
+    from mlflow import (  # noqa: F401
+        anthropic,
+        autogen,
+        bedrock,
+        catboost,
+        crewai,
+        diviner,
+        dspy,
+        fastai,
+        gemini,
+        groq,
+        h2o,
+        johnsnowlabs,
+        keras,
+        langchain,
+        lightgbm,
+        litellm,
+        llama_index,
+        llm,
+        metrics,
+        mistral,
+        onnx,
+        openai,
+        paddle,
+        pmdarima,
+        promptflow,
+        prophet,
+        pyfunc,
+        pyspark,
+        pytorch,
+        recipes,
+        rfunc,
+        sentence_transformers,
+        shap,
+        sklearn,
+        spacy,
+        spark,
+        statsmodels,
+        tensorflow,
+        transformers,
+        xgboost,
+    )
 
 if MLFLOW_CONFIGURE_LOGGING.get() is True:
     _configure_mlflow_loggers(root_module_name=__name__)

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -128,6 +128,7 @@ if TYPE_CHECKING:
         llm,
         metrics,
         mistral,
+        mleap,
         onnx,
         openai,
         paddle,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14861?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14861/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14861/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

We're using `LazyLoader` to import flavor modules to avoid `ImportError` when the package the flavor depends on, is not installed. Unfortunately, code completion in IDEs doesn't work well with the lazily-loaded modules (see the example below). This PR fixes this issue.

### Before

<img width="1188" alt="Screenshot 2025-03-05 at 20 57 17" src="https://github.com/user-attachments/assets/3262182c-babe-4df1-859e-040a0591a0eb" />

### After

<img width="1188" alt="Screenshot 2025-03-05 at 20 56 06" src="https://github.com/user-attachments/assets/7b7398a6-e80e-48d8-8542-d9e367da128e" />



### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
