### PR TITLE
Add prompt version tag editor to UI

### DIFF
--- a/mlflow/server/js/src/common/hooks/useEditKeyValueTagsModal.tsx
+++ b/mlflow/server/js/src/common/hooks/useEditKeyValueTagsModal.tsx
@@ -33,11 +33,13 @@ export const useEditKeyValueTagsModal = <T extends { tags?: KeyValueEntity[] }>(
   saveTagsHandler,
   allAvailableTags,
   valueRequired = false,
+  title,
 }: {
   onSuccess?: () => void;
   saveTagsHandler: (editedEntity: T, existingTags: KeyValueEntity[], newTags: KeyValueEntity[]) => Promise<any>;
   allAvailableTags?: string[];
   valueRequired?: boolean;
+  title?: React.ReactNode;
 }) => {
   const editedEntityRef = useRef<T>();
   const [errorMessage, setErrorMessage] = useState<string>('');
@@ -137,10 +139,12 @@ export const useEditKeyValueTagsModal = <T extends { tags?: KeyValueEntity[] }>(
       destroyOnClose
       visible={showModal}
       title={
-        <FormattedMessage
-          defaultMessage="Add/Edit tags"
-          description="Key-value tag editor modal > Title of the update tags modal"
-        />
+        title ?? (
+          <FormattedMessage
+            defaultMessage="Add/Edit tags"
+            description="Key-value tag editor modal > Title of the update tags modal"
+          />
+        )
       }
       onCancel={hideModal}
       footer={

--- a/mlflow/server/js/src/common/utils/TagUtils.ts
+++ b/mlflow/server/js/src/common/utils/TagUtils.ts
@@ -13,6 +13,28 @@ export const MLFLOW_INTERNAL_PREFIX = 'mlflow.';
 
 export const isUserFacingTag = (tagKey: string) => !tagKey.startsWith(MLFLOW_INTERNAL_PREFIX);
 
+export const diffCurrentAndNewTags = (
+  currentTags: KeyValueEntity[],
+  newTags: KeyValueEntity[],
+): {
+  addedOrModifiedTags: KeyValueEntity[];
+  deletedTags: KeyValueEntity[];
+} => {
+  const addedOrModifiedTags = newTags.filter(
+    ({ key: newTagKey, value: newTagValue }) =>
+      !currentTags.some(
+        ({ key: existingTagKey, value: existingTagValue }) =>
+          existingTagKey === newTagKey && newTagValue === existingTagValue,
+      ),
+  );
+
+  const deletedTags = currentTags.filter(
+    ({ key: existingTagKey }) => !newTags.some(({ key: newTagKey }) => existingTagKey === newTagKey),
+  );
+
+  return { addedOrModifiedTags, deletedTags };
+};
+
 export const getLoggedModelPathsFromTags = (runTags: Record<string, KeyValueEntity>) => {
   const models = Utils.getLoggedModelsFromTags(runTags);
   return models ? models.map((model) => (model as any).artifactPath) : [];

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -34,6 +34,7 @@ import ErrorUtils from '../../../common/utils/ErrorUtils';
 import { PromptPageErrorHandler } from './components/PromptPageErrorHandler';
 import { first, isEmpty } from 'lodash';
 import { PromptsListTableTagsBox } from './components/PromptDetailsTagsBox';
+import { useUpdatePromptVersionMetadataModal } from './hooks/useUpdatePromptVersionMetadataModal';
 
 const getAliasesModalTitle = (version: string) => (
   <FormattedMessage
@@ -67,6 +68,10 @@ const PromptsDetailsPage = () => {
   const { DeletePromptModal, openModal: openDeleteModal } = useDeletePromptModal({
     registeredPrompt: promptDetailsData?.prompt,
     onSuccess: () => navigate(Routes.promptsPageRoute),
+  });
+
+  const { EditPromptVersionMetadataModal, showEditPromptVersionMetadataModal } = useUpdatePromptVersionMetadataModal({
+    onSuccess: refetch,
   });
 
   const {
@@ -250,6 +255,7 @@ const PromptsDetailsPage = () => {
                   aliasesByVersion={aliasesByVersion}
                   showEditAliasesModal={showEditAliasesModal}
                   registeredPrompt={promptDetailsData?.prompt}
+                  showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
                 />
               )}
               {mode === PromptVersionsTableMode.COMPARE && (
@@ -261,6 +267,7 @@ const PromptsDetailsPage = () => {
                   showEditAliasesModal={showEditAliasesModal}
                   registeredPrompt={promptDetailsData?.prompt}
                   aliasesByVersion={aliasesByVersion}
+                  showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
                 />
               )}
             </div>
@@ -271,6 +278,7 @@ const PromptsDetailsPage = () => {
       {EditAliasesModal}
       {CreatePromptModal}
       {DeletePromptModal}
+      {EditPromptVersionMetadataModal}
     </ScrollablePageWrapper>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -267,7 +267,6 @@ const PromptsDetailsPage = () => {
                   showEditAliasesModal={showEditAliasesModal}
                   registeredPrompt={promptDetailsData?.prompt}
                   aliasesByVersion={aliasesByVersion}
-                  showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
                 />
               )}
             </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/api.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/api.ts
@@ -120,6 +120,14 @@ export const RegisteredPromptsApi = {
       error: defaultErrorHandler,
     });
   },
+  deleteRegisteredPromptVersionTag: (promptName: string, promptVersion: string, key: string) => {
+    fetchEndpoint({
+      relativeUrl: 'ajax-api/2.0/mlflow/model-versions/delete-tag',
+      method: 'DELETE',
+      body: JSON.stringify({ key, name: promptName, version: promptVersion }),
+      error: defaultErrorHandler,
+    });
+  },
   getPromptDetails: (promptName: string) => {
     const params = new URLSearchParams();
     params.append('name', promptName);

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentCompare.tsx
@@ -14,7 +14,6 @@ export const PromptContentCompare = ({
   registeredPrompt,
   aliasesByVersion,
   showEditAliasesModal,
-  showEditPromptVersionMetadataModal,
 }: {
   baselineVersion?: RegisteredPromptVersion;
   comparedVersion?: RegisteredPromptVersion;
@@ -23,7 +22,6 @@ export const PromptContentCompare = ({
   registeredPrompt?: RegisteredPrompt;
   aliasesByVersion: Record<string, string[]>;
   showEditAliasesModal?: (versionNumber: string) => void;
-  showEditPromptVersionMetadataModal: (promptVersion: RegisteredPromptVersion) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -80,7 +78,6 @@ export const PromptContentCompare = ({
             registeredPrompt={registeredPrompt}
             registeredPromptVersion={baselineVersion}
             showEditAliasesModal={showEditAliasesModal}
-            showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
             isBaseline
           />
         </div>
@@ -94,7 +91,6 @@ export const PromptContentCompare = ({
             registeredPrompt={registeredPrompt}
             registeredPromptVersion={comparedVersion}
             showEditAliasesModal={showEditAliasesModal}
-            showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
           />
         </div>
       </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentCompare.tsx
@@ -14,6 +14,7 @@ export const PromptContentCompare = ({
   registeredPrompt,
   aliasesByVersion,
   showEditAliasesModal,
+  showEditPromptVersionMetadataModal,
 }: {
   baselineVersion?: RegisteredPromptVersion;
   comparedVersion?: RegisteredPromptVersion;
@@ -22,6 +23,7 @@ export const PromptContentCompare = ({
   registeredPrompt?: RegisteredPrompt;
   aliasesByVersion: Record<string, string[]>;
   showEditAliasesModal?: (versionNumber: string) => void;
+  showEditPromptVersionMetadataModal: (promptVersion: RegisteredPromptVersion) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -78,6 +80,7 @@ export const PromptContentCompare = ({
             registeredPrompt={registeredPrompt}
             registeredPromptVersion={baselineVersion}
             showEditAliasesModal={showEditAliasesModal}
+            showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
             isBaseline
           />
         </div>
@@ -91,6 +94,7 @@ export const PromptContentCompare = ({
             registeredPrompt={registeredPrompt}
             registeredPromptVersion={comparedVersion}
             showEditAliasesModal={showEditAliasesModal}
+            showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
           />
         </div>
       </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentPreview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentPreview.tsx
@@ -13,10 +13,8 @@ import { RegisteredPrompt, RegisteredPromptVersion } from '../types';
 import { getPromptContentTagValue } from '../utils';
 import { PromptVersionMetadata } from './PromptVersionMetadata';
 import { FormattedMessage } from 'react-intl';
-import { CodeSnippet } from '@databricks/web-shared/snippet';
 import { uniq } from 'lodash';
 import { useDeletePromptVersionModal } from '../hooks/useDeletePromptVersionModal';
-import { CopyButton } from '@mlflow/mlflow/src/shared/building_blocks/CopyButton';
 import { ShowArtifactCodeSnippet } from '../../../components/artifact-view-components/ShowArtifactCodeSnippet';
 
 const PROMPT_VARIABLE_REGEX = /\{\{\s*(.*?)\s*\}\}/g;
@@ -28,6 +26,7 @@ export const PromptContentPreview = ({
   aliasesByVersion,
   registeredPrompt,
   showEditAliasesModal,
+  showEditPromptVersionMetadataModal,
 }: {
   promptVersion?: RegisteredPromptVersion;
   onUpdatedContent?: () => Promise<any>;
@@ -35,6 +34,7 @@ export const PromptContentPreview = ({
   aliasesByVersion: Record<string, string[]>;
   registeredPrompt?: RegisteredPrompt;
   showEditAliasesModal?: (versionNumber: string) => void;
+  showEditPromptVersionMetadataModal: (promptVersion: RegisteredPromptVersion) => void;
 }) => {
   const value = useMemo(() => (promptVersion ? getPromptContentTagValue(promptVersion) : ''), [promptVersion]);
 
@@ -114,6 +114,7 @@ export const PromptContentPreview = ({
         registeredPrompt={registeredPrompt}
         registeredPromptVersion={promptVersion}
         showEditAliasesModal={showEditAliasesModal}
+        showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
       />
       <Spacer shrinks={false} />
       <div

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
@@ -28,7 +28,7 @@ export const PromptVersionMetadata = ({
   registeredPromptVersion?: RegisteredPromptVersion;
   showEditAliasesModal?: (versionNumber: string) => void;
   onEditVersion?: (vesrion: RegisteredPromptVersion) => void;
-  showEditPromptVersionMetadataModal: (version: RegisteredPromptVersion) => void;
+  showEditPromptVersionMetadataModal?: (version: RegisteredPromptVersion) => void;
   aliasesByVersion: Record<string, string[]>;
   isBaseline?: boolean;
 }) => {
@@ -58,9 +58,11 @@ export const PromptVersionMetadata = ({
     />
   );
 
-  const onEditVersionMetadata = () => {
-    showEditPromptVersionMetadataModal(registeredPromptVersion);
-  };
+  const onEditVersionMetadata = showEditPromptVersionMetadataModal
+    ? () => {
+        showEditPromptVersionMetadataModal(registeredPromptVersion);
+      }
+    : undefined;
 
   return (
     <div

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
@@ -7,7 +7,7 @@ import { Link } from '../../../../common/utils/RoutingUtils';
 import Routes from '../../../routes';
 import { usePromptRunsInfo } from '../hooks/usePromptRunsInfo';
 import { REGISTERED_PROMPT_SOURCE_RUN_IDS } from '../utils';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { PromptVersionRuns } from './PromptVersionRuns';
 import { isUserFacingTag } from '@mlflow/mlflow/src/common/utils/TagUtils';
 import { KeyValueTag } from '@mlflow/mlflow/src/common/components/KeyValueTag';
@@ -20,6 +20,7 @@ export const PromptVersionMetadata = ({
   registeredPrompt,
   showEditAliasesModal,
   onEditVersion,
+  showEditPromptVersionMetadataModal,
   aliasesByVersion,
   isBaseline,
 }: {
@@ -27,6 +28,7 @@ export const PromptVersionMetadata = ({
   registeredPromptVersion?: RegisteredPromptVersion;
   showEditAliasesModal?: (versionNumber: string) => void;
   onEditVersion?: (vesrion: RegisteredPromptVersion) => void;
+  showEditPromptVersionMetadataModal: (version: RegisteredPromptVersion) => void;
   aliasesByVersion: Record<string, string[]>;
   isBaseline?: boolean;
 }) => {
@@ -55,6 +57,10 @@ export const PromptVersionMetadata = ({
       description="A label for the version number in the prompt details page"
     />
   );
+
+  const onEditVersionMetadata = () => {
+    showEditPromptVersionMetadataModal(registeredPromptVersion);
+  };
 
   return (
     <div
@@ -121,7 +127,7 @@ export const PromptVersionMetadata = ({
           <Typography.Text>{registeredPromptVersion.description}</Typography.Text>
         </>
       )}
-      {visibleTagList.length > 0 && <PromptVersionTags tags={visibleTagList} />}
+      <PromptVersionTags onEditVersionMetadata={onEditVersionMetadata} tags={visibleTagList} />
       {(isLoadingRuns || runIds.length > 0) && (
         <PromptVersionRuns isLoadingRuns={isLoadingRuns} runIds={runIds} runInfoMap={runInfoMap} />
       )}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionTags.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionTags.tsx
@@ -5,13 +5,14 @@ import { FormattedMessage } from 'react-intl';
 import { KeyValueTag } from '@mlflow/mlflow/src/common/components/KeyValueTag';
 import { KeyValueEntity } from '../../../types';
 import { useUpdatePromptVersionMetadataModal } from '../hooks/useUpdatePromptVersionMetadataModal';
+import { isNil } from 'lodash';
 
 export const PromptVersionTags = ({
   tags,
   onEditVersionMetadata,
 }: {
   tags: KeyValueEntity[];
-  onEditVersionMetadata: () => void;
+  onEditVersionMetadata?: () => void;
 }) => {
   const [showAll, setShowAll] = useState(false);
   const { theme } = useDesignSystemTheme();
@@ -19,6 +20,29 @@ export const PromptVersionTags = ({
   const displayThreshold = 3;
   const visibleCount = showAll ? tags.length : Math.min(displayThreshold, tags.length || 0);
   const hasMore = tags.length > displayThreshold;
+  const shouldAllowEditingMetadata = !isNil(onEditVersionMetadata);
+
+  const editButton =
+    tags.length > 0 ? (
+      <Button
+        componentId="mlflow.prompts.details.version.edit_tags"
+        size="small"
+        icon={<PencilIcon />}
+        onClick={onEditVersionMetadata}
+      />
+    ) : (
+      <Button
+        componentId="mlflow.prompts.details.version.add_tags"
+        size="small"
+        type="link"
+        onClick={onEditVersionMetadata}
+      >
+        <FormattedMessage
+          defaultMessage="Add"
+          description="Model registry > model version table > metadata column > 'add' button label"
+        />
+      </Button>
+    );
 
   return (
     <>
@@ -34,26 +58,8 @@ export const PromptVersionTags = ({
             {tags.slice(0, visibleCount).map((tag) => (
               <KeyValueTag css={{ margin: 0 }} key={tag.key} tag={tag} />
             ))}
-            {tags.length > 0 ? (
-              <Button
-                componentId="mlflow.prompts.details.version.edit_tags"
-                size="small"
-                icon={<PencilIcon />}
-                onClick={onEditVersionMetadata}
-              />
-            ) : (
-              <Button
-                componentId="mlflow.prompts.details.version.add_tags"
-                size="small"
-                type="link"
-                onClick={onEditVersionMetadata}
-              >
-                <FormattedMessage
-                  defaultMessage="Add"
-                  description="Model registry > model version table > metadata column > 'add' button label"
-                />
-              </Button>
-            )}
+            {shouldAllowEditingMetadata && editButton}
+            {!shouldAllowEditingMetadata && tags.length === 0 && <Typography.Hint>—</Typography.Hint>}
             {hasMore && (
               <Button
                 componentId="mlflow.prompts.details.version.tags.show_more"

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionTags.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionTags.tsx
@@ -1,11 +1,18 @@
 import { useState } from 'react';
-import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Button, PencilIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 
 import { KeyValueTag } from '@mlflow/mlflow/src/common/components/KeyValueTag';
 import { KeyValueEntity } from '../../../types';
+import { useUpdatePromptVersionMetadataModal } from '../hooks/useUpdatePromptVersionMetadataModal';
 
-export const PromptVersionTags = ({ tags }: { tags: KeyValueEntity[] }) => {
+export const PromptVersionTags = ({
+  tags,
+  onEditVersionMetadata,
+}: {
+  tags: KeyValueEntity[];
+  onEditVersionMetadata: () => void;
+}) => {
   const [showAll, setShowAll] = useState(false);
   const { theme } = useDesignSystemTheme();
 
@@ -25,8 +32,28 @@ export const PromptVersionTags = ({ tags }: { tags: KeyValueEntity[] }) => {
         <>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: theme.spacing.xs }}>
             {tags.slice(0, visibleCount).map((tag) => (
-              <KeyValueTag key={tag.key} tag={tag} />
+              <KeyValueTag css={{ margin: 0 }} key={tag.key} tag={tag} />
             ))}
+            {tags.length > 0 ? (
+              <Button
+                componentId="mlflow.prompts.details.version.edit_tags"
+                size="small"
+                icon={<PencilIcon />}
+                onClick={onEditVersionMetadata}
+              />
+            ) : (
+              <Button
+                componentId="mlflow.prompts.details.version.add_tags"
+                size="small"
+                type="link"
+                onClick={onEditVersionMetadata}
+              >
+                <FormattedMessage
+                  defaultMessage="Add"
+                  description="Model registry > model version table > metadata column > 'add' button label"
+                />
+              </Button>
+            )}
             {hasMore && (
               <Button
                 componentId="mlflow.prompts.details.version.tags.show_more"

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useUpdatePromptVersionMetadataModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useUpdatePromptVersionMetadataModal.tsx
@@ -1,0 +1,73 @@
+import { useMutation } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useEditKeyValueTagsModal } from '../../../../common/hooks/useEditKeyValueTagsModal';
+import { RegisteredPromptsApi } from '../api';
+import { RegisteredPrompt, RegisteredPromptVersion } from '../types';
+import { useCallback } from 'react';
+import { diffCurrentAndNewTags, isUserFacingTag } from '../../../../common/utils/TagUtils';
+
+type UpdatePromptVersionMetadataPayload = {
+  promptName: string;
+  promptVersion: string;
+  toAdd: { key: string; value: string }[];
+  toDelete: { key: string }[];
+};
+
+export const useUpdatePromptVersionMetadataModal = ({ onSuccess }: { onSuccess?: () => void }) => {
+  const updateMutation = useMutation<unknown, Error, UpdatePromptVersionMetadataPayload>({
+    mutationFn: async ({ toAdd, toDelete, promptName, promptVersion }) => {
+      return Promise.all([
+        ...toAdd.map(({ key, value }) =>
+          RegisteredPromptsApi.setRegisteredPromptVersionTag(promptName, promptVersion, key, value),
+        ),
+        ...toDelete.map(({ key }) =>
+          RegisteredPromptsApi.deleteRegisteredPromptVersionTag(promptName, promptVersion, key),
+        ),
+      ]);
+    },
+  });
+
+  const {
+    EditTagsModal: EditPromptVersionMetadataModal,
+    showEditTagsModal,
+    isLoading,
+  } = useEditKeyValueTagsModal<Pick<RegisteredPromptVersion, 'name' | 'version' | 'tags'>>({
+    valueRequired: true,
+    saveTagsHandler: (promptVersion, currentTags, newTags) => {
+      const { addedOrModifiedTags, deletedTags } = diffCurrentAndNewTags(currentTags, newTags);
+
+      return new Promise<void>((resolve, reject) => {
+        if (!promptVersion.name) {
+          return reject();
+        }
+        // Send all requests to the mutation
+        updateMutation.mutate(
+          {
+            promptName: promptVersion.name,
+            promptVersion: promptVersion.version,
+            toAdd: addedOrModifiedTags,
+            toDelete: deletedTags,
+          },
+          {
+            onSuccess: () => {
+              resolve();
+              onSuccess?.();
+            },
+            onError: reject,
+          },
+        );
+      });
+    },
+  });
+
+  const showEditPromptVersionMetadataModal = useCallback(
+    (promptVersion: RegisteredPromptVersion) =>
+      showEditTagsModal({
+        name: promptVersion.name,
+        version: promptVersion.version,
+        tags: promptVersion.tags?.filter((tag) => isUserFacingTag(tag.key)),
+      }),
+    [showEditTagsModal],
+  );
+
+  return { EditPromptVersionMetadataModal, showEditPromptVersionMetadataModal, isLoading };
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useUpdatePromptVersionMetadataModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useUpdatePromptVersionMetadataModal.tsx
@@ -1,9 +1,10 @@
 import { useMutation } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { useEditKeyValueTagsModal } from '../../../../common/hooks/useEditKeyValueTagsModal';
 import { RegisteredPromptsApi } from '../api';
-import { RegisteredPrompt, RegisteredPromptVersion } from '../types';
+import { RegisteredPromptVersion } from '../types';
 import { useCallback } from 'react';
 import { diffCurrentAndNewTags, isUserFacingTag } from '../../../../common/utils/TagUtils';
+import { FormattedMessage } from 'react-intl';
 
 type UpdatePromptVersionMetadataPayload = {
   promptName: string;
@@ -31,6 +32,12 @@ export const useUpdatePromptVersionMetadataModal = ({ onSuccess }: { onSuccess?:
     showEditTagsModal,
     isLoading,
   } = useEditKeyValueTagsModal<Pick<RegisteredPromptVersion, 'name' | 'version' | 'tags'>>({
+    title: (
+      <FormattedMessage
+        defaultMessage="Add/Edit Prompt Version Metadata"
+        description="Title for a modal that allows the user to add or edit metadata tags on prompt versions."
+      />
+    ),
     valueRequired: true,
     saveTagsHandler: (promptVersion, currentTags, newTags) => {
       const { addedOrModifiedTags, deletedTags } = diffCurrentAndNewTags(currentTags, newTags);

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useUpdateRegisteredPromptTags.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useUpdateRegisteredPromptTags.tsx
@@ -3,7 +3,7 @@ import { useEditKeyValueTagsModal } from '../../../../common/hooks/useEditKeyVal
 import { RegisteredPromptsApi } from '../api';
 import { RegisteredPrompt } from '../types';
 import { useCallback } from 'react';
-import { isUserFacingTag } from '../../../../common/utils/TagUtils';
+import { diffCurrentAndNewTags, isUserFacingTag } from '../../../../common/utils/TagUtils';
 
 type UpdateTagsPayload = {
   promptId: string;
@@ -26,19 +26,7 @@ export const useUpdateRegisteredPromptTags = ({ onSuccess }: { onSuccess?: () =>
   >({
     valueRequired: true,
     saveTagsHandler: (prompt, currentTags, newTags) => {
-      // First, determine new tags to be added
-      const addedOrModifiedTags = newTags.filter(
-        ({ key: newTagKey, value: newTagValue }) =>
-          !currentTags.some(
-            ({ key: existingTagKey, value: existingTagValue }) =>
-              existingTagKey === newTagKey && newTagValue === existingTagValue,
-          ),
-      );
-
-      // Next, determine those to be deleted
-      const deletedTags = currentTags.filter(
-        ({ key: existingTagKey }) => !newTags.some(({ key: newTagKey }) => existingTagKey === newTagKey),
-      );
+      const { addedOrModifiedTags, deletedTags } = diffCurrentAndNewTags(currentTags, newTags);
 
       return new Promise<void>((resolve, reject) => {
         if (!prompt.name) {

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1155,6 +1155,10 @@
     "defaultMessage": "Last 24 hours",
     "description": "Option for the start select dropdown to filter runs from the last 24 hours"
   },
+  "JGQ5B2": {
+    "defaultMessage": "Add",
+    "description": "Model registry > model version table > metadata column > 'add' button label"
+  },
   "JNS471": {
     "defaultMessage": "No results. Try using a different keyword or adjusting your filters.",
     "description": "Models table > no results after filtering"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3382,5 +3382,9 @@
   "zwO8+l": {
     "defaultMessage": "20",
     "description": "Label for 20 first runs visible in run count selector within runs compare configuration modal"
+  },
+  "zxfWCx": {
+    "defaultMessage": "Add/Edit Prompt Version Metadata",
+    "description": "Title for a modal that allows the user to add or edit metadata tags on prompt versions."
   }
 }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/14984?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14984/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14984/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As title, this PR adds a pencil icon so users can add tags to prompt versions



### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

No tags ("Add" button):

https://github.com/user-attachments/assets/603f4e4d-2afe-4e67-9e6b-d59976c9e932

Compare page:


https://github.com/user-attachments/assets/d3890046-31f8-4fa5-8b46-9eaf0a7915a1

Preview page:



https://github.com/user-attachments/assets/a3265c33-65c8-4463-9c23-8f7a3755b668


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
