### PR TITLE
Fix bugs inPrompt registry name validation

### DIFF
--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -6,7 +6,12 @@ from typing import Optional, Union
 from mlflow.entities.model_registry.model_version import ModelVersion
 from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
 from mlflow.exceptions import MlflowException
-from mlflow.prompt.constants import IS_PROMPT_TAG_KEY, PROMPT_TEMPLATE_VARIABLE_PATTERN, PROMPT_TEXT_DISPLAY_LIMIT, PROMPT_TEXT_TAG_KEY
+from mlflow.prompt.constants import (
+    IS_PROMPT_TAG_KEY,
+    PROMPT_TEMPLATE_VARIABLE_PATTERN,
+    PROMPT_TEXT_DISPLAY_LIMIT,
+    PROMPT_TEXT_TAG_KEY,
+)
 
 # Alias type
 PromptVersionTag = ModelVersionTag

--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -6,19 +6,7 @@ from typing import Optional, Union
 from mlflow.entities.model_registry.model_version import ModelVersion
 from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
 from mlflow.exceptions import MlflowException
-
-# A special tag in RegisteredModel to indicate that it is a prompt
-IS_PROMPT_TAG_KEY = "mlflow.prompt.is_prompt"
-# A special tag in ModelVersion to store the prompt text
-PROMPT_TEXT_TAG_KEY = "mlflow.prompt.text"
-# TODO: Replace this with model_ids in MLflow 3
-PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY = "mlflow.prompt.run_ids"
-
-_PROMPT_TEMPLATE_VARIABLE_PATTERN = re.compile(
-    r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\s*\}\}"
-)
-
-_PROMPT_TEXT_DISPLAY_LIMIT = 30
+from mlflow.prompt.constants import IS_PROMPT_TAG_KEY, PROMPT_TEMPLATE_VARIABLE_PATTERN, PROMPT_TEXT_DISPLAY_LIMIT, PROMPT_TEXT_TAG_KEY
 
 # Alias type
 PromptVersionTag = ModelVersionTag
@@ -71,12 +59,12 @@ class Prompt(ModelVersion):
             aliases=aliases,
         )
 
-        self._variables = set(_PROMPT_TEMPLATE_VARIABLE_PATTERN.findall(self.template))
+        self._variables = set(PROMPT_TEMPLATE_VARIABLE_PATTERN.findall(self.template))
 
     def __repr__(self) -> str:
         text = (
-            self.template[:_PROMPT_TEXT_DISPLAY_LIMIT] + "..."
-            if len(self.template) > _PROMPT_TEXT_DISPLAY_LIMIT
+            self.template[:PROMPT_TEXT_DISPLAY_LIMIT] + "..."
+            if len(self.template) > PROMPT_TEXT_DISPLAY_LIMIT
             else self.template
         )
         return f"Prompt(name={self.name}, version={self.version}, template={text})"

--- a/mlflow/prompt/constants.py
+++ b/mlflow/prompt/constants.py
@@ -1,0 +1,18 @@
+# A special tag in RegisteredModel to indicate that it is a prompt
+import re
+
+
+IS_PROMPT_TAG_KEY = "mlflow.prompt.is_prompt"
+# A special tag in ModelVersion to store the prompt text
+PROMPT_TEXT_TAG_KEY = "mlflow.prompt.text"
+# TODO: Replace this with model_ids in MLflow 3
+PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY = "mlflow.prompt.run_ids"
+
+PROMPT_TEMPLATE_VARIABLE_PATTERN = re.compile(
+    r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\s*\}\}"
+)
+
+PROMPT_TEXT_DISPLAY_LIMIT = 30
+
+# Alphanumeric, underscore, hyphen, and dot are allowed in prompt name
+PROMPT_NAME_RULE = re.compile(r"^[a-zA-Z0-9_.-]+$")

--- a/mlflow/prompt/constants.py
+++ b/mlflow/prompt/constants.py
@@ -1,7 +1,6 @@
 # A special tag in RegisteredModel to indicate that it is a prompt
 import re
 
-
 IS_PROMPT_TAG_KEY = "mlflow.prompt.is_prompt"
 # A special tag in ModelVersion to store the prompt text
 PROMPT_TEXT_TAG_KEY = "mlflow.prompt.text"

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -1,13 +1,14 @@
 import functools
 import re
 from textwrap import dedent
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import mlflow
+from mlflow.entities.model_registry.registered_model_tag import RegisteredModelTag
 from mlflow.exceptions import MlflowException
 from mlflow.prompt.constants import IS_PROMPT_TAG_KEY, PROMPT_NAME_RULE
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.utils.validation import _validate_model_name
+from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
+
 
 def add_prompt_filter_string(
     filter_string: Optional[str], is_prompt: bool = False
@@ -29,8 +30,10 @@ def add_prompt_filter_string(
     return filter_string
 
 
-def has_prompt_tag(tags: Optional[dict]) -> bool:
+def has_prompt_tag(tags: Optional[Union[list[RegisteredModelTag], dict[str, str]]]) -> bool:
     """Check if the given tags contain the prompt tag."""
+    if isinstance(tags, list):
+        return any(tag.key == IS_PROMPT_TAG_KEY for tag in tags)
     return IS_PROMPT_TAG_KEY in tags if tags else False
 
 
@@ -108,5 +111,34 @@ def validate_prompt_name(name: Any):
 
     if PROMPT_NAME_RULE.match(name) is None:
         raise MlflowException.invalid_parameter_value(
-            f"Prompt name can only contain alphanumeric characters, hyphens, underscores, and dots.",
+            "Prompt name can only contain alphanumeric characters, hyphens, underscores, and dots.",
         )
+
+
+def handle_resource_already_exist_error(
+    name: str,
+    is_existing_entity_prompt: bool,
+    is_new_entity_prompt: bool,
+):
+    """
+    Show a more specific error message for name conflict in Model Registry.
+
+    1. When creating a model with the same name as an existing model, say "model already exists".
+    2. When creating a prompt with the same name as an existing prompt, say "prompt already exists".
+    3. Otherwise, explain that a prompt and a model cannot have the same name.
+    """
+    old_entity = "Prompt" if is_existing_entity_prompt else "Registered Model"
+    new_entity = "Prompt" if is_new_entity_prompt else "Registered Model"
+
+    if old_entity != new_entity:
+        raise MlflowException(
+            f"Tried to create a {new_entity.lower()} with name {name!r}, but the name is "
+            f"already taken by a {old_entity.lower()}. MLflow does not allow creating a "
+            "model and a prompt with the same name.",
+            RESOURCE_ALREADY_EXISTS,
+        )
+
+    raise MlflowException(
+        f"{new_entity} (name={name}) already exists.",
+        RESOURCE_ALREADY_EXISTS,
+    )

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -34,6 +34,8 @@ def has_prompt_tag(tags: Optional[Union[list[RegisteredModelTag], dict[str, str]
     """Check if the given tags contain the prompt tag."""
     if isinstance(tags, dict):
         return IS_PROMPT_TAG_KEY in tags if tags else False
+    if not tags:
+        return
     return any(tag.key == IS_PROMPT_TAG_KEY for tag in tags)
 
 

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -32,9 +32,9 @@ def add_prompt_filter_string(
 
 def has_prompt_tag(tags: Optional[Union[list[RegisteredModelTag], dict[str, str]]]) -> bool:
     """Check if the given tags contain the prompt tag."""
-    if isinstance(tags, list):
-        return any(tag.key == IS_PROMPT_TAG_KEY for tag in tags)
-    return IS_PROMPT_TAG_KEY in tags if tags else False
+    if isinstance(tags, dict):
+        return IS_PROMPT_TAG_KEY in tags if tags else False
+    return any(tag.key == IS_PROMPT_TAG_KEY for tag in tags)
 
 
 def is_prompt_supported_registry(registry_uri: Optional[str] = None) -> bool:

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -1,12 +1,13 @@
 import functools
 import re
 from textwrap import dedent
-from typing import Optional
+from typing import Any, Optional
 
 import mlflow
-from mlflow.entities.model_registry.prompt import IS_PROMPT_TAG_KEY
 from mlflow.exceptions import MlflowException
-
+from mlflow.prompt.constants import IS_PROMPT_TAG_KEY, PROMPT_NAME_RULE
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.utils.validation import _validate_model_name
 
 def add_prompt_filter_string(
     filter_string: Optional[str], is_prompt: bool = False
@@ -96,3 +97,16 @@ def translate_prompt_exception(func):
                 raise e
 
     return wrapper
+
+
+def validate_prompt_name(name: Any):
+    """Validate the prompt name against the prompt specific rule"""
+    if not isinstance(name, str) or not name:
+        raise MlflowException.invalid_parameter_value(
+            "Prompt name must be a non-empty string.",
+        )
+
+    if PROMPT_NAME_RULE.match(name) is None:
+        raise MlflowException.invalid_parameter_value(
+            f"Prompt name can only contain alphanumeric characters, hyphens, underscores, and dots.",
+        )

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
@@ -104,8 +104,8 @@ describe('PromptsPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
-    await userEvent.type(screen.getByLabelText('Name (required):'), 'prompt7');
-    await userEvent.type(screen.getByLabelText('Prompt (required):'), 'lorem ipsum');
+    await userEvent.type(screen.getByLabelText('Name:'), 'prompt7');
+    await userEvent.type(screen.getByLabelText('Prompt:'), 'lorem ipsum');
     await userEvent.type(screen.getByLabelText('Commit message (optional):'), 'commit message');
     await userEvent.click(screen.getByText('Create'));
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -113,7 +113,7 @@ export const useCreatePromptModal = ({
                 }),
               },
               pattern: {
-                value: /^[a-zA-Z0-9_\-\.]+$/,
+                value: /^[a-zA-Z0-9_\-.]+$/,
                 message: intl.formatMessage({
                   defaultMessage: 'Only alphanumeric characters, underscores, hyphens, and dots are allowed',
                   description: 'A validation state for the prompt name format in the prompt creation modal',

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -98,7 +98,7 @@ export const useCreatePromptModal = ({
       )}
       {isCreatingNewPrompt && (
         <>
-          <FormUI.Label htmlFor="mlflow.prompts.create.name">Name (required):</FormUI.Label>
+          <FormUI.Label htmlFor="mlflow.prompts.create.name">Name:</FormUI.Label>
           <RHFControlledComponents.Input
             control={form.control}
             id="mlflow.prompts.create.name"
@@ -110,6 +110,13 @@ export const useCreatePromptModal = ({
                 message: intl.formatMessage({
                   defaultMessage: 'Name is required',
                   description: 'A validation state for the prompt name in the prompt creation modal',
+                }),
+              },
+              pattern: {
+                value: /^[a-zA-Z0-9_\-\.]+$/,
+                message: intl.formatMessage({
+                  defaultMessage: 'Only alphanumeric characters, underscores, hyphens, and dots are allowed',
+                  description: 'A validation state for the prompt name format in the prompt creation modal',
                 }),
               },
             }}
@@ -125,7 +132,7 @@ export const useCreatePromptModal = ({
           <Spacer />
         </>
       )}
-      <FormUI.Label htmlFor="mlflow.prompts.create.content">Prompt (required):</FormUI.Label>
+      <FormUI.Label htmlFor="mlflow.prompts.create.content">Prompt:</FormUI.Label>
       <RHFControlledComponents.TextArea
         control={form.control}
         id="mlflow.prompts.create.content"
@@ -145,7 +152,7 @@ export const useCreatePromptModal = ({
           defaultMessage: "Type prompt content here. Wrap variables with double curly brace e.g. '{{' name '}}'.",
           description: 'A placeholder for the prompt content in the prompt creation modal',
         })}
-        validationState={form.formState.errors.draftName ? 'error' : undefined}
+        validationState={form.formState.errors.draftValue ? 'error' : undefined}
       />
       {form.formState.errors.draftValue && (
         <FormUI.Message type="error" message={form.formState.errors.draftValue.message} />

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1063,6 +1063,10 @@
     "defaultMessage": "Monitoring",
     "description": "A button enabling evaluation results monitoring mode on the experiment page"
   },
+  "HZdpLU": {
+    "defaultMessage": "Only alphanumeric characters, underscores, hyphens, and dots are allowed",
+    "description": "A validation state for the prompt name format in the prompt creation modal"
+  },
   "Hk0RSH": {
     "defaultMessage": "Y-axis:",
     "description": "Label text for Y-axis in box plot comparison in MLflow"

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -194,6 +194,7 @@ class FileStore(AbstractStore):
         """
 
         self._check_root_dir()
+
         _validate_model_name(name)
         self._validate_registered_model_does_not_exist(name)
         for tag in tags or []:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -66,7 +66,6 @@ from mlflow.protos.databricks_pb2 import (
     FEATURE_DISABLED,
     INVALID_PARAMETER_VALUE,
     RESOURCE_DOES_NOT_EXIST,
-    ErrorCode,
 )
 from mlflow.store.artifact.utils.models import (
     get_model_name_and_version,
@@ -497,7 +496,7 @@ class MlflowClient:
         rm = None
         try:
             rm = registry_client.get_registered_model(name)
-        except MlflowException as e:
+        except MlflowException:
             # Create a new prompt (model) entry
             registry_client.create_registered_model(
                 name, description=commit_message, tags={IS_PROMPT_TAG_KEY: "true"}
@@ -512,7 +511,6 @@ class MlflowClient:
                 "name for the prompt.",
                 INVALID_PARAMETER_VALUE,
             )
-
 
         tags = tags or {}
         tags.update({IS_PROMPT_TAG_KEY: "true", PROMPT_TEXT_TAG_KEY: template})

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -1783,3 +1783,31 @@ def test_search_prompts_versions(store):
     )
     assert len(mvs) == 1
     assert mvs[0].name == "prompt_2"
+
+
+def test_create_registered_model_handle_prompt_properly(store):
+    prompt_tags = [RegisteredModelTag(key=IS_PROMPT_TAG_KEY, value="true")]
+
+    store.create_registered_model("model")
+
+    store.create_registered_model("prompt", tags=prompt_tags)
+
+    with pytest.raises(MlflowException, match=r"Registered Model \(name=model\) already exists"):
+        store.create_registered_model("model")
+
+    with pytest.raises(MlflowException, match=r"Prompt \(name=prompt\) already exists"):
+        store.create_registered_model("prompt", tags=prompt_tags)
+
+    with pytest.raises(
+        MlflowException,
+        match=r"Tried to create a prompt with name 'model', "
+        r"but the name is already taken by a registered model.",
+    ):
+        store.create_registered_model("model", tags=prompt_tags)
+
+    with pytest.raises(
+        MlflowException,
+        match=r"Tried to create a registered model with name 'prompt', "
+        r"but the name is already taken by a prompt.",
+    ):
+        store.create_registered_model("prompt")

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1903,3 +1903,31 @@ def test_search_prompts_versions(store):
     )
     assert len(mvs) == 1
     assert mvs[0].name == "prompt_2"
+
+
+def test_create_registered_model_handle_prompt_properly(store):
+    prompt_tags = [RegisteredModelTag(key=IS_PROMPT_TAG_KEY, value="true")]
+
+    store.create_registered_model("model")
+
+    store.create_registered_model("prompt", tags=prompt_tags)
+
+    with pytest.raises(MlflowException, match=r"Registered Model \(name=model\) already exists"):
+        store.create_registered_model("model")
+
+    with pytest.raises(MlflowException, match=r"Prompt \(name=prompt\) already exists"):
+        store.create_registered_model("prompt", tags=prompt_tags)
+
+    with pytest.raises(
+        MlflowException,
+        match=r"Tried to create a prompt with name 'model', "
+        r"but the name is already taken by a registered model.",
+    ):
+        store.create_registered_model("model", tags=prompt_tags)
+
+    with pytest.raises(
+        MlflowException,
+        match=r"Tried to create a registered model with name 'prompt', "
+        r"but the name is already taken by a prompt.",
+    ):
+        store.create_registered_model("prompt")

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1712,12 +1712,14 @@ def test_create_prompt_with_invalid_name(tracking_uri):
     with pytest.raises(MlflowException, match=r"Prompt name must be a non-empty string"):
         client.register_prompt(name=123, template="Hi, {{name}}!")
 
-    if tracking_uri.startswith("file"):
-        with pytest.raises(MlflowException, match=r"Prompt name cannot contain path separator"):
-            client.register_prompt(name="prompt_1/2", template="Hi, {{name}}!")
-
-        with pytest.raises(MlflowException, match=r"Prompt name cannot contain '%' character"):
-            client.register_prompt(name="m%6fdel", template="Hi, {{name}}!")
+    for invalid_pattern in [
+        "prompt_1/2",
+        "m%6fdel",
+        "prompt?!?",
+        "prompt with space",
+    ]:
+        with pytest.raises(MlflowException, match=r"Prompt name can only contain alphanumeric"):
+            client.register_prompt(name=invalid_pattern, template="Hi, {{name}}!")
 
     # Name conflicts with a model
     client.create_registered_model("model")


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Limit prompt name to alphanumeric+hyphen+underscore+dot to simplify processing. The validation is added in both UI and Python client.
2. Improve the error message of naming conflict between prompt and model. Validating it in file/sql store level so we can show correct message for both UI and Python client.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Prompt name validation**:

<img width="852" alt="Screenshot 2025-03-12 at 14 58 59" src="https://github.com/user-attachments/assets/61833914-a9f1-48f2-9459-5a3ab741dc53" />


**Conflict between prompts**

<img width="862" alt="Screenshot 2025-03-12 at 15 18 41" src="https://github.com/user-attachments/assets/6c68c468-1848-479f-b8d6-2c07f5d44cbd" />

**Conflict between prompt and model**

<img width="870" alt="Screenshot 2025-03-12 at 15 18 33" src="https://github.com/user-attachments/assets/1bcf6ebf-74ef-4e50-ba33-bbf0c32836d3" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
