### PR TITLE
Support passing Prompt object to `log_model` and add the argument to more flavors

### DIFF
--- a/docs/api_reference/source/conf.py
+++ b/docs/api_reference/source/conf.py
@@ -438,6 +438,7 @@ nitpick_ignore = [
     # sphinx can't resolve alias import e.g. from xyz import abc as xyz_abc in type annotations
     ("py:class", "mlflow.entities.assessment.Expectation"),
     ("py:class", "mlflow.entities.assessment.Feedback"),
+    ("py:class", "Prompt"),
 ]
 
 

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -10,6 +10,7 @@ import yaml
 import mlflow
 from mlflow import pyfunc
 from mlflow.dspy.wrapper import DspyChatModelWrapper, DspyModelWrapper
+from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.exceptions import INVALID_PARAMETER_VALUE, MlflowException
 from mlflow.models import (
     Model,
@@ -269,6 +270,7 @@ def log_model(
     extra_pip_requirements: Optional[Union[list[str], str]] = None,
     metadata: Optional[dict[str, Any]] = None,
     resources: Optional[Union[str, Path, list[Resource]]] = None,
+    prompts: Optional[list[Union[str, Prompt]]] = None,
 ):
     """
     Log a Dspy model along with metadata to MLflow.
@@ -300,6 +302,7 @@ def log_model(
             file.
         resources: A list of model resources or a resources.yaml file containing a list of
             resources required to serve the model.
+        prompts: {{ prompts }}
 
     .. code-block:: python
         :caption: Example
@@ -358,4 +361,5 @@ def log_model(
         extra_pip_requirements=extra_pip_requirements,
         metadata=metadata,
         resources=resources,
+        prompts=prompts,
     )

--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -8,6 +8,7 @@ from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
 from mlflow.exceptions import MlflowException
 from mlflow.prompt.constants import (
     IS_PROMPT_TAG_KEY,
+    PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY,
     PROMPT_TEMPLATE_VARIABLE_PATTERN,
     PROMPT_TEXT_DISPLAY_LIMIT,
     PROMPT_TEXT_TAG_KEY,
@@ -105,7 +106,10 @@ class Prompt(ModelVersion):
     @property
     def run_ids(self) -> list[str]:
         """Get the run IDs associated with the prompt."""
-        return self.tags.get(PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY, "").split(",")
+        run_tag = self.tags.get(PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY)
+        if not run_tag:
+            return []
+        return run_tag.split(",")
 
     @property
     def uri(self) -> str:

--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -102,6 +102,16 @@ class Prompt(ModelVersion):
         # Remove the prompt text tag as it should not be user-facing
         return {key: value for key, value in self._tags.items() if not _is_reserved_tag(key)}
 
+    @property
+    def run_ids(self) -> list[str]:
+        """Get the run IDs associated with the prompt."""
+        return self.tags.get(PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY, "").split(",")
+
+    @property
+    def uri(self) -> str:
+        """Return the URI of the prompt."""
+        return f"prompts:/{self.name}/{self.version}"
+
     def format(self, allow_partial: bool = False, **kwargs) -> Union[Prompt, str]:
         """
         Format the template text with the given keyword arguments.

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -28,6 +28,7 @@ from packaging.version import Version
 
 import mlflow
 from mlflow import pyfunc
+from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.exceptions import MlflowException
 from mlflow.langchain.databricks_dependencies import _detect_databricks_dependencies
 from mlflow.langchain.runnables import _load_runnables, _save_runnables
@@ -442,6 +443,7 @@ def log_model(
     model_config=None,
     streamable=None,
     resources: Optional[Union[list[Resource], str]] = None,
+    prompts: Optional[list[Union[str, Prompt]]] = None,
 ):
     """
     Log a LangChain model as an MLflow artifact for the current run.
@@ -566,6 +568,7 @@ def log_model(
             (e.g. on LLM model serving endpoints), we encourage explicitly passing dependencies
             via this parameter. Otherwise, ``log_model`` will attempt to infer dependencies,
             but dependency auto-inference is best-effort and may miss some dependencies.
+        prompts: {{ prompts }}
 
     Returns:
         A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
@@ -591,6 +594,7 @@ def log_model(
         model_config=model_config,
         streamable=streamable,
         resources=resources,
+        prompts=prompts,
     )
 
 

--- a/mlflow/llama_index/__init__.py
+++ b/mlflow/llama_index/__init__.py
@@ -7,6 +7,7 @@ import yaml
 
 import mlflow
 from mlflow import pyfunc
+from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.exceptions import MlflowException
 from mlflow.llama_index.pyfunc_wrapper import create_pyfunc_wrapper
 from mlflow.models import Model, ModelInputExample, ModelSignature
@@ -324,6 +325,7 @@ def log_model(
     extra_pip_requirements: Optional[Union[list[str], str]] = None,
     conda_env=None,
     metadata: Optional[dict[str, Any]] = None,
+    prompts: Optional[list[Union[str, Prompt]]] = None,
     **kwargs,
 ):
     """
@@ -434,6 +436,7 @@ def log_model(
         extra_pip_requirements: {{ extra_pip_requirements }}
         conda_env: {{ conda_env }}
         metadata: {{ metadata }}
+        prompts: {{ prompts }}
         kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
     """
 
@@ -452,6 +455,7 @@ def log_model(
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
         metadata=metadata,
+        prompts=prompts,
         **kwargs,
     )
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -841,14 +841,16 @@ class Model:
             local_path = tmp.path("model")
             if run_id is None:
                 run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
+            if prompts is not None:
+                # Convert to URIs for serialization
+                prompts = [pr.uri if isinstance(pr, Prompt) else pr for pr in prompts]
             mlflow_model = cls(
                 artifact_path=artifact_path,
                 run_id=run_id,
                 metadata=metadata,
                 resources=resources,
                 auth_policy=auth_policy,
-                # Convert to URIs for serialization
-                prompts=[pr.uri if isinstance(pr, Prompt) else pr for pr in prompts],
+                prompts=prompts,
             )
             flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
             # `save_model` calls `load_model` to infer the model requirements, which may result in

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -39,13 +39,14 @@ import os
 import warnings
 from functools import partial
 from string import Formatter
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import yaml
 from packaging.version import Version
 
 import mlflow
 from mlflow import pyfunc
+from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.environment_variables import MLFLOW_OPENAI_SECRET_SCOPE
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature
@@ -455,6 +456,7 @@ def log_model(
     extra_pip_requirements=None,
     metadata=None,
     example_no_conversion=None,
+    prompts: Optional[list[Union[str, Prompt]]] = None,
     **kwargs,
 ):
     """
@@ -494,6 +496,7 @@ def log_model(
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: {{ metadata }}
         example_no_conversion: {{ example_no_conversion }}
+        prompts: {{ prompts }}
         kwargs: Keyword arguments specific to the OpenAI task, such as the ``messages`` (see
             :ref:`mlflow.openai.messages` for more details on this parameter)
             or ``top_p`` value to use for chat completion.
@@ -545,6 +548,7 @@ def log_model(
         extra_pip_requirements=extra_pip_requirements,
         metadata=metadata,
         example_no_conversion=example_no_conversion,
+        prompts=prompts,
         **kwargs,
     )
 

--- a/mlflow/promptflow/__init__.py
+++ b/mlflow/promptflow/__init__.py
@@ -22,6 +22,7 @@ import yaml
 
 import mlflow
 from mlflow import pyfunc
+from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.models import Model, ModelSignature
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import _infer_signature_from_input_example
@@ -109,6 +110,7 @@ def log_model(
     metadata=None,
     model_config: Optional[dict[str, Any]] = None,
     example_no_conversion=None,
+    prompts: Optional[list[Union[str, Prompt]]] = None,
 ):
     """
     Log a Promptflow model as an MLflow artifact for the current run.
@@ -171,6 +173,7 @@ def log_model(
                         flow, artifact_path="promptflow_model", model_config=model_config
                     )
         example_no_conversion: {{ example_no_conversion }}
+        prompts: {{ prompts }}
 
     Returns
         A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
@@ -192,6 +195,7 @@ def log_model(
         metadata=metadata,
         model_config=model_config,
         example_no_conversion=example_no_conversion,
+        prompts=prompts,
     )
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -426,6 +426,7 @@ import mlflow
 import mlflow.models.signature
 import mlflow.pyfunc.loaders
 import mlflow.pyfunc.model
+from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.environment_variables import (
     _MLFLOW_IN_CAPTURE_MODULE_PROCESS,
     _MLFLOW_TESTING,
@@ -3321,7 +3322,7 @@ def log_model(
     streamable=None,
     resources: Optional[Union[str, list[Resource]]] = None,
     auth_policy: Optional[AuthPolicy] = None,
-    prompts=None,
+    prompts: Optional[list[Union[str, Prompt]]] = None,
 ):
     """
     Log a Pyfunc model with custom inference logic and optional data dependencies as an MLflow

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -11,6 +11,7 @@ from packaging.version import Version
 
 import mlflow
 from mlflow import pyfunc
+from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature, infer_pip_requirements
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -317,6 +318,7 @@ def log_model(
     conda_env=None,
     metadata: Optional[dict[str, Any]] = None,
     example_no_conversion: Optional[bool] = None,
+    prompts: Optional[list[Union[str, Prompt]]] = None,
 ):
     """
     .. note::
@@ -385,6 +387,7 @@ def log_model(
         conda_env: {{ conda_env }}
         metadata: {{ metadata }}
         example_no_conversion: {{ example_no_conversion }}
+        prompts: {{ prompts }}
     """
     if task is not None:
         metadata = _verify_task_and_update_metadata(task, metadata)
@@ -404,6 +407,7 @@ def log_model(
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
         example_no_conversion=example_no_conversion,
+        prompts=prompts,
     )
 
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -602,22 +602,24 @@ class MlflowClient:
     @experimental
     @require_prompt_registry
     @translate_prompt_exception
-    def log_prompt(self, run_id: str, prompt_uri: str) -> None:
+    def log_prompt(self, run_id: str, prompt: Union[str, Prompt]) -> None:
         """
         Associate a prompt registered within the MLflow Prompt Registry with an MLflow Run.
 
         Args:
             run_id: The ID of the run to log the prompt to.
-            prompt_uri: The prompt URI in the format "prompts:/name/version".
+            prompt: A Prompt object or the prompt URI in the format "prompts:/name/version".
         """
-        prompt = self.load_prompt(prompt_uri)
+        if isinstance(prompt, str):
+            prompt = self.load_prompt(prompt)
+
         if run_id_tags := prompt._tags.get(PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY):
             run_ids = run_id_tags.split(",")
             run_ids.append(run_id)
         else:
             run_ids = [run_id]
 
-        name, version = self.parse_prompt_uri(prompt_uri)
+        name, version = self.parse_prompt_uri(prompt.uri)
         self._get_registry_client().set_model_version_tag(
             name, version, PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY, ",".join(run_ids)
         )

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -28,6 +28,7 @@ import yaml
 from packaging.version import Version
 
 from mlflow import pyfunc
+from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.environment_variables import (
     MLFLOW_DEFAULT_PREDICTION_DEVICE,
     MLFLOW_HUGGINGFACE_DEVICE_MAP_STRATEGY,
@@ -811,6 +812,7 @@ def log_model(
     example_no_conversion: Optional[bool] = None,
     prompt_template: Optional[str] = None,
     save_pretrained: bool = True,
+    prompts: Optional[list[Union[str, Prompt]]] = None,
     **kwargs,
 ):
     """
@@ -1014,6 +1016,7 @@ def log_model(
         example_no_conversion: {{ example_no_conversion }}
         prompt_template: {{ prompt_template }}
         save_pretrained: {{ save_pretrained }}
+        prompts: {{ prompts }}
         kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
     """
     return Model.log(
@@ -1044,6 +1047,7 @@ def log_model(
         example_no_conversion=example_no_conversion,
         prompt_template=prompt_template,
         save_pretrained=save_pretrained,
+        prompts=prompts,
         **kwargs,
     )
 

--- a/tests/entities/test_prompt.py
+++ b/tests/entities/test_prompt.py
@@ -11,6 +11,7 @@ def test_prompt_initialization():
     assert prompt.name == "my_prompt"
     assert prompt.version == 1
     assert prompt.template == "Hello, {{name}}!"
+    assert prompt.uri == "prompts:/my_prompt/1"
     # Public property should not return the reserved tag
     assert prompt.tags == {}
     assert prompt._tags[IS_PROMPT_TAG_KEY] == "true"

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1776,6 +1776,22 @@ def test_delete_prompt_error(tracking_uri):
         client.delete_prompt("prompt", version=2)
 
 
+def test_log_prompt(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    prompt = client.register_prompt("prompt", template="Hi, {{name}}!")
+    assert prompt.run_ids == []
+
+    client.log_prompt("run1", prompt)
+    assert client.load_prompt("prompt").run_ids == ["run1"]
+
+    client.log_prompt("run2", prompt)
+    assert client.load_prompt("prompt").run_ids == ["run1", "run2"]
+
+    with pytest.raises(MlflowException, match=r"The `prompt` argument must be"):
+        client.log_prompt("run3", 123)
+
+
 @pytest.mark.parametrize("registry_uri", ["databricks", "databricks-uc", "uc://localhost:5000"])
 def test_crud_prompt_on_unsupported_registry(registry_uri):
     client = MlflowClient(registry_uri=registry_uri)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14948?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14948/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14948/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

Title, (1) update `log_model` signature to accept the `Prompt` object directly not only URI (2) Add the `prompts` arguments to all GenAI flavors not only pyfunc.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
