### PR TITLE
Fix assessment proto/dict conversion

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -139,7 +139,8 @@ class Assessment(_MlflowObject):
             feedback = None
 
         error = AssessmentError.from_proto(proto.error) if proto.error.error_code else None
-        metadata = proto.metadata
+        # Convert ScalarMapContainer to a normal Python dict
+        metadata = dict(proto.metadata) if proto.metadata else None
 
         return cls(
             _assessment_id=proto.assessment_id or None,
@@ -151,25 +152,25 @@ class Assessment(_MlflowObject):
             expectation=expectation,
             feedback=feedback,
             rationale=proto.rationale or None,
-            metadata=metadata or None,
+            metadata=metadata,
             error=error,
             span_id=proto.span_id or None,
         )
 
     def to_dictionary(self):
         return {
+            "assessment_id": self._assessment_id,
             "trace_id": self.trace_id,
             "name": self.name,
             "source": self.source.to_dictionary(),
             "create_time_ms": self.create_time_ms,
             "last_update_time_ms": self.last_update_time_ms,
-            "expectation": self.expectation,
-            "feedback": self.feedback,
+            "expectation": self.expectation.to_dictionary() if self.expectation else None,
+            "feedback": self.feedback.to_dictionary() if self.feedback else None,
             "rationale": self.rationale,
             "metadata": self.metadata,
             "error": self.error.to_dictionary() if self.error else None,
             "span_id": self.span_id,
-            "_assessment_id": self._assessment_id,
         }
 
 

--- a/mlflow/entities/assessment_error.py
+++ b/mlflow/entities/assessment_error.py
@@ -53,3 +53,10 @@ class AssessmentError(_MlflowObject):
             error_code=proto.error_code,
             error_message=proto.error_message or None,
         )
+
+    def to_dictionary(self):
+        return {"error_code": self.error_code, "error_message": self.error_message}
+
+    @classmethod
+    def from_dictionary(cls, error_dict):
+        return cls(**error_dict)

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -180,7 +180,7 @@ def test_assessment_value_validation():
         None,
     ],
 )
-def test_assessment_proto_conversion(expectation, feedback, error, source, metadata):
+def test_assessment_conversion(expectation, feedback, error, source, metadata):
     timestamp_ms = int(time.time() * 1000)
     assessment = Assessment(
         trace_id="trace_id",
@@ -202,3 +202,28 @@ def test_assessment_proto_conversion(expectation, feedback, error, source, metad
 
     result = Assessment.from_proto(proto)
     assert result == assessment
+
+    dict = assessment.to_dictionary()
+    assert dict["assessment_id"] == assessment._assessment_id
+    assert dict["trace_id"] == assessment.trace_id
+    assert dict["name"] == assessment.name
+    assert dict["source"] == {
+        "source_type": source.source_type,
+        "source_id": source.source_id,
+    }
+    assert dict["create_time_ms"] == assessment.create_time_ms
+    assert dict["last_update_time_ms"] == assessment.last_update_time_ms
+    assert dict["rationale"] == assessment.rationale
+    assert dict["metadata"] == metadata
+
+    if expectation:
+        assert dict["expectation"] == {"value": expectation.value}
+
+    if feedback:
+        assert dict["feedback"] == feedback.to_dictionary()
+
+    if error:
+        assert dict["error"] == {
+            "error_code": error.error_code,
+            "error_message": error.error_message,
+        }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15019?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15019/merge
```

For Databricks, use the following command:

```
%sh
OPTIONS=$(if pip freeze | grep -q 'git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/15019/merge#subdirectory=skinny
```

</p>
</details>

### What changes are proposed in this pull request?

Fix proto/dict conversion of assessment.
1. The `metadata` field in the assessment proto is not converted to dictionary.
2. The `AssessmentError` class doesn't implement `to_dictionary` method while it is being used.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="881" alt="Screenshot 2025-03-17 at 13 14 20" src="https://github.com/user-attachments/assets/ad6611e8-c51d-44cf-916a-185326346c5a" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
