### PR TITLE
Add core support for Async artifact logging of all types.

### DIFF
--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -48,6 +48,7 @@ from mlflow.tracing.utils import TraceJSONEncoder, exclude_immutable_tags
 from mlflow.tracking._tracking_service import utils
 from mlflow.tracking.metric_value_conversion_utils import convert_metric_value_to_float_if_possible
 from mlflow.utils import chunk_list
+from mlflow.utils.async_logging.run_artifact import RunArtifact
 from mlflow.utils.async_logging.run_operations import RunOperations, get_combined_run_operations
 from mlflow.utils.databricks_utils import get_workspace_url, is_in_databricks_notebook
 from mlflow.utils.mlflow_tags import IMMUTABLE_TAGS, MLFLOW_USER
@@ -934,18 +935,16 @@ class TrackingServiceClient:
         trace_data_json = json.dumps(trace_data.to_dict(), cls=TraceJSONEncoder, ensure_ascii=False)
         return artifact_repo.upload_trace_data(trace_data_json)
 
-    def _log_artifact_async(self, run_id, filename, artifact_path=None, artifact=None):
+    def _log_artifact_async(self, run_id, artifact: RunArtifact):
         """
         Write an artifact to the remote ``artifact_uri`` asynchronously.
 
         Args:
             run_id: String ID of the run.
-            filename: Filename of the artifact to be logged.
-            artifact_path: If provided, the directory in ``artifact_uri`` to write to.
-            artifact: The artifact to be logged.
+            artifact: The artifact to log.
         """
         artifact_repo = self._get_artifact_repo(run_id)
-        artifact_repo._log_artifact_async(filename, artifact_path, artifact)
+        return artifact_repo._log_artifact_async(artifact)
 
     def log_artifacts(self, run_id, local_dir, artifact_path=None):
         """Write a directory of files to the remote ``artifact_uri``.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -92,6 +92,7 @@ from mlflow.tracking.artifact_utils import _upload_artifacts_to_databricks
 from mlflow.tracking.multimedia import Image, compress_image_size, convert_to_pil_image
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils.annotations import deprecated, experimental
+from mlflow.utils.async_logging.run_artifact import RunArtifact
 from mlflow.utils.async_logging.run_operations import RunOperations
 from mlflow.utils.databricks_utils import (
     get_databricks_run_url,
@@ -2428,7 +2429,12 @@ class MlflowClient:
         filename = posixpath.basename(norm_path)
         artifact_dir = posixpath.dirname(norm_path)
         artifact_dir = None if artifact_dir == "" else artifact_dir
-        self._tracking_client._log_artifact_async(run_id, filename, artifact_dir, artifact)
+        run_artifact = RunArtifact(
+            filename=filename,
+            artifact_path=artifact_dir,
+            artifact=artifact
+        )
+        self._tracking_client._log_artifact_async(run_id, run_artifact)
 
     def log_text(self, run_id: str, text: str, artifact_file: str) -> None:
         """Log text as an artifact.

--- a/mlflow/utils/async_logging/async_artifacts_logging_queue.py
+++ b/mlflow/utils/async_logging/async_artifacts_logging_queue.py
@@ -112,9 +112,9 @@ class AsyncArtifactsLoggingQueue:
                 run_artifact.completion_event.set()
 
             except Exception as e:
-                run_artifact.completion_event.set()
                 _logger.error(f"Failed to log artifact {run_artifact.filename}. Exception: {e}")
                 run_artifact.exception = e
+                run_artifact.completion_event.set()
                 run_artifact.close()
 
         self._artifact_logging_worker_threadpool.submit(logging_func, run_artifact)

--- a/mlflow/utils/async_logging/async_artifacts_logging_queue.py
+++ b/mlflow/utils/async_logging/async_artifacts_logging_queue.py
@@ -8,13 +8,10 @@ import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, Callable, Union
+from typing import Callable
 
 from mlflow.utils.async_logging.run_artifact import RunArtifact
 from mlflow.utils.async_logging.run_operations import RunOperations
-
-if TYPE_CHECKING:
-    import PIL.Image
 
 _logger = logging.getLogger(__name__)
 
@@ -31,9 +28,7 @@ class AsyncArtifactsLoggingQueue:
             - artifact: The artifact to be logged.
     """
 
-    def __init__(
-        self, artifact_logging_func: Callable[[str, str, Union["PIL.Image.Image"]], None]
-    ) -> None:
+    def __init__(self, artifact_logging_func: Callable[[str, str], None]) -> None:
         self._queue: Queue[RunArtifact] = Queue()
         self._lock = threading.RLock()
         self._artifact_logging_func = artifact_logging_func
@@ -100,26 +95,27 @@ class AsyncArtifactsLoggingQueue:
         is set with the exception. If the queue is empty, it is ignored.
         """
         try:
-            run_artifact = self._queue.get(timeout=1)
+            run_artifact: RunArtifact = self._queue.get(timeout=1)
         except Empty:
             # Ignore empty queue exception
             return
 
-        def logging_func(run_artifact):
+        def logging_func(run_artifact: RunArtifact):
             try:
                 self._artifact_logging_func(
-                    filename=run_artifact.filename,
-                    artifact_path=run_artifact.artifact_path,
-                    artifact=run_artifact.artifact,
+                    run_artifact.local_filepath,
+                    run_artifact.artifact_path,
                 )
 
                 # Signal the artifact processing is done.
+                run_artifact.close()
                 run_artifact.completion_event.set()
 
             except Exception as e:
+                run_artifact.completion_event.set()
                 _logger.error(f"Failed to log artifact {run_artifact.filename}. Exception: {e}")
                 run_artifact.exception = e
-                run_artifact.completion_event.set()
+                run_artifact.close()
 
         self._artifact_logging_worker_threadpool.submit(logging_func, run_artifact)
 
@@ -181,13 +177,10 @@ class AsyncArtifactsLoggingQueue:
         self._artifact_status_check_threadpool = None
         self._stop_data_logging_thread_event = threading.Event()
 
-    def log_artifacts_async(self, filename, artifact_path, artifact) -> RunOperations:
+    def log_artifacts_async(self, artifact: RunArtifact) -> RunOperations:
         """Asynchronously logs runs artifacts.
 
         Args:
-            filename: Filename of the artifact to be logged.
-            artifact_path: Directory within the run's artifact directory in which to log the
-                artifact.
             artifact: The artifact to be logged.
 
         Returns:
@@ -201,12 +194,6 @@ class AsyncArtifactsLoggingQueue:
 
         if not self._is_activated:
             raise MlflowException("AsyncArtifactsLoggingQueue is not activated.")
-        artifact = RunArtifact(
-            filename=filename,
-            artifact_path=artifact_path,
-            artifact=artifact,
-            completion_event=threading.Event(),
-        )
         self._queue.put(artifact)
         operation_future = self._artifact_status_check_threadpool.submit(
             self._wait_for_artifact, artifact

--- a/mlflow/utils/async_logging/run_artifact.py
+++ b/mlflow/utils/async_logging/run_artifact.py
@@ -33,7 +33,6 @@ class RunArtifact:
             local_dir = self._tmpdir.name
 
         self.local_filepath = posixpath.join(local_dir, filename)
-        self.completion_event = threading.Event()
         self._exception = None
         self.completion_event = threading.Event() if completion_event is None else completion_event
         self._handle_image()

--- a/mlflow/utils/async_logging/run_artifact.py
+++ b/mlflow/utils/async_logging/run_artifact.py
@@ -1,8 +1,7 @@
+import posixpath
+import tempfile
 import threading
-from typing import TYPE_CHECKING, Union
-
-if TYPE_CHECKING:
-    import PIL
+from typing import Optional
 
 
 class RunArtifact:
@@ -10,23 +9,51 @@ class RunArtifact:
         self,
         filename: str,
         artifact_path: str,
-        artifact: Union["PIL.Image.Image"],
-        completion_event: threading.Event,
+        artifact: Optional["PIL.Image.Image"] = None,
+        completion_event: Optional[threading.Event] = None,
+        local_dir: Optional[str] = None,
     ) -> None:
         """Initializes an instance of `RunArtifacts`.
 
         Args:
-            filename: Filename of the artifact to be logged
+            filename: Real filename of the artifact to be logged
             artifact_path: Directory within the run's artifact directory in which to log the
                 artifact.
-            artifact: The artifact to be logged.
+            artifact (Deprecated): A PIL image to be logged.
             completion_event: A threading.Event object.
+            local_dir: Local directory in which the artifact is or will be stored. If not provided,
+                a temporary directory will be created and used.
         """
-        self.filename = filename
+        self._tmpdir = None
         self.artifact_path = artifact_path
-        self.artifact = artifact
-        self.completion_event = completion_event
+        self.filename = filename
+        self.image = artifact
+        if local_dir is None:
+            self._tmpdir = tempfile.TemporaryDirectory()
+            local_dir = self._tmpdir.name
+
+        self.local_filepath = posixpath.join(local_dir, filename)
+        self.completion_event = threading.Event()
         self._exception = None
+        self.completion_event = threading.Event() if completion_event is None else completion_event
+        self._handle_image()
+
+    def _handle_image(self):
+        if self.image is not None:
+            from PIL import Image
+            if isinstance(self.image, Image.Image):
+                self.image.save(self.local_filepath)
+
+    def close(self):
+        """Explicitly cleanup temp resources."""
+        if self._tmpdir:
+            self._tmpdir.cleanup()
+
+    def __del__(self):
+        """
+        Fallback cleanup if `close()` wasn't called.
+        """
+        self.close()
 
     @property
     def exception(self):

--- a/mlflow/utils/async_logging/run_operations.py
+++ b/mlflow/utils/async_logging/run_operations.py
@@ -4,14 +4,14 @@ class RunOperations:
     def __init__(self, operation_futures):
         self._operation_futures = operation_futures or []
 
-    def wait(self):
+    def wait(self, timeout=None):
         """Blocks on completion of all futures."""
         from mlflow.exceptions import MlflowException
 
         failed_operations = []
         for future in self._operation_futures:
             try:
-                future.result()
+                future.result(timeout=timeout)
             except Exception as e:
                 failed_operations.append(e)
 

--- a/tests/utils/test_async_artifacts_logging_queue.py
+++ b/tests/utils/test_async_artifacts_logging_queue.py
@@ -1,5 +1,7 @@
 import io
+import os
 import pickle
+import posixpath
 import random
 import threading
 import time
@@ -9,6 +11,7 @@ from PIL import Image
 
 from mlflow import MlflowException
 from mlflow.utils.async_logging.async_artifacts_logging_queue import AsyncArtifactsLoggingQueue
+from mlflow.utils.async_logging.run_artifact import RunArtifact
 
 TOTAL_ARTIFACTS = 5
 
@@ -18,20 +21,18 @@ class RunArtifacts:
         if throw_exception_on_artifact_number is None:
             throw_exception_on_artifact_number = []
         self.received_run_id = ""
-        self.received_artifacts = []
-        self.received_filenames = []
+        self.received_local_filepaths = []
         self.received_artifact_paths = []
         self.artifact_count = 0
         self.throw_exception_on_artifact_number = (
             throw_exception_on_artifact_number if throw_exception_on_artifact_number else []
         )
 
-    def consume_queue_data(self, filename, artifact_path, artifact):
+    def consume_queue_data(self, local_filepath, artifact_path):
         self.artifact_count += 1
         if self.artifact_count in self.throw_exception_on_artifact_number:
             raise MlflowException("Failed to log run data")
-        self.received_artifacts.append(artifact)
-        self.received_filenames.append(filename)
+        self.received_local_filepaths.append(local_filepath)
         self.received_artifact_paths.append(artifact_path)
 
 
@@ -39,52 +40,50 @@ def _get_run_artifacts(total_artifacts=TOTAL_ARTIFACTS):
     for num in range(0, total_artifacts):
         filename = f"image_{num}.png"
         artifact_path = f"images/artifact_{num}"
-        artifact = Image.new("RGB", (100, 100), color="red")
-        yield filename, artifact_path, artifact
+        image = Image.new("RGB", (100, 100), color="red")
+        artifact = RunArtifact(filename=filename, artifact_path=artifact_path, local_dir=None)
+        image.save(artifact.local_filepath)
+        yield artifact
 
 
 def _assert_sent_received_artifacts(
-    filenames_sent,
+    local_paths_sent,
     artifact_paths_sent,
-    artifacts_sent,
-    received_filenames,
+    received_local_paths,
     received_artifact_paths,
-    received_artifacts,
 ):
-    for num in range(1, len(filenames_sent)):
-        assert filenames_sent[num] == received_filenames[num]
+    for num in range(1, len(local_paths_sent)):
+        assert local_paths_sent[num] == received_local_paths[num]
 
     for num in range(1, len(artifact_paths_sent)):
         assert artifact_paths_sent[num] == received_artifact_paths[num]
 
-    for num in range(1, len(artifacts_sent)):
-        assert artifacts_sent[num] == received_artifacts[num]
+
+def _assert_file_cleanup(filelist):
+    for file in filelist:
+        assert not os.path.exists(file)
+        assert not os.path.exists(posixpath.dirname(file))
 
 
 def test_single_thread_publish_consume_queue():
     run_artifacts = RunArtifacts()
     async_logging_queue = AsyncArtifactsLoggingQueue(run_artifacts.consume_queue_data)
     async_logging_queue.activate()
-    filenames_sent = []
+    local_paths_sent = []
     artifact_paths_sent = []
-    artifacts_sent = []
-    for filename, artifact_path, artifact in _get_run_artifacts():
-        async_logging_queue.log_artifacts_async(
-            filename=filename, artifact_path=artifact_path, artifact=artifact
-        )
-        filenames_sent.append(filename)
-        artifact_paths_sent.append(artifact_path)
-        artifacts_sent.append(artifact)
+    for artifact in _get_run_artifacts():
+        async_logging_queue.log_artifacts_async(artifact)
+        local_paths_sent.append(artifact.local_filepath)
+        artifact_paths_sent.append(artifact.artifact_path)
     async_logging_queue.flush()
 
     _assert_sent_received_artifacts(
-        filenames_sent,
+        local_paths_sent,
         artifact_paths_sent,
-        artifacts_sent,
-        run_artifacts.received_filenames,
+        run_artifacts.received_local_filepaths,
         run_artifacts.received_artifact_paths,
-        run_artifacts.received_artifacts,
     )
+    _assert_file_cleanup(local_paths_sent)
 
 
 def test_queue_activation():
@@ -93,11 +92,9 @@ def test_queue_activation():
 
     assert not async_logging_queue._is_activated
 
-    for filename, artifact_path, artifact in _get_run_artifacts(1):
+    for artifact in _get_run_artifacts(1):
         with pytest.raises(MlflowException, match="AsyncArtifactsLoggingQueue is not activated."):
-            async_logging_queue.log_artifacts_async(
-                filename=filename, artifact_path=artifact_path, artifact=artifact
-            )
+            async_logging_queue.log_artifacts_async(artifact)
 
     async_logging_queue.activate()
     assert async_logging_queue._is_activated
@@ -109,27 +106,19 @@ def test_partial_logging_failed():
     async_logging_queue = AsyncArtifactsLoggingQueue(run_data.consume_queue_data)
     async_logging_queue.activate()
 
-    filenames_sent = []
+    local_paths_sent = []
     artifact_paths_sent = []
-    artifacts_sent = []
 
     run_operations = []
     batch_id = 1
-    for filename, artifact_path, artifact in _get_run_artifacts():
+    for artifact in _get_run_artifacts():
         if batch_id in [3, 4]:
             with pytest.raises(MlflowException, match="Failed to log run data"):
-                async_logging_queue.log_artifacts_async(
-                    filename=filename, artifact_path=artifact_path, artifact=artifact
-                ).wait()
+                async_logging_queue.log_artifacts_async(artifact).wait()
         else:
-            run_operations.append(
-                async_logging_queue.log_artifacts_async(
-                    filename=filename, artifact_path=artifact_path, artifact=artifact
-                )
-            )
-            filenames_sent.append(filename)
-            artifact_paths_sent.append(artifact_path)
-            artifacts_sent.append(artifact)
+            run_operations.append(async_logging_queue.log_artifacts_async(artifact))
+            local_paths_sent.append(artifact.local_filepath)
+            artifact_paths_sent.append(artifact.artifact_path)
 
         batch_id += 1
 
@@ -137,13 +126,12 @@ def test_partial_logging_failed():
         run_operation.wait()
 
     _assert_sent_received_artifacts(
-        filenames_sent,
+        local_paths_sent,
         artifact_paths_sent,
-        artifacts_sent,
-        run_data.received_filenames,
+        run_data.received_local_filepaths,
         run_data.received_artifact_paths,
-        run_data.received_artifacts,
     )
+    _assert_file_cleanup(local_paths_sent)
 
 
 def test_publish_multithread_consume_single_thread():
@@ -155,21 +143,15 @@ def test_publish_multithread_consume_single_thread():
     def _send_artifact(run_data_queueing_processor, run_operations=None):
         if run_operations is None:
             run_operations = []
-        filenames_sent = []
+        local_paths_sent = []
         artifact_paths_sent = []
-        artifacts_sent = []
 
-        for filename, artifact_path, artifact in _get_run_artifacts():
-            run_operations.append(
-                run_data_queueing_processor.log_artifacts_async(
-                    filename=filename, artifact_path=artifact_path, artifact=artifact
-                )
-            )
+        for artifact in _get_run_artifacts():
+            run_operations.append(run_data_queueing_processor.log_artifacts_async(artifact))
 
             time.sleep(random.randint(1, 3))
-            filenames_sent.append(filename)
-            artifact_paths_sent.append(artifact_path)
-            artifacts_sent.append(artifact)
+            local_paths_sent.append(artifact.local_filepath)
+            artifact_paths_sent.append(artifact.artifact_path)
 
     run_operations = []
     t1 = threading.Thread(target=_send_artifact, args=(async_logging_queue, run_operations))
@@ -183,22 +165,20 @@ def test_publish_multithread_consume_single_thread():
     for run_operation in run_operations:
         run_operation.wait()
 
-    assert len(run_data.received_filenames) == 2 * TOTAL_ARTIFACTS
+    assert len(run_data.received_local_filepaths) == 2 * TOTAL_ARTIFACTS
     assert len(run_data.received_artifact_paths) == 2 * TOTAL_ARTIFACTS
-    assert len(run_data.received_artifacts) == 2 * TOTAL_ARTIFACTS
+    _assert_file_cleanup(run_data.received_local_filepaths)
 
 
 class Consumer:
     def __init__(self) -> None:
-        self.filenames = []
+        self.local_paths = []
         self.artifact_paths = []
-        self.artifacts = []
 
-    def consume_queue_data(self, filename, artifact_path, artifact):
+    def consume_queue_data(self, local_filepath, artifact_path):
         time.sleep(0.5)
-        self.filenames.append(filename)
+        self.local_paths.append(local_filepath)
         self.artifact_paths.append(artifact_path)
-        self.artifacts.append(artifact)
 
 
 def test_async_logging_queue_pickle():
@@ -214,14 +194,8 @@ def test_async_logging_queue_pickle():
     async_logging_queue.activate()
 
     run_operations = []
-    for val in range(0, 10):
-        run_operations.append(
-            async_logging_queue.log_artifacts_async(
-                filename=f"image-{val}.png",
-                artifact_path="images/image-artifact.png",
-                artifact=Image.new("RGB", (100, 100), color="blue"),
-            )
-        )
+    for artifact in _get_run_artifacts():
+        run_operations.append(async_logging_queue.log_artifacts_async(artifact))
 
     # Pickle the queue
     buffer = io.BytesIO()
@@ -235,7 +209,7 @@ def test_async_logging_queue_pickle():
     for run_operation in run_operations:
         run_operation.wait()
 
-    assert len(consumer.filenames) == 10
+    assert len(consumer.local_paths) == TOTAL_ARTIFACTS
 
     # try to log using deserialized queue after activating it.
     deserialized_queue.activate()
@@ -243,16 +217,11 @@ def test_async_logging_queue_pickle():
 
     run_operations = []
 
-    for val in range(0, 10):
-        run_operations.append(
-            deserialized_queue.log_artifacts_async(
-                filename=f"image2-{val}.png",
-                artifact_path="images/image-artifact2.png",
-                artifact=Image.new("RGB", (100, 100), color="green"),
-            )
-        )
+    for artifact in _get_run_artifacts():
+        run_operations.append(deserialized_queue.log_artifacts_async(artifact))
 
     for run_operation in run_operations:
         run_operation.wait()
 
-    assert len(deserialized_queue._artifact_logging_func.__self__.filenames) == 10
+    assert len(deserialized_queue._artifact_logging_func.__self__.local_paths) == TOTAL_ARTIFACTS
+    _assert_file_cleanup(consumer.local_paths)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Stack-Attack/mlflow/pull/14961?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14961/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14961/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> [issues/14153](https://github.com/mlflow/mlflow/issues/14153)

### What changes are proposed in this pull request?

This PR adds experimental async artifact logging for all artifact types, but does not expose them in client.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
```pytest tests/tracking/test_log_image.py tests/tracking/test_artifact_utils.py tests/tracking/test_client.py tests/tracking/test_log_figure.py tests/tracking/test_mlflow_artifacts.py tests/tracking/test_model_registry.py tests/tracking/test_rest_tracking.py tests/tracking/test_tracking.py ```

`test_async_artifacts_logging_queue.py` is modified for new file-based logging structure
`def test_async_log_image_flush():` is maintained to verify backwards compatibility
Verified that the failing test also fails from master.

<img width="1859" alt="image" src="https://github.com/user-attachments/assets/37ced99c-cfe4-4338-b83a-62d1190b0e3b" />

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Add experimental async artifact logging.


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
