### PR TITLE
Unsupport search prompts by tags temporary

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListFilters.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListFilters.tsx
@@ -1,5 +1,6 @@
 import { TableFilterInput, TableFilterLayout } from '@databricks/design-system';
-// import { ModelSearchInputHelpTooltip } from '../../../../model-registry/components/model-list/ModelListFilters';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { ModelSearchInputHelpTooltip } from '../../../../model-registry/components/model-list/ModelListFilters';
 
 export const PromptsListFilters = ({
   searchFilter,

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListFilters.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListFilters.tsx
@@ -1,5 +1,5 @@
 import { TableFilterInput, TableFilterLayout } from '@databricks/design-system';
-import { ModelSearchInputHelpTooltip } from '../../../../model-registry/components/model-list/ModelListFilters';
+// import { ModelSearchInputHelpTooltip } from '../../../../model-registry/components/model-list/ModelListFilters';
 
 export const PromptsListFilters = ({
   searchFilter,
@@ -11,11 +11,12 @@ export const PromptsListFilters = ({
   return (
     <TableFilterLayout>
       <TableFilterInput
-        placeholder="Search prompts"
+        placeholder="Search prompts by name"
         componentId="mlflow.prompts.list.search"
         value={searchFilter}
         onChange={(e) => onSearchFilterChange(e.target.value)}
-        suffix={<ModelSearchInputHelpTooltip exampleEntityName="my-prompt-name" />}
+        // TODO: Add this back once we support searching with tags
+        // suffix={<ModelSearchInputHelpTooltip exampleEntityName="my-prompt-name" />}
       />
     </TableFilterLayout>
   );


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/14990?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/14990/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/14990/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

There is a unkown issue using `tags.xyz = "foo"` syntax in prompt search bar. It doesn't seem to be trivial so temporary removing the hint and show "Search prompts by name"

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
