### PR TITLE
Small fixes: search debounce, diff colors and alias modal captions

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -23,7 +23,7 @@ import {
 import { PromptDetailsMetadata } from './components/PromptDetailsMetadata';
 import { FormattedMessage } from 'react-intl';
 import { PromptVersionsTableMode } from './utils';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import Routes from '../../routes';
 import { CreatePromptModalMode, useCreatePromptModal } from './hooks/useCreatePromptModal';
 import { useDeletePromptModal } from './hooks/useDeletePromptModal';
@@ -32,11 +32,18 @@ import { useEditRegisteredModelAliasesModal } from '../../../model-registry/hook
 import { usePromptDetailsPageViewState } from './hooks/usePromptDetailsPageViewState';
 import { PromptContentPreview } from './components/PromptContentPreview';
 import { PromptContentCompare } from './components/PromptContentCompare';
-import { NotFoundError, PredefinedError, UnauthorizedError } from '../../../shared/web-shared/errors';
 import { withErrorBoundary } from '../../../common/utils/withErrorBoundary';
 import ErrorUtils from '../../../common/utils/ErrorUtils';
 import { PromptPageErrorHandler } from './components/PromptPageErrorHandler';
 import { first, isEmpty } from 'lodash';
+
+const getAliasesModalTitle = (version: string) => (
+  <FormattedMessage
+    defaultMessage="Add/edit alias for prompt version {version}"
+    description="Title for the edit aliases modal on the registered prompt details page"
+    values={{ version }}
+  />
+);
 
 const PromptsDetailsPage = () => {
   const { promptName } = useParams<{ promptName: string }>();
@@ -103,6 +110,14 @@ const PromptsDetailsPage = () => {
   const { EditAliasesModal, showEditAliasesModal } = useEditRegisteredModelAliasesModal({
     model: promptDetailsData?.prompt || null,
     onSuccess: refetch,
+    modalTitle: getAliasesModalTitle,
+    modalDescription: (
+      <FormattedMessage
+        // TODO: add a documentation link ("Learn more")
+        defaultMessage="Aliases allow you to assign a mutable, named reference to a particular prompt version."
+        description="Description for the edit aliases modal on the registered prompt details page"
+      />
+    ),
   });
 
   // If the load error occurs, throw the error into the error boundary

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
@@ -12,13 +12,16 @@ import { useNavigate } from '../../../common/utils/RoutingUtils';
 import { withErrorBoundary } from '../../../common/utils/withErrorBoundary';
 import ErrorUtils from '../../../common/utils/ErrorUtils';
 import { PromptPageErrorHandler } from './components/PromptPageErrorHandler';
+import { useDebounce } from 'use-debounce';
 
 const PromptsPage = () => {
   const [searchFilter, setSearchFilter] = useState('');
   const navigate = useNavigate();
 
+  const [debouncedSearchFilter] = useDebounce(searchFilter, 500);
+
   const { data, error, refetch, hasNextPage, hasPreviousPage, isLoading, onNextPage, onPreviousPage } =
-    usePromptsListQuery({ searchFilter });
+    usePromptsListQuery({ searchFilter: debouncedSearchFilter });
 
   const { EditTagsModal, showEditPromptTagsModal } = useUpdateRegisteredPromptTags({ onSuccess: refetch });
   const { CreatePromptModal, openModal: openCreateVersionModal } = useCreatePromptModal({

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentCompare.tsx
@@ -37,10 +37,13 @@ export const PromptContentCompare = ({
 
   const diff = useMemo(() => diffWords(baselineValue ?? '', comparedValue ?? '') ?? [], [baselineValue, comparedValue]);
 
-  const colors = {
-    addedBackground: theme.colors.green300,
-    removedBackground: theme.colors.red300,
-  };
+  const colors = useMemo(
+    () => ({
+      addedBackground: theme.isDarkMode ? theme.colors.green700 : theme.colors.green300,
+      removedBackground: theme.isDarkMode ? theme.colors.red700 : theme.colors.red300,
+    }),
+    [theme],
+  );
 
   return (
     <div

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -319,6 +319,10 @@
     "defaultMessage": "Value (optional)",
     "description": "Key-value tag editor modal > Value input label"
   },
+  "4GPLHq": {
+    "defaultMessage": "Aliases allow you to assign a mutable, named reference to a particular prompt version.",
+    "description": "Description for the edit aliases modal on the registered prompt details page"
+  },
   "4HbEVz": {
     "defaultMessage": "You need to select a served model endpoint using dropdown first",
     "description": "Experiment page > new run modal > invalid state - no model endpoint selected"
@@ -2018,6 +2022,10 @@
   "axF2gD": {
     "defaultMessage": "Full Path:",
     "description": "Label to display the full path of where the artifact of the experiment runs is located"
+  },
+  "b0KTgh": {
+    "defaultMessage": "Add/edit alias for prompt version {version}",
+    "description": "Title for the edit aliases modal on the registered prompt details page"
   },
   "bHuphj": {
     "defaultMessage": "See the documents below to learn how to customize this model and deploy it for batch or real-time scoring using the pyfunc model flavor.",

--- a/mlflow/server/js/src/model-registry/hooks/useEditRegisteredModelAliasesModal.tsx
+++ b/mlflow/server/js/src/model-registry/hooks/useEditRegisteredModelAliasesModal.tsx
@@ -20,9 +20,13 @@ const MAX_ALIASES_PER_MODEL_VERSION = 10;
 export const useEditRegisteredModelAliasesModal = ({
   model,
   onSuccess,
+  modalTitle,
+  modalDescription,
 }: {
   model: null | ModelEntity;
   onSuccess?: () => void;
+  modalTitle?: (version: string) => React.ReactNode;
+  modalDescription?: React.ReactNode;
 }) => {
   const [showModal, setShowModal] = useState(false);
   const [form] = LegacyForm.useForm();
@@ -151,27 +155,33 @@ export const useEditRegisteredModelAliasesModal = ({
       }
       destroyOnClose
       title={
-        <FormattedMessage
-          defaultMessage="Add/Edit alias for model version {version}"
-          description="Model registry > model version alias editor > Title of the update alias modal"
-          values={{ version: currentlyEditedVersion }}
-        />
+        modalTitle ? (
+          modalTitle(currentlyEditedVersion)
+        ) : (
+          <FormattedMessage
+            defaultMessage="Add/Edit alias for model version {version}"
+            description="Model registry > model version alias editor > Title of the update alias modal"
+            values={{ version: currentlyEditedVersion }}
+          />
+        )
       }
       onCancel={() => setShowModal(false)}
       confirmLoading={false}
     >
       <Typography.Paragraph>
-        <FormattedMessage
-          defaultMessage="Aliases allow you to assign a mutable, named reference to a particular model version. <link>Learn more</link>"
-          description="Explanation of registered model aliases"
-          values={{
-            link: (chunks) => (
-              <a href={mlflowAliasesLearnMoreLink} rel="noreferrer" target="_blank">
-                {chunks}
-              </a>
-            ),
-          }}
-        />
+        {modalDescription ?? (
+          <FormattedMessage
+            defaultMessage="Aliases allow you to assign a mutable, named reference to a particular model version. <link>Learn more</link>"
+            description="Explanation of registered model aliases"
+            values={{
+              link: (chunks) => (
+                <a href={mlflowAliasesLearnMoreLink} rel="noreferrer" target="_blank">
+                  {chunks}
+                </a>
+              ),
+            }}
+          />
+        )}
       </Typography.Paragraph>
       <LegacyForm form={form} layout="vertical">
         <LegacyForm.Item>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/hubertzub-db/mlflow/pull/14941?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14941/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14941/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

Fixes few issues with prompt mgmt UI:
- unreadable diff colors in dark mode
- captions in alias management modal
- search filter not being debounced

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

![Screenshot 2025-03-11 at 08 47 33](https://github.com/user-attachments/assets/9a6f6f0c-72d7-4321-87c1-3e42e09b9886)
![colors-after](https://github.com/user-attachments/assets/694be260-5fb3-47cb-8158-91f89beb290f)


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
