### PR TITLE
Fix error message for prompt registry

### DIFF
--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -158,7 +158,8 @@ class Prompt(ModelVersion):
         """
         if IS_PROMPT_TAG_KEY not in model_version.tags:
             raise MlflowException.invalid_parameter_value(
-                f"Name `{model_version.name}` is registered as a model, not a prompt",
+                f"Name `{model_version.name}` is registered as a model, not a prompt. MLflow "
+                "does not allow registering a prompt with the same name as an existing model.",
             )
 
         if PROMPT_TEXT_TAG_KEY not in model_version.tags:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -55,7 +55,11 @@ from mlflow.entities.span import NO_OP_SPAN_REQUEST_ID, NoOpSpan, create_mlflow_
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_LOGGING
 from mlflow.exceptions import MlflowException
-from mlflow.prompt.registry_utils import has_prompt_tag, require_prompt_registry
+from mlflow.prompt.registry_utils import (
+    has_prompt_tag,
+    require_prompt_registry,
+    translate_prompt_exception,
+)
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     FEATURE_DISABLED,
@@ -410,6 +414,7 @@ class MlflowClient:
 
     @experimental
     @require_prompt_registry
+    @translate_prompt_exception
     def register_prompt(
         self,
         name: str,
@@ -476,6 +481,7 @@ class MlflowClient:
         """
         registry_client = self._get_registry_client()
 
+        is_new_prompt = False
         try:
             rm = registry_client.get_registered_model(name)
 
@@ -494,22 +500,32 @@ class MlflowClient:
                 registry_client.create_registered_model(
                     name, description=description, tags={IS_PROMPT_TAG_KEY: "true"}
                 )
+                is_new_prompt = True
             else:
                 raise
 
         tags = tags or {}
         tags.update({IS_PROMPT_TAG_KEY: "true", PROMPT_TEXT_TAG_KEY: template})
 
-        mv: ModelVersion = registry_client.create_model_version(
-            name=name,
-            description=description,
-            source="dummy-source",  # Required field, but not used for prompts
-            tags=tags,
-        )
+        try:
+            mv: ModelVersion = registry_client.create_model_version(
+                name=name,
+                description=description,
+                source="dummy-source",  # Required field, but not used for prompts
+                tags=tags,
+            )
+        except Exception:
+            if is_new_prompt:
+                # When a model version creation fails for the first version of a prompt,
+                # delete the registered model to avoid leaving a prompt with no versions
+                registry_client.delete_registered_model(name)
+            raise
+
         return Prompt.from_model_version(mv)
 
     @experimental
     @require_prompt_registry
+    @translate_prompt_exception
     def load_prompt(self, name_or_uri: str, version: Optional[int] = None) -> Prompt:
         """
         Load a :py:class:`Prompt <mlflow.entities.Prompt>` from the MLflow Prompt Registry.
@@ -549,17 +565,14 @@ class MlflowClient:
 
         registry_client = self._get_registry_client()
         if version is None:
-            try:
-                mv = registry_client.get_latest_versions(name, stages=ALL_STAGES)[0]
-            except MlflowException as e:
-                if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
-                    raise MlflowException(f"Prompt '{name}' not found", RESOURCE_DOES_NOT_EXIST)
+            mv = registry_client.get_latest_versions(name, stages=ALL_STAGES)[0]
         else:
-            mv = self._validate_prompt(name, version)
+            mv = self.get_model_version(name, version)
         return Prompt.from_model_version(mv)
 
     @experimental
     @require_prompt_registry
+    @translate_prompt_exception
     def delete_prompt(self, name: str, version: int):
         """
         Delete a :py:class:`Prompt <mlflow.entities.Prompt>` from the MLflow Prompt Registry.
@@ -580,6 +593,7 @@ class MlflowClient:
     # TODO: Use model_id in MLflow 3.0
     @experimental
     @require_prompt_registry
+    @translate_prompt_exception
     def log_prompt(self, run_id: str, prompt_uri: str) -> None:
         """
         Associate a prompt registered within the MLflow Prompt Registry with an MLflow Run.
@@ -603,6 +617,7 @@ class MlflowClient:
     # TODO: Use model_id in MLflow 3.0
     @experimental
     @require_prompt_registry
+    @translate_prompt_exception
     def detach_prompt_from_run(self, run_id: str, prompt_uri: str) -> None:
         """
         Detach a prompt registered within the MLflow Prompt Registry from an MLflow Run.
@@ -634,6 +649,7 @@ class MlflowClient:
     # TODO: Use model_id in MLflow 3.0
     @experimental
     @require_prompt_registry
+    @translate_prompt_exception
     def list_logged_prompts(self, run_id: str) -> list[Prompt]:
         """
         List all prompts associated with an MLflow Run.
@@ -656,6 +672,7 @@ class MlflowClient:
 
     @experimental
     @require_prompt_registry
+    @translate_prompt_exception
     def set_prompt_alias(self, name: str, alias: str, version: int) -> None:
         """
         Set an alias for a :py:class:`Prompt <mlflow.entities.Prompt>`.
@@ -670,6 +687,7 @@ class MlflowClient:
 
     @experimental
     @require_prompt_registry
+    @translate_prompt_exception
     def delete_prompt_alias(self, name: str, alias: str) -> None:
         """
         Delete an alias for a :py:class:`Prompt <mlflow.entities.Prompt>`.
@@ -680,25 +698,12 @@ class MlflowClient:
         """
         self.delete_registered_model_alias(name, alias)
 
-    def _validate_prompt(self, name: str, version: int) -> ModelVersion:
+    def _validate_prompt(self, name: str, version: int):
         registry_client = self._get_registry_client()
-
-        try:
-            mv = registry_client.get_model_version(name, version)
-        except MlflowException as e:
-            if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
-                raise MlflowException(
-                    f"Prompt '{name}' with version {version} not found", RESOURCE_DOES_NOT_EXIST
-                )
+        mv = registry_client.get_model_version(name, version)
 
         if IS_PROMPT_TAG_KEY not in mv.tags:
-            raise MlflowException(
-                f"Name `{name}` is used for a model, not a prompt. MLflow does not allow "
-                "registering a prompt with the same name as an existing model.",
-                INVALID_PARAMETER_VALUE,
-            )
-
-        return mv
+            raise MlflowException(f"Prompt '{name}' does not exist.", RESOURCE_DOES_NOT_EXIST)
 
     def parse_prompt_uri(self, uri: str) -> tuple[str, str]:
         """

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -9,6 +9,7 @@ import posixpath
 import re
 
 from mlflow.entities import Dataset, DatasetInput, InputTag, Param, RunTag
+from mlflow.entities.model_registry.prompt import PROMPT_TEXT_TAG_KEY
 from mlflow.environment_variables import (
     MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH,
     MLFLOW_TRUNCATE_LONG_VALUES,
@@ -298,6 +299,13 @@ def _validate_model_version_tag(key, value):
     _validate_tag_name(key)
     _validate_tag_value(value)
     _validate_length_limit("key", MAX_MODEL_REGISTRY_TAG_KEY_LENGTH, key)
+
+    # Check prompt text tag particularly for showing friendly error message
+    if key == PROMPT_TEXT_TAG_KEY and len(value) > MAX_MODEL_REGISTRY_TAG_VALUE_LENGTH:
+        raise MlflowException.invalid_parameter_value(
+            f"Prompt text exceeds max length of {MAX_MODEL_REGISTRY_TAG_VALUE_LENGTH} characters.",
+        )
+
     _validate_length_limit("value", MAX_MODEL_REGISTRY_TAG_VALUE_LENGTH, value)
 
 

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -147,7 +147,7 @@ def test_crud_prompts(tmp_path):
 
     mlflow.delete_prompt("prompt_1", version=2)
 
-    with pytest.raises(MlflowException, match=r"Prompt (.*) with version 2 not found"):
+    with pytest.raises(MlflowException, match=r"Prompt \(name=prompt_1, version=2\) not found"):
         mlflow.load_prompt("prompt_1", version=2)
 
     mlflow.delete_prompt("prompt_1", version=1)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1676,10 +1676,99 @@ def test_crud_prompts(tracking_uri):
 
     client.delete_prompt("prompt_1", version=2)
 
-    with pytest.raises(MlflowException, match=r"Prompt (.*) with version 2 not found"):
+    with pytest.raises(MlflowException, match=r"Prompt \(name=prompt_1, version=2\) not found"):
         client.load_prompt("prompt_1", version=2)
 
     client.delete_prompt("prompt_1", version=1)
+
+
+def test_create_prompt_error_handling(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    # Exceeds the max length
+    with pytest.raises(MlflowException, match=r"Prompt text exceeds max length of"):
+        client.register_prompt(name="prompt_1", template="Hi" * 10000)
+
+    # When the first version creation fails, RegisteredModel should not be created
+    with pytest.raises(MlflowException, match=r"Prompt with name=prompt_1 not found"):
+        client.load_prompt("prompt_1")
+
+    client.register_prompt("prompt_1", template="Hi, {{title}} {{name}}!")
+    assert client.load_prompt("prompt_1") is not None
+
+    # When the subsequent version creation fails, RegisteredModel should remain
+    with pytest.raises(MlflowException, match=r"Prompt text exceeds max length of"):
+        client.register_prompt(name="prompt_1", template="Hi" * 10000)
+
+    assert client.load_prompt("prompt_1") is not None
+
+
+def test_create_prompt_with_invalid_name(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    with pytest.raises(MlflowException, match=r"Missing value for required parameter 'name'."):
+        client.register_prompt(name="", template="Hi, {{name}}!")
+
+    if tracking_uri.startswith("file"):
+        with pytest.raises(MlflowException, match=r"Prompt name cannot contain path separator"):
+            client.register_prompt(name="prompt_1/2", template="Hi, {{name}}!")
+
+        with pytest.raises(MlflowException, match=r"Prompt name cannot contain '%' character"):
+            client.register_prompt(name="m%6fdel", template="Hi, {{name}}!")
+
+    # Name conflicts with a model
+    client.create_registered_model("model")
+    with pytest.raises(MlflowException, match=r"Model 'model' exists with the same name."):
+        client.register_prompt(name="model", template="Hi, {{name}}!")
+
+
+def test_load_prompt_error(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    with pytest.raises(MlflowException, match=r"Prompt with name=test not found"):
+        client.load_prompt("test")
+
+    if tracking_uri.startswith("file"):
+        error_msg = r"Prompt with name=test not found"
+    else:
+        error_msg = r"Prompt \(name=test, version=2\) not found"
+
+    with pytest.raises(MlflowException, match=error_msg):
+        client.load_prompt("test", version=2)
+
+    # Load prompt with a model name
+    client.create_registered_model("model")
+    client.create_model_version("model", "source")
+
+    with pytest.raises(MlflowException, match=r"Name `model` is registered as a model"):
+        client.load_prompt("model")
+
+    with pytest.raises(MlflowException, match=r"Name `model` is registered as a model"):
+        client.load_prompt("model", version=1)
+
+
+def test_delete_prompt_error(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    if tracking_uri.startswith("file"):
+        error_msg = r"Prompt with name=test not found"
+    else:
+        error_msg = r"Prompt \(name=test, version=1\) not found"
+
+    with pytest.raises(MlflowException, match=error_msg):
+        client.delete_prompt("test", version=1)
+
+    # Delete prompt with a model name
+    client.create_registered_model("test")
+    client.create_model_version("test", "source")
+
+    with pytest.raises(MlflowException, match=r"Prompt 'test' does not exist."):
+        client.delete_prompt("test", version=1)
+
+    client.register_prompt(name="prompt", template="Hi, {{name}}!")
+
+    with pytest.raises(MlflowException, match=r"Prompt \(name=prompt, version=2\) not found"):
+        client.delete_prompt("prompt", version=2)
 
 
 @pytest.mark.parametrize("registry_uri", ["databricks", "databricks-uc", "uc://localhost:5000"])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14929?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14929/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14929/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

Fix error messages for the prompt registry. Every message saying "Registered Model ..

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
