### PR TITLE
Handle GeneratorExit in `trace` wrapper

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -198,6 +198,7 @@ def _wrap_function(
                 try:
                     yield result
                 except GeneratorExit:
+                    # Swallow `GeneratorExit` raised when the generator is closed
                     pass
 
         def __init__(self, fn, args, kwargs):
@@ -214,7 +215,7 @@ def _wrap_function(
             # of start_span and OTel's use_span can execute).
             if exc_type is not None:
                 self.coro.throw(exc_type, exc_value, traceback)
-            self.coro.close()  # This triggers GeneratorExit
+            self.coro.close()
 
     if inspect.iscoroutinefunction(fn):
 

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -195,7 +195,10 @@ def _wrap_function(
                 span.set_inputs(capture_function_input_args(fn, args, kwargs))
                 result = yield  # sync/async function output to be sent here
                 span.set_outputs(result)
-                yield result
+                try:
+                    yield result
+                except GeneratorExit:
+                    pass
 
         def __init__(self, fn, args, kwargs):
             self.coro = self._wrapping_logic(fn, args, kwargs)
@@ -211,7 +214,7 @@ def _wrap_function(
             # of start_span and OTel's use_span can execute).
             if exc_type is not None:
                 self.coro.throw(exc_type, exc_value, traceback)
-            self.coro.close()
+            self.coro.close()  # This triggers GeneratorExit
 
     if inspect.iscoroutinefunction(fn):
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/14986?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14986/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14986/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://github.com/mlflow/mlflow/actions/runs/13828218638/job/38686953493?pr=14978.

```
  -                 'end_time_unix_nano': <ANY>,
  ?                                       ^^^^^
  +                 'end_time_unix_nano': '1741847487441287500',
  ?                                       ^^^^^^^^^^^^^^^^^^^^^
  +                 'events': [
  +                     {
  +                         'attributes': {
  +                             'exception.escaped': 'False',
  +                             'exception.message': '',
  +                             'exception.stacktrace': 'Traceback (most recent call last):\n'
  +                             '  File '
  +                             '"D:\\a\\mlflow\\mlflow\\.venv\\lib\\site-packages\\opentelemetry\\trace\\__init__.py", '
  +                             'line 587, in use_span\n'
  +                             '    yield span\n'
  +                             '  File '
  +                             '"D:\\a\\mlflow\\mlflow\\mlflow\\tracing\\fluent.py", '
  +                             'line 449, in start_span\n'
  +                             '    yield mlflow_span\n'
  +                             '  File '
  +                             '"D:\\a\\mlflow\\mlflow\\mlflow\\tracing\\fluent.py", '
  +                             'line 198, in _wrapping_logic\n'
  +                             '    yield result\n'
  +                             'GeneratorExit\n',
  +                             'exception.type': 'GeneratorExit',
  +                         },
  +                         'name': 'exception',
  +                         'time_unix_nano': '1741847487441287500',
  +                     },
  +                 ],
                    'name': '_predict',
                    'parent_span_id': '',
  -                 'span_id': <ANY>,
```

https://github.com/open-telemetry/opentelemetry-python/pull/4406 triggered the error.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
