### PR TITLE
Show images in the metric tab

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.ts
@@ -33,7 +33,7 @@ const parseImageFile = (filename: string) => {
   // The variables retrieved here are not reliable on OSS due to the usage of "%" as the separator.
   // Need to switch to a different separator on the backend to fully resolve the issue.
   const [serializedImageKey, stepLabel, stepString, timestampLabel, timestampString, ..._] = fileKey.split(delimiter);
-  const isCompressed = fileKey.includes('compressed');
+  const isCompressed = fileKey.endsWith('compressed');
 
   if (stepLabel !== 'step' || timestampLabel !== 'timestamp') {
     throw new ImagePathParseError(

--- a/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.ts
@@ -30,8 +30,10 @@ const parseImageFile = (filename: string) => {
   if (delimiter === undefined) {
     throw new ImagePathParseError('Logged image path parse: incorrect filename format for image file', filename);
   }
-  const [serializedImageKey, stepLabel, stepString, timestampLabel, timestampString, _, compressed] =
-    fileKey.split(delimiter);
+  // The variables retrieved here are not reliable on OSS due to the usage of "%" as the separator.
+  // Need to switch to a different separator on the backend to fully resolve the issue.
+  const [serializedImageKey, stepLabel, stepString, timestampLabel, timestampString, ..._] = fileKey.split(delimiter);
+  const isCompressed = fileKey.includes('compressed');
 
   if (stepLabel !== 'step' || timestampLabel !== 'timestamp') {
     throw new ImagePathParseError(
@@ -43,7 +45,6 @@ const parseImageFile = (filename: string) => {
   const step = parseInt(stepString, 10);
   const timestamp = parseInt(timestampString, 10);
   const imageKey = serializedImageKey.replace(/#/g, '/');
-  const isCompressed = compressed !== undefined;
 
   if (isCompressed) {
     fileKey = fileKey.slice(0, -('compressed'.length + 1));


### PR DESCRIPTION
### Related Issues/PRs

Resolve #15013

### What changes are proposed in this pull request?

There is an issue that images are not displayed correctly on the run metrics tab. This is caused by incorrectly decoding the file name that uses "%" as the separator. The full resolution needs replacing the separator, but this PR fixes the immediate issue.

![image](https://github.com/user-attachments/assets/b08802a4-84db-42a6-a5be-adf6facede57)


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="446" alt="image" src="https://github.com/user-attachments/assets/9709a0e0-595d-4607-9897-8faf9acde72e" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Show images in the run metrics tab.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
