### PR TITLE
fix: sorting order for grouping in run view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
@@ -174,6 +174,7 @@ export const ExperimentViewRuns = React.memo((props: ExperimentViewRunsProps) =>
     runsHiddenMode: uiState.runsHiddenMode,
     runsVisibilityMap: uiState.runsVisibilityMap,
     useGroupedValuesInCharts: uiState.useGroupedValuesInCharts,
+    searchFacetsState,
   });
 
   const [notificationsFn, notificationContainer] = useLegacyNotification();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.group-row-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.group-row-utils.ts
@@ -1,4 +1,4 @@
-import { compact, entries, isObject, isNil, isUndefined, reject, values, Dictionary, isEqual, sortBy } from 'lodash';
+import { compact, entries, isObject, isNil, isUndefined, reject, values, Dictionary } from 'lodash';
 import {
   type RowGroupRenderMetadata,
   type RowRenderMetadata,
@@ -18,6 +18,7 @@ import {
 } from '../../../../common/utils/FeatureUtils';
 import { determineIfRowIsHidden } from './experimentPage.common-row-utils';
 import { removeOutliersFromMetricHistory } from '../../runs-charts/components/RunsCharts.common';
+import { type ExperimentPageSearchFacetsState } from '../models/ExperimentPageSearchFacetsState';
 
 type AggregableParamEntity = { key: string; value: string };
 type AggregableMetricEntity = { key: string; value: number; step: number; min?: number; max?: number };
@@ -534,6 +535,7 @@ export const getGroupedRowRenderMetadata = ({
   groupsExpanded,
   runData,
   groupBy,
+  searchFacetsState,
   runsHidden = [],
   runsVisibilityMap = {},
   runsHiddenMode = RUNS_VISIBILITY_MODE.FIRST_10_RUNS,
@@ -542,6 +544,7 @@ export const getGroupedRowRenderMetadata = ({
   groupsExpanded: Record<string, boolean>;
   runData: SingleRunData[];
   groupBy: null | RunsGroupByConfig | string;
+  searchFacetsState?: Readonly<ExperimentPageSearchFacetsState>;
   runsHidden?: string[];
   runsVisibilityMap?: Record<string, boolean>;
   runsHiddenMode?: RUNS_VISIBILITY_MODE;
@@ -726,7 +729,74 @@ export const getGroupedRowRenderMetadata = ({
     }
   }
 
+  const [entity, sortKey] = extractSortKey(searchFacetsState);
+  if (entity && sortKey && searchFacetsState) {
+    const parentList: RowGroupRenderMetadata[] = [];
+    // key: parent groupId, value: list of parent group's children
+    const childrenMap: Map<string, RowRenderMetadata[]> = new Map();
+
+    for (const res of result) {
+      if ('groupId' in res) {
+        parentList.push(res);
+      } else {
+        const parentGroupId = res.rowUuid.replace(`.${res.runInfo.runUuid}`, ''); // dont forget .
+        const groupList = childrenMap.get(parentGroupId) ?? [];
+        groupList.push(res);
+        childrenMap.set(parentGroupId, groupList);
+      }
+    }
+
+    const orderByAscVal = searchFacetsState.orderByAsc ? 1 : -1;
+    parentList.sort((a, b) => {
+      switch (entity) {
+        case 'metrics':
+          const aMetricSoryKeyValue = a.aggregatedMetricEntities.find((agg) => agg.key === sortKey)?.value;
+          const bMetricSoryKeyValue = b.aggregatedMetricEntities.find((agg) => agg.key === sortKey)?.value;
+          if (aMetricSoryKeyValue && bMetricSoryKeyValue && aMetricSoryKeyValue !== bMetricSoryKeyValue) {
+            return aMetricSoryKeyValue > bMetricSoryKeyValue ? orderByAscVal : -orderByAscVal;
+          }
+          return 0;
+        case 'params':
+          const aParamSortKeyValue = a.aggregatedParamEntities.find((agg) => agg.key === sortKey)?.value;
+          const bParamSortKeyValue = b.aggregatedParamEntities.find((agg) => agg.key === sortKey)?.value;
+          if (aParamSortKeyValue && bParamSortKeyValue && aParamSortKeyValue !== bParamSortKeyValue) {
+            return aParamSortKeyValue > bParamSortKeyValue ? orderByAscVal : -orderByAscVal;
+          }
+          return 0;
+        default:
+          return 0;
+      }
+    });
+
+    const sortedResultList: (RowGroupRenderMetadata | RowRenderMetadata)[] = [];
+    for (const parent of parentList) {
+      sortedResultList.push(parent);
+      if (childrenMap.has(parent.groupId)) {
+        // no need to sort childenList because `result` is already sorted
+        const childenList = childrenMap.get(parent.groupId) ?? [];
+        sortedResultList.push(...childenList);
+      }
+    }
+    return sortedResultList;
+  }
   return result;
+};
+
+const extractSortKey = (
+  searchFacetsState?: ExperimentPageSearchFacetsState,
+): ['metrics' | 'params' | undefined, string | undefined] => {
+  if (!searchFacetsState) {
+    return [undefined, undefined];
+  }
+  const { orderByKey } = searchFacetsState;
+  const regex = /^(metrics|params)\.`(.*?)`$/;
+  const match = orderByKey.match(regex);
+  if (match && match.length === 3) {
+    const entity = match[1] === 'metrics' || match[1] === 'params' ? match[1] : undefined;
+    const sortKey = match[2];
+    return [entity, sortKey];
+  }
+  return [undefined, undefined];
 };
 
 export const createSearchFilterFromRunGroupInfo = (groupInfo: RunGroupParentInfo) =>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.group-row-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.group-row-utils.ts
@@ -752,14 +752,22 @@ export const getGroupedRowRenderMetadata = ({
         case 'metrics':
           const aMetricSoryKeyValue = a.aggregatedMetricEntities.find((agg) => agg.key === sortKey)?.value;
           const bMetricSoryKeyValue = b.aggregatedMetricEntities.find((agg) => agg.key === sortKey)?.value;
-          if (aMetricSoryKeyValue && bMetricSoryKeyValue && aMetricSoryKeyValue !== bMetricSoryKeyValue) {
+          if (
+            aMetricSoryKeyValue !== undefined &&
+            bMetricSoryKeyValue !== undefined &&
+            aMetricSoryKeyValue !== bMetricSoryKeyValue
+          ) {
             return aMetricSoryKeyValue > bMetricSoryKeyValue ? orderByAscVal : -orderByAscVal;
           }
           return 0;
         case 'params':
           const aParamSortKeyValue = a.aggregatedParamEntities.find((agg) => agg.key === sortKey)?.value;
           const bParamSortKeyValue = b.aggregatedParamEntities.find((agg) => agg.key === sortKey)?.value;
-          if (aParamSortKeyValue && bParamSortKeyValue && aParamSortKeyValue !== bParamSortKeyValue) {
+          if (
+            aParamSortKeyValue !== undefined &&
+            bParamSortKeyValue !== undefined &&
+            aParamSortKeyValue !== bParamSortKeyValue
+          ) {
             return aParamSortKeyValue > bParamSortKeyValue ? orderByAscVal : -orderByAscVal;
           }
           return 0;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-utils.ts
@@ -32,6 +32,7 @@ import { shouldEnableToggleIndividualRunsInGroups } from '../../../../common/uti
 import { getGroupedRowRenderMetadata, type RunsGroupByConfig } from './experimentPage.group-row-utils';
 import { type ExperimentPageUIState, RUNS_VISIBILITY_MODE } from '../models/ExperimentPageUIState';
 import { determineIfRowIsHidden } from './experimentPage.common-row-utils';
+import { type ExperimentPageSearchFacetsState } from '../models/ExperimentPageSearchFacetsState';
 
 /**
  * A simple tree-like interface used in nested rows calculations.
@@ -225,6 +226,7 @@ export const prepareRunsGridData = ({
   groupBy = null,
   groupsExpanded = {},
   useGroupedValuesInCharts,
+  searchFacetsState,
 }: PrepareRunsGridDataParams) => {
   const experimentNameMap = Utils.getExperimentNameMap(Utils.sortExperimentsById(experiments)) as Record<
     string,
@@ -243,6 +245,7 @@ export const prepareRunsGridData = ({
         runData,
         groupBy,
         groupsExpanded,
+        searchFacetsState,
         runsHidden,
         runsVisibilityMap,
         runsHiddenMode,
@@ -432,6 +435,7 @@ export const useExperimentRunRows = ({
   runsHiddenMode,
   groupsExpanded = {},
   useGroupedValuesInCharts,
+  searchFacetsState,
 }: PrepareRunsGridDataParams) =>
   useMemo(
     () =>
@@ -453,6 +457,7 @@ export const useExperimentRunRows = ({
         groupsExpanded,
         runsHiddenMode,
         useGroupedValuesInCharts,
+        searchFacetsState,
       }),
     [
       // Explicitly include each dependency here to avoid unnecessary recalculations
@@ -473,6 +478,7 @@ export const useExperimentRunRows = ({
       groupsExpanded,
       runsHiddenMode,
       useGroupedValuesInCharts,
+      searchFacetsState,
     ],
   );
 
@@ -571,6 +577,8 @@ type PrepareRunsGridDataParams = Pick<
     runUuidsMatchingFilter: string[];
 
     groupBy: string | RunsGroupByConfig | null;
+
+    searchFacetsState?: Readonly<ExperimentPageSearchFacetsState>;
   };
 
 export const extractRunRowParamFloat = (run: RunRowType, paramName: string, fallback = undefined) => {


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> fix #14840

### What changes are proposed in this pull request?

Fix the issue of sorting order for grouping in run view. For more info, see #14840

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/user-attachments/assets/31d2d78c-946b-4a69-8fa4-9179a53c79c6

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
