### PR TITLE
Spark udf fix

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1722,6 +1722,8 @@ def _convert_struct_values(
                     ]
                 )
             else:
+                if isinstance(field_type, pydantic.BaseModel):
+                    field_values = model_dump_compat(field_values)
                 field_values = _convert_struct_values(field_values, field_type)
         elif isinstance(field_type, MapType):
             if is_pandas_df:
@@ -1989,18 +1991,6 @@ def build_model_env(model_uri, save_path):
         shutil.rmtree(local_model_path, ignore_errors=True)
         if tmp_archive_path and os.path.exists(tmp_archive_path):
             os.remove(tmp_archive_path)
-
-
-def _convert_data_to_spark_compat(data):
-    if isinstance(data, list):
-        return [_convert_data_to_spark_compat(d) for d in data]
-    if isinstance(data, dict):
-        return {k: _convert_data_to_spark_compat(v) for k, v in data.items()}
-    if isinstance(data, np.ndarray):
-        return data.tolist()
-    if isinstance(data, pydantic.BaseModel):
-        return model_dump_compat(data)
-    return data
 
 
 def spark_udf(
@@ -2444,7 +2434,6 @@ e.g., struct<a:int, b:array<int>>.
             )
 
         result = predict_fn(pdf, params)
-        result = _convert_data_to_spark_compat(result)
 
         if isinstance(result, dict):
             result = {k: list(v) for k, v in result.items()}
@@ -2452,6 +2441,13 @@ e.g., struct<a:int, b:array<int>>.
         if isinstance(result_type, ArrayType) and isinstance(result_type.elementType, ArrayType):
             result_values = _convert_array_values(result, result_type)
             return pandas.Series(result_values)
+
+        if isinstance(result_type, SparkStructType):
+            if isinstance(result, list) and isinstance(result[0], pydantic.BaseModel):
+                result = pandas.DataFrame([model_dump_compat(r) for r in result])
+            else:
+                result = pandas.DataFrame(result)
+            return _convert_struct_values(result, result_type)
 
         if not isinstance(result, pandas.DataFrame):
             if isinstance(result_type, MapType):
@@ -2462,11 +2458,7 @@ e.g., struct<a:int, b:array<int>>.
                     pandas.DataFrame([result]) if np.isscalar(result) else pandas.DataFrame(result)
                 )
 
-        if isinstance(result_type, SparkStructType):
-            return _convert_struct_values(result, result_type)
-
         elem_type = result_type.elementType if isinstance(result_type, ArrayType) else result_type
-
         if type(elem_type) == IntegerType:
             result = result.select_dtypes(
                 [np.byte, np.ubyte, np.short, np.ushort, np.int32]

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2443,7 +2443,11 @@ e.g., struct<a:int, b:array<int>>.
             return pandas.Series(result_values)
 
         if isinstance(result_type, SparkStructType):
-            if isinstance(result, list) and isinstance(result[0], pydantic.BaseModel):
+            if (
+                isinstance(result, list)
+                and len(result) > 0
+                and isinstance(result[0], pydantic.BaseModel)
+            ):
                 result = pandas.DataFrame([model_dump_compat(r) for r in result])
             else:
                 result = pandas.DataFrame(result)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15058?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15058/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15058/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15058
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We should not modify the model output type inside spark_udf since python int cannot be casted as int32.
This PR fixes it by removing the _convert_data_to_spark_compat function (which was initially introduced to support type hint cases)
Added test cases that don't pass on master but pass on this PR.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
