### PR TITLE
Prompt registry backend fixes

### DIFF
--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -56,8 +56,7 @@ def require_prompt_registry(func):
 
         if not is_prompt_supported_registry(registry_uri):
             raise MlflowException(
-                f"The '{func.__name__}' API is not supported in the current model registry "
-                "type. Prompts are supported only in the OSS MLflow Tracking Server."
+                f"The '{func.__name__}' API is only available with the OSS MLflow Tracking Server."
             )
         return func(*args, **kwargs)
 

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 from typing import Optional
 
 import mlflow
+from mlflow.entities.model_registry import ModelVersion
 from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY
 from mlflow.exceptions import MlflowException
 
@@ -97,3 +98,12 @@ def translate_prompt_exception(func):
                 raise e
 
     return wrapper
+
+
+def validate_model_version_not_prompt(mv: ModelVersion):
+    """Validate that the given model version is not a prompt."""
+    if has_prompt_tag(mv.tags):
+        raise MlflowException(
+            f"The name `{mv.name}` is registered as a prompt. "
+            "Please use the prompt APIs to interact with it."
+        )

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -4,7 +4,6 @@ from textwrap import dedent
 from typing import Optional
 
 import mlflow
-from mlflow.entities.model_registry import ModelVersion
 from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY
 from mlflow.exceptions import MlflowException
 
@@ -98,12 +97,3 @@ def translate_prompt_exception(func):
                 raise e
 
     return wrapper
-
-
-def validate_model_version_not_prompt(mv: ModelVersion):
-    """Validate that the given model version is not a prompt."""
-    if has_prompt_tag(mv.tags):
-        raise MlflowException(
-            f"The name `{mv.name}` is registered as a prompt. "
-            "Please use the prompt APIs to interact with it."
-        )

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -89,5 +89,7 @@ def get_model_name_and_version(client, models_uri):
     if model_version is not None:
         return model_name, model_version
     if model_alias is not None:
-        return model_name, client.get_model_version_by_alias(model_name, model_alias).version
+        # NB: Call get_model_version_by_alias of registry client directly to bypass prompt check
+        mv = client._get_registry_client().get_model_version_by_alias(model_name, model_alias)
+        return model_name, mv.version
     return model_name, str(_get_latest_model_version(client, model_name, model_stage))

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -88,8 +88,12 @@ def get_model_name_and_version(client, models_uri):
     (model_name, model_version, model_stage, model_alias) = _parse_model_uri(models_uri)
     if model_version is not None:
         return model_name, model_version
+
+    # NB: Call get_model_version_by_alias of registry client directly to bypass prompt check
+    if isinstance(client, mlflow.MlflowClient):
+        client = client._get_registry_client()
+
     if model_alias is not None:
-        # NB: Call get_model_version_by_alias of registry client directly to bypass prompt check
-        mv = client._get_registry_client().get_model_version_by_alias(model_name, model_alias)
+        mv = client.get_model_version_by_alias(model_name, model_alias)
         return model_name, mv.version
     return model_name, str(_get_latest_model_version(client, model_name, model_stage))

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -638,7 +638,14 @@ class SqlAlchemyStore(AbstractStore):
                 expected_stages = {get_canonical_stage(stage) for stage in ALL_STAGES}
             else:
                 expected_stages = {get_canonical_stage(stage) for stage in stages}
-            return [mv for mv in latest_versions if mv.current_stage in expected_stages]
+            mvs = [mv for mv in latest_versions if mv.current_stage in expected_stages]
+
+            # Populate aliases for each model version
+            for mv in mvs:
+                model_aliases = sql_registered_model.registered_model_aliases
+                mv.aliases = [alias.alias for alias in model_aliases if alias.version == mv.version]
+
+            return mvs
 
     @classmethod
     def _get_registered_model_tag(cls, session, name, key):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -483,6 +483,11 @@ class MlflowClient:
         """
         registry_client = self._get_registry_client()
 
+        if not isinstance(name, str) or not name:
+            raise MlflowException.invalid_parameter_value(
+                "Prompt name must be a non-empty string.",
+            )
+
         is_new_prompt = False
         try:
             rm = registry_client.get_registered_model(name)

--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -5,7 +5,6 @@ from unittest.mock import ANY
 import pytest
 import requests
 
-from mlflow import MlflowClient
 from mlflow.entities import FileInfo
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.environment_variables import MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE
@@ -13,6 +12,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.databricks_models_artifact_repo import (
     DatabricksModelsArtifactRepository,
 )
+from mlflow.tracking._model_registry.client import ModelRegistryClient
 from mlflow.utils.file_utils import _Chunk
 
 DATABRICKS_MODEL_ARTIFACT_REPOSITORY_PACKAGE = (
@@ -63,7 +63,7 @@ def test_init_with_stage_uri_containing_profile(stage_uri_with_profile):
         "run12345",
     )
     get_latest_versions_patch = mock.patch.object(
-        MlflowClient, "get_latest_versions", return_value=[model_version_detailed]
+        ModelRegistryClient, "get_latest_versions", return_value=[model_version_detailed]
     )
     with get_latest_versions_patch:
         repo = DatabricksModelsArtifactRepository(stage_uri_with_profile)
@@ -125,7 +125,7 @@ def test_init_with_stage_uri_and_profile_is_inferred(stage_uri_without_profile):
         "run12345",
     )
     get_latest_versions_patch = mock.patch.object(
-        MlflowClient, "get_latest_versions", return_value=[model_version_detailed]
+        ModelRegistryClient, "get_latest_versions", return_value=[model_version_detailed]
     )
     with (
         get_latest_versions_patch,

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -12,6 +12,7 @@ from mlflow.store.artifact.unity_catalog_models_artifact_repo import (
 from mlflow.store.artifact.unity_catalog_oss_models_artifact_repo import (
     UnityCatalogOSSModelsArtifactRepository,
 )
+from mlflow.tracking._model_registry.client import ModelRegistryClient
 from mlflow.utils.os import is_windows
 
 from tests.store.artifact.constants import (
@@ -125,7 +126,7 @@ def test_models_artifact_repo_init_with_stage_uri_and_not_using_databricks_regis
         "run12345",
     )
     get_latest_versions_patch = mock.patch.object(
-        MlflowClient, "get_latest_versions", return_value=[model_version_detailed]
+        ModelRegistryClient, "get_latest_versions", return_value=[model_version_detailed]
     )
     get_model_version_download_uri_patch = mock.patch.object(
         MlflowClient, "get_model_version_download_uri", return_value=artifact_location

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -6,6 +6,7 @@ from mlflow import MlflowClient
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.utils.models import _parse_model_uri, get_model_name_and_version
+from mlflow.tracking._model_registry.client import ModelRegistryClient
 
 
 @pytest.mark.parametrize(
@@ -121,7 +122,7 @@ def test_parse_models_uri_invalid_input(uri):
 
 def test_get_model_name_and_version_with_version():
     with mock.patch.object(
-        MlflowClient, "get_latest_versions", return_value=[]
+        ModelRegistryClient, "get_latest_versions", return_value=[]
     ) as mlflow_client_mock:
         assert get_model_name_and_version(MlflowClient(), "models:/AdsModel1/123") == (
             "AdsModel1",
@@ -132,7 +133,7 @@ def test_get_model_name_and_version_with_version():
 
 def test_get_model_name_and_version_with_stage():
     with mock.patch.object(
-        MlflowClient,
+        ModelRegistryClient,
         "get_latest_versions",
         return_value=[
             ModelVersion(
@@ -152,7 +153,7 @@ def test_get_model_name_and_version_with_stage():
 
 def test_get_model_name_and_version_with_latest():
     with mock.patch.object(
-        MlflowClient,
+        ModelRegistryClient,
         "get_latest_versions",
         return_value=[
             ModelVersion(
@@ -176,7 +177,7 @@ def test_get_model_name_and_version_with_latest():
 
 def test_get_model_name_and_version_with_alias():
     with mock.patch.object(
-        MlflowClient,
+        ModelRegistryClient,
         "get_model_version_by_alias",
         return_value=ModelVersion(
             name="mv1", version="10", creation_timestamp=123, aliases=["Champion"]

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -7,6 +7,7 @@ import pytest
 from mlflow.entities.model_registry import ModelVersion, ModelVersionTag, RegisteredModelTag
 from mlflow.entities.model_registry.model_version_status import ModelVersionStatus
 from mlflow.exceptions import MlflowException
+from mlflow.prompt.registry_utils import IS_PROMPT_TAG_KEY
 from mlflow.protos.model_registry_pb2 import (
     CreateModelVersion,
     CreateRegisteredModel,
@@ -456,3 +457,37 @@ def test_await_model_version_creation_failed(store):
         pytest.raises(MlflowException, match="Model version creation failed for model name"),
     ):
         store._await_model_version_creation(pending_mv, 0.5)
+
+
+@pytest.mark.parametrize("is_prompt", [True, False], ids=["prompt", "model"])
+def test_await_model_version_creation_show_correct_message_for_prompt(store, is_prompt):
+    tags = [ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true")] if is_prompt else []
+    pending = ModelVersion(
+        name="test",
+        version="1",
+        creation_timestamp=123,
+        tags=tags,
+        status=ModelVersionStatus.to_string(ModelVersionStatus.PENDING_REGISTRATION),
+    )
+    completed = ModelVersion(
+        name="test",
+        version="1",
+        creation_timestamp=123,
+        tags=tags,
+        status=ModelVersionStatus.to_string(ModelVersionStatus.READY),
+    )
+
+    with (
+        mock.patch("mlflow.store.model_registry.abstract_store._logger") as mock_logger,
+        mock.patch.object(store, "get_model_version", return_value=completed),
+    ):
+        store._await_model_version_creation(pending, 10)
+
+    mock_logger.info.assert_called_once()
+    info_message = mock_logger.mock_calls[0][1][0]
+    if is_prompt:
+        assert "prompt" in info_message
+        assert "model" not in info_message
+    else:
+        assert "prompt" not in info_message
+        assert "model" in info_message

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1706,8 +1706,11 @@ def test_create_prompt_error_handling(tracking_uri):
 def test_create_prompt_with_invalid_name(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
-    with pytest.raises(MlflowException, match=r"Missing value for required parameter 'name'."):
+    with pytest.raises(MlflowException, match=r"Prompt name must be a non-empty string"):
         client.register_prompt(name="", template="Hi, {{name}}!")
+
+    with pytest.raises(MlflowException, match=r"Prompt name must be a non-empty string"):
+        client.register_prompt(name=123, template="Hi, {{name}}!")
 
     if tracking_uri.startswith("file"):
         with pytest.raises(MlflowException, match=r"Prompt name cannot contain path separator"):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1778,7 +1778,7 @@ def test_delete_prompt_error(tracking_uri):
 def test_crud_prompt_on_unsupported_registry(registry_uri):
     client = MlflowClient(registry_uri=registry_uri)
 
-    with pytest.raises(MlflowException, match=r"The 'register_prompt' API is not supported"):
+    with pytest.raises(MlflowException, match=r"The 'register_prompt' API is only available"):
         client.register_prompt(
             name="prompt_1",
             template="Hi, {{title}} {{name}}! How are you today?",
@@ -1786,10 +1786,10 @@ def test_crud_prompt_on_unsupported_registry(registry_uri):
             tags={"model": "my-model"},
         )
 
-    with pytest.raises(MlflowException, match=r"The 'load_prompt' API is not supported"):
+    with pytest.raises(MlflowException, match=r"The 'load_prompt' API is only available"):
         client.load_prompt("prompt_1")
 
-    with pytest.raises(MlflowException, match=r"The 'delete_prompt' API is not supported"):
+    with pytest.raises(MlflowException, match=r"The 'delete_prompt' API is only available"):
         client.delete_prompt("prompt_1")
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1833,20 +1833,29 @@ def test_block_handling_prompt_with_model_apis(tracking_uri):
     assert prompt.name == "prompt"
     assert prompt.aliases == ["alias"]
 
-    with pytest.raises(MlflowException, match=r"Registered Model with name=prompt not found"):
-        client.get_registered_model("prompt")
+    apis_to_args = [
+        (client.rename_registered_model, ["prompt", "new_name"]),
+        (client.update_registered_model, ["prompt", "new_description"]),
+        (client.delete_registered_model, ["prompt"]),
+        (client.get_registered_model, ["prompt"]),
+        (client.get_latest_versions, ["prompt"]),
+        (client.set_registered_model_tag, ["prompt", "tag", "value"]),
+        (client.delete_registered_model_tag, ["prompt", "tag"]),
+        (client.update_model_version, ["prompt", 1, "new_description"]),
+        (client.transition_model_version_stage, ["prompt", 1, "Production"]),
+        (client.delete_model_version, ["prompt", 1]),
+        (client.get_model_version, ["prompt", 1]),
+        (client.get_model_version_download_uri, ["prompt", 1]),
+        (client.set_model_version_tag, ["prompt", 1, "tag", "value"]),
+        (client.delete_model_version_tag, ["prompt", 1, "tag"]),
+        (client.set_registered_model_alias, ["prompt", "alias", 1]),
+        (client.delete_registered_model_alias, ["prompt", "alias"]),
+        (client.get_model_version_by_alias, ["prompt", "alias"]),
+    ]
 
-    with pytest.raises(
-        MlflowException, match=r"Model Version \(name=prompt, version=1\) not found"
-    ):
-        client.get_model_version("prompt", 1)
-
-    with pytest.raises(MlflowException, match=r"Registered Model with name=prompt not found"):
-        client.get_latest_versions("prompt")
-
-    client.set_prompt_alias("prompt", "alias", 1)
-    with pytest.raises(MlflowException, match=r"Registered Model with name=prompt not found"):
-        client.get_model_version_by_alias("prompt", "alias")
+    for api, args in apis_to_args:
+        with pytest.raises(MlflowException, match=r"Registered Model with name='prompt' not found"):
+            api(*args)
 
     with pytest.raises(MlflowException, match=r"Model with uri 'models:/prompt/1' not found"):
         client.copy_model_version("models:/prompt/1", "new_model")

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1824,6 +1824,34 @@ def test_block_create_prompt_with_existing_model_name(tracking_uri):
         )
 
 
+def test_block_handling_prompt_with_model_apis(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+    client.register_prompt("prompt", template="Hi, {{name}}!")
+    client.set_prompt_alias("prompt", alias="alias", version=1)
+    # Validate the prompt is registered
+    prompt = client.load_prompt("prompt", version=1)
+    assert prompt.name == "prompt"
+    assert prompt.aliases == ["alias"]
+
+    with pytest.raises(MlflowException, match=r"Registered Model with name=prompt not found"):
+        client.get_registered_model("prompt")
+
+    with pytest.raises(
+        MlflowException, match=r"Model Version \(name=prompt, version=1\) not found"
+    ):
+        client.get_model_version("prompt", 1)
+
+    with pytest.raises(MlflowException, match=r"Registered Model with name=prompt not found"):
+        client.get_latest_versions("prompt")
+
+    client.set_prompt_alias("prompt", "alias", 1)
+    with pytest.raises(MlflowException, match=r"Registered Model with name=prompt not found"):
+        client.get_model_version_by_alias("prompt", "alias")
+
+    with pytest.raises(MlflowException, match=r"Model with uri 'models:/prompt/1' not found"):
+        client.copy_model_version("models:/prompt/1", "new_model")
+
+
 def test_log_and_detach_prompt(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14942?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14942/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14942/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

Resolve a few backend issues about prompt registry

1. Block calling `get_xyz` API of Model Registry with a prompt name.
2. Fix the cryptic error message when passing non-string name to `register_prompt` API: `TypeError: bad argument type for built-in operation`
3.  Adjust the info message `"Waiting up to 300 seconds for model version to finish creation..."` when registering a model via RestStore, to say "prompt" when appropriate.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

For issue (1):

![Screenshot 2025-03-11 at 17 06 35](https://github.com/user-attachments/assets/b0af2b2a-4829-4e10-93dd-ee50937cde0e)


For issue (2):

![Screenshot 2025-03-11 at 17 04 20](https://github.com/user-attachments/assets/43dac40e-8588-47c1-bc8b-47917095f0d9)


For issue (3):

![Screenshot 2025-03-11 at 17 07 09](https://github.com/user-attachments/assets/61884799-8b7b-48da-b13c-0444e6859818)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
