### PR TITLE
Trace server experiment

### DIFF
--- a/mlflow/tracing/destination.py
+++ b/mlflow/tracing/destination.py
@@ -52,7 +52,7 @@ class Databricks(TraceDestination):
 
     If neither experiment_id nor experiment_name is specified, an active experiment
     when traces are created will be used as the destination.
-      If both are specified,
+    If both are specified, they must refer to the same experiment.
 
     Attributes:
         experiment_id: The ID of the experiment to log traces to.

--- a/mlflow/tracing/destination.py
+++ b/mlflow/tracing/destination.py
@@ -50,9 +50,12 @@ class Databricks(TraceDestination):
     By setting this destination in the :py:func:`mlflow.tracing.set_destination` function,
     MLflow will log traces to the specified experiment.
 
+    Either experiment_id or experiment_name must be specified. If both are specified,
+    they must refer to the same experiment.
+
     Attributes:
-        experiment_id: The ID of the experiment to log traces to. If not specified,
-            the current active experiment will be used.
+        experiment_id: The ID of the experiment to log traces to.
+        experiment_name: The name of the experiment to log traces to.
     """
 
     experiment_id: Optional[str] = None

--- a/mlflow/tracing/destination.py
+++ b/mlflow/tracing/destination.py
@@ -50,8 +50,9 @@ class Databricks(TraceDestination):
     By setting this destination in the :py:func:`mlflow.tracing.set_destination` function,
     MLflow will log traces to the specified experiment.
 
-    Either experiment_id or experiment_name must be specified. If both are specified,
-    they must refer to the same experiment.
+    If neither experiment_id nor experiment_name is specified, an active experiment
+    when traces are created will be used as the destination.
+      If both are specified,
 
     Attributes:
         experiment_id: The ID of the experiment to log traces to.
@@ -62,11 +63,6 @@ class Databricks(TraceDestination):
     experiment_name: Optional[str] = None
 
     def __post_init__(self):
-        if self.experiment_id is None and self.experiment_name is None:
-            raise MlflowException.invalid_parameter_value(
-                "Either experiment_id or experiment_name must be specified"
-            )
-
         if self.experiment_id is not None:
             self.experiment_id = str(self.experiment_id)
 

--- a/tests/tracing/test_destination.py
+++ b/tests/tracing/test_destination.py
@@ -1,0 +1,26 @@
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.tracing.destination import Databricks
+
+
+def test_set_destination_databricks():
+    destination = Databricks(experiment_id="123")
+    assert destination.type == "databricks"
+    assert destination.experiment_id == "123"
+
+    destination = Databricks(experiment_id=123)
+    assert destination.experiment_id == "123"
+
+    destination = Databricks(experiment_name="Default")
+    assert destination.experiment_name == "Default"
+    assert destination.experiment_id == "0"
+
+    destination = Databricks(experiment_name="Default", experiment_id="0")
+    assert destination.experiment_id == "0"
+
+    with pytest.raises(MlflowException, match=r"Either experiment_id or experiment_name"):
+        Databricks()
+
+    with pytest.raises(MlflowException, match=r"experiment_id and experiment_name must"):
+        Databricks(experiment_name="Default", experiment_id="123")

--- a/tests/tracing/test_destination.py
+++ b/tests/tracing/test_destination.py
@@ -19,8 +19,5 @@ def test_set_destination_databricks():
     destination = Databricks(experiment_name="Default", experiment_id="0")
     assert destination.experiment_id == "0"
 
-    with pytest.raises(MlflowException, match=r"Either experiment_id or experiment_name"):
-        Databricks()
-
     with pytest.raises(MlflowException, match=r"experiment_id and experiment_name must"):
         Databricks(experiment_name="Default", experiment_id="123")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14969?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14969/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14969/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

* Adding `experiment_name` argument to the `Databricks` destination for user convenience
* Support casting int experiment ID into str

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
