### PR TITLE
Update Assessment to allow Feedback/Expectation to also have an Error

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -87,12 +87,13 @@ class Assessment(_MlflowObject):
         return self._assessment_id
 
     def __post_init__(self):
-        if (
-            sum([self.expectation is not None, self.feedback is not None, self.error is not None])
-            != 1
-        ):
+        if (self.expectation is not None) + (self.feedback is not None) > 1:
             raise MlflowException.invalid_parameter_value(
-                "Exactly one of `expectation`, `feedback` or `error` should be specified.",
+                "Only one of `expectation` or `feedback` should be specified.",
+            )
+        if (self.expectation is None) and (self.feedback is None) and (self.error is None):
+            raise MlflowException.invalid_parameter_value(
+                "At least one of `expectation`, `feedback` or `error` should be specified.",
             )
 
     def to_proto(self):

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -95,6 +95,10 @@ class Assessment(_MlflowObject):
             raise MlflowException.invalid_parameter_value(
                 "At least one of `expectation`, `feedback` or `error` should be specified.",
             )
+        if (self.expectation is not None) and self.error is not None:
+            raise MlflowException.invalid_parameter_value(
+                "Expectations cannot have `error` specified.",
+            )
 
     def to_proto(self):
         assessment = ProtoAssessment()

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -87,13 +87,9 @@ class Assessment(_MlflowObject):
         return self._assessment_id
 
     def __post_init__(self):
-        if (self.expectation is not None) + (self.feedback is not None) > 1:
+        if (self.expectation is not None) + (self.feedback is not None) != 1:
             raise MlflowException.invalid_parameter_value(
-                "Only one of `expectation` or `feedback` should be specified.",
-            )
-        if (self.expectation is None) and (self.feedback is None) and (self.error is None):
-            raise MlflowException.invalid_parameter_value(
-                "At least one of `expectation`, `feedback` or `error` should be specified.",
+                "Exactly one of `expectation` or `feedback` should be specified.",
             )
         if (self.expectation is not None) and self.error is not None:
             raise MlflowException.invalid_parameter_value(

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -236,11 +236,13 @@ def log_feedback(
         )
 
     """
+    if value is None and error is None:
+        raise MlflowException.invalid_parameter_value("Either `value` or `error` must be provided.")
     return MlflowClient().log_assessment(
         trace_id=trace_id,
         name=name,
         source=_parse_source(source),
-        feedback=Feedback(value) if value is not None else None,
+        feedback=Feedback(value),
         error=error,
         rationale=rationale,
         metadata=metadata,

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -203,6 +203,7 @@ def log_feedback(
         mlflow.log_feedback(
             trace_id="1234",
             name="faithfulness",
+            source=source,
             value=0.9,
             rationale="The model is faithful to the input.",
             metadata={"model": "gpt-4o-mini"},

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -12,7 +12,7 @@ from typing import Any, Optional
 import pydantic
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.json_format import MessageToJson, ParseDict
-from google.protobuf.struct_pb2 import Value
+from google.protobuf.struct_pb2 import NULL_VALUE, Value
 
 from mlflow.exceptions import MlflowException
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
@@ -176,6 +176,9 @@ def set_pb_value(proto: Value, value: Any):
         proto.number_value = value
     elif isinstance(value, str):
         proto.string_value = value
+    elif value is None:
+        proto.null_value = NULL_VALUE
+
     else:
         raise ValueError(f"Unsupported value type: {type(value)}")
 

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -36,7 +36,7 @@ def test_assessment_creation():
     assessment_with_error = Assessment(
         **{
             **default_params,
-            "feedback": None,
+            "feedback": Feedback(None),
             "error": AssessmentError(error_code="E001", error_message="An error occurred."),
         }
     )
@@ -79,6 +79,7 @@ def test_assessment_equality():
     )
     assessment_5 = Assessment(
         source=source_1,
+        feedback=Feedback(None),
         error=AssessmentError(
             error_code="E002",
             error_message="A different error occurred.",
@@ -87,6 +88,7 @@ def test_assessment_equality():
     )
     assessment_6 = Assessment(
         source=source_1,
+        feedback=Feedback(None),
         error=AssessmentError(
             error_code="E001",
             error_message="Another error message.",
@@ -114,7 +116,7 @@ def test_assessment_value_validation():
     # Valid cases
     Assessment(expectation=Expectation("MLflow"), **common_args)
     Assessment(feedback=Feedback("This is correct."), **common_args)
-    Assessment(error=AssessmentError(error_code="E001"), **common_args)
+    Assessment(feedback=Feedback(None), error=AssessmentError(error_code="E001"), **common_args)
     Assessment(
         feedback=Feedback("This is correct."),
         error=AssessmentError(error_code="E001"),
@@ -122,11 +124,11 @@ def test_assessment_value_validation():
     )
 
     # Invalid case: no value specified
-    with pytest.raises(MlflowException, match=r"At least one of"):
+    with pytest.raises(MlflowException, match=r"Exactly one of"):
         Assessment(**common_args)
 
     # Invalid case: both feedback and expectation specified
-    with pytest.raises(MlflowException, match=r"Only one of"):
+    with pytest.raises(MlflowException, match=r"Exactly one of"):
         Assessment(
             expectation=Expectation("MLflow"),
             feedback=Feedback("This is correct."),
@@ -142,7 +144,7 @@ def test_assessment_value_validation():
         )
 
     # Invalid case: All three are set
-    with pytest.raises(MlflowException, match=r"Only one of"):
+    with pytest.raises(MlflowException, match=r"Exactly one of"):
         Assessment(
             expectation=Expectation("MLflow"),
             feedback=Feedback("This is correct."),
@@ -150,13 +152,18 @@ def test_assessment_value_validation():
             **common_args,
         )
 
+
 @pytest.mark.parametrize(
     ("expectation", "feedback", "error"),
     [
         (Expectation("MLflow"), None, None),
         (None, Feedback("This is correct."), None),
-        (None, None, AssessmentError(error_code="E001")),
-        (None, None, AssessmentError(error_code="E001", error_message="An error occurred.")),
+        (None, Feedback(None), AssessmentError(error_code="E001")),
+        (
+            None,
+            Feedback(None),
+            AssessmentError(error_code="E001", error_message="An error occurred."),
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -114,16 +114,22 @@ def test_assessment_value_validation():
     # Valid cases
     Assessment(expectation=Expectation("MLflow"), **common_args)
     Assessment(feedback=Feedback("This is correct."), **common_args)
+    Assessment(error=AssessmentError(error_code="E001"), **common_args)
+    Assessment(
+        feedback=Feedback("This is correct."),
+        error=AssessmentError(error_code="E001"),
+        **common_args,
+    )
 
     # Invalid case: no value specified
-    with pytest.raises(MlflowException, match=r"Exactly one of"):
+    with pytest.raises(MlflowException, match=r"At least one of"):
         Assessment(**common_args)
 
-    # Invalid case: both value and error specified
-    with pytest.raises(MlflowException, match=r"Exactly one of"):
+    # Invalid case: both feedback and expectation specified
+    with pytest.raises(MlflowException, match=r"Only one of"):
         Assessment(
             expectation=Expectation("MLflow"),
-            error=AssessmentError(error_code="E001", error_message="An error occurred."),
+            feedback=Feedback("This is correct."),
             **common_args,
         )
 

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -133,6 +133,22 @@ def test_assessment_value_validation():
             **common_args,
         )
 
+    # Invalid case: Expectation with an error
+    with pytest.raises(MlflowException, match=r"Expectations cannot have"):
+        Assessment(
+            expectation=Expectation("MLflow"),
+            error=AssessmentError(error_code="E001"),
+            **common_args,
+        )
+
+    # Invalid case: All three are set
+    with pytest.raises(MlflowException, match=r"Only one of"):
+        Assessment(
+            expectation=Expectation("MLflow"),
+            feedback=Feedback("This is correct."),
+            error=AssessmentError(error_code="E001"),
+            **common_args,
+        )
 
 @pytest.mark.parametrize(
     ("expectation", "feedback", "error"),

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -146,7 +146,7 @@ def test_log_feedback_with_error(store):
     assert assessment.create_time_ms is not None
     assert assessment.last_update_time_ms is not None
     assert assessment.expectation is None
-    assert assessment.feedback is None
+    assert assessment.feedback.value is None
     assert assessment.rationale is None
     assert assessment.error.error_code == "RATE_LIMIT_EXCEEDED"
     assert assessment.error.error_message == "Rate limit for the judge exceeded."
@@ -183,7 +183,7 @@ def test_log_feedback_with_value_and_error(store):
 
 
 def test_log_feedback_invalid_parameters():
-    with pytest.raises(MlflowException, match=r"At least one of"):
+    with pytest.raises(MlflowException, match=r"Either `value` or `error` must be provided."):
         mlflow.log_feedback(
             trace_id="1234",
             name="faithfulness",

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -152,24 +152,42 @@ def test_log_feedback_with_error(store):
     assert assessment.error.error_message == "Rate limit for the judge exceeded."
 
 
-def test_log_feedback_invalid_parameters():
-    with pytest.raises(MlflowException, match=r"Exactly one of `expectation`, "):
-        mlflow.log_feedback(
-            trace_id="1234",
-            name="faithfulness",
-            source=AssessmentSourceType.LLM_JUDGE,
-        )
+def test_log_feedback_with_value_and_error(store):
+    mlflow.set_tracking_uri("databricks")
 
-    with pytest.raises(MlflowException, match=r"Exactly one of `expectation`, "):
+    mlflow.log_feedback(
+        trace_id="1234",
+        name="faithfulness",
+        source=AssessmentSourceType.LLM_JUDGE,
+        value=0.5,
+        error=AssessmentError(
+            error_code="RATE_LIMIT_EXCEEDED",
+            error_message="Rate limit for the judge exceeded.",
+        ),
+    )
+
+    assert store.create_assessment.call_count == 1
+    assessment = store.create_assessment.call_args[0][0]
+    assert assessment.name == "faithfulness"
+    assert assessment.trace_id == "1234"
+    assert assessment.span_id is None
+    assert assessment.source.source_type == "LLM_JUDGE"
+    assert assessment.source.source_id is None
+    assert assessment.create_time_ms is not None
+    assert assessment.last_update_time_ms is not None
+    assert assessment.expectation is None
+    assert assessment.feedback == Feedback(value=0.5)
+    assert assessment.rationale is None
+    assert assessment.error.error_code == "RATE_LIMIT_EXCEEDED"
+    assert assessment.error.error_message == "Rate limit for the judge exceeded."
+
+
+def test_log_feedback_invalid_parameters():
+    with pytest.raises(MlflowException, match=r"At least one of"):
         mlflow.log_feedback(
             trace_id="1234",
             name="faithfulness",
             source=AssessmentSourceType.LLM_JUDGE,
-            value=1.0,
-            error=AssessmentError(
-                error_code="RATE_LIMIT_EXCEEDED",
-                error_message="Rate limit for the judge exceeded.",
-            ),
         )
 
     with pytest.raises(MlflowException, match=r"`source` must be provided."):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/brilee/mlflow/pull/14892?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14892/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14892/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

Allow Assessment to simultaneously have a Feedback/Expectation + Error.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [] No (this PR will be included in the next minor release)
