### PR TITLE
Render version metadata

### DIFF
--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -37,7 +37,11 @@ class Prompt(ModelVersion):
             https://jinja.palletsprojects.com/en/stable/api/#notes-on-identifiers
         commit_message: The commit message for the prompt version. Optional.
         creation_timestamp: Timestamp of the prompt creation. Optional.
-        tags: A dictionary of tags associated with the prompt. Optional.
+        version_metadata: A dictionary of metadata associated with the **prompt version**.
+            This is useful for storing version-specific information, such as the author of
+            the changes. Optional.
+        prompt_tags: A dictionary of tags associated with the entire prompt. This is different
+            from the `version_metadata` as it is not tied to a specific version of the prompt.
     """
 
     def __init__(
@@ -47,24 +51,29 @@ class Prompt(ModelVersion):
         template: str,
         commit_message: Optional[str] = None,
         creation_timestamp: Optional[int] = None,
-        tags: Optional[dict[str, str]] = None,
+        version_metadata: Optional[dict[str, str]] = None,
+        prompt_tags: Optional[dict[str, str]] = None,
         aliases: Optional[list[str]] = None,
     ):
         # Store template text as a tag
-        tags = tags or {}
-        tags[PROMPT_TEXT_TAG_KEY] = template
-        tags[IS_PROMPT_TAG_KEY] = "true"
+        version_metadata = version_metadata or {}
+        version_metadata[PROMPT_TEXT_TAG_KEY] = template
+        version_metadata[IS_PROMPT_TAG_KEY] = "true"
 
         super().__init__(
             name=name,
             version=version,
             creation_timestamp=creation_timestamp,
             description=commit_message,
-            tags=[ModelVersionTag(key=key, value=value) for key, value in tags.items()],
+            # "version_metadata" is represented as ModelVersion tags.
+            tags=[ModelVersionTag(key=key, value=value) for key, value in version_metadata.items()],
             aliases=aliases,
         )
 
         self._variables = set(PROMPT_TEMPLATE_VARIABLE_PATTERN.findall(self.template))
+
+        # Store the prompt-level tags (from RegisteredModel).
+        self._prompt_tags = prompt_tags or {}
 
     def __repr__(self) -> str:
         text = (
@@ -97,10 +106,17 @@ class Prompt(ModelVersion):
         return self.description  # inherited from ModelVersion
 
     @property
-    def tags(self) -> dict[str, str]:
+    def version_metadata(self) -> dict[str, str]:
         """Return the tags of the prompt as a dictionary."""
         # Remove the prompt text tag as it should not be user-facing
         return {key: value for key, value in self._tags.items() if not _is_reserved_tag(key)}
+
+    @property
+    def tags(self) -> dict[str, str]:
+        """
+        Return the prompt-level tags (from RegisteredModel).
+        """
+        return {key: value for key, value in self._prompt_tags.items() if not _is_reserved_tag(key)}
 
     def format(self, allow_partial: bool = False, **kwargs) -> Union[Prompt, str]:
         """
@@ -147,14 +163,22 @@ class Prompt(ModelVersion):
                     template=template,
                     commit_message=self.commit_message,
                     creation_timestamp=self.creation_timestamp,
-                    tags=self.tags,
+                    prompt_tags=self._prompt_tags,
+                    version_metadata=self.version_metadata,
+                    aliases=self.aliases,
                 )
         return template
 
     @classmethod
-    def from_model_version(cls, model_version: ModelVersion) -> Prompt:
+    def from_model_version(
+        cls, model_version: ModelVersion, prompt_tags: Optional[dict[str, str]] = None
+    ) -> Prompt:
         """
         Create a Prompt object from a ModelVersion object.
+
+        Args:
+            model_version: The ModelVersion object to convert to a Prompt.
+            prompt_tags: The prompt-level tags (from RegisteredModel). Optional.
         """
         if IS_PROMPT_TAG_KEY not in model_version.tags:
             raise MlflowException.invalid_parameter_value(
@@ -173,6 +197,7 @@ class Prompt(ModelVersion):
             template=model_version.tags[PROMPT_TEXT_TAG_KEY],
             commit_message=model_version.description,
             creation_timestamp=model_version.creation_timestamp,
-            tags=model_version.tags,
+            version_metadata=model_version.tags,
+            prompt_tags=prompt_tags,
             aliases=model_version.aliases,
         )

--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -118,8 +118,8 @@ class Prompt(ModelVersion):
         Return the prompt-level tags (from RegisteredModel).
         """
         return {key: value for key, value in self._prompt_tags.items() if not _is_reserved_tag(key)}
-      
-    @property  
+
+    @property
     def run_ids(self) -> list[str]:
         """Get the run IDs associated with the prompt."""
         run_tag = self._tags.get(PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY)

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.test.tsx
@@ -61,6 +61,7 @@ describe('PromptsDetailsPage', () => {
     });
 
     expect(screen.getByRole('status', { name: 'some_tag' })).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'some_version_tag' })).toBeInTheDocument();
   });
 
   it("should preview prompt versions' contents, aliases and commit message", async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
@@ -9,6 +9,11 @@ import { usePromptRunsInfo } from '../hooks/usePromptRunsInfo';
 import { REGISTERED_PROMPT_SOURCE_RUN_IDS } from '../utils';
 import { useMemo } from 'react';
 import { PromptVersionRuns } from './PromptVersionRuns';
+import { isUserFacingTag } from '@mlflow/mlflow/src/common/utils/TagUtils';
+import { KeyValueTag } from '@mlflow/mlflow/src/common/components/KeyValueTag';
+import { PromptVersionTags } from './PromptVersionTags';
+
+const MAX_VISIBLE_TAGS = 3;
 
 export const PromptVersionMetadata = ({
   registeredPromptVersion,
@@ -40,6 +45,8 @@ export const PromptVersionMetadata = ({
   if (!registeredPrompt || !registeredPromptVersion) {
     return null;
   }
+
+  const visibleTagList = registeredPromptVersion?.tags?.filter((tag) => isUserFacingTag(tag.key)) || [];
 
   const versionElement = (
     <FormattedMessage
@@ -114,7 +121,10 @@ export const PromptVersionMetadata = ({
           <Typography.Text>{registeredPromptVersion.description}</Typography.Text>
         </>
       )}
-      {(isLoadingRuns || runIds) && (
+      {visibleTagList.length > 0 && (
+        <PromptVersionTags tags={visibleTagList} />
+      )}
+      {(isLoadingRuns || runIds.length > 0) && (
         <PromptVersionRuns isLoadingRuns={isLoadingRuns} runIds={runIds} runInfoMap={runInfoMap} />
       )}
     </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
@@ -121,9 +121,7 @@ export const PromptVersionMetadata = ({
           <Typography.Text>{registeredPromptVersion.description}</Typography.Text>
         </>
       )}
-      {visibleTagList.length > 0 && (
-        <PromptVersionTags tags={visibleTagList} />
-      )}
+      {visibleTagList.length > 0 && <PromptVersionTags tags={visibleTagList} />}
       {(isLoadingRuns || runIds.length > 0) && (
         <PromptVersionRuns isLoadingRuns={isLoadingRuns} runIds={runIds} runInfoMap={runInfoMap} />
       )}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionTags.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionTags.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+
+import { KeyValueTag } from '@mlflow/mlflow/src/common/components/KeyValueTag';
+import { KeyValueEntity } from '../../../types';
+
+export const PromptVersionTags = ({tags}: {tags: KeyValueEntity[]}) => {
+  const [showAll, setShowAll] = useState(false);
+  const { theme } = useDesignSystemTheme();
+
+  const displayThreshold = 3;
+  const visibleCount = showAll ? tags.length : Math.min(displayThreshold, tags.length || 0);
+  const hasMore = tags.length > displayThreshold;
+
+  return (
+    <>
+      <Typography.Text bold>
+        <FormattedMessage
+          defaultMessage="Metadata:"
+          description="A key-value pair for the metadata in the prompt details page"
+        />
+      </Typography.Text>
+      <div>
+          <>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: theme.spacing.xs }}>
+              {tags.slice(0, visibleCount).map((tag) => <KeyValueTag key={tag.key} tag={tag} />)}
+              {hasMore && (
+                <Button
+                  componentId="mlflow.prompts.details.version.tags.show_more"
+                  size="small"
+                  type="link"
+                  onClick={() => setShowAll(!showAll)}
+                >
+                  {showAll ? (
+                    <FormattedMessage
+                      defaultMessage="Show less"
+                      description="Label for a link that shows less tags when clicked"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      defaultMessage={'{count} more...'}
+                      description="Label for a link that renders the remaining tags when clicked"
+                      values={{ count: tags.length - visibleCount }}
+                    />
+                  )}
+                </Button>
+              )}
+            </div>
+          </>
+      </div>
+    </>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionTags.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionTags.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { KeyValueTag } from '@mlflow/mlflow/src/common/components/KeyValueTag';
 import { KeyValueEntity } from '../../../types';
 
-export const PromptVersionTags = ({tags}: {tags: KeyValueEntity[]}) => {
+export const PromptVersionTags = ({ tags }: { tags: KeyValueEntity[] }) => {
   const [showAll, setShowAll] = useState(false);
   const { theme } = useDesignSystemTheme();
 
@@ -22,32 +22,34 @@ export const PromptVersionTags = ({tags}: {tags: KeyValueEntity[]}) => {
         />
       </Typography.Text>
       <div>
-          <>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: theme.spacing.xs }}>
-              {tags.slice(0, visibleCount).map((tag) => <KeyValueTag key={tag.key} tag={tag} />)}
-              {hasMore && (
-                <Button
-                  componentId="mlflow.prompts.details.version.tags.show_more"
-                  size="small"
-                  type="link"
-                  onClick={() => setShowAll(!showAll)}
-                >
-                  {showAll ? (
-                    <FormattedMessage
-                      defaultMessage="Show less"
-                      description="Label for a link that shows less tags when clicked"
-                    />
-                  ) : (
-                    <FormattedMessage
-                      defaultMessage={'{count} more...'}
-                      description="Label for a link that renders the remaining tags when clicked"
-                      values={{ count: tags.length - visibleCount }}
-                    />
-                  )}
-                </Button>
-              )}
-            </div>
-          </>
+        <>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: theme.spacing.xs }}>
+            {tags.slice(0, visibleCount).map((tag) => (
+              <KeyValueTag key={tag.key} tag={tag} />
+            ))}
+            {hasMore && (
+              <Button
+                componentId="mlflow.prompts.details.version.tags.show_more"
+                size="small"
+                type="link"
+                onClick={() => setShowAll(!showAll)}
+              >
+                {showAll ? (
+                  <FormattedMessage
+                    defaultMessage="Show less"
+                    description="Label for a link that shows less tags when clicked"
+                  />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage={'{count} more...'}
+                    description="Label for a link that renders the remaining tags when clicked"
+                    values={{ count: tags.length - visibleCount }}
+                  />
+                )}
+              </Button>
+            )}
+          </div>
+        </>
       </div>
     </>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -5,6 +5,8 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { RegisteredPrompt, RegisteredPromptVersion } from '../types';
 import { useCreateRegisteredPromptMutation } from './useCreateRegisteredPromptMutation';
 import { getPromptContentTagValue } from '../utils';
+import { CollapsibleSection } from '@mlflow/mlflow/src/common/components/CollapsibleSection';
+import { EditableTagsTableView } from '@mlflow/mlflow/src/common/components/EditableTagsTableView';
 
 export enum CreatePromptModalMode {
   CreatePrompt = 'CreatePrompt',
@@ -30,6 +32,7 @@ export const useCreatePromptModal = ({
       draftName: '',
       draftValue: '',
       commitMessage: '',
+      tags: [] as { key: string; value: string }[],
     },
   });
 
@@ -72,6 +75,7 @@ export const useCreatePromptModal = ({
             content: values.draftValue,
             commitMessage: values.commitMessage,
             promptName,
+            tags: values.tags,
           },
           {
             onSuccess: (data) => {
@@ -175,6 +179,7 @@ export const useCreatePromptModal = ({
         commitMessage: '',
         draftName: '',
         draftValue: getPromptContentTagValue(latestVersion) ?? '',
+        tags: [],
       });
     }
     setOpen(true);

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreateRegisteredPromptMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreateRegisteredPromptMutation.tsx
@@ -7,18 +7,19 @@ type UpdateContentPayload = {
   createPromptEntity?: boolean;
   content: string;
   commitMessage?: string;
+  tags: { key: string; value: string }[];
 };
 
 export const useCreateRegisteredPromptMutation = () => {
   const updateMutation = useMutation<{ version: string }, Error, UpdateContentPayload>({
-    mutationFn: async ({ promptName, createPromptEntity, content, commitMessage }) => {
+    mutationFn: async ({ promptName, createPromptEntity, content, commitMessage, tags }) => {
       if (createPromptEntity) {
         await RegisteredPromptsApi.createRegisteredPrompt(promptName);
       }
 
       const version = await RegisteredPromptsApi.createRegisteredPromptVersion(
         promptName,
-        [{ key: REGISTERED_PROMPT_CONTENT_TAG_KEY, value: content }],
+        [{ key: REGISTERED_PROMPT_CONTENT_TAG_KEY, value: content }, ...tags],
         commitMessage,
       );
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/test-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/test-utils.ts
@@ -122,7 +122,7 @@ export const getMockedRegisteredPromptVersionsResponse = (name = 'prompt1', n = 
             last_updated_timestamp: 1620000000000,
             description: 'some commit message for version 1',
             tags: [
-              { key: 'some_tag', value: 'abc' },
+              { key: 'some_version_tag', value: 'abc' },
               { key: REGISTERED_PROMPT_CONTENT_TAG_KEY, value: 'content of prompt version 1' },
               ...tags,
             ],
@@ -134,7 +134,7 @@ export const getMockedRegisteredPromptVersionsResponse = (name = 'prompt1', n = 
             last_updated_timestamp: 1620000000000,
             description: 'some commit message for version 2',
             tags: [
-              { key: 'another_tag', value: 'xyz' },
+              { key: 'another_version_tag', value: 'xyz' },
               { key: REGISTERED_PROMPT_CONTENT_TAG_KEY, value: 'content for prompt version 2' },
               ...tags,
             ],
@@ -146,7 +146,7 @@ export const getMockedRegisteredPromptVersionsResponse = (name = 'prompt1', n = 
             last_updated_timestamp: 1620000000000,
             description: 'some commit message for version 3',
             tags: [
-              { key: 'another_tag', value: 'xyz' },
+              { key: 'another_version_tag', value: 'xyz' },
               { key: REGISTERED_PROMPT_CONTENT_TAG_KEY, value: 'text of prompt version 3' },
               ...tags,
             ],

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1019,6 +1019,10 @@
     "defaultMessage": "Delete Model",
     "description": "Title text for delete model modal on model view page"
   },
+  "GgPNAZ": {
+    "defaultMessage": "Metadata:",
+    "description": "A key-value pair for the metadata in the prompt details page"
+  },
   "Gm77Ws": {
     "defaultMessage": "Loading artifact failed",
     "description": "Run page > artifact view > error state > default error message"

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -333,6 +333,7 @@ def register_prompt(
     name: str,
     template: str,
     commit_message: Optional[str] = None,
+    version_metadata: Optional[dict[str, str]] = None,
     tags: Optional[dict[str, str]] = None,
 ) -> Prompt:
     """
@@ -353,7 +354,15 @@ def register_prompt(
             by the `format` method.
         commit_message: A message describing the changes made to the prompt, similar to a
             Git commit message. Optional.
-        tags: A dictionary of tags associated with the prompt. Optional.
+        version_metadata: A dictionary of metadata associated with the **prompt version**.
+            This is useful for storing version-specific information, such as the author of
+            the changes. Optional.
+        tags: A dictionary of tags associated with the entire prompt. This is different from
+            the `version_metadata` as it is not tied to a specific version of the prompt,
+            but to the prompt as a whole. For example, you can use tags to add an application
+            name for which the prompt is created. Since the application uses the prompt in
+            multiple versions, it makes sense to use tags instead of version-specific metadata.
+            Optional.
 
     Returns:
         A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
@@ -368,6 +377,7 @@ def register_prompt(
         mlflow.register_prompt(
             name="my_prompt",
             template="Respond to the user's message as a {{style}} AI.",
+            version_metadata={"author": "Alice"},
         )
 
         # Load the prompt from the registry
@@ -390,10 +400,15 @@ def register_prompt(
             name="my_prompt",
             template="Respond to the user's message as a {{style}} AI. {{greeting}}",
             commit_message="Add a greeting to the prompt.",
+            version_metadata={"author": "Bob"},
         )
     """
     return MlflowClient().register_prompt(
-        name=name, template=template, commit_message=commit_message, tags=tags
+        name=name,
+        template=template,
+        commit_message=commit_message,
+        tags=tags,
+        version_metadata=version_metadata,
     )
 
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -427,7 +427,8 @@ class MlflowClient:
         name: str,
         template: str,
         commit_message: Optional[str] = None,
-        tags: Optional[dict[str, Any]] = None,
+        version_metadata: Optional[dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> Prompt:
         """
         Register a new :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
@@ -452,6 +453,7 @@ class MlflowClient:
             client.register_prompt(
                 name="my_prompt",
                 template="Respond to the user's message as a {{style}} AI.",
+                version_metadata={"author": "Alice"},
             )
 
             # Load the prompt from the registry
@@ -474,6 +476,7 @@ class MlflowClient:
                 name="my_prompt",
                 template="Respond to the user's message as a {{style}} AI. {{greeting}}",
                 commit_message="Add a greeting to the prompt.",
+                version_metadata={"author": "Bob"},
             )
 
         Args:
@@ -483,7 +486,15 @@ class MlflowClient:
                 by the `format` method.
             commit_message: A message describing the changes made to the prompt, similar to a
                 Git commit message. Optional.
-            tags: A dictionary of tags associated with the prompt. Optional.
+            version_metadata: A dictionary of metadata associated with the **prompt version**.
+                This is useful for storing version-specific information, such as the author of
+                the changes. Optional.
+            tags: A dictionary of tags associated with the entire prompt. This is different from
+                the `version_metadata` as it is not tied to a specific version of the prompt,
+                but to the prompt as a whole. For example, you can use tags to add an application
+                name for which the prompt is created. Since the application uses the prompt in
+                multiple versions, it makes sense to use tags instead of version-specific metadata.
+                Optional.
 
         Returns:
             A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
@@ -494,12 +505,13 @@ class MlflowClient:
 
         is_new_prompt = False
         rm = None
+        tags = tags or {}
         try:
             rm = registry_client.get_registered_model(name)
         except MlflowException:
             # Create a new prompt (model) entry
             registry_client.create_registered_model(
-                name, description=commit_message, tags={IS_PROMPT_TAG_KEY: "true"}
+                name, description=commit_message, tags={IS_PROMPT_TAG_KEY: "true", **tags}
             )
             is_new_prompt = True
 
@@ -512,15 +524,21 @@ class MlflowClient:
                 INVALID_PARAMETER_VALUE,
             )
 
-        tags = tags or {}
-        tags.update({IS_PROMPT_TAG_KEY: "true", PROMPT_TEXT_TAG_KEY: template})
+        # Update the prompt tags
+        if not is_new_prompt:
+            for key, value in tags.items():
+                registry_client.set_registered_model_tag(name, key, value)
+
+        # Version metadata is represented as ModelVersion tags in the registry
+        version_metadata = version_metadata or {}
+        version_metadata.update({IS_PROMPT_TAG_KEY: "true", PROMPT_TEXT_TAG_KEY: template})
 
         try:
             mv: ModelVersion = registry_client.create_model_version(
                 name=name,
                 description=commit_message,
                 source="dummy-source",  # Required field, but not used for prompts
-                tags=tags,
+                tags=version_metadata,
             )
         except Exception:
             if is_new_prompt:
@@ -529,7 +547,10 @@ class MlflowClient:
                 registry_client.delete_registered_model(name)
             raise
 
-        return Prompt.from_model_version(mv)
+        # Fetch the prompt-level tags from the registered model
+        prompt_tags = registry_client.get_registered_model(name)._tags
+
+        return Prompt.from_model_version(mv, prompt_tags=prompt_tags)
 
     @experimental
     @require_prompt_registry
@@ -576,7 +597,11 @@ class MlflowClient:
             mv = registry_client.get_latest_versions(name, stages=ALL_STAGES)[0]
         else:
             mv = registry_client.get_model_version(name, version)
-        return Prompt.from_model_version(mv)
+
+        # Fetch the prompt-level tags from the registered model
+        prompt_tags = registry_client.get_registered_model(name)._tags
+
+        return Prompt.from_model_version(mv, prompt_tags=prompt_tags)
 
     @experimental
     @require_prompt_registry

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1646,14 +1646,12 @@ def test_crud_prompts(tracking_uri):
         name="prompt_1",
         template="Hi, {{title}} {{name}}! How are you today?",
         commit_message="A friendly greeting",
-        tags={"model": "my-model"},
     )
 
     prompt = client.load_prompt("prompt_1")
     assert prompt.name == "prompt_1"
     assert prompt.template == "Hi, {{title}} {{name}}! How are you today?"
     assert prompt.commit_message == "A friendly greeting"
-    assert prompt.tags == {"model": "my-model"}
 
     client.register_prompt(
         name="prompt_1",
@@ -1680,6 +1678,57 @@ def test_crud_prompts(tracking_uri):
         client.load_prompt("prompt_1", version=2)
 
     client.delete_prompt("prompt_1", version=1)
+
+
+def test_create_prompt_with_tags_and_metadata(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    client.register_prompt(
+        name="prompt_1",
+        template="Hi, {{name}}!",
+        tags={
+            "application": "greeting",
+            "language": "en",
+        },
+        version_metadata={"author": "Alice"},
+    )
+
+    prompt = client.load_prompt("prompt_1")
+    assert prompt.template == "Hi, {{name}}!"
+    assert prompt.tags == {
+        "application": "greeting",
+        "language": "en",
+    }
+    assert prompt.version_metadata == {"author": "Alice"}
+
+    client.register_prompt(
+        name="prompt_1",
+        template="こんにちは、{{name}}!",
+        tags={
+            # Add a new tag
+            "project": "toy",
+            # Overwrite an existing tag
+            "language": "ja",
+        },
+        version_metadata={"author": "Bob", "date": "2022-01-01"},
+    )
+
+    prompt = client.load_prompt("prompt_1", version=2)
+    assert prompt.template == "こんにちは、{{name}}!"
+    assert prompt.tags == {
+        "application": "greeting",
+        "project": "toy",
+        "language": "ja",
+    }
+    assert prompt.version_metadata == {"author": "Bob", "date": "2022-01-01"}
+
+    # Prompt level tags for version 1 should also be updated
+    prompt = client.load_prompt("prompt_1", version=1)
+    assert prompt.tags == {
+        "application": "greeting",
+        "project": "toy",
+        "language": "ja",
+    }
 
 
 def test_create_prompt_error_handling(tracking_uri):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14964?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14964/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14964/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

The `tags` field exist in both a prompt and prompt version (as a part of RegisteredModel and ModelVersion, respectively). 

Currently, UI and API confuses two, namely,

1. The `tags` attributes in `mlflow.register_prompt` API creates tags in a prompt **version**.
2. The `tags` field in the `Prompt` entity contain tags in a prompt **version**.
3. The `tags` field in the prompt list shows tags in a prompt (not version).
4. Tags on a prompt **version** are not rendered anywhere on the UI.

This PR aims to resolve this confusion.

* Rename prompt version tags to **"version metadata"** in Python API. (The `tags` attribute and field are still there to represent prompt-level tags).
* Show version metadata in the prompt version page.

What is not added in the PR is
* UI form to add version metadata upon creation.
    * Adding key-value form in the modal makes it a bit dirty. I hoped we have some sort of JSON editor, do you know if there is @daniellok-db @hubertzub-db?
* Search support with prompt version tag. 


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
