### PR TITLE
Add logging of result table for DSPy optimizer tracking

### DIFF
--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -142,12 +142,6 @@ def autolog(
 
         return _trace_disabled_fn(self, *args, **kwargs)
 
-    def patch_construct_result_table_fn(original, self, *args, **kwargs):
-        result = original(self, *args, **kwargs)
-        if get_autologging_config(FLAVOR_NAME, "log_evals") and result is not None:
-            mlflow.log_table(result, "result_table.json")
-        return result
-
     from dspy.evaluate import Evaluate
     from dspy.teleprompt import Teleprompter
 
@@ -172,15 +166,6 @@ def autolog(
             Evaluate,
             call_patch,
             patch_fn,
-        )
-
-    result_table_patch = "_construct_result_table"
-    if hasattr(Evaluate, result_table_patch):
-        safe_patch(
-            FLAVOR_NAME,
-            Evaluate,
-            result_table_patch,
-            patch_construct_result_table_fn,
         )
 
 

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -384,16 +384,18 @@ class MlflowCallback(BaseCallback):
         return {**inputs_wo_kwargs, **kwargs}
 
     def _generate_result_table(
-        self, outputs: list[tuple[dspy.Example, dspy.Example, Any]]
+        self, outputs: list[tuple[dspy.Example, dspy.Prediction, Any]]
     ) -> dict[str, list[Any]]:
-        result = defaultdict(list)
+        result = {"score": []}
         for i, (example, prediction, score) in enumerate(outputs):
             for k, v in example.items():
+                if f"example_{k}" not in result:
+                    result[f"example_{k}"] = [None] * i
                 result[f"example_{k}"].append(v)
 
-            if not hasattr(prediction, "items"):
-                prediction = dict(prediction)
             for k, v in prediction.items():
+                if f"pred_{k}" not in result:
+                    result[f"pred_{k}"] = [None] * i
                 result[f"pred_{k}"].append(v)
 
             result["score"].append(score)

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -271,9 +271,7 @@ class MlflowCallback(BaseCallback):
         elif isinstance(outputs, dspy.Prediction):
             score = float(outputs)
             try:
-                mlflow.log_table(
-                    self._generate_result_table(outputs.outputs), "result_table.json"
-                )
+                mlflow.log_table(self._generate_result_table(outputs.outputs), "result_table.json")
             except Exception:
                 _logger.debug("Failed to log result table.", exc_info=True)
         mlflow.log_metric("eval", score)

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -264,7 +264,12 @@ class MlflowCallback(BaseCallback):
         if exception:
             mlflow.end_run(status=RunStatus.to_string(RunStatus.FAILED))
             return
-        score = outputs if isinstance(outputs, float) else outputs[0]
+        if isinstance(outputs, float):
+            score = outputs
+        elif isinstance(outputs, list):
+            score = outputs[0]
+        elif isinstance(outputs, dspy.Prediction):
+            score = float(outputs)
         mlflow.log_metric("eval", score)
 
         if self._call_id_to_run_id.pop(call_id, None):

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -272,7 +272,7 @@ class MlflowCallback(BaseCallback):
             score = float(outputs)
             try:
                 mlflow.log_table(
-                    self._generate_result_table(outputs.all_outputs), "result_table.json"
+                    self._generate_result_table(outputs.outputs), "result_table.json"
                 )
             except Exception:
                 _logger.debug("Failed to log result table.", exc_info=True)

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -262,7 +262,8 @@ class MlflowCallback(BaseCallback):
         if not get_autologging_config(FLAVOR_NAME, "log_evals"):
             return
         if exception:
-            mlflow.end_run(status=RunStatus.FAILED)
+            mlflow.end_run(status=RunStatus.to_string(RunStatus.FAILED))
+            return
         score = outputs if isinstance(outputs, float) else outputs[0]
         mlflow.log_metric("eval", score)
 

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -639,15 +639,21 @@ def test_autolog_log_nested_compile():
     assert "best_model.json" in artifacts
 
 
-skip_if_callback_unavailable = pytest.mark.skipif(
+skip_if_evaluate_callback_unavailable = pytest.mark.skipif(
     Version(importlib.metadata.version("dspy")) < Version("2.6.12"),
     reason="evaluate callback is available since 2.6.12",
 )
 
 
-@skip_if_callback_unavailable
+# _construct_result_table is available since 2.6.14
+is_construct_result_table_available = Version(importlib.metadata.version("dspy")) >= Version(
+    "2.6.12"
+)
+
+
+@skip_if_evaluate_callback_unavailable
 @pytest.mark.parametrize("log_evals", [True, False])
-def test_autolog_log_evals(log_evals):
+def test_autolog_log_evals(log_evals, tmp_path):
     dspy.settings.configure(
         lm=DummyLM(
             {
@@ -669,9 +675,6 @@ def test_autolog_log_evals(log_evals):
     run = mlflow.last_active_run()
     if log_evals:
         assert run is not None
-        client = MlflowClient()
-        artifacts = (x.path for x in client.list_artifacts(run.info.run_id))
-        assert "model.json" in artifacts
         assert run.data.metrics == {"eval": 50.0}
         assert run.data.params == {
             "Predict.signature.fields.0.description": "${question}",
@@ -680,11 +683,27 @@ def test_autolog_log_evals(log_evals):
             "Predict.signature.fields.1.prefix": "Answer:",
             "Predict.signature.instructions": "Given the fields `question`, produce the fields `answer`.",  # noqa: E501
         }
+        client = MlflowClient()
+        artifacts = (x.path for x in client.list_artifacts(run.info.run_id))
+        assert "model.json" in artifacts
+        if is_construct_result_table_available:
+            assert "result_table.json" in artifacts
+            client.download_artifacts(
+                run_id=run.info.run_id, path="result_table.json", dst_path=tmp_path
+            )
+            result_table = json.loads((tmp_path / "result_table.json").read_text())
+            assert result_table == {
+                "columns": ["question", "example_answer", "pred_answer", "answer_exact_match"],
+                "data": [
+                    ["What is 1 + 1?", "2", "2", True],
+                    ["What is 2 + 2?", "4", "1000", False],
+                ],
+            }
     else:
         assert run is None
 
 
-@skip_if_callback_unavailable
+@skip_if_evaluate_callback_unavailable
 def test_autolog_log_compile_with_evals():
     class EvalOptimizer(dspy.teleprompt.Teleprompter):
         def compile(self, program, eval, trainset, valset):

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -645,10 +645,8 @@ skip_if_evaluate_callback_unavailable = pytest.mark.skipif(
 )
 
 
-# _construct_result_table is available since 2.6.14
-is_construct_result_table_available = Version(importlib.metadata.version("dspy")) >= Version(
-    "2.6.12"
-)
+# Evaluate.call starts to return dspy.Prediction since 2.7.0
+is_result_table_available = Version(importlib.metadata.version("dspy")) >= Version("2.6.11")
 
 
 @skip_if_evaluate_callback_unavailable
@@ -686,14 +684,14 @@ def test_autolog_log_evals(log_evals, tmp_path):
         client = MlflowClient()
         artifacts = (x.path for x in client.list_artifacts(run.info.run_id))
         assert "model.json" in artifacts
-        if is_construct_result_table_available:
+        if is_result_table_available:
             assert "result_table.json" in artifacts
             client.download_artifacts(
                 run_id=run.info.run_id, path="result_table.json", dst_path=tmp_path
             )
             result_table = json.loads((tmp_path / "result_table.json").read_text())
             assert result_table == {
-                "columns": ["question", "example_answer", "pred_answer", "answer_exact_match"],
+                "columns": ["example_question", "example_answer", "pred_answer", "score"],
                 "data": [
                     ["What is 1 + 1?", "2", "2", True],
                     ["What is 2 + 2?", "4", "1000", False],


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15061?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15061/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15061/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15061
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?
This PR enables the logging of the result table as json using the output of `dspy.Evaluate` so that users can use MLflow evaluate UI to analyze the result of programs per example.

<img width="1111" alt="image" src="https://github.com/user-attachments/assets/196b4cb3-c7ae-4935-8de6-335adea8e008" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The result table of the DSPy evaluate will be logged to a relevant run.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
