### PR TITLE
Fix Gemini dev test

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -857,7 +857,6 @@ gemini:
     module_name: "google.genai"
     install_dev: |
       pip install git+https://github.com/googleapis/python-genai
-      export GOOGLE_GENAI_DEV=true
   autologging:
     minimum: "1.0.0"
     maximum: "1.5.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -857,6 +857,7 @@ gemini:
     module_name: "google.genai"
     install_dev: |
       pip install git+https://github.com/googleapis/python-genai
+      export GOOGLE_GENAI_DEV=true
   autologging:
     minimum: "1.0.0"
     maximum: "1.5.0"

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -5,7 +5,6 @@ https://github.com/googleapis/python-genai
 
 import base64
 import importlib.metadata
-import os
 from unittest.mock import patch
 
 import pytest
@@ -17,10 +16,7 @@ from mlflow.entities.span import SpanType
 
 from tests.tracing.helper import get_traces
 
-is_gemini_larger_than_1_5 = (
-    Version(importlib.metadata.version("google.genai")) > Version("1.5.0")
-    or os.environ.get("GOOGLE_GENAI_DEV") == "true"
-)
+is_gemini_1_7_or_newer = Version(importlib.metadata.version("google.genai")) >= Version("1.7.0")
 
 _CONTENT = {"parts": [{"text": "test answer"}], "role": "model"}
 
@@ -98,7 +94,7 @@ TOOL_ATTRIBUTE = [
                     "a": {"type": "number", "description": None, "enum": None},
                     "b": {"type": "number", "description": None, "enum": None},
                 },
-                "required": ["a", "b"] if is_gemini_larger_than_1_5 else None,
+                "required": ["a", "b"] if is_gemini_1_7_or_newer else None,
             },
         },
     },

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -4,15 +4,22 @@ https://github.com/googleapis/python-genai
 """
 
 import base64
+import importlib.metadata
+import os
 from unittest.mock import patch
 
 import pytest
 from google import genai
+from packaging.version import Version
 
 import mlflow
 from mlflow.entities.span import SpanType
 
 from tests.tracing.helper import get_traces
+
+is_gemini_larger_than_1_5 = Version(importlib.metadata.version("google.genai")) > Version(
+    "1.5.0"
+) or os.environ.get("GOOGLE_GENAI_DEV")
 
 _CONTENT = {"parts": [{"text": "test answer"}], "role": "model"}
 
@@ -90,7 +97,7 @@ TOOL_ATTRIBUTE = [
                     "a": {"type": "number", "description": None, "enum": None},
                     "b": {"type": "number", "description": None, "enum": None},
                 },
-                "required": None,
+                "required": ["a", "b"] if is_gemini_larger_than_1_5 else None,
             },
         },
     },

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -17,9 +17,10 @@ from mlflow.entities.span import SpanType
 
 from tests.tracing.helper import get_traces
 
-is_gemini_larger_than_1_5 = Version(importlib.metadata.version("google.genai")) > Version(
-    "1.5.0"
-) or os.environ.get("GOOGLE_GENAI_DEV")
+is_gemini_larger_than_1_5 = (
+    Version(importlib.metadata.version("google.genai")) > Version("1.5.0")
+    or os.environ.get("GOOGLE_GENAI_DEV") == "true"
+)
 
 _CONTENT = {"parts": [{"text": "test answer"}], "role": "model"}
 


### PR DESCRIPTION
### Related Issues/PRs

Fix Gemini dev test

### What changes are proposed in this pull request?

The behavior regarding required field of tools is changed in https://github.com/googleapis/python-genai/commit/891d736de4c561cb794ee4e91151b97ae5d55425

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
