### PR TITLE
FileStore order_by fix

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -2243,7 +2243,7 @@ class FileStore(AbstractStore):
         experiment_ids: list[str],
         filter_string: Optional[str] = None,
         max_results: Optional[int] = None,
-        order_by: Optional[list[list[str, Any]]] = None,
+        order_by: Optional[list[dict[str, Any]]] = None,
         page_token: Optional[str] = None,
     ) -> PagedList[LoggedModel]:
         """
@@ -2256,9 +2256,16 @@ class FileStore(AbstractStore):
             order_by: List of dictionaries to specify the ordering of the search results.
                 The following fields are supported:
 
-                field_name (str): Required. Name of the field to order by, e.g. "model_id".
-                ascending or descending: (str): Optional. Whether the order is ascending or not.
-                    Default is ascending. e.g. "ASC" or "DESC".
+                field_name (str): Required. Name of the field to order by, e.g. "metrics.accuracy".
+                ascending: (bool): Optional. Whether the order is ascending or not.
+                dataset_name: (str): Optional. If ``field_name`` refers to a metric, this field
+                    specifies the name of the dataset associated with the metric. Only metrics
+                    associated with the specified dataset name will be considered for ordering.
+                    This field may only be set if ``field_name`` refers to a metric.
+                dataset_digest (str): Optional. If ``field_name`` refers to a metric, this field
+                    specifies the digest of the dataset associated with the metric. Only metrics
+                    associated with the specified dataset name and digest will be considered for
+                    ordering. This field may only be set if ``dataset_name`` is also set.
             page_token: Token specifying the next page of results.
 
         Returns:

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1921,9 +1921,7 @@ class SearchLoggedModelsUtils(SearchUtils):
         dataset_digest: Optional[str] = None
 
     @classmethod
-    def parse_order_by_for_logged_models(
-        cls, order_by: dict[str, Any]
-    ) -> tuple[str, bool, str, str]:
+    def parse_order_by_for_logged_models(cls, order_by: dict[str, Any]) -> OrderBy:
         if not isinstance(order_by, dict):
             raise MlflowException.invalid_parameter_value(
                 "`order_by` must be a list of dictionaries."

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1910,7 +1910,9 @@ class SearchLoggedModelsUtils(SearchUtils):
         return [model for model in models if model_matches(model)]
 
     @classmethod
-    def parse_order_by_for_logged_models(cls, order_by: dict[str, Any]) -> dict[str, Any]:
+    def parse_order_by_for_logged_models(
+        cls, order_by: dict[str, Any]
+    ) -> tuple[str, bool, str, str]:
         if not isinstance(order_by, dict):
             raise MlflowException.invalid_parameter_value(
                 "`order_by` must be a list of dictionaries."
@@ -1921,7 +1923,7 @@ class SearchLoggedModelsUtils(SearchUtils):
                 "`field_name` in the `order_by` clause must be specified."
             )
         if "." in field_name:
-            entity, _ = field_name.split(".")
+            entity = field_name.split(".", 1)[0]
             if entity != "metrics":
                 raise MlflowException.invalid_parameter_value(
                     f"Invalid order by field name: {entity}, only `metrics.<name>` is allowed."
@@ -1956,7 +1958,7 @@ class SearchLoggedModelsUtils(SearchUtils):
         dataset_digest: Optional[str],
     ):
         if "." in key:
-            metric_key = key.split(".")[1]
+            metric_key = key.split(".", 1)[1]
             metric_values = [
                 m.value
                 for m in model.metrics

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1910,40 +1910,114 @@ class SearchLoggedModelsUtils(SearchUtils):
         return [model for model in models if model_matches(model)]
 
     @classmethod
-    def parse_order_by_for_logged_models(cls, order_by):
-        token_value, is_ascending = cls._parse_order_by_string(order_by)
-        token_value = token_value.strip()
-        if token_value not in cls.VALID_ORDER_BY_ATTRIBUTE_KEYS:
+    def parse_order_by_for_logged_models(cls, order_by: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(order_by, dict):
             raise MlflowException.invalid_parameter_value(
-                f"Invalid order by key '{token_value}' specified. Valid keys "
-                f"are '{cls.VALID_ORDER_BY_ATTRIBUTE_KEYS}'",
+                "`order_by` must be a list of dictionaries."
             )
-        identifier = cls._get_identifier(token_value, cls.VALID_ORDER_BY_ATTRIBUTE_KEYS)
-        return identifier["type"], identifier["key"], is_ascending
+        field_name = order_by.get("field_name")
+        if field_name is None:
+            raise MlflowException.invalid_parameter_value(
+                "`field_name` in the `order_by` clause must be specified."
+            )
+        if "." in field_name:
+            entity, _ = field_name.split(".")
+            if entity != "metrics":
+                raise MlflowException.invalid_parameter_value(
+                    f"Invalid order by field name: {entity}, only `metrics.<name>` is allowed."
+                )
+        else:
+            field_name = field_name.strip()
+            if field_name not in cls.VALID_ORDER_BY_ATTRIBUTE_KEYS:
+                raise MlflowException.invalid_parameter_value(
+                    f"Invalid order by field name: {field_name}."
+                )
+        ascending = order_by.get("ascending", True)
+        if ascending not in [True, False]:
+            raise MlflowException.invalid_parameter_value(
+                "Value of `ascending` in the `order_by` clause must be a boolean, got "
+                f"{type(ascending)} for field {field_name}."
+            )
+        dataset_name = order_by.get("dataset_name")
+        dataset_digest = order_by.get("dataset_digest")
+        if dataset_digest and not dataset_name:
+            raise MlflowException.invalid_parameter_value(
+                "`dataset_digest` can only be specified if `dataset_name` is also specified."
+            )
+        return field_name, ascending, dataset_name, dataset_digest
 
     @classmethod
-    def _get_sort_key(cls, order_by_list):
-        order_by = []
-        parsed_order_by = map(cls.parse_order_by_for_logged_models, order_by_list or [])
-        for type_, key, ascending in parsed_order_by:
-            if type_ == "attribute":
-                order_by.append((key, ascending))
-            else:
-                raise MlflowException.invalid_parameter_value(f"Invalid order_by entity: {type_}")
+    def _apply_reversor_for_logged_model(
+        cls,
+        model: LoggedModel,
+        key: str,
+        ascending: bool,
+        dataset_name: Optional[str],
+        dataset_digest: Optional[str],
+    ):
+        if "." in key:
+            metric_key = key.split(".")[1]
+            metric_values = [
+                m.value
+                for m in model.metrics
+                if m.key == metric_key
+                and (dataset_name is None or m.dataset_name == dataset_name)
+                and (dataset_digest is None or m.dataset_digest == dataset_digest)
+            ]
+            value = None if len(metric_values) == 0 else max(metric_values)
+            return _LoggedModelMetricComp(value) if ascending else _LoggedModelMetricReversor(value)
+        else:
+            value = getattr(model, key)
+        return value if ascending else _Reversor(value)
+
+    @classmethod
+    def _get_sort_key(cls, order_by_list: Optional[list[dict[str, Any]]]):
+        parsed_order_by = list(map(cls.parse_order_by_for_logged_models, order_by_list or []))
 
         # Add a tie-breaker
-        if not any(key == "creation_timestamp" for key, _ in order_by):
-            order_by.append(("creation_timestamp", False))
-        if not any(key == "model_id" for key, _ in order_by):
-            order_by.append(("model_id", True))
+        if not any(key == "creation_timestamp" for key, _, _, _ in parsed_order_by):
+            parsed_order_by.append(("creation_timestamp", False, None, None))
+        if not any(key == "model_id" for key, _, _, _ in parsed_order_by):
+            parsed_order_by.append(("model_id", True, None, None))
 
         return lambda logged_model: tuple(
-            _apply_reversor(logged_model, k, asc) for (k, asc) in order_by
+            cls._apply_reversor_for_logged_model(logged_model, k, asc, dataset_name, dataset_digest)
+            for (k, asc, dataset_name, dataset_digest) in parsed_order_by
         )
 
     @classmethod
     def sort(cls, models, order_by_list):
         return sorted(models, key=cls._get_sort_key(order_by_list))
+
+
+class _LoggedModelMetricComp:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __eq__(self, other):
+        return other.obj == self.obj
+
+    def __lt__(self, other):
+        if self.obj is None:
+            return False
+        if other.obj is None:
+            return True
+        return self.obj < other.obj
+
+
+class _LoggedModelMetricReversor:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __eq__(self, other):
+        return other.obj == self.obj
+
+    def __lt__(self, other):
+        if self.obj is None:
+            return False
+        if other.obj is None:
+            return True
+        return other.obj < self.obj
 
 
 @dataclass

--- a/tests/store/tracking/test_file_store_logged_model.py
+++ b/tests/store/tracking/test_file_store_logged_model.py
@@ -1,5 +1,6 @@
 import time
 import uuid
+from dataclasses import dataclass
 from unittest import mock
 
 import pytest
@@ -8,6 +9,7 @@ import mlflow
 from mlflow.entities.logged_model_parameter import LoggedModelParameter
 from mlflow.entities.logged_model_status import LoggedModelStatus
 from mlflow.entities.logged_model_tag import LoggedModelTag
+from mlflow.entities.metric import Metric
 from mlflow.exceptions import MlflowException
 from mlflow.store.tracking.file_store import SEARCH_LOGGED_MODEL_MAX_RESULTS_DEFAULT, FileStore
 
@@ -15,6 +17,12 @@ from mlflow.store.tracking.file_store import SEARCH_LOGGED_MODEL_MAX_RESULTS_DEF
 @pytest.fixture
 def store(tmp_path):
     return FileStore(str(tmp_path.joinpath("mlruns")))
+
+
+@dataclass
+class DummyDataset:
+    name: str
+    digest: str
 
 
 def assert_logged_model_attributes(
@@ -518,21 +526,31 @@ def test_search_logged_models_order_by(store):
     )
 
     # model_id
-    models = store.search_logged_models(experiment_ids=[exp_id], order_by=["model_id ASC"])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "model_id"}]
+    )
     assert_models_match(models, sorted(logged_models, key=lambda x: x.model_id))
-    models = store.search_logged_models(experiment_ids=[exp_id], order_by=["model_id DESC"])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "model_id", "ascending": False}]
+    )
     assert_models_match(
         models,
         sorted(logged_models, key=lambda x: x.model_id, reverse=True),
     )
 
     # name
-    models = store.search_logged_models(experiment_ids=[exp_id], order_by=["name"])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "name", "ascending": True}]
+    )
     assert_models_match(
         models, sorted(logged_models, key=lambda x: (x.name, -x.creation_timestamp, x.model_id))
     )
     models = store.search_logged_models(
-        experiment_ids=[exp_id], order_by=["name DESC", "model_id DESC"]
+        experiment_ids=[exp_id],
+        order_by=[
+            {"field_name": "name", "ascending": False},
+            {"field_name": "model_id", "ascending": False},
+        ],
     )
     assert_models_match(
         models,
@@ -540,12 +558,16 @@ def test_search_logged_models_order_by(store):
     )
 
     # model_type
-    models = store.search_logged_models(experiment_ids=[exp_id], order_by=["model_type"])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "model_type", "ascending": True}]
+    )
     assert_models_match(
         models,
         sorted(logged_models, key=lambda x: x.model_type),
     )
-    models = store.search_logged_models(experiment_ids=[exp_id], order_by=["model_type DESC"])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "model_type", "ascending": False}]
+    )
     assert_models_match(
         models,
         sorted(
@@ -556,12 +578,16 @@ def test_search_logged_models_order_by(store):
     )
 
     # status
-    models = store.search_logged_models(experiment_ids=[exp_id], order_by=["status"])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "status", "ascending": True}]
+    )
     assert_models_match(
         models,
         sorted(logged_models, key=lambda x: (x.status, -x.creation_timestamp, x.model_id)),
     )
-    models = store.search_logged_models(experiment_ids=[exp_id], order_by=["status DESC"])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "status", "ascending": False}]
+    )
     assert_models_match(
         models,
         sorted(
@@ -572,13 +598,19 @@ def test_search_logged_models_order_by(store):
     )
 
     # source_run_id
-    models = store.search_logged_models(experiment_ids=[exp_id], order_by=["source_run_id"])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "source_run_id", "ascending": True}]
+    )
     assert_models_match(
         models,
         sorted(logged_models, key=lambda x: (x.source_run_id, -x.creation_timestamp, x.model_id)),
     )
     models = store.search_logged_models(
-        experiment_ids=[exp_id], order_by=["source_run_id DESC", "model_id DESC"]
+        experiment_ids=[exp_id],
+        order_by=[
+            {"field_name": "source_run_id", "ascending": False},
+            {"field_name": "model_id", "ascending": False},
+        ],
     )
     assert_models_match(
         models,
@@ -590,13 +622,15 @@ def test_search_logged_models_order_by(store):
     )
 
     # creation_timestamp
-    models = store.search_logged_models(experiment_ids=[exp_id], order_by=["creation_timestamp"])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "creation_timestamp", "ascending": True}]
+    )
     assert_models_match(
         models,
         sorted(logged_models, key=lambda x: (x.creation_timestamp, x.model_id)),
     )
     models = store.search_logged_models(
-        experiment_ids=[exp_id], order_by=["creation_timestamp DESC"]
+        experiment_ids=[exp_id], order_by=[{"field_name": "creation_timestamp", "ascending": False}]
     )
     assert_models_match(
         models,
@@ -605,7 +639,7 @@ def test_search_logged_models_order_by(store):
 
     # last_updated_timestamp
     models = store.search_logged_models(
-        experiment_ids=[exp_id], order_by=["last_updated_timestamp"]
+        experiment_ids=[exp_id], order_by=[{"field_name": "last_updated_timestamp"}]
     )
     assert_models_match(
         models,
@@ -615,7 +649,8 @@ def test_search_logged_models_order_by(store):
         ),
     )
     models = store.search_logged_models(
-        experiment_ids=[exp_id], order_by=["last_updated_timestamp DESC"]
+        experiment_ids=[exp_id],
+        order_by=[{"field_name": "last_updated_timestamp", "ascending": False}],
     )
     assert_models_match(
         models,
@@ -624,6 +659,241 @@ def test_search_logged_models_order_by(store):
             key=lambda x: (-x.last_updated_timestamp, -x.creation_timestamp, x.model_id),
         ),
     )
+
+
+def test_search_logged_models_order_by_metrics(store):
+    exp_id = store.create_experiment("test")
+    run_id = store.create_run(exp_id, "user", 0, [], "test_run").info.run_id
+    model1 = store.create_logged_model(exp_id, source_run_id=run_id)
+    # model1:
+    # metric1+dataset1+digest1: 0.1
+    # metric1+dataset1+digest2: 1.0
+    # metric2+dataset2+digest2: step 0 - 0.2; step 1 - 1.0
+    store.log_batch(
+        run_id,
+        metrics=[
+            Metric(
+                key="metric1",
+                value=0.1,
+                timestamp=0,
+                step=0,
+                model_id=model1.model_id,
+                dataset_name="dataset1",
+                dataset_digest="digest1",
+                run_id=run_id,
+            ),
+            Metric(
+                key="metric1",
+                value=1.0,
+                timestamp=0,
+                step=0,
+                model_id=model1.model_id,
+                dataset_name="dataset1",
+                dataset_digest="digest2",
+                run_id=run_id,
+            ),
+            Metric(
+                key="metric2",
+                value=0.2,
+                timestamp=0,
+                step=0,
+                model_id=model1.model_id,
+                dataset_name="dataset2",
+                dataset_digest="digest2",
+                run_id=run_id,
+            ),
+            Metric(
+                key="metric2",
+                value=1.0,
+                timestamp=0,
+                step=1,
+                model_id=model1.model_id,
+                dataset_name="dataset2",
+                dataset_digest="digest2",
+                run_id=run_id,
+            ),
+        ],
+        params=[],
+        tags=[],
+    )
+
+    model2 = store.create_logged_model(exp_id, source_run_id=run_id)
+    # model2:
+    # metric1+dataset1+digest1: 0.2
+    # metric1+dataset1+digest2: 0.1
+    # metric2+dataset2+digest2: 0.5
+    # metric2+dataset3+digest3: 0.1
+    # metric3: 1.0
+    store.log_batch(
+        run_id,
+        metrics=[
+            Metric(
+                key="metric1",
+                value=0.2,
+                timestamp=0,
+                step=0,
+                model_id=model2.model_id,
+                dataset_name="dataset1",
+                dataset_digest="digest1",
+                run_id=run_id,
+            ),
+            Metric(
+                key="metric1",
+                value=0.1,
+                timestamp=0,
+                step=0,
+                model_id=model2.model_id,
+                dataset_name="dataset1",
+                dataset_digest="digest2",
+                run_id=run_id,
+            ),
+            Metric(
+                key="metric2",
+                value=0.5,
+                timestamp=0,
+                step=0,
+                model_id=model2.model_id,
+                dataset_name="dataset2",
+                dataset_digest="digest2",
+                run_id=run_id,
+            ),
+            Metric(
+                key="metric2",
+                value=0.1,
+                timestamp=0,
+                step=0,
+                model_id=model2.model_id,
+                dataset_name="dataset3",
+                dataset_digest="digest3",
+                run_id=run_id,
+            ),
+            Metric(
+                key="metric3",
+                value=1.0,
+                timestamp=0,
+                step=1,
+                model_id=model2.model_id,
+                dataset_name=None,
+                dataset_digest=None,
+                run_id=run_id,
+            ),
+        ],
+        params=[],
+        tags=[],
+    )
+    model1 = store.get_logged_model(model1.model_id)
+    model2 = store.get_logged_model(model2.model_id)
+
+    # order by metric key only
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "metrics.metric1"}]
+    )
+    assert_models_match(models, [model2, model1])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "metrics.metric1", "ascending": False}]
+    )
+    assert_models_match(models, [model1, model2])
+    # only model2 has metric3
+    # no matter it's ASC or DESC, model2 should be first
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "metrics.metric3"}]
+    )
+    assert_models_match(models, [model2, model1])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "metrics.metric3", "ascending": False}]
+    )
+    assert_models_match(models, [model2, model1])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id],
+        order_by=[
+            {"field_name": "metrics.metric1", "ascending": False},
+            {"field_name": "metrics.metric3"},
+        ],
+    )
+    assert_models_match(models, [model1, model2])
+
+    # order by metric key + dataset_name
+    models = store.search_logged_models(
+        experiment_ids=[exp_id],
+        order_by=[
+            {"field_name": "metrics.metric1", "dataset_name": "dataset1", "ascending": False}
+        ],
+    )
+    assert_models_match(models, [model1, model2])
+    # neither of them have metric1 + dataset2, so the order is by creation_timestamp DESC
+    models = store.search_logged_models(
+        experiment_ids=[exp_id],
+        order_by=[
+            {"field_name": "metrics.metric1", "dataset_name": "dataset2", "ascending": False}
+        ],
+    )
+    assert_models_match(models, [model2, model1])
+    # only model2 has metric2+dataset3, so it always comes first
+    models = store.search_logged_models(
+        experiment_ids=[exp_id],
+        order_by=[{"field_name": "metrics.metric2", "dataset_name": "dataset3", "ascending": True}],
+    )
+    assert_models_match(models, [model2, model1])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id],
+        order_by=[
+            {"field_name": "metrics.metric2", "dataset_name": "dataset3", "ascending": False}
+        ],
+    )
+    assert_models_match(models, [model2, model1])
+
+    # order by metric key + dataset_name + dataset_digest
+    models = store.search_logged_models(
+        experiment_ids=[exp_id],
+        order_by=[
+            {
+                "field_name": "metrics.metric1",
+                "dataset_name": "dataset1",
+                "dataset_digest": "digest1",
+            }
+        ],
+    )
+    assert_models_match(models, [model1, model2])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id],
+        order_by=[
+            {
+                "field_name": "metrics.metric1",
+                "dataset_name": "dataset1",
+                "dataset_digest": "digest2",
+            }
+        ],
+    )
+    assert_models_match(models, [model2, model1])
+    # max value of different steps is taken, so metric2's value of model1 > model2
+    models = store.search_logged_models(
+        experiment_ids=[exp_id],
+        order_by=[
+            {
+                "field_name": "metrics.metric2",
+                "dataset_name": "dataset2",
+                "dataset_digest": "digest2",
+                "ascending": False,
+            }
+        ],
+    )
+    assert_models_match(models, [model1, model2])
+    # neither of them have metric4, so it's sorted based on second condition
+    models = store.search_logged_models(
+        experiment_ids=[exp_id],
+        order_by=[
+            {
+                "field_name": "metrics.metric4",
+            },
+            {
+                "field_name": "metrics.metric2",
+                "dataset_name": "dataset2",
+                "dataset_digest": "digest2",
+                "ascending": False,
+            },
+        ],
+    )
+    assert_models_match(models, [model1, model2])
 
 
 def test_search_logged_models_pagination(store):
@@ -651,6 +921,14 @@ def test_search_logged_models_errors(store):
     with pytest.raises(MlflowException, match=r"Invalid attribute key 'artifact_location'"):
         store.search_logged_models(experiment_ids=[exp_id], filter_string="artifact_location='abc'")
     with pytest.raises(
-        MlflowException, match=r"Invalid order by key 'artifact_location' specified."
+        MlflowException, match=r"`field_name` in the `order_by` clause must be specified"
     ):
-        store.search_logged_models(experiment_ids=[exp_id], order_by=["artifact_location"])
+        store.search_logged_models(experiment_ids=[exp_id], order_by=[{}])
+    with pytest.raises(MlflowException, match=r"`order_by` must be a list of dictionaries."):
+        store.search_logged_models(experiment_ids=[exp_id], order_by=["model_id"])
+    with pytest.raises(MlflowException, match=r"Invalid order by field name: artifact_location"):
+        store.search_logged_models(
+            experiment_ids=[exp_id], order_by=[{"field_name": "artifact_location"}]
+        )
+    with pytest.raises(MlflowException, match=r"Invalid order by field name: params"):
+        store.search_logged_models(experiment_ids=[exp_id], order_by=[{"field_name": "params.x"}])

--- a/tests/store/tracking/test_file_store_logged_model.py
+++ b/tests/store/tracking/test_file_store_logged_model.py
@@ -666,9 +666,9 @@ def test_search_logged_models_order_by_metrics(store):
     run_id = store.create_run(exp_id, "user", 0, [], "test_run").info.run_id
     model1 = store.create_logged_model(exp_id, source_run_id=run_id)
     # model1:
-    # metric1+dataset1+digest1: 0.1
-    # metric1+dataset1+digest2: 1.0
-    # metric2+dataset2+digest2: step 0 - 0.2; step 1 - 1.0
+    # metric1+dataset1+digest1+timestamp0: 0.1
+    # metric1+dataset1+digest2+timestamp1: 1.0
+    # metric2+dataset2+digest2: timestamp 0 - 0.2; timestamp 1 - 1.0
     store.log_batch(
         run_id,
         metrics=[
@@ -685,7 +685,7 @@ def test_search_logged_models_order_by_metrics(store):
             Metric(
                 key="metric1",
                 value=1.0,
-                timestamp=0,
+                timestamp=1,
                 step=0,
                 model_id=model1.model_id,
                 dataset_name="dataset1",
@@ -705,7 +705,7 @@ def test_search_logged_models_order_by_metrics(store):
             Metric(
                 key="metric2",
                 value=1.0,
-                timestamp=0,
+                timestamp=1,
                 step=1,
                 model_id=model1.model_id,
                 dataset_name="dataset2",
@@ -719,10 +719,10 @@ def test_search_logged_models_order_by_metrics(store):
 
     model2 = store.create_logged_model(exp_id, source_run_id=run_id)
     # model2:
-    # metric1+dataset1+digest1: 0.2
-    # metric1+dataset1+digest2: 0.1
-    # metric2+dataset2+digest2: 0.5
-    # metric2+dataset3+digest3: 0.1
+    # metric1+dataset1+digest1+timestamp0: 0.2
+    # metric1+dataset1+digest2+timestamp1: 0.1
+    # metric2+dataset2+digest2+timestamp0: 0.5
+    # metric2+dataset3+digest3+timestamp1: 0.1
     # metric3: 1.0
     store.log_batch(
         run_id,
@@ -740,7 +740,7 @@ def test_search_logged_models_order_by_metrics(store):
             Metric(
                 key="metric1",
                 value=0.1,
-                timestamp=0,
+                timestamp=1,
                 step=0,
                 model_id=model2.model_id,
                 dataset_name="dataset1",
@@ -760,7 +760,7 @@ def test_search_logged_models_order_by_metrics(store):
             Metric(
                 key="metric2",
                 value=0.1,
-                timestamp=0,
+                timestamp=1,
                 step=0,
                 model_id=model2.model_id,
                 dataset_name="dataset3",
@@ -793,6 +793,10 @@ def test_search_logged_models_order_by_metrics(store):
         experiment_ids=[exp_id], order_by=[{"field_name": "metrics.metric1", "ascending": False}]
     )
     assert_models_match(models, [model1, model2])
+    models = store.search_logged_models(
+        experiment_ids=[exp_id], order_by=[{"field_name": "metrics.metric1", "dataset_name": ""}]
+    )
+    assert_models_match(models, [model2, model1])
     # only model2 has metric3
     # no matter it's ASC or DESC, model2 should be first
     models = store.search_logged_models(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15044?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15044/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15044/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15044
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix FileStore's order_by, it should support list[dict] and metrics.<key>

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
