### PR TITLE
fix: fix tag names for autocomplete

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
@@ -90,8 +90,6 @@ export const RunsSearchAutoComplete = (props: RunsSearchAutoCompleteProps) => {
     const mergedEntityNames = getEntityNamesFromRunsData(runsData, existingEntityNames);
     existingEntityNamesRef.current = mergedEntityNames;
     return getOptionsFromEntityNames(mergedEntityNames);
-    // existingEntityNamesRef is only set here. Omit from dependencies to avoid infinite loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runsData]);
 
   useEffect(() => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.utils.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ExperimentRunsSelectorResult } from '../../utils/experimentRuns.selector';
+import { type KeyValueEntity } from '@mlflow/mlflow/src/experiment-tracking/types';
 
 export type Option = {
   label?: string | React.ReactNode;
@@ -43,27 +44,27 @@ export const getEntityNamesFromRunsData = (
   newRunsData: ExperimentRunsSelectorResult,
   existingNames: EntityNameGroup,
 ): EntityNameGroup => {
-  const mergeDedup = (list1: any[], list2: any[]) => [...new Set([...list1, ...list2])];
-  const getTagNames = (tagsList: any[]) => tagsList.flatMap((tagRecord) => Object.keys(tagRecord));
+  const mergeDedup = (list1: string[], list2: string[]) => [...new Set([...list1, ...list2])];
+  const getTagNames = (tagsList: Record<string, KeyValueEntity>[]) =>
+    tagsList.flatMap((tagRecord) => Object.keys(tagRecord));
 
   const metricNames = mergeDedup(existingNames.metricNames, newRunsData.metricKeyList);
   const paramNames = mergeDedup(existingNames.paramNames, newRunsData.paramKeyList);
-  const tagNames = mergeDedup(getTagNames(existingNames.tagNames), getTagNames(newRunsData.tagsList));
+
   // Filter out internal tag names and wrap names that include control characters in backticks.
-  const tagNamesCleaned = tagNames
+  const tagNamesCleaned = getTagNames(newRunsData.tagsList)
     .filter((s: string) => !s.startsWith('mlflow.'))
     .map((s: string) => {
-      if (s.includes('"') || s.includes(' ') || s.includes('.')) {
+      if (s.includes('"') || s.includes(' ') || s.includes('.') || /^\d+$/.test(s)) {
         return `\`${s}\``;
       } else if (s.includes('`')) {
         return `"${s}"`;
-      } else return s;
+      } else {
+        return s;
+      }
     });
-  return {
-    metricNames,
-    paramNames,
-    tagNames: tagNamesCleaned,
-  };
+  const newTagNames = mergeDedup(existingNames.tagNames, tagNamesCleaned);
+  return { metricNames, paramNames, tagNames: newTagNames };
 };
 
 export const getOptionsFromEntityNames = (entityNames: EntityNameGroup): OptionGroup[] => [
@@ -146,7 +147,7 @@ export const getEntitiesAndIndices = (str: string) => {
 export const getFilteredOptionsFromEntityName = (
   baseOptions: OptionGroup[],
   entityBeingEdited: Entity,
-  suggestionLimits: any,
+  suggestionLimits: Record<string, number>,
 ): OptionGroup[] => {
   return baseOptions
     .map((group) => {
@@ -156,7 +157,7 @@ export const getFilteredOptionsFromEntityName = (
           value: match.value,
           label: boldedText(match.value, entityBeingEdited.name.trim()),
         }));
-      const limitForGroup = (suggestionLimits as any)[group.label];
+      const limitForGroup = suggestionLimits[group.label];
       const ellipsized = [
         ...newOptions.slice(0, limitForGroup),
         ...(newOptions.length > limitForGroup ? [{ label: '...', value: `..._${group.label}` }] : []),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Gumichocopengin8/mlflow/pull/15030?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15030/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15030/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15030
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Incorrect tag names were listed in autocomplete components such as `tags.0`, `tags.1`, `tags.2` etc.
Also, numeric tag names were not enclosed with backquotes like `` tags.`100` ``

https://github.com/user-attachments/assets/bec5260b-299e-4050-80a1-ab0755e18a07


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->


https://github.com/user-attachments/assets/492b70e1-b983-4ec4-8db0-17a254feff06



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
