### PR TITLE
Support auto-association of prompt with active run

### DIFF
--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -19,7 +19,7 @@ PromptVersionTag = ModelVersionTag
 
 
 def _is_reserved_tag(key: str) -> bool:
-    return key in {IS_PROMPT_TAG_KEY, PROMPT_TEXT_TAG_KEY}
+    return key in {IS_PROMPT_TAG_KEY, PROMPT_TEXT_TAG_KEY, PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY}
 
 
 # Prompt is implemented as a special type of ModelVersion. MLflow stores both prompts
@@ -82,6 +82,17 @@ class Prompt(ModelVersion):
         """
         return self._tags[PROMPT_TEXT_TAG_KEY]
 
+    def to_single_brace_format(self) -> str:
+        """
+        Convert the template text to single brace format. This is useful for integrating with other
+        systems that use single curly braces for variable replacement, such as LangChain's prompt
+        template. Default is False.
+        """
+        t = self.template
+        for var in self.variables:
+            t = re.sub(r"\{\{\s*" + var + r"\s*\}\}", "{" + var + "}", t)
+        return t
+
     @property
     def variables(self) -> set[str]:
         """
@@ -106,7 +117,7 @@ class Prompt(ModelVersion):
     @property
     def run_ids(self) -> list[str]:
         """Get the run IDs associated with the prompt."""
-        run_tag = self.tags.get(PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY)
+        run_tag = self._tags.get(PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY)
         if not run_tag:
             return []
         return run_tag.split(",")

--- a/tests/entities/test_prompt.py
+++ b/tests/entities/test_prompt.py
@@ -35,6 +35,21 @@ def test_prompt_variables_extraction(template, expected):
     assert prompt.variables == expected
 
 
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        ("Hello, {{name}}!", "Hello, {name}!"),
+        ("Hello, {{ title }} {{ name }}!", "Hello, {title} {name}!"),
+        ("Hello, {{ person.name.first }}", "Hello, {person.name.first}"),
+        ("Hello, {{name1}}", "Hello, {name1}"),
+        ("Hello, {name}", "Hello, {name}"),
+    ],
+)
+def test_prompt_to_single_brace_format(template, expected):
+    prompt = Prompt(name="test", version=1, template=template)
+    assert prompt.to_single_brace_format() == expected
+
+
 def test_prompt_format():
     prompt = Prompt(name="test", version=1, template="Hello, {{title}} {{name}}!")
     result = prompt.format(title="Ms.", name="Alice")

--- a/tests/langchain/sample_code/chain_with_mlflow_prompt.py
+++ b/tests/langchain/sample_code/chain_with_mlflow_prompt.py
@@ -1,0 +1,13 @@
+from langchain.schema.output_parser import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+
+import mlflow
+from mlflow.models import set_model
+
+prompt = ChatPromptTemplate.from_template(
+    mlflow.load_prompt("prompts:/qa_prompt@production").to_single_brace_format()
+)
+chain = prompt | ChatOpenAI(temperature=0) | StrOutputParser()
+
+set_model(chain)

--- a/tests/langgraph/test_langgraph_autolog.py
+++ b/tests/langgraph/test_langgraph_autolog.py
@@ -131,8 +131,6 @@ def test_langgraph_tracing_with_custom_span():
 
     input_example = {"messages": [{"role": "user", "content": "what is the weather in sf?"}]}
 
-    mlflow.register_prompt(name="prompt_1", template="what is the weather in {{city}}?")
-
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(
             "tests/langgraph/sample_code/langgraph_with_custom_span.py",
@@ -141,9 +139,6 @@ def test_langgraph_tracing_with_custom_span():
         )
 
     loaded_graph = mlflow.langchain.load_model(model_info.model_uri)
-
-    prompts = mlflow.MlflowClient().list_logged_prompts(model_info.run_id)
-    assert len(prompts) == 1
 
     # No trace should be created for the first call
     assert mlflow.get_last_active_trace() is None

--- a/tests/langgraph/test_langgraph_autolog.py
+++ b/tests/langgraph/test_langgraph_autolog.py
@@ -131,6 +131,8 @@ def test_langgraph_tracing_with_custom_span():
 
     input_example = {"messages": [{"role": "user", "content": "what is the weather in sf?"}]}
 
+    mlflow.register_prompt(name="prompt_1", template="what is the weather in {{city}}?")
+
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(
             "tests/langgraph/sample_code/langgraph_with_custom_span.py",
@@ -139,6 +141,9 @@ def test_langgraph_tracing_with_custom_span():
         )
 
     loaded_graph = mlflow.langchain.load_model(model_info.model_uri)
+
+    prompts = mlflow.MlflowClient().list_logged_prompts(model_info.run_id)
+    assert len(prompts) == 1
 
     # No trace should be created for the first call
     assert mlflow.get_last_active_trace() is None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14944?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14944/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14944/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

When a prompt is loaded inside an Active Run, associate it with the run for lineage purpose.

For example, following code will automatically associate the prompt to the evaluation Run.

```
import mlflow
import openai
import pandas as pd
from typing import List

eval_data = pd.DataFrame(
    {
        "inputs": [
            "What is MLflow?",
            "What is Spark?",
        ],
        "ground_truth": [
            "MLflow is an open-source platform for managing the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, a company that specializes in big data and machine learning solutions. MLflow is designed to address the challenges that data scientists and machine learning engineers face when developing, training, and deploying machine learning models.",
            "Apache Spark is an open-source, distributed computing system designed for big data processing and analytics. It was developed in response to limitations of the Hadoop MapReduce computing model, offering improvements in speed and ease of use. Spark provides libraries for various tasks such as data ingestion, processing, and analysis through its components like Spark SQL for structured data, Spark Streaming for real-time data processing, and MLlib for machine learning tasks",
        ],
    }
)


def predict(inputs: pd.DataFrame) -> List[str]:
    predictions = []
    system_prompt = mlflow.load_prompt("prompts:/qa_system_prompt/1")

    for _, row in inputs.iterrows():
        completion = openai.chat.completions.create(
            model="gpt-4o-mini",
            messages=[
                {"role": "system", "content": system_prompt.format()},
                {"role": "user", "content": row["inputs"]},
            ],
        )
        predictions.append(completion.choices[0].message.content)

    return predictions


with mlflow.start_run(run_name="evaluation"):
    results = mlflow.evaluate(
        model=predict,
        data=eval_data,
        targets="ground_truth",
        model_type="question-answering",
    )
```


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
