### PR TITLE
Add eval logging for DSPy

### DIFF
--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -71,10 +71,10 @@ def autolog(
             callbacks=[c for c in dspy.settings.callbacks if not isinstance(c, MlflowCallback)]
         )
 
-    # Patch teleprompter/evaluator not to generate traces by default
     def patch_fn(original, self, *args, **kwargs):
         # NB: Since calling mlflow.dspy.autolog() again does not unpatch a function, we need to
         # check this flag at runtime to determine if we should generate traces.
+        # method to disable tracing for compile and evaluate by default
         @trace_disabled
         def _trace_disabled_fn(self, *args, **kwargs):
             return original(self, *args, **kwargs)
@@ -92,6 +92,7 @@ def autolog(
                 if callback:
                     callback.optimizer_stack_level -= 1
                     if callback.optimizer_stack_level == 0:
+                        # Reset the callback state after the completion of root compile
                         callback.reset()
 
         if isinstance(self, Teleprompter):

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -44,7 +44,7 @@ class MlflowCallback(BaseCallback):
         self._dependencies_schema = dependencies_schema
         # call_id: (LiveSpan, OTel token)
         self._call_id_to_span: dict[str, SpanWithToken] = {}
-        
+
         ###### state management for optimization process ######
         # TODO: support running multiple optimization processes in parallel
         # optimizer_stack_level is used to determine if the callback is called within compile
@@ -218,8 +218,8 @@ class MlflowCallback(BaseCallback):
     def on_evaluate_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         """
         Callback handler at the beginning of evaluation call. Available with DSPy>=2.6.9.
-        This callback starts a nested run for each evaluation call within optimization,
-        and created a new run when Evaluate is called outside of compile and there is no active run.
+        This callback starts a nested run for each evaluation call if called within optimization,
+        and created a new run when called outside of optimization and there is no active run.
         """
         if not get_autologging_config(FLAVOR_NAME, "log_evals"):
             return

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -49,7 +49,8 @@ class MlflowCallback(BaseCallback):
         self._lock = threading.Lock()
 
         ###### state management for optimization process ######
-        # TODO: support running multiple optimization processes in parallel
+        # The current callback logic assumes there is no optimization running in parallel.
+        # The state management may not work when multiple optimizations are running in parallel.
         # optimizer_stack_level is used to determine if the callback is called within compile
         # we cannot use boolean flag because the callback can be nested
         self.optimizer_stack_level = 0

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -228,11 +228,13 @@ class MlflowCallback(BaseCallback):
             return
 
         if self.optimizer_stack_level > 0:
-            key = "eval_score"
+            key = "eval"
             if callback_metadata := inputs.get("callback_metadata"):
                 if "metric_key" in callback_metadata:
                     key = callback_metadata["metric_key"]
             with _lock:
+                # we may want to include optimizer_stack_level in the key
+                # to handle nested optimization
                 step = self._evaluation_counter[key]
                 self._evaluation_counter[key] += 1
             run = mlflow.start_run(run_name=f"{key}_{step}", nested=True)

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from functools import wraps
 from typing import Any, Optional, Union
 
@@ -7,6 +8,7 @@ from dspy.utils.callback import BaseCallback
 
 import mlflow
 from mlflow.dspy.save import FLAVOR_NAME
+from mlflow.dspy.util import save_dspy_module_state
 from mlflow.entities import SpanStatusCode, SpanType
 from mlflow.entities.span_event import SpanEvent
 from mlflow.exceptions import MlflowException
@@ -42,8 +44,17 @@ class MlflowCallback(BaseCallback):
         self._dependencies_schema = dependencies_schema
         # call_id: (LiveSpan, OTel token)
         self._call_id_to_span: dict[str, SpanWithToken] = {}
-        # used to determine the behavior of the evaluation callback
-        self.within_compile = False
+        
+        ###### state management for optimization process ######
+        # TODO: support running multiple optimization processes in parallel
+        # optimizer_stack_level is used to determine if the callback is called within compile
+        # we cannot use boolean flag because the callback can be nested
+        self.optimizer_stack_level = 0
+        # call_id: (is_minibatch, step)
+        self._call_id_to_eval_state: dict[str, tuple[bool, int]] = {}
+        self._call_id_to_run_id: dict[str, str] = {}
+        self._evaluation_counter = defaultdict(int)
+        self._best_score = 0
 
     def set_dependencies_schema(self, dependencies_schema: dict[str, Any]):
         if self._dependencies_schema:
@@ -203,6 +214,80 @@ class MlflowCallback(BaseCallback):
     ):
         if call_id in self._call_id_to_span:
             self._end_span(call_id, outputs, exception)
+
+    def on_evaluate_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        """
+        Callback handler at the beginning of evaluation call. Available with DSPy>=2.6.9.
+        This callback starts a nested run for each evaluation call within optimization,
+        and created a new run when Evaluate is called outside of compile and there is no active run.
+        """
+        if not get_autologging_config(FLAVOR_NAME, "log_evals"):
+            return
+        if devset := inputs.get("devset"):
+            is_minibatch = len(devset) < len(instance.devset)
+        else:
+            is_minibatch = False
+
+        if self.optimizer_stack_level > 0:
+            key = "minibatch" if is_minibatch else "full"
+            step = self._evaluation_counter[key]
+            run = mlflow.start_run(run_name=f"eval_{key}_{step}", nested=True)
+            self._evaluation_counter[key] += 1
+            self._call_id_to_eval_state[call_id] = (is_minibatch, step)
+            self._call_id_to_run_id[call_id] = run.info.run_id
+        else:
+            if mlflow.active_run() is None:
+                run = mlflow.start_run()
+                self._call_id_to_run_id[call_id] = run.info.run_id
+        if program := inputs.get("program"):
+            save_dspy_module_state(program, "model.json")
+
+    def on_evaluate_end(
+        self,
+        call_id: str,
+        outputs: Any,
+        exception: Optional[Exception] = None,
+    ):
+        """
+        Callback handler at the end of evaluation call. Available with DSPy>=2.6.9.
+        This callback logs the evaluation score to the individual run
+        and add eval metric to the parent run if called within optimization.
+        """
+        if not get_autologging_config(FLAVOR_NAME, "log_evals"):
+            return
+        score = outputs if isinstance(outputs, float) else outputs[0]
+        mlflow.log_metric("eval", score)
+
+        if self._call_id_to_run_id.pop(call_id, None):
+            mlflow.end_run()
+        if self.optimizer_stack_level > 0 and mlflow.active_run() is not None:
+            if call_id not in self._call_id_to_eval_state:
+                return
+            is_minibatch, step = self._call_id_to_eval_state.pop(call_id)
+            if is_minibatch:
+                mlflow.log_metric(
+                    "eval_minibatch",
+                    score,
+                    step=step,
+                )
+            else:
+                mlflow.log_metric(
+                    "eval_full",
+                    score,
+                    step=step,
+                )
+                self._best_score = max(self._best_score, score)
+                mlflow.log_metric(
+                    "eval_full_best_score",
+                    self._best_score,
+                    step=step,
+                )
+
+    def reset(self):
+        self._call_id_to_eval_state: dict[str, tuple[bool, int]] = {}
+        self._call_id_to_run_id: dict[str, str] = {}
+        self._evaluation_counter = defaultdict(int)
+        self._best_score = 0
 
     def _start_span(
         self,

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -614,10 +614,13 @@ def test_autolog_log_nested_compile():
     assert "best_model.json" in artifacts
 
 
-@pytest.mark.skipif(
+skip_if_callback_unavailable = pytest.mark.skipif(
     Version(importlib.metadata.version("dspy")) < Version("2.6.12"),
     reason="evaluate callback is available since 2.6.12",
 )
+
+
+@skip_if_callback_unavailable
 @pytest.mark.parametrize("log_evals", [True, False])
 def test_autolog_log_evals(log_evals):
     dspy.settings.configure(
@@ -649,10 +652,7 @@ def test_autolog_log_evals(log_evals):
         assert run is None
 
 
-@pytest.mark.skipif(
-    Version(importlib.metadata.version("dspy")) < Version("2.6.12"),
-    reason="evaluate callback is available since 2.6.12",
-)
+@skip_if_callback_unavailable
 def test_autolog_log_compile_with_evals():
     class EvalOptimizer(dspy.teleprompt.Teleprompter):
         def compile(self, program, eval, trainset):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/14962?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14962/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14962/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR introduces auto logging for evaluation calls when configured `log_evals`. Combined with `log_compile`, users can see parent-child runs for the optimization process.

#### MIPRO example
```
import mlflow
from dspy.teleprompt import MIPROv2


teleprompter = dspy.teleprompt.MIPROv2(
    metric=gsm8k_metric,
    auto="light",
)
mlflow.dspy.autolog(log_compiles=True, log_evals=True)
optimized_program = teleprompter.compile(
    program,
    trainset=trainset,
    max_bootstrapped_demos=3,
    max_labeled_demos=4,
    requires_permission_to_run=False,
)
```

Experiment Page
![image](https://github.com/user-attachments/assets/b3c6466c-48e4-4364-bfed-a4129b836a7d)

Parent Run
![image](https://github.com/user-attachments/assets/265af5d5-6c38-4b99-8012-1539a3894485)

Child Run
![image](https://github.com/user-attachments/assets/6b0140a9-d7d9-4b01-aa1b-1541af1de5b7)

####  Example BootstrapFewShotRandomSearch
ParentRun
![image](https://github.com/user-attachments/assets/33fcd7ce-eaeb-4ccf-8074-0bd854a69063)


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

 Auto logging option `log_evals` for DSPy evaluation calls.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
