### PR TITLE
Add deprecation warnings in langchain & openai autolog

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -1021,7 +1021,7 @@ def autolog(
             MlflowLangchainTracer as a callback during inference. If ``False``, no traces are
             collected during inference. Default to ``True``.
     """
-    enabled_configs = {
+    user_specified_args = {
         key
         for key, value in {
             "log_input_examples": log_input_examples,
@@ -1033,11 +1033,11 @@ def autolog(
         }.items()
         if value is True or value is not None
     }
-    if any(enabled_configs):
+    if user_specified_args:
         color_warning(
             "The following parameters are deprecated in langchain autologging and will be removed "
-            f"in a future release: `{', '.join(enabled_configs)}`. Langchain autologging will not "
-            "support automatic model logging and its related attributes. Please log your model "
+            f"in a future release: `{', '.join(user_specified_args)}`. Langchain autologging will "
+            "not support automatic model logging and any related parameters. Please log your model "
             "manually with `mlflow.langchain.log_model` if needed.",
             stacklevel=2,
             color="red",

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -1031,12 +1031,12 @@ def autolog(
             "registered_model_name": registered_model_name,
             "extra_tags": extra_tags,
         }.items()
-        if value is True
+        if value is True or value is not None
     }
     if any(enabled_configs):
         color_warning(
-            "The follow parameters are deprecated in langchain autologging and will be removed "
-            f"in a future release: `{', '.join(enabled_configs)}`. Langchain autologging no longer "
+            "The following parameters are deprecated in langchain autologging and will be removed "
+            f"in a future release: `{', '.join(enabled_configs)}`. Langchain autologging will not "
             "support automatic model logging and its related attributes. Please log your model "
             "manually with `mlflow.langchain.log_model` if needed.",
             stacklevel=2,

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -100,6 +100,7 @@ from mlflow.utils.model_utils import (
     _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
+from mlflow.utils.warnings_utils import color_warning
 
 logger = logging.getLogger(mlflow.__name__)
 
@@ -1020,6 +1021,29 @@ def autolog(
             MlflowLangchainTracer as a callback during inference. If ``False``, no traces are
             collected during inference. Default to ``True``.
     """
+    enabled_configs = {
+        key
+        for key, value in {
+            "log_input_examples": log_input_examples,
+            "log_model_signatures": log_model_signatures,
+            "log_models": log_models,
+            "log_datasets": log_datasets,
+            "registered_model_name": registered_model_name,
+            "extra_tags": extra_tags,
+        }.items()
+        if value is True
+    }
+    if any(enabled_configs):
+        color_warning(
+            "The follow parameters are deprecated in langchain autologging and will be removed "
+            f"in a future release: `{', '.join(enabled_configs)}`. Langchain autologging no longer "
+            "support automatic model logging and its related attributes. Please log your model "
+            "manually with `mlflow.langchain.log_model` if needed.",
+            stacklevel=2,
+            color="red",
+            category=FutureWarning,
+        )
+
     from mlflow.langchain.langchain_tracer import (
         patched_callback_manager_init,
         patched_callback_manager_merge,

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -95,6 +95,7 @@ from mlflow.utils.openai_utils import (
     _validate_model_params,
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
+from mlflow.utils.warnings_utils import color_warning
 
 FLAVOR_NAME = "openai"
 MODEL_FILENAME = "model.yaml"
@@ -947,6 +948,29 @@ def _autolog(
     extra_tags=None,
     log_traces=True,
 ):
+    enabled_configs = {
+        key
+        for key, value in {
+            "log_input_examples": log_input_examples,
+            "log_model_signatures": log_model_signatures,
+            "log_models": log_models,
+            "log_datasets": log_datasets,
+            "registered_model_name": registered_model_name,
+            "extra_tags": extra_tags,
+        }.items()
+        if value is True
+    }
+    if any(enabled_configs):
+        color_warning(
+            "The follow parameters are deprecated in OpenAI autologging and will be removed "
+            f"in a future release: `{', '.join(enabled_configs)}`. OpenAI autologging no longer "
+            "support automatic model logging and its related attributes. Please log your model "
+            "manually with `mlflow.openai.log_model` if needed.",
+            stacklevel=2,
+            color="red",
+            category=FutureWarning,
+        )
+
     from openai.resources.chat.completions import AsyncCompletions as AsyncChatCompletions
     from openai.resources.chat.completions import Completions as ChatCompletions
     from openai.resources.completions import AsyncCompletions, Completions

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -948,7 +948,7 @@ def _autolog(
     extra_tags=None,
     log_traces=True,
 ):
-    enabled_configs = {
+    user_specified_args = {
         key
         for key, value in {
             "log_input_examples": log_input_examples,
@@ -960,11 +960,11 @@ def _autolog(
         }.items()
         if value is True or value is not None
     }
-    if any(enabled_configs):
+    if user_specified_args:
         color_warning(
             "The following parameters are deprecated in OpenAI autologging and will be removed "
-            f"in a future release: `{', '.join(enabled_configs)}`. OpenAI autologging will not "
-            "support automatic model logging and its related attributes. Please log your model "
+            f"in a future release: `{', '.join(user_specified_args)}`. OpenAI autologging will not "
+            "support automatic model logging and any related parameters. Please log your model "
             "manually with `mlflow.openai.log_model` if needed.",
             stacklevel=2,
             color="red",

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -958,12 +958,12 @@ def _autolog(
             "registered_model_name": registered_model_name,
             "extra_tags": extra_tags,
         }.items()
-        if value is True
+        if value is True or value is not None
     }
     if any(enabled_configs):
         color_warning(
-            "The follow parameters are deprecated in OpenAI autologging and will be removed "
-            f"in a future release: `{', '.join(enabled_configs)}`. OpenAI autologging no longer "
+            "The following parameters are deprecated in OpenAI autologging and will be removed "
+            f"in a future release: `{', '.join(enabled_configs)}`. OpenAI autologging will not "
             "support automatic model logging and its related attributes. Please log your model "
             "manually with `mlflow.openai.log_model` if needed.",
             stacklevel=2,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15045?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15045/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15045/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15045
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
log_models and its related params are deprecated in langchain & openai autolog. Raise deprecation warnings if they're used.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

<img width="1123" alt="image" src="https://github.com/user-attachments/assets/519e72bd-76a9-4717-9044-644a9a6cfa7a" />


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
