### PR TITLE
Create mlflow run for DSPy compile

### DIFF
--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -1,4 +1,5 @@
-from mlflow.dspy.save import FLAVOR_NAME
+from mlflow.dspy.save import FLAVOR_NAME, log_model
+from mlflow.dspy.util import save_dspy_module_state
 from mlflow.tracing.provider import trace_disabled
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
@@ -13,6 +14,8 @@ def autolog(
     log_traces: bool = True,
     log_traces_from_compile: bool = False,
     log_traces_from_eval: bool = True,
+    log_compiles: bool = False,
+    log_models: bool = False,
     disable: bool = False,
     silent: bool = False,
 ):
@@ -30,6 +33,10 @@ def autolog(
             `built-in evaluator <https://dspy.ai/learn/evaluation/metrics/#evaluation>`_.
             If ``False``, traces are only logged from normal model inference and disabled when
             running the evaluator. Default to ``True``.
+        log_compiles: If ``True``, information about the optimization process is logged when
+            `Teleprompter.compile()` is called.
+        log_models: If ``True``, optimized models are logged as MLflow model artifacts.
+            If ``False``, optimized models are not logged.
         disable: If ``True``, disables the DSPy autologging integration. If ``False``,
             enables the DSPy autologging integration.
         silent: If ``True``, suppress all event logs and warnings from MLflow during DSPy
@@ -45,6 +52,8 @@ def autolog(
         log_traces=log_traces,
         log_traces_from_compile=log_traces_from_compile,
         log_traces_from_eval=log_traces_from_eval,
+        log_compiles=log_compiles,
+        log_models=log_models,
         disable=disable,
         silent=silent,
     )
@@ -54,7 +63,7 @@ def autolog(
     from mlflow.dspy.callback import MlflowCallback
 
     # Enable tracing by setting the MlflowCallback
-    if log_traces and not disable:
+    if not disable:
         if not any(isinstance(c, MlflowCallback) for c in dspy.settings.callbacks):
             dspy.settings.configure(callbacks=[*dspy.settings.callbacks, MlflowCallback()])
     else:
@@ -66,6 +75,37 @@ def autolog(
     def trace_disabled_fn(original, self, *args, **kwargs):
         # NB: Since calling mlflow.dspy.autolog() again does not unpatch a function, we need to
         # check this flag at runtime to determine if we should generate traces.
+        @trace_disabled
+        def _fn(self, *args, **kwargs):
+            return original(self, *args, **kwargs)
+
+        def _compile_fn(self, *args, **kwargs):
+            if callback := _active_callback():
+                callback._within_compile = True
+            try:
+                if get_autologging_config(FLAVOR_NAME, "log_traces_from_compile"):
+                    result = original(self, *args, **kwargs)
+                else:
+                    result = _fn(self, *args, **kwargs)
+                return result
+            finally:
+                if callback:
+                    callback._within_compile = False
+
+        if isinstance(self, Teleprompter):
+            if not get_autologging_config(FLAVOR_NAME, "log_compiles"):
+                return _compile_fn(self, *args, **kwargs)
+
+            # TODO: we may want to save the trainset with mlflow.log_input()
+            program = _compile_fn(self, *args, **kwargs)
+            # Save the state of the best model in json format
+            # so that users can see the demonstrations and instructions.
+            save_dspy_module_state(program, "best_model.json")
+            if get_autologging_config(FLAVOR_NAME, "log_models"):
+                log_model(program, "model")
+
+            return program
+
         if isinstance(self, Teleprompter) and get_autologging_config(
             FLAVOR_NAME, "log_traces_from_compile"
         ):
@@ -74,10 +114,6 @@ def autolog(
         if isinstance(self, Evaluate) and get_autologging_config(
             FLAVOR_NAME, "log_traces_from_eval"
         ):
-            return original(self, *args, **kwargs)
-
-        @trace_disabled
-        def _fn(self, *args, **kwargs):
             return original(self, *args, **kwargs)
 
         return _fn(self, *args, **kwargs)
@@ -96,6 +132,7 @@ def autolog(
                 cls,
                 compile_patch,
                 trace_disabled_fn,
+                manage_run=get_autologging_config(FLAVOR_NAME, "log_compiles"),
             )
 
     call_patch = "__call__"
@@ -117,9 +154,21 @@ def _autolog(
     log_traces: bool,
     log_traces_from_compile: bool,
     log_traces_from_eval: bool,
+    log_compiles: bool,
+    log_models: bool,
     disable: bool = False,
     silent: bool = False,
 ):
     """
-    TODO: Implement patching logic for autologging models and artifacts.
+    TODO: Implement patching logic for autologging artifacts.
     """
+
+
+def _active_callback():
+    import dspy
+
+    from mlflow.dspy.callback import MlflowCallback
+
+    for callback in dspy.settings.callbacks:
+        if isinstance(callback, MlflowCallback):
+            return callback

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -62,7 +62,7 @@ def autolog(
         silent=silent,
     )
 
-    if log_model and (not log_compiles):
+    if log_models and (not log_compiles):
         _logger.warning(
             "`log_model=True` is not effective without `log_compiles=True`. "
             "Consider setting `log_compiles=True` to log models."

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -1,3 +1,5 @@
+import logging
+
 from mlflow.dspy.save import FLAVOR_NAME, log_model
 from mlflow.dspy.util import save_dspy_module_state
 from mlflow.tracing.provider import trace_disabled
@@ -7,6 +9,8 @@ from mlflow.utils.autologging_utils import (
     get_autologging_config,
     safe_patch,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 @experimental
@@ -57,6 +61,12 @@ def autolog(
         disable=disable,
         silent=silent,
     )
+
+    if log_model and (not log_compiles):
+        _logger.warning(
+            "`log_model=True` is not effective without `log_compiles=True`. "
+            "Consider setting `log_compiles=True` to log models."
+        )
 
     import dspy
 

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -43,7 +43,7 @@ class MlflowCallback(BaseCallback):
         # call_id: (LiveSpan, OTel token)
         self._call_id_to_span: dict[str, SpanWithToken] = {}
         # used to determine the behavior of the evaluation callback
-        self._within_compile = False
+        self.within_compile = False
 
     def set_dependencies_schema(self, dependencies_schema: dict[str, Any]):
         if self._dependencies_schema:

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -1,10 +1,12 @@
 import logging
+from functools import wraps
 from typing import Any, Optional, Union
 
 import dspy
 from dspy.utils.callback import BaseCallback
 
 import mlflow
+from mlflow.dspy.save import FLAVOR_NAME
 from mlflow.entities import SpanStatusCode, SpanType
 from mlflow.entities.span_event import SpanEvent
 from mlflow.exceptions import MlflowException
@@ -16,8 +18,20 @@ from mlflow.tracing.utils import (
     start_client_span_or_trace,
 )
 from mlflow.tracing.utils.token import SpanWithToken
+from mlflow.utils.autologging_utils import (
+    get_autologging_config,
+)
 
 _logger = logging.getLogger(__name__)
+
+
+def skip_if_trace_disabled(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if get_autologging_config(FLAVOR_NAME, "log_traces"):
+            func(*args, **kwargs)
+
+    return wrapper
 
 
 class MlflowCallback(BaseCallback):
@@ -28,6 +42,8 @@ class MlflowCallback(BaseCallback):
         self._dependencies_schema = dependencies_schema
         # call_id: (LiveSpan, OTel token)
         self._call_id_to_span: dict[str, SpanWithToken] = {}
+        # used to determine the behavior of the evaluation callback
+        self._within_compile = False
 
     def set_dependencies_schema(self, dependencies_schema: dict[str, Any]):
         if self._dependencies_schema:
@@ -37,6 +53,7 @@ class MlflowCallback(BaseCallback):
             )
         self._dependencies_schema = dependencies_schema
 
+    @skip_if_trace_disabled
     def on_module_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         span_type = self._get_span_type_for_module(instance)
         attributes = self._get_span_attribute_for_module(instance)
@@ -55,6 +72,7 @@ class MlflowCallback(BaseCallback):
             attributes=attributes,
         )
 
+    @skip_if_trace_disabled
     def on_module_end(
         self, call_id: str, outputs: Optional[Any], exception: Optional[Exception] = None
     ):
@@ -66,6 +84,7 @@ class MlflowCallback(BaseCallback):
 
         self._end_span(call_id, outputs, exception)
 
+    @skip_if_trace_disabled
     def on_lm_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         span_type = (
             SpanType.CHAT_MODEL if getattr(instance, "model_type", None) == "chat" else SpanType.LLM
@@ -94,6 +113,7 @@ class MlflowCallback(BaseCallback):
             except Exception as e:
                 _logger.debug(f"Failed to set input messages for {span}. Error: {e}")
 
+    @skip_if_trace_disabled
     def on_lm_end(
         self, call_id: str, outputs: Optional[Any], exception: Optional[Exception] = None
     ):
@@ -123,6 +143,7 @@ class MlflowCallback(BaseCallback):
             for o in outputs
         ]
 
+    @skip_if_trace_disabled
     def on_adapter_format_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         self._start_span(
             call_id,
@@ -132,11 +153,13 @@ class MlflowCallback(BaseCallback):
             attributes={},
         )
 
+    @skip_if_trace_disabled
     def on_adapter_format_end(
         self, call_id: str, outputs: Optional[Any], exception: Optional[Exception] = None
     ):
         self._end_span(call_id, outputs, exception)
 
+    @skip_if_trace_disabled
     def on_adapter_parse_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         self._start_span(
             call_id,
@@ -146,11 +169,13 @@ class MlflowCallback(BaseCallback):
             attributes={},
         )
 
+    @skip_if_trace_disabled
     def on_adapter_parse_end(
         self, call_id: str, outputs: Optional[Any], exception: Optional[Exception] = None
     ):
         self._end_span(call_id, outputs, exception)
 
+    @skip_if_trace_disabled
     def on_tool_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         # DSPy uses the special "finish" tool to signal the end of the agent.
         if instance.name == "finish":
@@ -172,6 +197,7 @@ class MlflowCallback(BaseCallback):
             },
         )
 
+    @skip_if_trace_disabled
     def on_tool_end(
         self, call_id: str, outputs: Optional[Any], exception: Optional[Exception] = None
     ):

--- a/mlflow/dspy/util.py
+++ b/mlflow/dspy/util.py
@@ -1,0 +1,24 @@
+import logging
+import tempfile
+from pathlib import Path
+
+import mlflow
+
+_logger = logging.getLogger(__name__)
+
+
+def save_dspy_module_state(program, file_name: str = "model.json"):
+    """
+    Save the state of states of dspy `Module` to a temporary directory and log it as an artifact.
+
+    Args:
+        program: The dspy `Module` to be saved.
+        file_name: The name of the file to save the dspy module state. Default is `model.json`.
+    """
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir, file_name)
+            program.save(path)
+            mlflow.log_artifact(path)
+    except Exception:
+        _logger.warning("Failed to save dspy module state", exc_info=True)

--- a/mlflow/dspy/util.py
+++ b/mlflow/dspy/util.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger(__name__)
 
 def save_dspy_module_state(program, file_name: str = "model.json"):
     """
-    Save the state of states of dspy `Module` to a temporary directory and log it as an artifact.
+    Save states of dspy `Module` to a temporary directory and log it as an artifact.
 
     Args:
         program: The dspy `Module` to be saved.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from mlflow.tracing.export.inference_table import _TRACE_BUFFER
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracking._tracking_service.utils import _use_tracking_uri
+from mlflow.tracking.fluent import _last_active_run_id
 from mlflow.utils.file_utils import path_to_local_sqlite_uri
 from mlflow.utils.os import is_windows
 
@@ -169,6 +170,11 @@ def clean_up_mlruns_directory(request):
                 raise
             # `shutil.rmtree` can't remove files owned by root in a docker container.
             subprocess.run(["sudo", "rm", "-rf", mlruns_dir], check=True)
+
+
+@pytest.fixture(autouse=True)
+def clean_up_last_active_run():
+    _last_active_run_id.set(None)
 
 
 @pytest.fixture

--- a/tests/dspy/conftest.py
+++ b/tests/dspy/conftest.py
@@ -1,0 +1,7 @@
+import dspy
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_dspy_settings():
+    dspy.settings.configure(callbacks=[], lm=None, adapter=None)

--- a/tests/dspy/test_dspy_util.py
+++ b/tests/dspy/test_dspy_util.py
@@ -1,0 +1,20 @@
+import dspy
+
+import mlflow
+from mlflow.dspy.util import save_dspy_module_state
+from mlflow.tracking import MlflowClient
+
+
+def test_save_dspy_module_state(tmp_path):
+    program = dspy.ChainOfThought("question -> answer")
+
+    with mlflow.start_run() as run:
+        save_dspy_module_state(program)
+
+    client = MlflowClient()
+    artifacts = (x.path for x in client.list_artifacts(run.info.run_id))
+    assert "model.json" in artifacts
+    client.download_artifacts(run_id=run.info.run_id, path="model.json", dst_path=tmp_path)
+    loaded_program = dspy.ChainOfThought("b -> a")
+    loaded_program.load(tmp_path / "model.json")
+    assert loaded_program.dump_state() == program.dump_state()

--- a/tests/dspy/test_dspy_util.py
+++ b/tests/dspy/test_dspy_util.py
@@ -1,10 +1,16 @@
 import dspy
+import pytest
+from packaging.version import Version
 
 import mlflow
 from mlflow.dspy.util import save_dspy_module_state
 from mlflow.tracking import MlflowClient
 
 
+@pytest.mark.skipif(
+    Version(dspy.__version__) < Version("2.5.43"),
+    reason="dump_state works differently in older versions",
+)
 def test_save_dspy_module_state(tmp_path):
     program = dspy.ChainOfThought("question -> answer")
 

--- a/tests/dspy/test_dspy_util.py
+++ b/tests/dspy/test_dspy_util.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+
 import dspy
 import pytest
 from packaging.version import Version
@@ -8,7 +10,7 @@ from mlflow.tracking import MlflowClient
 
 
 @pytest.mark.skipif(
-    Version(dspy.__version__) < Version("2.5.43"),
+    Version(importlib.metadata.version("dspy")) < Version("2.5.43"),
     reason="dump_state works differently in older versions",
 )
 def test_save_dspy_module_state(tmp_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14949?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14949/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14949/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs
N/A

### What changes are proposed in this pull request?

This PR introduces new options to DSPy autologging:

- `log_compiles`: create a run for each optimization and log program params 
- `log_models`: log models when an optimizer is called

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

When mlflow.dspy.autolog is called with `log_compiles`, a mlflow run is created and program params are logged.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
