### PR TITLE
Thread safety and Databricks model serving support for last_active_trace()

### DIFF
--- a/mlflow/tracing/buffer.py
+++ b/mlflow/tracing/buffer.py
@@ -1,0 +1,87 @@
+from threading import RLock
+from typing import Any, Optional, Union
+
+from cachetools import TTLCache
+
+from mlflow.entities import Trace
+from mlflow.environment_variables import (
+    MLFLOW_TRACE_BUFFER_MAX_SIZE,
+    MLFLOW_TRACE_BUFFER_TTL_SECONDS,
+)
+
+
+class _TraceBuffer:
+    """
+    A thread-safe buffer that stores traces in memory with a TTL.
+    """
+
+    def __init__(self, max_size: int, ttl_seconds: int):
+        self._cache = TTLCache(
+            maxsize=max_size,
+            ttl=ttl_seconds,
+        )
+        self._buffer_lock = RLock()
+
+    def insert(self, request_id: str, trace: Trace):
+        """
+        Insert the specified trace to the buffer and associate it with the specified request ID.
+        This method is thread-safe.
+        """
+        with self._buffer_lock:
+            self._cache[request_id] = trace
+
+    def get(self, request_id: str, default=None) -> Union[Trace, Any]:
+        """
+        Get the trace with the specified request ID from the buffer. If the trace is not found,
+        return the default value. This method is thread-safe.
+        """
+        with self._buffer_lock:
+            return self._cache.get(request_id, default)
+
+    def pop(self, request_id: str, default=None) -> Union[Trace, Any]:
+        """
+        Remove and return the trace with the specified request ID from the buffer. If the trace is
+        not found, return the default value. This method is thread-safe.
+        """
+        with self._buffer_lock:
+            return self._cache.pop(request_id, default)
+
+    def latest(self) -> Optional[Trace]:
+        """
+        Get the latest trace from the buffer. This method is thread-safe.
+
+        Returns:
+            The latest trace in the buffer, or None if the buffer is empty.
+        """
+        with self._buffer_lock:
+            if len(self._cache) > 0:
+                last_active_request_id = list(self._cache.keys())[-1]
+                return self._cache.get(last_active_request_id)
+
+    def clear(self):
+        """
+        Clear all traces from the buffer. This method is thread-safe.
+        """
+        with self._buffer_lock:
+            self._cache.clear()
+
+    def __len__(self) -> int:
+        """
+        Get the number of traces in the buffer. This method is thread-safe.
+
+        Returns:
+            The number of traces in the buffer.
+        """
+        with self._buffer_lock:
+            return len(self._cache)
+
+
+# Traces are stored in memory after completion so they can be retrieved conveniently.
+# For example, Databricks model serving fetches the trace data from the buffer after
+# making the prediction request, and logging them into the Inference Table.
+TRACE_BUFFER = _TraceBuffer(
+    max_size=MLFLOW_TRACE_BUFFER_MAX_SIZE.get(),
+    ttl_seconds=MLFLOW_TRACE_BUFFER_TTL_SECONDS.get(),
+)
+
+__all__ = ["TRACE_BUFFER"]

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -53,4 +53,4 @@ class InferenceTableSpanExporter(SpanExporter):
                 continue
 
             # Add the trace to the in-memory buffer so it can be retrieved by upstream
-            TRACE_BUFFER.add(trace)
+            TRACE_BUFFER.insert(trace.info.request_id, trace)

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -1,14 +1,10 @@
 import logging
 from typing import Any, Optional, Sequence
 
-from cachetools import TTLCache
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter
 
-from mlflow.environment_variables import (
-    MLFLOW_TRACE_BUFFER_MAX_SIZE,
-    MLFLOW_TRACE_BUFFER_TTL_SECONDS,
-)
+from mlflow.tracing.buffer import TRACE_BUFFER
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 
 _logger = logging.getLogger(__name__)
@@ -19,21 +15,10 @@ def pop_trace(request_id: str) -> Optional[dict[str, Any]]:
     Pop the completed trace data from the buffer. This method is used in
     the Databricks model serving so please be careful when modifying it.
     """
-    return _TRACE_BUFFER.pop(request_id, None)
-
-
-# For Inference Table, we use special TTLCache to store the finished traces
-# so that they can be retrieved by Databricks model serving. The values
-# in the buffer are not Trace dataclass, but rather a dictionary with the schema
-# that is used within Databricks model serving.
-def _initialize_trace_buffer():  # Define as a function for testing purposes
-    return TTLCache(
-        maxsize=MLFLOW_TRACE_BUFFER_MAX_SIZE.get(),
-        ttl=MLFLOW_TRACE_BUFFER_TTL_SECONDS.get(),
-    )
-
-
-_TRACE_BUFFER = _initialize_trace_buffer()
+    trace_opt = TRACE_BUFFER.pop(request_id, None)
+    if trace_opt is not None:
+        # Convert the Trace to a dictionary with the schema that is used in Databricks model serving
+        return trace_opt.to_dict()
 
 
 class InferenceTableSpanExporter(SpanExporter):
@@ -68,4 +53,4 @@ class InferenceTableSpanExporter(SpanExporter):
                 continue
 
             # Add the trace to the in-memory buffer so it can be retrieved by upstream
-            _TRACE_BUFFER[trace.info.request_id] = trace.to_dict()
+            TRACE_BUFFER.add(trace)

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -66,10 +66,10 @@ class MlflowSpanExporter(SpanExporter):
                 continue
 
             # Add the trace to the in-memory buffer
-            TRACE_BUFFER[trace.info.request_id] = trace
+            TRACE_BUFFER.insert(trace.info.request_id, trace)
             # Add evaluation trace to the in-memory buffer with eval_request_id key
             if eval_request_id := trace.info.tags.get(TraceTagKey.EVAL_REQUEST_ID):
-                TRACE_BUFFER[eval_request_id] = trace
+                TRACE_BUFFER.insert(eval_request_id, trace)
 
             if not maybe_get_request_id(is_evaluate=True):
                 # Display the trace in the UI if the trace is not generated from within

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -45,7 +45,6 @@ from mlflow.tracing.utils.search import extract_span_inputs_outputs, traces_to_d
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.annotations import experimental
-from mlflow.utils.databricks_utils import is_in_databricks_model_serving_environment
 
 _logger = logging.getLogger(__name__)
 
@@ -675,10 +674,6 @@ def get_last_active_trace() -> Optional[Trace]:
     """
     Get the last active trace in the same process if exists.
 
-    .. warning::
-
-        This function DOES NOT work in the model deployed in Databricks model serving.
-
     .. note::
 
         The last active trace is only stored in-memory for the time defined by the TTL
@@ -716,13 +711,6 @@ def get_last_active_trace() -> Optional[Trace]:
     Returns:
         The last active trace if exists, otherwise None.
     """
-    if is_in_databricks_model_serving_environment():
-        raise MlflowException(
-            "The function `mlflow.get_last_active_trace` is not supported in "
-            "Databricks model serving.",
-            error_code=BAD_REQUEST,
-        )
-
     return TRACE_BUFFER.latest()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ from opentelemetry import trace as trace_api
 
 import mlflow
 from mlflow.tracing.display.display_handler import IPythonTraceDisplayHandler
-from mlflow.tracing.export.inference_table import _TRACE_BUFFER
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracking._tracking_service.utils import _use_tracking_uri
@@ -59,7 +58,6 @@ def reset_tracing():
 
     # Clear other global state and singletons
     TRACE_BUFFER.clear()
-    _TRACE_BUFFER.clear()
     InMemoryTraceManager.reset()
     IPythonTraceDisplayHandler._instance = None
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3079,9 +3079,9 @@ def test_langchain_model_not_inject_callback_when_disabled(monkeypatch, model_pa
     loaded_model.predict({"product": "shoe"})
 
     # Trace should be logged to the inference table
-    from mlflow.tracing.export.inference_table import _TRACE_BUFFER
+    from mlflow.tracing.buffer import TRACE_BUFFER
 
-    assert _TRACE_BUFFER == {}
+    assert len(TRACE_BUFFER) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/tracing/export/test_inference_table_exporter.py
+++ b/tests/tracing/export/test_inference_table_exporter.py
@@ -1,11 +1,9 @@
 from unittest import mock
 
-import mlflow
 from mlflow.entities import LiveSpan, Trace
+from mlflow.tracing.buffer import TRACE_BUFFER
 from mlflow.tracing.export.inference_table import (
-    _TRACE_BUFFER,
     InferenceTableSpanExporter,
-    _initialize_trace_buffer,
     pop_trace,
 )
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -49,7 +47,7 @@ def test_export():
     assert len(exporter._trace_manager._traces) == 0
 
     # Trace should be added to the in-memory buffer and can be extracted
-    assert len(_TRACE_BUFFER) == 1
+    assert len(TRACE_BUFFER) == 1
     trace_dict = pop_trace(_REQUEST_ID)
     trace_info = trace_dict["info"]
     assert trace_info["timestamp_ms"] == 0
@@ -99,9 +97,6 @@ def test_export_warn_invalid_attributes():
 
 def test_export_trace_buffer_not_exceeds_max_size(monkeypatch):
     monkeypatch.setenv("MLFLOW_TRACE_BUFFER_MAX_SIZE", "1")
-    monkeypatch.setattr(
-        mlflow.tracing.export.inference_table, "_TRACE_BUFFER", _initialize_trace_buffer()
-    )
 
     exporter = InferenceTableSpanExporter()
 

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -279,9 +279,11 @@ def test_enable_mlflow_tracing_switch_in_serving_fluent(monkeypatch, enable_mlfl
             foo()
 
     if enable_mlflow_tracing:
-        assert sorted(TRACE_BUFFER) == request_ids
-    else:
-        assert len(TRACE_BUFFER) == 0
+        for request_id in reversed(request_ids):
+            assert TRACE_BUFFER.latest().info.request_id == request_id
+            TRACE_BUFFER.pop(request_id)
+
+    assert len(TRACE_BUFFER) == 0
 
 
 @pytest.mark.parametrize("enable_mlflow_tracing", [True, False])

--- a/tests/tracing/utils/test_timeout.py
+++ b/tests/tracing/utils/test_timeout.py
@@ -8,7 +8,8 @@ import mlflow
 from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.pyfunc.context import Context, set_prediction_context
-from mlflow.tracing.export.inference_table import _TRACE_BUFFER, pop_trace
+from mlflow.tracing.buffer import TRACE_BUFFER
+from mlflow.tracing.export.inference_table import TRACE_BUFFER, pop_trace
 from mlflow.tracing.trace_manager import _Trace
 from mlflow.tracing.utils.timeout import MlflowTraceTimeoutCache
 
@@ -111,7 +112,7 @@ def test_trace_halted_after_timeout_in_model_serving(
         executor.map(_run_single, ["request-id-1", "request-id-2", "request-id-3"], [5, 6, 1])
 
     # All traces should be logged
-    assert len(_TRACE_BUFFER) == 3
+    assert len(TRACE_BUFFER) == 3
 
     # Long operation should be halted
     assert pop_trace(request_id="request-id-1")["info"]["status"] == SpanStatusCode.ERROR


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/14911?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14911/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14911/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Thread safety and Databricks model serving support for last_active_trace()

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

`mlflow.last_active_trace()` API is now threadsafe and can be called from Databricks Model Serving

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
