### PR TITLE
fix: compare model version table adjustment

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.css
@@ -32,11 +32,6 @@
   text-overflow: ellipsis;
 }
 
-.responsive-table-container {
-  width: 100%;
-  overflow-x: auto;
-}
-
 .compare-table .diff-row .data-value {
   background-color: rgba(249, 237, 190, 0.5) ;
   color: #555;

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.css
@@ -14,22 +14,10 @@
   display: inline-flex;
 }
 
-.compare-table th.inter-title {
-  padding: 20px 0 0;
-  background: transparent;
-}
-
 .compare-table .head-value {
   overflow: hidden;
   overflow-wrap: break-word;
   z-index: 10;
-}
-
-.compare-table td.data-value,
-.compare-table th.data-value {
-  overflow: hidden;
-  max-width: 120px;
-  text-overflow: ellipsis;
 }
 
 .compare-table .diff-row .data-value {
@@ -52,23 +40,3 @@
   color: #555;
 }
 
-/* Overrides to make it look more like antd */
-.compare-table {
-  width: 100%;
-  max-width: 100%;
-  margin-bottom: 20px;
-}
-.compare-table th,
-.compare-table td {
-  padding: 12px 8px;
-  border-bottom: 1px solid #e8e8e8;
-}
-.compare-table th {
-  color: rgba(0,0,0,.85);
-  font-weight: 500;
-  background-color:rgb(250, 250, 250);
-  text-align: left;
-}
-.compare-table > tbody > tr:hover:not(.diff-row) > td:not(.highlight-data) {
-  background-color: rgb(250, 250, 250);
-}

--- a/mlflow/server/js/src/lang/de-DE.json
+++ b/mlflow/server/js/src/lang/de-DE.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "Durchsuchen",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "Nur Unterschiede anzeigen",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1031,10 +1031,6 @@
     "defaultMessage": "Last modified",
     "description": "Column title for last modified timestamp for a model in the registered model page"
   },
-  "H+4gFh": {
-    "defaultMessage": "Show diff only",
-    "description": "Toggle text that determines whether to show diff only in the model\n                      comparison page"
-  },
   "H7JwOl": {
     "defaultMessage": "Delete version",
     "description": "A label for a button to delete prompt version on the prompt details page"
@@ -1194,6 +1190,10 @@
   "K+5g8S": {
     "defaultMessage": "Trace data is not available for in-progress traces. Please wait for the trace to complete.",
     "description": "Experiment page > traces data drawer > in-progress description"
+  },
+  "K32dke": {
+    "defaultMessage": "Show diff only",
+    "description": "Toggle text that determines whether to show diff only in the model comparison page"
   },
   "K5rmCE": {
     "defaultMessage": "S3",

--- a/mlflow/server/js/src/lang/es-ES.json
+++ b/mlflow/server/js/src/lang/es-ES.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "Explorar",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "Mostrar solo diff",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/fr-FR.json
+++ b/mlflow/server/js/src/lang/fr-FR.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "Parcourir",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "Afficher la différence uniquement",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/it-IT.json
+++ b/mlflow/server/js/src/lang/it-IT.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "Esplora",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "Mostra solo differenze",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/ja-JP.json
+++ b/mlflow/server/js/src/lang/ja-JP.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "閲覧",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "差分のみ表示",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/ko-KR.json
+++ b/mlflow/server/js/src/lang/ko-KR.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "찾아보기",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "차이점만 표시",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/pt-BR.json
+++ b/mlflow/server/js/src/lang/pt-BR.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "Procurar",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "Mostrar apenas as diferenças",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/pt-PT.json
+++ b/mlflow/server/js/src/lang/pt-PT.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "Procurar",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "Mostrar apenas as diferenças",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/zh-CN.json
+++ b/mlflow/server/js/src/lang/zh-CN.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "浏览",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "仅显示差异",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/zh-HK.json
+++ b/mlflow/server/js/src/lang/zh-HK.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "瀏覽",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "僅顯示差異",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/lang/zh-TW.json
+++ b/mlflow/server/js/src/lang/zh-TW.json
@@ -2318,7 +2318,7 @@
     "defaultMessage" : "瀏覽",
     "description" : "Button text for browsing tables on the configure inference form"
   },
-  "H+4gFh" : {
+  "K32dke" : {
     "defaultMessage" : "僅顯示差異",
     "description" : "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.css
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.css
@@ -1,0 +1,32 @@
+.sticky-header {
+  position: sticky;
+  left: 0;
+}
+
+.compare-model-table {
+  display: block;
+  overflow: auto;
+  width: 100%;
+}
+
+.compare-table-row {
+  display: inline-flex;
+}
+
+.compare-table .head-value {
+  overflow: hidden;
+  overflow-wrap: break-word;
+  z-index: 10;
+}
+
+.compare-table .diff-row .data-value {
+  background-color: rgba(249, 237, 190, 0.5) ;
+  color: #555;
+}
+
+.compare-table .diff-row:hover,
+.compare-table .diff-row .head-value,
+.compare-table .diff-row .head-value > span {
+  background-color: rgba(249, 237, 190, 1.0) ;
+  color: #555;
+}

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
@@ -91,9 +91,9 @@ export class CompareModelVersionsViewImpl extends Component<
   state = {
     inputActive: true,
     outputActive: true,
-    onlyShowParameterDiff: false,
-    onlyShowSchemaDiff: false,
-    onlyShowMetricDiff: false,
+    onlyShowParameterDiff: true,
+    onlyShowSchemaDiff: true,
+    onlyShowMetricDiff: true,
     compareByColumnNameToggle: false,
   };
 
@@ -147,6 +147,7 @@ export class CompareModelVersionsViewImpl extends Component<
       runDisplayNames,
       paramLists,
       metricLists,
+      intl,
     } = this.props;
     const title = (
       <FormattedMessage
@@ -165,6 +166,11 @@ export class CompareModelVersionsViewImpl extends Component<
       <Link to={ModelRegistryRoutes.getModelPageRoute(modelName)}>{modelName}</Link>,
     ];
 
+    const showdiffIntlMessage = intl.formatMessage({
+      defaultMessage: 'Show diff only',
+      description: 'Toggle text that determines whether to show diff only in the model comparison page',
+    });
+
     return (
       <div>
         <PageHeader title={title} breadcrumbs={breadcrumbs} />
@@ -175,27 +181,41 @@ export class CompareModelVersionsViewImpl extends Component<
               {this.renderModelVersionInfo()}
             </>,
           )}
-          <CollapsibleSection title="Parameters">
+          <CollapsibleSection
+            title={intl.formatMessage({
+              defaultMessage: 'Parameters',
+              description: 'Table title text for parameters table in the model comparison page',
+            })}
+          >
             <Switch
-              componentId="codegen_mlflow_app_src_model-registry_components_CompareModelVersionsView.tsx_180"
-              label="Show diff only"
+              componentId="mlflow.model-registry.compare-model-versions-parameters-diff-switch"
+              label={showdiffIntlMessage}
               checked={this.state.onlyShowParameterDiff}
               onChange={(checked, e) => this.setState({ onlyShowParameterDiff: checked })}
             />
             <Spacer size="sm" />
-            {this.renderTable(<>{this.renderParams()}</>)}
+            {this.renderTable(this.renderParams())}
           </CollapsibleSection>
-          <CollapsibleSection title="Schema">
+          <CollapsibleSection
+            title={intl.formatMessage({
+              defaultMessage: 'Schema',
+              description: 'Table title text for schema table in the model comparison page',
+            })}
+          >
             <Switch
-              componentId="codegen_mlflow_app_src_model-registry_components_CompareModelVersionsView.tsx_190"
-              label="Ignore column ordering"
+              componentId="mlflow.model-registry.compare-model-versions-schema-ignore-column-order-switch"
+              label={intl.formatMessage({
+                defaultMessage: 'Ignore column ordering',
+                description:
+                  'Toggle text that determines whether to ignore column order in the\n                      model comparison page',
+              })}
               checked={this.state.compareByColumnNameToggle}
               onChange={(checked, e) => this.setState({ compareByColumnNameToggle: checked })}
             />
             <Spacer size="sm" />
             <Switch
-              componentId="codegen_mlflow_app_src_model-registry_components_CompareModelVersionsView.tsx_197"
-              label="Show diff only"
+              componentId="mlflow.model-registry.compare-model-versions-schema-diff-switch"
+              label={showdiffIntlMessage}
               checked={this.state.onlyShowSchemaDiff}
               onChange={(checked, e) => this.setState({ onlyShowSchemaDiff: checked })}
             />
@@ -211,17 +231,15 @@ export class CompareModelVersionsViewImpl extends Component<
               {this.state.inputActive && (
                 <>
                   {this.renderTable(
-                    <>
-                      {this.renderSchema(
-                        'inputActive',
-                        <FormattedMessage
-                          defaultMessage="Inputs"
-                          description="Table section name for schema inputs in the model comparison page"
-                        />,
-                        inputsListByIndex,
-                        inputsListByName,
-                      )}
-                    </>,
+                    this.renderSchema(
+                      'inputActive',
+                      <FormattedMessage
+                        defaultMessage="Inputs"
+                        description="Table section name for schema inputs in the model comparison page"
+                      />,
+                      inputsListByIndex,
+                      inputsListByName,
+                    ),
                   )}
                 </>
               )}
@@ -238,31 +256,34 @@ export class CompareModelVersionsViewImpl extends Component<
               {this.state.outputActive && (
                 <>
                   {this.renderTable(
-                    <>
-                      {this.renderSchema(
-                        'outputActive',
-                        <FormattedMessage
-                          defaultMessage="Outputs"
-                          description="Table section name for schema outputs in the model comparison page"
-                        />,
-                        outputsListByIndex,
-                        outputsListByName,
-                      )}
-                    </>,
+                    this.renderSchema(
+                      'outputActive',
+                      <FormattedMessage
+                        defaultMessage="Outputs"
+                        description="Table section name for schema outputs in the model comparison page"
+                      />,
+                      outputsListByIndex,
+                      outputsListByName,
+                    ),
                   )}
                 </>
               )}
             </div>
           </CollapsibleSection>
-          <CollapsibleSection title="Metrics">
+          <CollapsibleSection
+            title={intl.formatMessage({
+              defaultMessage: 'Metrics',
+              description: 'Table title text for metrics table in the model comparison page',
+            })}
+          >
             <Switch
-              componentId="codegen_mlflow_app_src_model-registry_components_CompareModelVersionsView.tsx_259"
-              label="Show diff only"
+              componentId="mlflow.model-registry.compare-model-versions-metrics-diff-switch"
+              label={showdiffIntlMessage}
               checked={this.state.onlyShowMetricDiff}
               onChange={(checked, e) => this.setState({ onlyShowMetricDiff: checked })}
             />
             <Spacer size="sm" />
-            {this.renderTable(<> {this.renderMetrics()}</>)}
+            {this.renderTable(this.renderMetrics())}
           </CollapsibleSection>
         </div>
         <LegacyTabs>

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
@@ -177,7 +177,7 @@ export class CompareModelVersionsViewImpl extends Component<
           )}
           <CollapsibleSection title="Parameters">
             <Switch
-              componentId="codegen_mlflow_app_sTODO"
+              componentId="codegen_mlflow_app_src_model-registry_components_CompareModelVersionsView.tsx_180"
               label="Show diff only"
               checked={this.state.onlyShowParameterDiff}
               onChange={(checked, e) => this.setState({ onlyShowParameterDiff: checked })}
@@ -187,14 +187,14 @@ export class CompareModelVersionsViewImpl extends Component<
           </CollapsibleSection>
           <CollapsibleSection title="Schema">
             <Switch
-              componentId="codegen_mlflow_app_sTODO"
+              componentId="codegen_mlflow_app_src_model-registry_components_CompareModelVersionsView.tsx_190"
               label="Ignore column ordering"
               checked={this.state.compareByColumnNameToggle}
               onChange={(checked, e) => this.setState({ compareByColumnNameToggle: checked })}
             />
             <Spacer size="sm" />
             <Switch
-              componentId="codegen_mlflow_app_sTODO"
+              componentId="codegen_mlflow_app_src_model-registry_components_CompareModelVersionsView.tsx_197"
               label="Show diff only"
               checked={this.state.onlyShowSchemaDiff}
               onChange={(checked, e) => this.setState({ onlyShowSchemaDiff: checked })}
@@ -256,7 +256,7 @@ export class CompareModelVersionsViewImpl extends Component<
           </CollapsibleSection>
           <CollapsibleSection title="Metrics">
             <Switch
-              componentId="codegen_mlflow_app_sTODO"
+              componentId="codegen_mlflow_app_src_model-registry_components_CompareModelVersionsView.tsx_259"
               label="Show diff only"
               checked={this.state.onlyShowMetricDiff}
               onChange={(checked, e) => this.setState({ onlyShowMetricDiff: checked })}

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
@@ -441,6 +441,7 @@ export class CompareModelVersionsViewImpl extends Component<
             defaultMessage="Parameters"
             description="Field name text for parameters table in the model comparison page"
           />,
+          true,
           this.state.onlyShowParameterDiff,
         )}
       </>

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
@@ -10,10 +10,18 @@ import { connect } from 'react-redux';
 import { Link } from '../../common/utils/RoutingUtils';
 import _ from 'lodash';
 import { FormattedMessage, injectIntl, IntlShape } from 'react-intl';
-import { Switch, LegacyTabs, useDesignSystemTheme } from '@databricks/design-system';
+import {
+  Switch,
+  LegacyTabs,
+  useDesignSystemTheme,
+  TableRow,
+  TableCell,
+  Table,
+  Spacer,
+} from '@databricks/design-system';
 
 import { getParams, getRunInfo } from '../../experiment-tracking/reducers/Reducers';
-import '../../experiment-tracking/components/CompareRunView.css';
+import './CompareModelVersionsView.css';
 import { CompareRunScatter } from '../../experiment-tracking/components/CompareRunScatter';
 import { CompareRunBox } from '../../experiment-tracking/components/CompareRunBox';
 import CompareRunContour from '../../experiment-tracking/components/CompareRunContour';
@@ -26,8 +34,11 @@ import { ModelRegistryRoutes } from '../routes';
 import { getModelVersionSchemas } from '../reducers';
 import { PageHeader } from '../../shared/building_blocks/PageHeader';
 import type { RunInfoEntity } from '../../experiment-tracking/types';
+import { CollapsibleSection } from '../../common/components/CollapsibleSection';
 
 const { TabPane } = LegacyTabs;
+
+const DEFAULT_TABLE_COLUMN_WIDTH = 200;
 
 function CenteredText(props: any) {
   const { theme } = useDesignSystemTheme();
@@ -36,43 +47,6 @@ function CenteredText(props: any) {
       css={{
         textAlign: 'center',
         color: theme.colors.textSecondary,
-      }}
-      {...props}
-    />
-  );
-}
-
-function CompareTable(props: any) {
-  const { theme } = useDesignSystemTheme();
-  return (
-    <table
-      className="compare-table table"
-      css={{
-        'th.main-table-header': {
-          backgroundColor: theme.colors.white,
-          padding: 0,
-        },
-        'td.highlight-data': {
-          backgroundColor: theme.colors.backgroundValidationWarning,
-        },
-      }}
-      {...props}
-    />
-  );
-}
-
-function CollapseButton(props: any) {
-  const { theme } = useDesignSystemTheme();
-  return (
-    <button
-      css={{
-        textAlign: 'left',
-        display: 'flex',
-        alignItems: 'center',
-        border: 'none',
-        backgroundColor: theme.colors.white,
-        paddingLeft: 0,
-        cursor: 'pointer',
       }}
       {...props}
     />
@@ -106,16 +80,21 @@ export class CompareModelVersionsViewImpl extends Component<
   CompareModelVersionsViewImplProps,
   CompareModelVersionsViewImplState
 > {
+  compareModelVersionViewRef: any;
+
+  constructor(props: CompareModelVersionsViewImplProps) {
+    super(props);
+    this.compareModelVersionViewRef = React.createRef();
+    this.onCompareModelTableScrollHandler = this.onCompareModelTableScrollHandler.bind(this);
+  }
+
   state = {
     inputActive: true,
     outputActive: true,
-    paramsToggle: true,
-    paramsActive: true,
-    schemaToggle: true,
-    compareByColumnNameToggle: false,
     schemaActive: true,
-    metricToggle: true,
-    metricActive: true,
+    onlyShowParameterDiff: false,
+    onlyShowSchemaDiff: false,
+    onlyShowMetricDiff: false,
   };
 
   icons = {
@@ -131,6 +110,30 @@ export class CompareModelVersionsViewImpl extends Component<
       [active]: !state[active],
     }));
   };
+
+  onCompareModelTableScrollHandler(e: React.ChangeEvent<HTMLDivElement>) {
+    const blocks = this.compareModelVersionViewRef.current?.querySelectorAll('.compare-model-table');
+    blocks.forEach((_: any, index: any) => {
+      const block = blocks[index];
+      if (block !== e.target) {
+        block.scrollLeft = e.target.scrollLeft;
+      }
+    });
+  }
+
+  getTableHeaderColumnWidth() {
+    return {
+      width: `${DEFAULT_TABLE_COLUMN_WIDTH}px`,
+      minWidth: `${DEFAULT_TABLE_COLUMN_WIDTH}px`,
+      maxWidth: `${DEFAULT_TABLE_COLUMN_WIDTH}px`,
+    };
+  }
+
+  getTableBodyColumnWidth() {
+    const runInfoLength = this.props.runInfos.length;
+    const widthStyle = `max(${DEFAULT_TABLE_COLUMN_WIDTH}px, calc(100vw / ${runInfoLength}))`;
+    return { width: widthStyle, minWidth: widthStyle, maxWidth: widthStyle };
+  }
 
   render() {
     const {
@@ -163,95 +166,97 @@ export class CompareModelVersionsViewImpl extends Component<
     ];
 
     return (
-      <div
-        className="CompareModelVersionsView"
-        // @ts-expect-error TS(2322): Type '{ '.compare-table': { minWidth: number; }; '... Remove this comment to see the full error message
-        css={{
-          ...styles.compareModelVersionsView,
-          ...styles.wrapper(runInfos.length),
-        }}
-      >
+      <div>
         <PageHeader title={title} breadcrumbs={breadcrumbs} />
-        <div className="responsive-table-container">
-          <CompareTable>
-            {this.renderTableHeader()}
-            {this.renderModelVersionInfo()}
-            {this.renderSectionHeader(
-              'paramsActive',
-              'paramsToggle',
-              <FormattedMessage
-                defaultMessage="Parameters"
-                description="Table title text for parameters table in the model comparison page"
-              />,
-            )}
-            {this.renderParams()}
-            {this.renderSectionHeader(
-              'schemaActive',
-              'schemaToggle',
-              <FormattedMessage
-                defaultMessage="Schema"
-                description="Table title text for schema table in the model comparison page"
-              />,
-              false,
-              // @ts-expect-error TS(2345): Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
-              <Switch
-                className="toggle-switch"
-                // @ts-expect-error TS(2322): Type '{ className: string; style: { marginLeft: st... Remove this comment to see the full error message
-                style={{ marginLeft: 'auto' }}
-                onChange={() => this.onToggleClick('compareByColumnNameToggle')}
-              />,
-              <div className="padding-left-text padding-right-text">
-                <span>
-                  <FormattedMessage
-                    defaultMessage="Ignore column ordering"
-                    description="Toggle text that determines whether to ignore column order in the
-                      model comparison page"
-                  />
-                </span>
-              </div>,
-            )}
-            {this.renderSchemaSectionHeader(
-              'inputActive',
-              <FormattedMessage
-                defaultMessage="Inputs"
-                description="Table subtitle for schema inputs in the model comparison page"
-              />,
-            )}
-            {this.renderSchema(
-              'inputActive',
-              <FormattedMessage
-                defaultMessage="Inputs"
-                description="Table section name for schema inputs in the model comparison page"
-              />,
-              inputsListByIndex,
-              inputsListByName,
-            )}
-            {this.renderSchemaSectionHeader(
-              'outputActive',
-              <FormattedMessage
-                defaultMessage="Outputs"
-                description="Table subtitle for schema outputs in the model comparison page"
-              />,
-            )}
-            {this.renderSchema(
-              'outputActive',
-              <FormattedMessage
-                defaultMessage="Outputs"
-                description="Table section name for schema outputs in the model comparison page"
-              />,
-              outputsListByIndex,
-              outputsListByName,
-            )}
-            {this.renderSectionHeader(
-              'metricActive',
-              'metricToggle',
-              <FormattedMessage
-                defaultMessage="Metrics"
-                description="Table title text for metrics table in the model comparison page"
-              />,
-            )}
-            {this.renderMetrics()}
-          </CompareTable>
+        <div ref={this.compareModelVersionViewRef}>
+          {this.renderTable(
+            <>
+              {this.renderTableHeader()}
+              {this.renderModelVersionInfo()}
+            </>,
+          )}
+          <CollapsibleSection title="Parameters">
+            <Switch
+              componentId="codegen_mlflow_app_sTODO"
+              label="Show diff only"
+              checked={this.state.onlyShowParameterDiff}
+              onChange={(checked, e) => this.setState({ onlyShowParameterDiff: checked })}
+            />
+            <Spacer size="sm" />
+            {this.renderTable(<>{this.renderParams()}</>)}
+          </CollapsibleSection>
+          <CollapsibleSection title="Schema">
+            <Switch
+              componentId="codegen_mlflow_app_sTODO"
+              label="Show diff only"
+              checked={this.state.onlyShowSchemaDiff}
+              onChange={(checked, e) => this.setState({ onlyShowSchemaDiff: checked })}
+            />
+            <Spacer size="sm" />
+            <div>
+              {this.renderSchemaSectionHeader(
+                'inputActive',
+                <FormattedMessage
+                  defaultMessage="Inputs"
+                  description="Table subtitle for schema inputs in the model comparison page"
+                />,
+              )}
+              {this.state.inputActive && (
+                <>
+                  {this.renderTable(
+                    <>
+                      {this.renderSchema(
+                        'inputActive',
+                        <FormattedMessage
+                          defaultMessage="Inputs"
+                          description="Table section name for schema inputs in the model comparison page"
+                        />,
+                        inputsListByIndex,
+                        inputsListByName,
+                      )}
+                    </>,
+                  )}
+                </>
+              )}
+            </div>
+            <Spacer size="sm" />
+            <div>
+              {this.renderSchemaSectionHeader(
+                'outputActive',
+                <FormattedMessage
+                  defaultMessage="Outputs"
+                  description="Table subtitle for schema outputs in the model comparison page"
+                />,
+              )}
+              {this.state.outputActive && (
+                <>
+                  {this.renderTable(
+                    <>
+                      {this.renderSchema(
+                        'outputActive',
+                        <FormattedMessage
+                          defaultMessage="Outputs"
+                          description="Table section name for schema outputs in the model comparison page"
+                        />,
+                        outputsListByIndex,
+                        outputsListByName,
+                      )}
+                    </>,
+                  )}
+                </>
+              )}
+            </div>
+          </CollapsibleSection>
+          <CollapsibleSection title="Metrics">
+            <Switch
+              componentId="codegen_mlflow_app_sTODO"
+              label="Show diff only"
+              checked={this.state.onlyShowMetricDiff}
+              onChange={(checked, e) => this.setState({ onlyShowMetricDiff: checked })}
+            />
+            <Spacer size="sm" />
+            {this.renderTable(<> {this.renderMetrics()}</>)}
+          </CollapsibleSection>
         </div>
         <LegacyTabs>
           <TabPane
@@ -303,184 +308,151 @@ export class CompareModelVersionsViewImpl extends Component<
     );
   }
 
+  renderTable(children: React.ReactNode) {
+    return (
+      // @ts-expect-error TS(2322): Property 'onScroll' does not exist... Remove this comment to see the full error message
+      <Table className="table compare-table compare-model-table" onScroll={this.onCompareModelTableScrollHandler}>
+        {children}
+      </Table>
+    );
+  }
+
   renderTableHeader() {
     const { runInfos, runInfosValid } = this.props;
     return (
-      <thead>
-        <tr className="table-row">
-          <th scope="row" className="row-header block-content">
-            <FormattedMessage
-              defaultMessage="Run ID:"
-              description="Text for run ID header in the main table in the model comparison page"
-            />
-          </th>
-          {runInfos.map((r, idx) => (
-            <th scope="column" className="data-value block-content" key={r.runUuid}>
-              {/* Do not show links for invalid run IDs */}
-              {runInfosValid[idx] ? (
-                <Link to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
-              ) : (
-                r.runUuid
-              )}
-            </th>
-          ))}
-        </tr>
-      </thead>
+      <TableRow className="compare-table-row">
+        <TableCell
+          className="head-value sticky-header"
+          css={{
+            backgroundColor: 'var(--table-header-background-color)',
+            ...this.getTableHeaderColumnWidth(),
+          }}
+        >
+          <FormattedMessage
+            defaultMessage="Run ID:"
+            description="Text for run ID header in the main table in the model comparison page"
+          />
+        </TableCell>
+        {runInfos.map((r, idx) => (
+          <TableCell className="data-value" css={{ ...this.getTableBodyColumnWidth() }} key={r.runUuid}>
+            {/* Do not show links for invalid run IDs */}
+            {runInfosValid[idx] ? (
+              <Link to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
+            ) : (
+              r.runUuid
+            )}
+          </TableCell>
+        ))}
+      </TableRow>
     );
   }
 
   renderModelVersionInfo() {
     const { runInfos, runInfosValid, versionsToRuns, runNames, modelName } = this.props;
     return (
-      <tbody className="scrollable-table">
-        <tr className="table-row">
-          <th scope="row" className="data-value block-content">
+      <>
+        <TableRow className="compare-table-row">
+          <TableCell
+            className="head-value sticky-header"
+            css={{
+              backgroundColor: 'var(--table-header-background-color)',
+              ...this.getTableHeaderColumnWidth(),
+            }}
+          >
             <FormattedMessage
               defaultMessage="Model Version:"
               description="Text for model version row header in the main table in the model
                 comparison page"
             />
-          </th>
+          </TableCell>
           {Object.keys(versionsToRuns).map((modelVersion) => {
             const run = versionsToRuns[modelVersion];
             return (
-              <td className="meta-info block-content" key={run}>
+              <TableCell className="data-value" key={run} css={{ ...this.getTableBodyColumnWidth() }}>
                 <Link to={ModelRegistryRoutes.getModelVersionPageRoute(modelName, modelVersion)}>{modelVersion}</Link>
-              </td>
+              </TableCell>
             );
           })}
-        </tr>
-        <tr className="table-row">
-          <th scope="row" className="data-value block-content">
+        </TableRow>
+        <TableRow className="compare-table-row">
+          <TableCell
+            className="head-value sticky-header"
+            css={{
+              backgroundColor: 'var(--table-header-background-color)',
+              ...this.getTableHeaderColumnWidth(),
+            }}
+          >
             <FormattedMessage
               defaultMessage="Run Name:"
               description="Text for run name row header in the main table in the model comparison
                 page"
             />
-          </th>
+          </TableCell>
           {runNames.map((runName, i) => {
             return (
-              <td className="meta-info block-content" key={runInfos[i].runUuid}>
+              <TableCell className="data-value" key={runInfos[i].runUuid} css={{ ...this.getTableBodyColumnWidth() }}>
                 <div className="truncate-text single-line cell-content">{runName}</div>
-              </td>
+              </TableCell>
             );
           })}
-        </tr>
-        <tr className="table-row">
-          <th scope="row" className="data-value block-content">
+        </TableRow>
+        <TableRow className="compare-table-row">
+          <TableCell
+            className="head-value sticky-header"
+            css={{
+              backgroundColor: 'var(--table-header-background-color)',
+              ...this.getTableHeaderColumnWidth(),
+            }}
+          >
             <FormattedMessage
               defaultMessage="Start Time:"
               description="Text for start time row header in the main table in the model comparison
                 page"
             />
-          </th>
+          </TableCell>
           {runInfos.map((run, idx) => {
             /* Do not attempt to get timestamps for invalid run IDs */
             const startTime =
               run.startTime && runInfosValid[idx] ? Utils.formatTimestamp(run.startTime, this.props.intl) : '(unknown)';
             return (
-              <td className="meta-info block-content" key={run.runUuid}>
+              <TableCell className="data-value" key={run.runUuid} css={{ ...this.getTableBodyColumnWidth() }}>
                 {startTime}
-              </td>
+              </TableCell>
             );
           })}
-        </tr>
-      </tbody>
-    );
-  }
-
-  /* additional Switch and Text are antd Switch component and the text followed by the toggle switch
-  this is currently used in schema section where we have an additional switch toggle for
-  ignore column ordering, same logic can be applied if future section needs additional toggle */
-  renderSectionHeader(
-    activeSection: any,
-    toggleSection: any,
-    sectionName: any,
-    leftToggle = true,
-    additionalSwitch = null,
-    additionalSwitchText = null,
-  ) {
-    const { runInfos } = this.props;
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    const isActive = this.state[activeSection];
-    const { downIcon, rightIcon } = this.icons;
-    return (
-      <tbody>
-        <tr>
-          <th scope="rowgroup" className="block-content main-table-header" colSpan={runInfos.length + 1}>
-            <div className="switch-button-container">
-              <CollapseButton onClick={() => this.onToggleClick(activeSection)}>
-                {isActive ? downIcon : rightIcon}
-                <span className="header">{sectionName}</span>
-              </CollapseButton>
-              {additionalSwitch}
-              {additionalSwitchText}
-              <Switch
-                defaultChecked
-                className="toggle-switch"
-                // @ts-expect-error TS(2322): Type '{ defaultChecked: true; className: string; s... Remove this comment to see the full error message
-                style={leftToggle ? { marginLeft: 'auto' } : {}}
-                onChange={() => this.onToggleClick(toggleSection)}
-              />
-              <div className="padding-left-text">
-                <span>
-                  <FormattedMessage
-                    defaultMessage="Show diff only"
-                    description="Toggle text that determines whether to show diff only in the model
-                      comparison page"
-                  />
-                </span>
-              </div>
-            </div>
-          </th>
-        </tr>
-      </tbody>
+        </TableRow>
+      </>
     );
   }
 
   renderParams() {
     return (
-      <tbody className="scrollable-table">
+      <>
         {this.renderDataRows(
           this.props.paramLists,
           <FormattedMessage
             defaultMessage="Parameters"
             description="Field name text for parameters table in the model comparison page"
           />,
-          this.state.paramsActive,
-          this.state.paramsToggle,
+          this.state.onlyShowParameterDiff,
         )}
-      </tbody>
+      </>
     );
   }
 
-  renderSchemaSectionHeader(activeSection: any, sectionName: any) {
-    const { runInfos } = this.props;
-    const { schemaActive } = this.state;
+  renderSchemaSectionHeader(activeSection: string, sectionName: React.ReactNode) {
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     const isActive = this.state[activeSection];
     const { minusIcon, plusIcon } = this.icons;
     return (
-      <tbody>
-        <tr className={`${schemaActive ? '' : 'hidden-row'}`}>
-          <th scope="rowgroup" className="schema-table-header block-content" colSpan={runInfos.length + 1}>
-            <button className="schema-collapse-button" onClick={() => this.onToggleClick(activeSection)}>
-              {isActive ? minusIcon : plusIcon}
-              <strong style={{ paddingLeft: 4 }}>{sectionName}</strong>
-            </button>
-          </th>
-        </tr>
-      </tbody>
+      <button onClick={() => this.onToggleClick(activeSection)}>
+        {isActive ? minusIcon : plusIcon}
+        <strong style={{ paddingLeft: 4 }}>{sectionName}</strong>
+      </button>
     );
   }
 
   renderSchema(activeSection: any, sectionName: any, listByIndex: any, listByName: any) {
-    const { schemaActive, compareByColumnNameToggle, schemaToggle } = this.state;
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    const isActive = this.state[activeSection];
-    const showSchemaSection = schemaActive && isActive;
-    const showListByIndex = !compareByColumnNameToggle && !_.isEmpty(listByIndex);
-    const showListByName = compareByColumnNameToggle && !_.isEmpty(listByName);
     const listByIndexHeaderMap = (key: any, data: any) => (
       <>
         {sectionName} [{key}]
@@ -496,30 +468,27 @@ export class CompareModelVersionsViewImpl extends Component<
       />
     );
     return (
-      <tbody className="scrollable-table schema-scrollable-table">
+      <>
         {this.renderDataRows(
           listByIndex,
           schemaFieldName,
-          showSchemaSection && showListByIndex,
-          schemaToggle,
+          this.state.onlyShowSchemaDiff,
           listByIndexHeaderMap,
           schemaFormatter,
         )}
         {this.renderDataRows(
           listByName,
           schemaFieldName,
-          showSchemaSection && showListByName,
-          schemaToggle,
+          this.state.onlyShowSchemaDiff,
           listByNameHeaderMap,
           schemaFormatter,
         )}
-      </tbody>
+      </>
     );
   }
 
   renderMetrics() {
     const { runInfos, metricLists } = this.props;
-    const { metricActive, metricToggle } = this.state;
     const { chartIcon } = this.icons;
     const metricsHeaderMap = (key: any, data: any) => {
       return (
@@ -540,31 +509,28 @@ export class CompareModelVersionsViewImpl extends Component<
       );
     };
     return (
-      <tbody className="scrollable-table">
+      <>
         {this.renderDataRows(
           metricLists,
           <FormattedMessage
             defaultMessage="Metrics"
             description="Field name text for metrics table in the model comparison page"
           />,
-          metricActive,
-          metricToggle,
+          this.state.onlyShowMetricDiff,
           metricsHeaderMap,
           Utils.formatMetric,
         )}
-      </tbody>
+      </>
     );
   }
 
-  // eslint-disable-next-line no-unused-vars
   renderDataRows(
     list: any,
     fieldName: any,
-    show = true,
-    toggle = false,
+    onlyShowDiff: boolean,
     headerMap = (key: any, data: any) => key,
     formatter = (value: any) => (isNaN(value) ? `"${value}"` : value),
-  ) {
+  ): React.ReactNode {
     // @ts-expect-error TS(2554): Expected 2 arguments, but got 1.
     const keys = CompareRunUtil.getKeys(list);
     const data = {};
@@ -578,8 +544,14 @@ export class CompareModelVersionsViewImpl extends Component<
     });
     if (_.isEmpty(keys) || _.isEmpty(list)) {
       return (
-        <tr className={`table-row ${show ? '' : 'hidden-row'}`}>
-          <th scope="row" className="rowHeader block-content">
+        <TableRow className="compare-table-row">
+          <TableCell
+            className="head-value sticky-header"
+            css={{
+              backgroundColor: 'var(--table-header-background-color)',
+              ...this.getTableHeaderColumnWidth(),
+            }}
+          >
             <CenteredText>
               <FormattedMessage
                 defaultMessage="{fieldName} are empty"
@@ -588,8 +560,8 @@ export class CompareModelVersionsViewImpl extends Component<
                 values={{ fieldName: fieldName }}
               />
             </CenteredText>
-          </th>
-        </tr>
+          </TableCell>
+        </TableRow>
       );
     }
     // @ts-expect-error TS(2345): Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
@@ -603,41 +575,50 @@ export class CompareModelVersionsViewImpl extends Component<
     const resultRows = keys.map((k) => {
       // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       const isDifferent = data[k].length > 1 && _.uniq(data[k]).length > 1;
+      if (onlyShowDiff && !isDifferent) {
+        return null;
+      }
       identical = !isDifferent && identical;
       return (
-        <tr key={k} className={`table-row ${(toggle && !isDifferent) || !show ? 'hidden-row' : ''}`}>
-          <th scope="row" className="rowHeader block-content">
+        <TableRow key={k} className={`compare-table-row ${isDifferent ? 'diff-row' : ''}`}>
+          <TableCell
+            className="head-value sticky-header"
+            css={{
+              backgroundColor: 'var(--table-header-background-color)',
+              ...this.getTableHeaderColumnWidth(),
+            }}
+          >
             {/* @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message */}
             {headerMap(k, data[k])}
-          </th>
+          </TableCell>
           {/* @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message */}
           {data[k].map((value: any, i: any) => (
-            <td
-              className={`data-value block-content ${isDifferent ? 'highlight-data' : ''}`}
+            <TableCell
+              className={`data-value`}
+              css={{ ...this.getTableBodyColumnWidth() }}
               key={this.props.runInfos[i].runUuid}
             >
               <span className="truncate-text single-line cell-content">
                 {value === undefined ? '-' : formatter(value)}
               </span>
-            </td>
+            </TableCell>
           ))}
-        </tr>
+        </TableRow>
       );
     });
-    if (identical && toggle) {
+    if (identical && onlyShowDiff) {
       return (
-        <tr className={`table-row ${show ? '' : 'hidden-row'}`}>
-          <th scope="row" className="rowHeader block-content">
+        <TableRow className={`compare-table-row`}>
+          <TableCell className="data-value" css={{ ...this.getTableBodyColumnWidth() }}>
             <CenteredText>
               <FormattedMessage
                 defaultMessage="{fieldName} are identical"
-                // eslint-disable-next-line max-len
                 description="Default text in data table where items are identical in the model comparison page"
                 values={{ fieldName: fieldName }}
               />
             </CenteredText>
-          </th>
-        </tr>
+          </TableCell>
+        </TableRow>
       );
     }
     return resultRows;
@@ -659,11 +640,10 @@ const getModelVersionSchemaColumnsByIndex = (columns: any) => {
 };
 
 const getModelVersionSchemaColumnsByName = (columns: any) => {
-  const columnsByName = {};
+  const columnsByName: Record<string, { key: string; value: string }> = {};
   columns.forEach((column: any) => {
     const name = column.name ? column.name : '-';
     const type = column.type ? column.type : '-';
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     columnsByName[name] = {
       key: name,
       value: type,
@@ -731,88 +711,6 @@ const mapStateToProps = (state: any, ownProps: any) => {
     outputsListByName,
     outputsListByIndex,
   };
-};
-
-const DEFAULT_COLUMN_WIDTH = 200;
-
-const styles = {
-  wrapper: (numRuns: any) => ({
-    '.compare-table': {
-      // 1 extra unit for header column
-      minWidth: (numRuns + 1) * DEFAULT_COLUMN_WIDTH,
-    },
-  }),
-  compareModelVersionsView: {
-    'button:focus': {
-      outline: 'none',
-      boxShadow: 'none',
-    },
-    'td.block-content th.block-content': {
-      whiteSpace: 'nowrap',
-      textOverflow: 'ellipsis',
-      tableLayout: 'fixed',
-      boxSizing: 'content-box',
-    },
-    'th.schema-table-header': {
-      height: 28,
-      padding: 0,
-    },
-    'tr.table-row': {
-      display: 'table',
-      width: '100%',
-      tableLayout: 'fixed',
-    },
-    'tr.hidden-row': {
-      display: 'none',
-    },
-    'tbody.scrollable-table': {
-      width: '100%',
-      display: 'block',
-      border: 'none',
-      maxHeight: 400,
-      overflowY: 'auto',
-    },
-    'tbody.schema-scrollable-table': {
-      maxHeight: 200,
-    },
-    '.switch-button-container': {
-      display: 'flex',
-      paddingTop: 16,
-      paddingBottom: 16,
-    },
-    'button.schema-collapse-button': {
-      textAlign: 'left',
-      display: 'block',
-      width: '100%',
-      height: '100%',
-      border: 'none',
-    },
-    '.collapse-button': {
-      textAlign: 'left',
-      display: 'flex',
-      alignItems: 'center',
-      border: 'none',
-      backgroundColor: 'white',
-      paddingLeft: 0,
-    },
-    '.cell-content': {
-      maxWidth: '200px',
-      minWidth: '100px',
-    },
-    '.padding-left-text': {
-      paddingLeft: 8,
-    },
-    '.padding-right-text': {
-      paddingRight: 16,
-    },
-    '.toggle-switch': {
-      marginTop: 2,
-    },
-    '.header': {
-      paddingLeft: 8,
-      fontSize: 16,
-    },
-  },
 };
 
 export const CompareModelVersionsView = connect(mapStateToProps)(injectIntl(CompareModelVersionsViewImpl));

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
@@ -91,7 +91,6 @@ export class CompareModelVersionsViewImpl extends Component<
   state = {
     inputActive: true,
     outputActive: true,
-    schemaActive: true,
     onlyShowParameterDiff: false,
     onlyShowSchemaDiff: false,
     onlyShowMetricDiff: false,
@@ -308,7 +307,7 @@ export class CompareModelVersionsViewImpl extends Component<
     );
   }
 
-  renderTable(children: React.ReactNode) {
+  renderTable(children: React.ReactNode): React.ReactNode {
     return (
       // @ts-expect-error TS(2322): Property 'onScroll' does not exist... Remove this comment to see the full error message
       <Table className="table compare-table compare-model-table" onScroll={this.onCompareModelTableScrollHandler}>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Gumichocopengin8/mlflow/pull/15012?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15012/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/15012/merge#subdirectory=skinny
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Dark mode theme was not applied to Compare model version tables. 
- The table components were not aligned with other components, so use table components from `@databricks/design-system`
- The new compare model version view should look similar to compare experiment tables

#### Before

https://github.com/user-attachments/assets/7a055d74-e345-45ae-8276-9c68ef17e4af


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->


https://github.com/user-attachments/assets/10cfa560-6f3a-40d6-9d04-57e06c712f6d



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
