### PR TITLE
Add redirects for previously standalone pages

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -208,7 +208,39 @@ const config: Config = {
           },
           {
             to: "model",
-            from: ["/models"],
+            from: ["/models", "/models.html"],
+          },
+          {
+            to: "/tracking",
+            from: ["/tracking.html"],
+          },
+          {
+            to: "/projects",
+            from: ["/projects.html"],
+          },
+          {
+            to: "/model/signatures",
+            from: ["/model/signatures.html"],
+          },
+          {
+            to: "/model/signatures",
+            from: ["/model/dependencies.html"],
+          },
+          {
+            to: "/model/models-from-code",
+            from: ["/model/models-from-code.html"],
+          },
+          {
+            to: "/llms/deployments/uc_integration",
+            from: ["/llms/deployments/uc_integration.html"],
+          },
+          {
+            to: "/llms/prompt-engineering",
+            from: ["/llms/prompt-engineering.html"],
+          },
+          {
+            to: "/plugins",
+            from: ["/plugins.html"],
           },
         ],
       },

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -197,7 +197,7 @@ const config: Config = {
     [
       "@docusaurus/plugin-client-redirects",
       {
-        fromExtensions: "html",
+        fromExtensions: ["html"],
         redirects: [
           {
             to: "/tracing",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -200,15 +200,15 @@ const config: Config = {
         fromExtensions: ["html"],
         redirects: [
           {
-            to: "/tracing",
+            to: "/tracing/",
             from: ["/llms/tracing"],
           },
           {
-            to: "/dataset",
+            to: "/dataset/",
             from: ["/tracking/data-api/index"],
           },
           {
-            to: "/model",
+            to: "/model/",
             from: ["/models"],
           },
         ],

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -197,50 +197,19 @@ const config: Config = {
     [
       "@docusaurus/plugin-client-redirects",
       {
+        fromExtensions: "html",
         redirects: [
           {
             to: "/tracing",
             from: ["/llms/tracing"],
           },
           {
-            to: "dataset",
+            to: "/dataset",
             from: ["/tracking/data-api/index"],
           },
           {
-            to: "model",
+            to: "/model",
             from: ["/models", "/models.html"],
-          },
-          {
-            to: "/tracking",
-            from: ["/tracking.html"],
-          },
-          {
-            to: "/projects",
-            from: ["/projects.html"],
-          },
-          {
-            to: "/model/signatures",
-            from: ["/model/signatures.html"],
-          },
-          {
-            to: "/model/signatures",
-            from: ["/model/dependencies.html"],
-          },
-          {
-            to: "/model/models-from-code",
-            from: ["/model/models-from-code.html"],
-          },
-          {
-            to: "/llms/deployments/uc_integration",
-            from: ["/llms/deployments/uc_integration.html"],
-          },
-          {
-            to: "/llms/prompt-engineering",
-            from: ["/llms/prompt-engineering.html"],
-          },
-          {
-            to: "/plugins",
-            from: ["/plugins.html"],
           },
         ],
       },

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -209,7 +209,7 @@ const config: Config = {
           },
           {
             to: "/model",
-            from: ["/models", "/models.html"],
+            from: ["/models"],
           },
         ],
       },


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14882?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14882/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14882/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

My bad, I didn't catch these during the RST migration. Some previous pages were standalone, e.g. `dependencies.html`, and they have now been changed to `dependencies/index.html`. I went through links that we mention in our changelog and added redirects for them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Test using build docs job

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
