### PR TITLE
Add prompts to run overview page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.intg.test.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter } from '../../../common/utils/RoutingUtils';
 import { cloneDeep, merge } from 'lodash';
 import userEvent from '@testing-library/user-event';
 import { getRunApi, setTagApi } from '../../actions';
+import { usePromptVersionsForRunQuery } from '../../pages/prompts/hooks/usePromptVersionsForRunQuery';
 import { NOTE_CONTENT_TAG } from '../../utils/NoteUtils';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { EXPERIMENT_PARENT_ID_TAG } from '../experiment-page/utils/experimentPage.common-utils';
@@ -22,6 +23,22 @@ jest.mock('../../../common/components/Prompt', () => ({
 jest.mock('../../actions', () => ({
   setTagApi: jest.fn(() => ({ type: 'setTagApi', payload: Promise.resolve() })),
   getRunApi: jest.fn(() => ({ type: 'getRunApi', payload: Promise.resolve() })),
+}));
+
+const testPromptName = 'test-prompt';
+const testPromptVersion = 1;
+
+jest.mock('../../pages/prompts/hooks/usePromptVersionsForRunQuery', () => ({
+  usePromptVersionsForRunQuery: jest.fn(() => ({
+    data: {
+      model_versions: [
+        {
+          name: testPromptName,
+          version: testPromptVersion,
+        },
+      ],
+    },
+  })),
 }));
 
 jest.setTimeout(30000); // Larget timeout for integration testing
@@ -320,6 +337,15 @@ describe('RunViewOverview integration', () => {
     await waitFor(() => {
       expect(screen.getByText('Parent run name loading')).toBeInTheDocument();
       expect(getRunApi).toBeCalledWith(testParentRunUuid);
+    });
+  });
+
+  test('Run overview contains prompts', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(`${testPromptName} (v${testPromptVersion})`)).toBeInTheDocument();
+      expect(usePromptVersionsForRunQuery).toBeCalledWith({ runUuid: testRunUuid });
     });
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.tsx
@@ -62,6 +62,18 @@ export const RunViewOverview = ({
   const registeredModelVersionSummaries = registeredModelVersionSummariesForRun;
   const shouldDisplayLoggedModelsBox = loggedModels?.length > 0;
 
+  const renderPromptMetadataRow = () => (
+    <DetailsOverviewMetadataRow
+      title={
+        <FormattedMessage
+          defaultMessage="Registered prompts"
+          description="Run page > Overview > Run prompts section label"
+        />
+      }
+      value={<RunViewRegisteredPromptsBox runUuid={runUuid} />}
+    />
+  );
+
   const renderDetails = () => {
     return (
       <DetailsOverviewMetadataTable>
@@ -174,15 +186,7 @@ export const RunViewOverview = ({
             )
           }
         />
-        <DetailsOverviewMetadataRow
-          title={
-            <FormattedMessage
-              defaultMessage="Registered prompts"
-              description="Run page > Overview > Run prompts section label"
-            />
-          }
-          value={<RunViewRegisteredPromptsBox runUuid={runUuid} />}
-        />
+        {renderPromptMetadataRow()}
       </DetailsOverviewMetadataTable>
     );
   };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.tsx
@@ -19,6 +19,7 @@ import { RunViewTagsBox } from './overview/RunViewTagsBox';
 import { RunViewDescriptionBox } from './overview/RunViewDescriptionBox';
 import { DetailsOverviewMetadataRow } from '../DetailsOverviewMetadataRow';
 import { RunViewRegisteredModelsBox } from './overview/RunViewRegisteredModelsBox';
+import { RunViewRegisteredPromptsBox } from './overview/RunViewRegisteredPromptsBox';
 import { RunViewLoggedModelsBox } from './overview/RunViewLoggedModelsBox';
 import { RunViewSourceBox } from './overview/RunViewSourceBox';
 import { DetailsOverviewMetadataTable } from '@mlflow/mlflow/src/experiment-tracking/components/DetailsOverviewMetadataTable';
@@ -172,6 +173,15 @@ export const RunViewOverview = ({
               <EmptyValue />
             )
           }
+        />
+        <DetailsOverviewMetadataRow
+          title={
+            <FormattedMessage
+              defaultMessage="Registered prompts"
+              description="Run page > Overview > Run prompts section label"
+            />
+          }
+          value={<RunViewRegisteredPromptsBox runUuid={runUuid} />}
         />
       </DetailsOverviewMetadataTable>
     );

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
@@ -1,0 +1,41 @@
+import { ParagraphSkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Link } from '../../../../common/utils/RoutingUtils';
+import { usePromptVersionsForRunQuery } from '../../../pages/prompts/hooks/usePromptVersionsForRunQuery';
+import Routes from '../../../routes';
+
+export const RunViewRegisteredPromptsBox = ({ runUuid }: { runUuid: string }) => {
+  const { theme } = useDesignSystemTheme();
+  const { data, isLoading } = usePromptVersionsForRunQuery({ runUuid });
+  const promptVersions = data?.model_versions;
+
+  if (isLoading) {
+    return <ParagraphSkeleton />;
+  }
+
+  if (!promptVersions || promptVersions.length === 0) {
+    return <Typography.Hint>—</Typography.Hint>;
+  }
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'row',
+        gap: theme.spacing.sm,
+        flexWrap: 'wrap',
+        padding: `${theme.spacing.sm}px 0px`,
+      }}
+    >
+      {promptVersions.map((promptVersion, index) => {
+        const to = Routes.getPromptDetailsPageRoute(encodeURIComponent(promptVersion.name));
+        const displayText = `${promptVersion.name} (v${promptVersion.version})`;
+        return (
+          <Typography.Text key={displayText} css={{ whiteSpace: 'nowrap' }}>
+            <Link to={to}>{displayText}</Link>
+            {index < promptVersions.length - 1 && ','}
+          </Typography.Text>
+        );
+      })}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
@@ -5,14 +5,14 @@ import Routes from '../../../routes';
 
 export const RunViewRegisteredPromptsBox = ({ runUuid }: { runUuid: string }) => {
   const { theme } = useDesignSystemTheme();
-  const { data, isLoading } = usePromptVersionsForRunQuery({ runUuid });
+  const { data, error, isLoading } = usePromptVersionsForRunQuery({ runUuid });
   const promptVersions = data?.model_versions;
 
   if (isLoading) {
     return <ParagraphSkeleton />;
   }
 
-  if (!promptVersions || promptVersions.length === 0) {
+  if (error || !promptVersions || promptVersions.length === 0) {
     return <Typography.Hint>—</Typography.Hint>;
   }
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/api.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/api.ts
@@ -1,7 +1,7 @@
 import { matchPredefinedError, UnknownError } from '@databricks/web-shared/errors';
 import { fetchEndpoint } from '../../../common/utils/FetchUtils';
 import { RegisteredPrompt, RegisteredPromptsListResponse, RegisteredPromptVersion } from './types';
-import { IS_PROMPT_TAG_NAME, IS_PROMPT_TAG_VALUE } from './utils';
+import { IS_PROMPT_TAG_NAME, IS_PROMPT_TAG_VALUE, REGISTERED_PROMPT_SOURCE_RUN_IDS } from './utils';
 
 const defaultErrorHandler = async ({
   reject,
@@ -134,6 +134,20 @@ export const RegisteredPromptsApi = {
   getPromptVersions: (promptName: string) => {
     const params = new URLSearchParams();
     params.append('filter', `name='${promptName}' AND tags.\`${IS_PROMPT_TAG_NAME}\` = '${IS_PROMPT_TAG_VALUE}'`);
+    const relativeUrl = ['ajax-api/2.0/mlflow/model-versions/search', params.toString()].join('?');
+    return fetchEndpoint({
+      relativeUrl,
+      error: defaultErrorHandler,
+    }) as Promise<{
+      model_versions?: RegisteredPromptVersion[];
+    }>;
+  },
+  getPromptVersionsForRun: (runUuid: string) => {
+    const params = new URLSearchParams();
+    params.append(
+      'filter',
+      `tags.\`${IS_PROMPT_TAG_NAME}\` = '${IS_PROMPT_TAG_VALUE}' AND tags.\`${REGISTERED_PROMPT_SOURCE_RUN_IDS}\` ILIKE "%${runUuid}%"`,
+    );
     const relativeUrl = ['ajax-api/2.0/mlflow/model-versions/search', params.toString()].join('?');
     return fetchEndpoint({
       relativeUrl,

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/usePromptVersionsForRunQuery.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/usePromptVersionsForRunQuery.tsx
@@ -1,0 +1,38 @@
+import { QueryFunctionContext, useQuery, UseQueryOptions } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import type { PromptVersionsForRunResponse, RegisteredPromptDetailsResponse, RegisteredPromptVersion } from '../types';
+import { RegisteredPromptsApi } from '../api';
+
+const queryFn = async ({ queryKey }: QueryFunctionContext<PromptVersionsForRunQueryKey>) => {
+  const [, { runUuid }] = queryKey;
+  return RegisteredPromptsApi.getPromptVersionsForRun(runUuid);
+};
+
+type PromptVersionsForRunQueryKey = ['run_uuid', { runUuid: string }];
+
+export const usePromptVersionsForRunQuery = (
+  { runUuid }: { runUuid: string },
+  options: UseQueryOptions<
+    PromptVersionsForRunResponse,
+    Error,
+    PromptVersionsForRunResponse,
+    PromptVersionsForRunQueryKey
+  > = {},
+) => {
+  const queryResult = useQuery<
+    PromptVersionsForRunResponse,
+    Error,
+    PromptVersionsForRunResponse,
+    PromptVersionsForRunQueryKey
+  >(['run_uuid', { runUuid }], {
+    queryFn,
+    retry: false,
+    ...options,
+  });
+
+  return {
+    data: queryResult.data,
+    error: queryResult.error ?? undefined,
+    isLoading: queryResult.isLoading,
+    refetch: queryResult.refetch,
+  };
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
@@ -21,3 +21,7 @@ export type RegisteredPromptDetailsResponse = {
   prompt?: RegisteredPrompt;
   versions: RegisteredPromptVersion[];
 };
+
+export type PromptVersionsForRunResponse = {
+  model_versions?: RegisteredPromptVersion[];
+};

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1651,6 +1651,10 @@
     "defaultMessage": "Registered Models",
     "description": "Text for registered model link in the title for model comparison page"
   },
+  "UCQwvo": {
+    "defaultMessage": "Registered prompts",
+    "description": "Run page > Overview > Run prompts section label"
+  },
   "UEDu0c": {
     "defaultMessage": "MLflow UI automatically fetches metric histories for active runs and updates the metrics plot with a {interval} second interval.",
     "description": "Helpful tooltip message to explain the automatic metrics plot update"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14960?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14960/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14960/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds prompt versions to the run overview. A few details:

1. I add a new row to the run details table, the component fetches its own data
2. In order to fetch the data, I add a new API to query model versions by run UUID

Note: we don't currently support linking directly to model versions. I think this can be supported by adding some URL parameters, but maybe in a future PR.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/c82bb6ed-f8c9-466b-9736-1abe7557ed1e

If no prompts:

<img width="1017" alt="Screenshot 2025-03-12 at 3 55 41 PM" src="https://github.com/user-attachments/assets/9f7883ca-6e14-4983-aac2-362c975fefa9" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
