### PR TITLE
fix: adjust table theme color in `Compare Run View`

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.tsx
@@ -17,7 +17,6 @@ import {
 } from '@databricks/design-system';
 import { getParams, getRunInfo } from '../reducers/Reducers';
 import { connect } from 'react-redux';
-import './CompareRunView.css';
 import Utils from '../../common/utils/Utils';
 import { getLatestMetrics } from '../reducers/MetricReducer';
 import CompareRunUtil from './CompareRunUtil';

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunScatter.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunScatter.tsx
@@ -10,7 +10,6 @@ import React, { Component } from 'react';
 import { getParams, getRunInfo } from '../reducers/Reducers';
 import { connect } from 'react-redux';
 import { FormUI, SimpleSelect, SimpleSelectOption, SimpleSelectOptionGroup, Spacer } from '@databricks/design-system';
-import './CompareRunView.css';
 import Utils from '../../common/utils/Utils';
 import { getLatestMetrics } from '../reducers/MetricReducer';
 import CompareRunUtil from './CompareRunUtil';

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.css
@@ -10,6 +10,10 @@
   width: 100%;
 }
 
+.compare-table-row {
+  display: inline-flex;
+}
+
 .compare-table th.inter-title {
   padding: 20px 0 0;
   background: transparent;
@@ -18,6 +22,7 @@
 .compare-table .head-value {
   overflow: hidden;
   overflow-wrap: break-word;
+  z-index: 10;
 }
 
 .compare-table td.data-value,
@@ -38,6 +43,11 @@
 }
 
 .compare-table .diff-row .head-value {
+  background-color: rgba(249, 237, 190, 1.0) ;
+  color: #555;
+}
+
+.compare-table .diff-row .head-value > span {
   background-color: rgba(249, 237, 190, 1.0) ;
   color: #555;
 }

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -8,7 +8,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage, type IntlShape } from 'react-intl';
-import { Spacer, Switch, LegacyTabs, LegacyTooltip } from '@databricks/design-system';
+import { Spacer, Switch, LegacyTabs, LegacyTooltip, Table, TableRow, TableCell } from '@databricks/design-system';
+import { type Theme } from '@emotion/react';
 
 import { getExperiment, getParams, getRunInfo, getRunTags } from '../reducers/Reducers';
 import './CompareRunView.css';
@@ -125,11 +126,11 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       const { name, basename } = experimentNameMap[experimentId];
       return (
-        <td className="meta-info" key={runUuid}>
+        <TableCell className="meta-info" key={runUuid}>
           <Link to={Routes.getExperimentPageRoute(experimentId)} title={name}>
             {basename}
           </Link>
-        </td>
+        </TableCell>
       );
     });
   }
@@ -240,13 +241,14 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       );
     }
     return (
-      <table
+      <Table
         className="table compare-table compare-run-table"
         css={{ maxHeight: '500px' }}
+        // @ts-expect-error TS(2322): Property 'onScroll' does not exist... Remove this comment to see the full error message
         onScroll={this.onCompareRunTableScrollHandler}
       >
-        <tbody>{dataRows}</tbody>
-      </table>
+        {dataRows}
+      </Table>
     );
   }
 
@@ -289,21 +291,22 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       );
     }
     return (
-      <table
+      <Table
         className="table compare-table compare-run-table"
         css={{ maxHeight: '300px' }}
+        // @ts-expect-error TS(2322): Property 'onScroll' does not exist... Remove this comment to see the full error message
         onScroll={this.onCompareRunTableScrollHandler}
       >
-        <tbody>{dataRows}</tbody>
-      </table>
+        {dataRows}
+      </Table>
     );
   }
 
-  renderArtifactTable(colWidth: any) {
+  renderArtifactTable(colWidth: number) {
     return <CompareRunArtifactView runUuids={this.props.runUuids} runInfos={this.props.runInfos} colWidth={colWidth} />;
   }
 
-  renderTagTable(colWidth: any) {
+  renderTagTable(colWidth: number) {
     const dataRows = this.renderDataRows(
       this.props.tagLists,
       colWidth,
@@ -322,17 +325,18 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       );
     }
     return (
-      <table
+      <Table
         className="table compare-table compare-run-table"
         css={{ maxHeight: '500px' }}
+        // @ts-expect-error TS(2322): Property 'onScroll' does not exist... Remove this comment to see the full error message
         onScroll={this.onCompareRunTableScrollHandler}
       >
-        <tbody>{dataRows}</tbody>
-      </table>
+        {dataRows}
+      </Table>
     );
   }
 
-  renderTimeRows(colWidthStyle: any) {
+  renderTimeRows(colWidthStyle: Record<string, string>) {
     const unknown = (
       <FormattedMessage
         defaultMessage="(unknown)"
@@ -383,12 +387,15 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       },
     ];
     return rows.map(({ key, title, data }) => (
-      <tr key={key}>
-        <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
+      <TableRow key={key} className="compare-table-row">
+        <TableCell
+          className="head-value sticky-header"
+          css={{ backgroundColor: 'var(--table-header-background-color)', ...colWidthStyle }}
+        >
           {title}
-        </th>
+        </TableCell>
         {data.map(([runUuid, value]) => (
-          <td className="data-value" key={runUuid as string} css={colWidthStyle}>
+          <TableCell className="data-value" key={runUuid as string} css={colWidthStyle}>
             <LegacyTooltip
               title={value}
               // @ts-expect-error TS(2322): Type '{ children: any; title: any; color: string; ... Remove this comment to see the full error message
@@ -400,9 +407,9 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
             >
               {value}
             </LegacyTooltip>
-          </td>
+          </TableCell>
         ))}
-      </tr>
+      </TableRow>
     ));
   }
 
@@ -515,77 +522,80 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
             description: 'Compare table title on the compare runs page',
           })}
         >
-          <table
+          <Table
             className="table compare-table compare-run-table"
             ref={this.runDetailsTableRef}
+            // @ts-expect-error TS(2322): Property 'onScroll' does not exist... Remove this comment to see the full error message
             onScroll={this.onCompareRunTableScrollHandler}
           >
-            <thead>
-              <tr>
-                <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
+            <TableRow className="compare-table-row">
+              <TableCell
+                className="head-value sticky-header"
+                css={{ backgroundColor: 'var(--table-header-background-color)', ...colWidthStyle }}
+              >
+                <FormattedMessage
+                  defaultMessage="Run ID:"
+                  description="Row title for the run id on the experiment compare runs page"
+                />
+              </TableCell>
+              {this.props.runInfos.map((r) => (
+                <TableCell className="data-value" key={r.runUuid} css={colWidthStyle}>
+                  <LegacyTooltip
+                    title={r.runUuid}
+                    // @ts-expect-error TS(2322): Type '{ children: Element; title: any; color: stri... Remove this comment to see the full error message
+                    color="gray"
+                    placement="topLeft"
+                    overlayStyle={{ maxWidth: '400px' }}
+                    mouseEnterDelay={1.0}
+                  >
+                    <Link to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
+                  </LegacyTooltip>
+                </TableCell>
+              ))}
+            </TableRow>
+            <TableRow className="compare-table-row">
+              <TableCell
+                className="head-value sticky-header"
+                css={{ backgroundColor: 'var(--table-header-background-color)', ...colWidthStyle }}
+              >
+                <FormattedMessage
+                  defaultMessage="Run Name:"
+                  description="Row title for the run name on the experiment compare runs page"
+                />
+              </TableCell>
+              {runNames.map((runName, i) => {
+                return (
+                  <TableCell className="data-value" key={runInfos[i].runUuid} css={colWidthStyle}>
+                    <div className="truncate-text single-line">
+                      <LegacyTooltip
+                        title={runName}
+                        // @ts-expect-error TS(2322): Type '{ children: string; title: string; color: st... Remove this comment to see the full error message
+                        color="gray"
+                        placement="topLeft"
+                        overlayStyle={{ maxWidth: '400px' }}
+                        mouseEnterDelay={1.0}
+                      >
+                        {runName}
+                      </LegacyTooltip>
+                    </div>
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+            {this.renderTimeRows(colWidthStyle)}
+            {this.shouldShowExperimentNameRow() && (
+              <TableRow className="compare-table-row">
+                <TableCell className="data-value">
                   <FormattedMessage
-                    defaultMessage="Run ID:"
-                    description="Row title for the run id on the experiment compare runs page"
+                    defaultMessage="Experiment Name:"
+                    // eslint-disable-next-line max-len
+                    description="Row title for the experiment IDs of runs on the experiment compare runs page"
                   />
-                </th>
-                {this.props.runInfos.map((r) => (
-                  <th scope="row" className="data-value" key={r.runUuid} css={colWidthStyle}>
-                    <LegacyTooltip
-                      title={r.runUuid}
-                      // @ts-expect-error TS(2322): Type '{ children: Element; title: any; color: stri... Remove this comment to see the full error message
-                      color="gray"
-                      placement="topLeft"
-                      overlayStyle={{ maxWidth: '400px' }}
-                      mouseEnterDelay={1.0}
-                    >
-                      <Link to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
-                    </LegacyTooltip>
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
-                  <FormattedMessage
-                    defaultMessage="Run Name:"
-                    description="Row title for the run name on the experiment compare runs page"
-                  />
-                </th>
-                {runNames.map((runName, i) => {
-                  return (
-                    <td className="data-value" key={runInfos[i].runUuid} css={colWidthStyle}>
-                      <div className="truncate-text single-line">
-                        <LegacyTooltip
-                          title={runName}
-                          // @ts-expect-error TS(2322): Type '{ children: string; title: string; color: st... Remove this comment to see the full error message
-                          color="gray"
-                          placement="topLeft"
-                          overlayStyle={{ maxWidth: '400px' }}
-                          mouseEnterDelay={1.0}
-                        >
-                          {runName}
-                        </LegacyTooltip>
-                      </div>
-                    </td>
-                  );
-                })}
-              </tr>
-              {this.renderTimeRows(colWidthStyle)}
-              {this.shouldShowExperimentNameRow() && (
-                <tr>
-                  <th scope="row" className="data-value">
-                    <FormattedMessage
-                      defaultMessage="Experiment Name:"
-                      // eslint-disable-next-line max-len
-                      description="Row title for the experiment IDs of runs on the experiment compare runs page"
-                    />
-                  </th>
-                  {this.renderExperimentNameRowItems()}
-                </tr>
-              )}
-            </tbody>
-          </table>
+                </TableCell>
+                {this.renderExperimentNameRowItems()}
+              </TableRow>
+            )}
+          </Table>
         </CollapsibleSection>
         <CollapsibleSection title={paramsLabel}>
           <Switch
@@ -628,7 +638,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
     );
   }
 
-  genWidthStyle(width: any) {
+  genWidthStyle(width: number): Record<string, string> {
     return {
       width: `${width}px`,
       minWidth: `${width}px`,
@@ -669,14 +679,17 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
           const { values, hasDiff } = data[k];
           const rowClass = highlightDiff && hasDiff ? 'diff-row' : undefined;
           return (
-            <tr key={k} className={rowClass}>
-              <th scope="row" className="head-value sticky-header" css={colWidthStyle}>
+            <TableRow key={k} className={`${rowClass} compare-table-row`}>
+              <TableCell
+                className="head-value sticky-header"
+                css={{ backgroundColor: 'var(--table-header-background-color)', ...colWidthStyle }}
+              >
                 {headerMap(k, values)}
-              </th>
+              </TableCell>
               {values.map((value: any, i: any) => {
                 const cellText = value === undefined ? '' : formatter(value);
                 return (
-                  <td className="data-value" key={this.props.runInfos[i].runUuid} css={colWidthStyle}>
+                  <TableCell className="data-value" key={this.props.runInfos[i].runUuid} css={colWidthStyle}>
                     <LegacyTooltip
                       title={cellText}
                       // @ts-expect-error TS(2322): Type '{ children: Element; title: any; color: stri... Remove this comment to see the full error message
@@ -687,10 +700,10 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
                     >
                       <span className="truncate-text single-line">{cellText}</span>
                     </LegacyTooltip>
-                  </td>
+                  </TableCell>
                 );
               })}
-            </tr>
+            </TableRow>
           );
         })
     );


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Gumichocopengin8/mlflow/pull/14914?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14914/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14914/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> close #11592

### What changes are proposed in this pull request?

Correctly apply light mode and dark mode in compare run view tables

#### Before


https://github.com/user-attachments/assets/f63bcfff-6972-4e25-a764-0ff9bc35dc22



<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### After

https://github.com/user-attachments/assets/bc8d1353-eeba-4242-9484-45ec86422fe9


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
