### PR TITLE
Fix false alert from AMD GPU monitor

### DIFF
--- a/docs/docs/system-metrics/index.mdx
+++ b/docs/docs/system-metrics/index.mdx
@@ -20,10 +20,16 @@ To install `psutil`, run the following command:
 pip install psutil
 ```
 
-If you want to catch GPU metrics, you also need to install `pynvml`:
+If you want to catch Nvidia GPU metrics, you also need to install `pynvml`:
 
 ```bash
 pip install pynvml
+```
+
+If you are using AMD/HIP GPUs, install [pyrsmi](https://github.com/ROCm/pyrsmi) instead of `pynvml`:
+
+```bash
+pip install pyrsmi
 ```
 
 ## Turn on/off System Metrics Logging

--- a/mlflow/system_metrics/metrics/rocm_monitor.py
+++ b/mlflow/system_metrics/metrics/rocm_monitor.py
@@ -15,6 +15,7 @@ _logger = logging.getLogger(__name__)
 is_rocml_available = False
 try:
     from pyrsmi import rocml
+
     is_rocml_available = True
 except ImportError:
     # If `pyrsmi` is not installed, a warning will be logged at monitor instantiation.

--- a/mlflow/system_metrics/metrics/rocm_monitor.py
+++ b/mlflow/system_metrics/metrics/rocm_monitor.py
@@ -12,8 +12,10 @@ from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonito
 
 _logger = logging.getLogger(__name__)
 
+is_rocml_available = False
 try:
     from pyrsmi import rocml
+    is_rocml_available = True
 except ImportError:
     # If `pyrsmi` is not installed, a warning will be logged at monitor instantiation.
     # We don't log a warning here to avoid spamming warning at every import.
@@ -116,4 +118,5 @@ class ROCMMonitor(BaseMetricsMonitor):
         return {k: round(sum(v) / len(v), 1) for k, v in self._metrics.items()}
 
     def __del__(self):
-        rocml.smi_shutdown()
+        if is_rocml_available:
+            rocml.smi_shutdown()

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -185,14 +185,14 @@ class SystemMetricsMonitor:
         # NVIDIA GPU
         try:
             return GPUMonitor()
-        except Exception as e:
-            _logger.debug(f"Failed to initialize GPU monitor for NVIDIA GPU: {e}")
+        except Exception:
+            _logger.debug("Failed to initialize GPU monitor for NVIDIA GPU.", exc_info=True)
 
         # Falling back to pyrocml (AMD/HIP GPU)
         try:
             return ROCMMonitor()
-        except Exception as e:
-            _logger.debug(f"Failed to initialize GPU monitor for AMD/HIP GPU: {e}")
+        except Exception:
+            _logger.debug("Failed to initialize GPU monitor for AMD/HIP GPU.", exc_info=True)
 
         _logger.info("Skip logging GPU metrics. Set logger level to DEBUG for more details.")
         return None

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -182,23 +182,17 @@ class SystemMetricsMonitor:
         self._process = None
 
     def _initialize_gpu_monitor(self) -> Optional[BaseMetricsMonitor]:
-        err = None
+        # NVIDIA GPU
         try:
-            # NVIDIA GPU
             return GPUMonitor()
-        except (ImportError, RuntimeError):
-            # ImportError raised if pynvml is not installed.
-            # RuntimeError raised if pynvml cannot be initialized
-            # (typically no NVIDIA GPU available).
-            # Falling back to pyrocml (AMD/HIP GPU)
-            try:
-                return ROCMMonitor()
-            except (ImportError, RuntimeError) as e:
-                err = e
         except Exception as e:
-            err = e
+            _logger.debug(f"Failed to initialize GPU monitor for NVIDIA GPU: {e}")
 
-        _logger.warning(
-            f"Skip logging GPU metrics because initialization failed with error: {err}."
-        )
+        # Falling back to pyrocml (AMD/HIP GPU)
+        try:
+            return ROCMMonitor()
+        except Exception as e:
+            _logger.debug(f"Failed to initialize GPU monitor for AMD/HIP GPU: {e}")
+
+        _logger.info("Skip logging GPU metrics. Set logger level to DEBUG for more details.")
         return None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14884?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14884/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14884/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

After GPU metrics for AMD GPUs was introduced in https://github.com/mlflow/mlflow/pull/12694, MLflow started to raise the following warning when system metrics is enabled but AMD GPU is not available. 

```
2025/03/06 08:03:02 WARNING mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics because initialization failed with error: `pyrsmi` is not installed, to log GPU metrics please run `pip install pyrsmi` to install it..
2025/03/06 08:03:02 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.
Exception ignored in: <function ROCMMonitor.__del__ at 0x7f586c52c2c0>
Traceback (most recent call last):
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-751a17c9-3ea8-4df7-846e-dfd502c69f04/lib/python3.12/site-packages/mlflow/system_metrics/metrics/rocm_monitor.py", line 119, in __del__
    rocml.smi_shutdown()
    ^^^^^
NameError: name 'rocml' is not defined
2025/03/06 08:03:17 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...
2025/03/06 08:03:17 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!
```

While this doesn't block the code execution and other system metrics logging, the warning is confusing and looks scary.

This is due to incorrect error handling and destructor implementation. This PR fixes that so the warning won't show up when AMD GPU is not available.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

* When neither of Nvidia/AMD GPU is available
```
2025/03/06 08:06:23 INFO mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics. Set logger level to DEBUG for more details
2025/03/06 08:06:23 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.
2025/03/06 08:06:38 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...
2025/03/06 08:06:38 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!
```

* When logger is set to debug level in above case
```
2025/03/06 08:14:23 DEBUG mlflow.system_metrics.system_metrics_monitor: Failed to initialize GPU monitor for NVIDIA GPU: `pynvml` is not installed, to log GPU metrics please run `pip install pynvml` to install it.
2025/03/06 08:14:23 DEBUG mlflow.system_metrics.system_metrics_monitor: Failed to initialize GPU monitor for AMD/HIP GPU: `pyrsmi` is not installed, to log GPU metrics please run `pip install pyrsmi` to install it.
...
```

* When Nvidia GPU is available
```
2025/03/06 08:16:06 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.
2025/03/06 08:16:21 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...
2025/03/06 08:16:21 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!
```
GPU metrics are logged in the run.

* When AMD GPU is available
I don't have quick env to test AMD GPU monitoring, but I don't touch any logic in the monitor itself, so testing with Nvidia case should be sufficient.


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `name 'rocml' is not defined` false alarm when system metrics monitoring is enabled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
