### PR TITLE
Auto-populate search experiment input from URL and generate shareable URL with filter for experiment

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentGetShareLinkModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentGetShareLinkModal.tsx
@@ -44,7 +44,12 @@ const serializePersistedState = async (state: ShareableViewState) => {
   return JSON.stringify(state);
 };
 
-const getShareableUrl = (experimentId: string, shareStateHash: string, viewMode?: ExperimentViewRunsCompareMode) => {
+const getShareableUrl = (
+  experimentId: string,
+  shareStateHash: string,
+  viewMode?: ExperimentViewRunsCompareMode,
+  searchFilter?: string,
+) => {
   // As a start, get the route
   const route = Routes.getExperimentPageRoute(experimentId);
 
@@ -57,6 +62,10 @@ const getShareableUrl = (experimentId: string, shareStateHash: string, viewMode?
   // If the view mode is set, add it to the query params
   if (viewMode) {
     queryParams.set(EXPERIMENT_PAGE_VIEW_MODE_QUERY_PARAM_KEY, viewMode);
+  }
+  // If a search filter is provided, add it as "searchExperiment".
+  if (searchFilter) {
+    queryParams.set('searchExperiment', searchFilter);
   }
 
   // In regular implementation, build the hash part of the URL
@@ -107,8 +116,11 @@ export const ExperimentGetShareLinkModal = ({
 
         setLinkInProgress(false);
         setGeneratedState(state);
-
-        setSharedStateUrl(getShareableUrl(experimentId, hash, viewMode));
+        // Retrieve the search filter.
+        // First, check if it's in the merged state; if not, try the URL.
+        const searchFilter =
+          (state as any).searchExperiment || new URLSearchParams(window.location.href).get('searchExperiment') || '';
+        setSharedStateUrl(getShareableUrl(experimentId, hash, viewMode, searchFilter));
       } catch (e) {
         Utils.logErrorAndNotifyUser('Failed to create shareable link for experiment');
         throw e;


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/15011?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15011/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/15011/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

Fix for #14841 

### What changes are proposed in this pull request?

This update makes it easier to share and revisit filtered experiment views. Now, when you type into the experiment search field, the URL automatically updates with your search term. If you share that URL, anyone opening it will see the experiment search box already filled with the same filter, so they immediately get the same results you saw.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:

https://github.com/user-attachments/assets/95c6980f-4a09-444c-9ee4-58eaaedc0157

After:

https://github.com/user-attachments/assets/c38e4f86-b31e-4e34-a0e1-b638914b143f


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

This update makes it easier to share and revisit filtered experiment views. Now, when you type into the experiment search field, the URL automatically updates with your search term. If you share that URL, anyone opening it will see the experiment search box already filled with the same filter, so they immediately get the same results you saw.


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
