### PR TITLE
fix: class component to functional component

### DIFF
--- a/mlflow/server/js/src/common/components/Spinner.tsx
+++ b/mlflow/server/js/src/common/components/Spinner.tsx
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import spinner from '../static/mlflow-spinner.png';
 import { Interpolation, keyframes, Theme } from '@emotion/react';
 
@@ -6,14 +5,12 @@ type Props = {
   showImmediately?: boolean;
 };
 
-export class Spinner extends Component<Props> {
-  render() {
-    return (
-      <div css={(theme) => styles.spinner(theme, this.props.showImmediately)}>
-        <img alt="Page loading..." src={spinner} />
-      </div>
-    );
-  }
+export function Spinner({ showImmediately }: Props) {
+  return (
+    <div css={(theme) => styles.spinner(theme, showImmediately)}>
+      <img alt="Page loading..." src={spinner} />
+    </div>
+  );
 }
 
 const styles = {

--- a/mlflow/server/js/src/experiment-tracking/components/HtmlTableView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/HtmlTableView.tsx
@@ -5,7 +5,6 @@
  * annotations are already looking good, please remove this comment.
  */
 
-import React, { Component } from 'react';
 import { LegacyTable } from '@databricks/design-system';
 import './HtmlTableView.css';
 
@@ -17,21 +16,17 @@ type Props = {
   scroll?: any;
 };
 
-export class HtmlTableView extends Component<Props> {
-  render() {
-    const styles = this.props.styles || {};
-
-    return (
-      <LegacyTable
-        className="html-table-view"
-        data-test-id={this.props.testId}
-        dataSource={this.props.values}
-        columns={this.props.columns}
-        scroll={this.props.scroll}
-        size="middle"
-        pagination={false}
-        style={styles}
-      />
-    );
-  }
+export function HtmlTableView({ columns, values, styles = {}, testId, scroll }: Props) {
+  return (
+    <LegacyTable
+      className="html-table-view"
+      data-test-id={testId}
+      dataSource={values}
+      columns={columns}
+      scroll={scroll}
+      size="middle"
+      pagination={false}
+      style={styles}
+    />
+  );
 }

--- a/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotControls.tsx
@@ -1,12 +1,5 @@
-/**
- * NOTE: this code file was automatically migrated to TypeScript using ts-migrate and
- * may contain multiple `any` type annotations and `@ts-expect-error` directives.
- * If possible, please improve types while making changes to this file. If the type
- * annotations are already looking good, please remove this comment.
- */
-
-import React from 'react';
 import { Button, LegacySelect } from '@databricks/design-system';
+import { type Theme } from '@emotion/react';
 import { FormattedMessage } from 'react-intl';
 
 type Props = {
@@ -14,91 +7,88 @@ type Props = {
   metricKeys: string[];
   selectedParamKeys: string[];
   selectedMetricKeys: string[];
-  handleParamsSelectChange: (...args: any[]) => any;
-  handleMetricsSelectChange: (...args: any[]) => any;
-  onClearAllSelect: (...args: any[]) => any;
+  handleParamsSelectChange: (paramValues: string[]) => void;
+  handleMetricsSelectChange: (metricValues: string[]) => void;
+  onClearAllSelect: () => void;
 };
 
-export class ParallelCoordinatesPlotControls extends React.Component<Props> {
-  render() {
-    const {
-      paramKeys,
-      metricKeys,
-      selectedParamKeys,
-      selectedMetricKeys,
-      handleParamsSelectChange,
-      handleMetricsSelectChange,
-      onClearAllSelect,
-    } = this.props;
-    return (
-      <div css={styles.wrapper}>
-        <div>
-          <FormattedMessage
-            defaultMessage="Parameters:"
-            description="Label text for parameters in parallel coordinates plot in MLflow"
-          />
-        </div>
-        <LegacySelect
-          mode="multiple"
-          css={styles.select}
-          placeholder={
-            <FormattedMessage
-              defaultMessage="Please select parameters"
-              description="Placeholder text for parameters in parallel coordinates plot in MLflow"
-            />
-          }
-          value={selectedParamKeys}
-          onChange={handleParamsSelectChange}
-        >
-          {paramKeys.map((key) => (
-            <LegacySelect.Option value={key} key={key}>
-              {key}
-            </LegacySelect.Option>
-          ))}
-        </LegacySelect>
-        <div style={{ marginTop: 20 }}>
-          <FormattedMessage
-            defaultMessage="Metrics:"
-            description="Label text for metrics in parallel coordinates plot in MLflow"
-          />
-        </div>
-        <LegacySelect
-          mode="multiple"
-          css={styles.select}
-          placeholder={
-            <FormattedMessage
-              defaultMessage="Please select metrics"
-              description="Placeholder text for metrics in parallel coordinates plot in MLflow"
-            />
-          }
-          value={selectedMetricKeys}
-          onChange={handleMetricsSelectChange}
-        >
-          {metricKeys.map((key) => (
-            <LegacySelect.Option value={key} key={key}>
-              {key}
-            </LegacySelect.Option>
-          ))}
-        </LegacySelect>
-        <div style={{ marginTop: 20 }}>
-          <Button
-            componentId="codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84"
-            data-test-id="clear-button"
-            onClick={onClearAllSelect}
-          >
-            <FormattedMessage
-              defaultMessage="Clear All"
-              description="String for the clear button to clear any selected parameters and metrics"
-            />
-          </Button>
-        </div>
+export function ParallelCoordinatesPlotControls({
+  paramKeys,
+  metricKeys,
+  selectedParamKeys,
+  selectedMetricKeys,
+  handleParamsSelectChange,
+  handleMetricsSelectChange,
+  onClearAllSelect,
+}: Props) {
+  return (
+    <div css={styles.wrapper}>
+      <div>
+        <FormattedMessage
+          defaultMessage="Parameters:"
+          description="Label text for parameters in parallel coordinates plot in MLflow"
+        />
       </div>
-    );
-  }
+      <LegacySelect
+        mode="multiple"
+        css={styles.select}
+        placeholder={
+          <FormattedMessage
+            defaultMessage="Please select parameters"
+            description="Placeholder text for parameters in parallel coordinates plot in MLflow"
+          />
+        }
+        value={selectedParamKeys}
+        onChange={handleParamsSelectChange}
+      >
+        {paramKeys.map((key) => (
+          <LegacySelect.Option value={key} key={key}>
+            {key}
+          </LegacySelect.Option>
+        ))}
+      </LegacySelect>
+      <div style={{ marginTop: 20 }}>
+        <FormattedMessage
+          defaultMessage="Metrics:"
+          description="Label text for metrics in parallel coordinates plot in MLflow"
+        />
+      </div>
+      <LegacySelect
+        mode="multiple"
+        css={styles.select}
+        placeholder={
+          <FormattedMessage
+            defaultMessage="Please select metrics"
+            description="Placeholder text for metrics in parallel coordinates plot in MLflow"
+          />
+        }
+        value={selectedMetricKeys}
+        onChange={handleMetricsSelectChange}
+      >
+        {metricKeys.map((key) => (
+          <LegacySelect.Option value={key} key={key}>
+            {key}
+          </LegacySelect.Option>
+        ))}
+      </LegacySelect>
+      <div style={{ marginTop: 20 }}>
+        <Button
+          componentId="codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84"
+          data-test-id="clear-button"
+          onClick={onClearAllSelect}
+        >
+          <FormattedMessage
+            defaultMessage="Clear All"
+            description="String for the clear button to clear any selected parameters and metrics"
+          />
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 const styles = {
-  wrapper: (theme: any) => ({
+  wrapper: (theme: Theme) => ({
     padding: `0 ${theme.spacing.xs}px`,
   }),
   select: { width: '100%' },

--- a/mlflow/server/js/src/experiment-tracking/components/RunNotFoundView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/RunNotFoundView.tsx
@@ -1,4 +1,3 @@
-import React, { Component } from 'react';
 import Routes from '../routes';
 import { ErrorView } from '../../common/components/ErrorView';
 
@@ -6,14 +5,12 @@ type Props = {
   runId: string;
 };
 
-export class RunNotFoundView extends Component<Props> {
-  render() {
-    return (
-      <ErrorView
-        statusCode={404}
-        subMessage={`Run ID ${this.props.runId} does not exist`}
-        fallbackHomePageReactRoute={Routes.rootRoute}
-      />
-    );
-  }
+export function RunNotFoundView({ runId }: Props) {
+  return (
+    <ErrorView
+      statusCode={404}
+      subMessage={`Run ID ${runId} does not exist`}
+      fallbackHomePageReactRoute={Routes.rootRoute}
+    />
+  );
 }

--- a/mlflow/server/js/src/model-registry/components/CreateModelButton.tsx
+++ b/mlflow/server/js/src/model-registry/components/CreateModelButton.tsx
@@ -1,53 +1,42 @@
-import React from 'react';
-import { Button } from '@databricks/design-system';
+import React, { useState } from 'react';
+import { Button, ButtonProps } from '@databricks/design-system';
 import { CreateModelModal } from './CreateModelModal';
 import { FormattedMessage } from 'react-intl';
 
 type Props = {
-  buttonType?: string;
+  buttonType?: ButtonProps['type'];
   buttonText?: React.ReactNode;
 };
 
-type State = {
-  modalVisible: boolean;
-};
+export function CreateModelButton({
+  buttonType = 'primary',
+  buttonText = <FormattedMessage defaultMessage="Create Model" description="Create button to register a new model" />,
+}: Props) {
+  const [modalVisible, setModalVisible] = useState<boolean>(false);
 
-export class CreateModelButton extends React.Component<Props, State> {
-  state = {
-    modalVisible: false,
+  const hideModal = () => {
+    setModalVisible(false);
   };
 
-  hideModal = () => {
-    this.setState({ modalVisible: false });
+  const showModal = () => {
+    setModalVisible(true);
   };
 
-  showModal = () => {
-    this.setState({ modalVisible: true });
-  };
-
-  render() {
-    const { modalVisible } = this.state;
-    const buttonType = this.props.buttonType || 'primary';
-    const buttonText = this.props.buttonText || (
-      <FormattedMessage defaultMessage="Create Model" description="Create button to register a new model" />
-    );
-
-    return (
-      <div css={styles.wrapper}>
-        <Button
-          className="create-model-btn"
-          css={styles.getButtonSize(buttonType)}
-          // @ts-expect-error TS(2322): Type 'string' is not assignable to type '"link" | ... Remove this comment to see the full error message
-          type={buttonType}
-          onClick={this.showModal}
-          data-testid="create-model-button"
-        >
-          {buttonText}
-        </Button>
-        <CreateModelModal modalVisible={modalVisible} hideModal={this.hideModal} />
-      </div>
-    );
-  }
+  return (
+    <div css={styles.wrapper}>
+      <Button
+        componentId="codegen_mlflow_app_src_model-registry_components_CreateModelButton.tsx_28"
+        className="create-model-btn"
+        css={styles.getButtonSize(buttonType)}
+        type={buttonType}
+        onClick={showModal}
+        data-testid="create-model-button"
+      >
+        {buttonText}
+      </Button>
+      <CreateModelModal modalVisible={modalVisible} hideModal={hideModal} />
+    </div>
+  );
 }
 
 const styles = {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Gumichocopengin8/mlflow/pull/14959?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14959/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14959/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Convert some class components to functional components since [the official React team recommends to use functional components](https://react.dev/reference/react/Component).

I could convert
- `mlflow/server/js/src/experiment-tracking/components/modals/ConfirmModal.tsx`
- `mlflow/server/js/src/model-registry/components/ModelStageTransitionDropdown.tsx`
- `mlflow/server/js/src/model-registry/components/RegisterModelForm.tsx`

into functional components, but reverted the change due to `setState` in enzyme test cases (its not supported in functional components).

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

<img width="309" alt="image" src="https://github.com/user-attachments/assets/e94a4c13-ebf4-41bd-8261-001b13ba5e65" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
