### PR TITLE
Copy button added for new run using notebook

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/CreateNotebookRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/CreateNotebookRunModal.tsx
@@ -144,18 +144,14 @@ mlflow.end_run()
           key="classical-ml"
         >
           <div style={{ position: 'relative' }}>
-            <CodeSnippet
-              style={{ padding: '5px', height: snippetHeight }}
-              language="python"
-              theme={codeSnippetTheme}
-            >
+            <CodeSnippet style={{ padding: '5px', height: snippetHeight }} language="python" theme={codeSnippetTheme}>
               {classical_ml_text}
             </CodeSnippet>
             <CopyButton
               copyText={classical_ml_text}
               showLabel={false}
               icon={<CopyIcon />}
-              style={{ position: 'absolute', top: theme.spacing.sm, right: theme.spacing.md }}
+              style={{ position: 'absolute', top: theme.spacing.xs, right: theme.spacing.xs }}
             />
           </div>
         </LegacyTabPane>
@@ -164,18 +160,14 @@ mlflow.end_run()
           key="llm"
         >
           <div style={{ position: 'relative' }}>
-            <CodeSnippet
-              style={{ padding: '5px', height: snippetHeight }}
-              language="python"
-              theme={codeSnippetTheme}
-            >
+            <CodeSnippet style={{ padding: '5px', height: snippetHeight }} language="python" theme={codeSnippetTheme}>
               {llm_text}
             </CodeSnippet>
             <CopyButton
               copyText={llm_text}
               showLabel={false}
               icon={<CopyIcon />}
-              style={{ position: 'absolute', top: theme.spacing.sm, right: theme.spacing.md }}
+              style={{ position: 'absolute', top: theme.spacing.xs, right: theme.spacing.xs }}
             />
           </div>
         </LegacyTabPane>

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/CreateNotebookRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/CreateNotebookRunModal.tsx
@@ -143,45 +143,41 @@ mlflow.end_run()
           tab={<FormattedMessage defaultMessage="Classical ML" description="Example text snippet for classical ML" />}
           key="classical-ml"
         >
-          <CodeSnippet
-            style={{ padding: '5px', height: snippetHeight }}
-            language="python"
-            theme={codeSnippetTheme}
-            actions={
-              <div
-                style={{
-                  marginTop: theme.spacing.sm,
-                  marginRight: theme.spacing.md,
-                }}
-              >
-                <CopyButton copyText={classical_ml_text} showLabel={false} icon={<CopyIcon />} />
-              </div>
-            }
-          >
-            {classical_ml_text}
-          </CodeSnippet>
+          <div style={{ position: 'relative' }}>
+            <CodeSnippet
+              style={{ padding: '5px', height: snippetHeight }}
+              language="python"
+              theme={codeSnippetTheme}
+            >
+              {classical_ml_text}
+            </CodeSnippet>
+            <CopyButton
+              copyText={classical_ml_text}
+              showLabel={false}
+              icon={<CopyIcon />}
+              style={{ position: 'absolute', top: theme.spacing.sm, right: theme.spacing.md }}
+            />
+          </div>
         </LegacyTabPane>
         <LegacyTabPane
           tab={<FormattedMessage defaultMessage="LLM" description="Example text snippet for LLM" />}
           key="llm"
         >
-          <CodeSnippet
-            style={{ padding: '5px', height: snippetHeight }}
-            language="python"
-            theme={codeSnippetTheme}
-            actions={
-              <div
-                style={{
-                  marginTop: theme.spacing.sm,
-                  marginRight: theme.spacing.md,
-                }}
-              >
-                <CopyButton copyText={llm_text} showLabel={false} icon={<CopyIcon />} />
-              </div>
-            }
-          >
-            {llm_text}
-          </CodeSnippet>
+          <div style={{ position: 'relative' }}>
+            <CodeSnippet
+              style={{ padding: '5px', height: snippetHeight }}
+              language="python"
+              theme={codeSnippetTheme}
+            >
+              {llm_text}
+            </CodeSnippet>
+            <CopyButton
+              copyText={llm_text}
+              showLabel={false}
+              icon={<CopyIcon />}
+              style={{ position: 'absolute', top: theme.spacing.sm, right: theme.spacing.md }}
+            />
+          </div>
         </LegacyTabPane>
       </LegacyTabs>
     </Modal>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/15066?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15066/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15066/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15066
```

</p>
</details>

### Related Issues/PRs

Copy button for Examples in the New run using notebooks was not present

### What changes are proposed in this pull request?

Added the copy button for copying the code in New run using notebook

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:
<img width="705" alt="Screenshot 2025-03-21 at 10 52 35 PM" src="https://github.com/user-attachments/assets/8449d69d-995f-473a-b17a-2f100627492e" />

<img width="676" alt="Screenshot 2025-03-21 at 10 52 52 PM" src="https://github.com/user-attachments/assets/09ff1655-5ff8-4d27-9104-0626eecd3bba" />

After:
<img width="689" alt="Screenshot 2025-03-21 at 10 53 03 PM" src="https://github.com/user-attachments/assets/983fd0e8-f602-475d-843e-5cc74509e5a7" />
<img width="678" alt="Screenshot 2025-03-21 at 10 53 08 PM" src="https://github.com/user-attachments/assets/b3cbe8e4-3b20-444d-a7f6-1c4cda0e3b94" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
