### PR TITLE
fix: enable show diff in compare experiment page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -309,12 +309,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
   }
 
   renderTagTable(colWidth: number) {
-    const dataRows = this.renderDataRows(
-      this.props.tagLists,
-      colWidth,
-      this.state.onlyShowTagDiff,
-      true,
-    );
+    const dataRows = this.renderDataRows(this.props.tagLists, colWidth, this.state.onlyShowTagDiff, true);
     if (dataRows.length === 0) {
       return (
         <h2>

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -45,7 +45,13 @@ type CompareRunViewProps = {
   intl: IntlShape;
 };
 
-type CompareRunViewState = any;
+type CompareRunViewState = {
+  tableWidth: number | null;
+  onlyShowParamDiff: boolean;
+  onlyShowTagDiff: boolean;
+  onlyShowMetricDiff: boolean;
+};
+
 class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState> {
   compareRunViewRef: any;
   runDetailsTableRef: any;
@@ -108,9 +114,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
     const minColWidth = 200;
     let colWidth = minColWidth;
 
-    // @ts-expect-error TS(4111): Property 'tableWidth' comes from an index signatur... Remove this comment to see the full error message
     if (this.state.tableWidth !== null) {
-      // @ts-expect-error TS(4111): Property 'tableWidth' comes from an index signatur... Remove this comment to see the full error message
       colWidth = Math.round(this.state.tableWidth / (this.props.runInfos.length + 1));
       if (colWidth < minColWidth) {
         colWidth = minColWidth;
@@ -211,7 +215,6 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
     const dataRows = this.renderDataRows(
       this.props.paramLists,
       colWidth,
-      // @ts-expect-error TS(4111): Property 'onlyShowParamDiff' comes from an index s... Remove this comment to see the full error message
       this.state.onlyShowParamDiff,
       true,
       (key: any, data: any) => key,
@@ -260,7 +263,6 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
     const dataRows = this.renderDataRows(
       this.props.metricLists,
       colWidth,
-      // @ts-expect-error TS(4111): Property 'onlyShowMetricDiff' comes from an index ... Remove this comment to see the full error message
       this.state.onlyShowMetricDiff,
       true,
       (key, data) => {
@@ -310,7 +312,6 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
     const dataRows = this.renderDataRows(
       this.props.tagLists,
       colWidth,
-      // @ts-expect-error TS(4111): Property 'onlyShowTagDiff' comes from an index sig... Remove this comment to see the full error message
       this.state.onlyShowTagDiff,
       true,
     );
@@ -602,7 +603,6 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
             componentId="codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_570"
             label={diffOnlyLabel}
             aria-label={[paramsLabel, diffOnlyLabel].join(' - ')}
-            // @ts-expect-error TS(4111): Property 'onlyShowParamDiff' comes from an index s... Remove this comment to see the full error message
             checked={this.state.onlyShowParamDiff}
             onChange={(checked, e) => this.setState({ onlyShowParamDiff: checked })}
           />
@@ -614,7 +614,6 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
             componentId="codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_581"
             label={diffOnlyLabel}
             aria-label={[metricsLabel, diffOnlyLabel].join(' - ')}
-            // @ts-expect-error TS(4111): Property 'onlyShowMetricDiff' comes from an index ... Remove this comment to see the full error message
             checked={this.state.onlyShowMetricDiff}
             onChange={(checked, e) => this.setState({ onlyShowMetricDiff: checked })}
           />
@@ -627,7 +626,6 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
             componentId="codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_592"
             label={diffOnlyLabel}
             aria-label={[tagsLabel, diffOnlyLabel].join(' - ')}
-            // @ts-expect-error TS(4111): Property 'onlyShowTagDiff' comes from an index sig... Remove this comment to see the full error message
             checked={this.state.onlyShowTagDiff}
             onChange={(checked, e) => this.setState({ onlyShowTagDiff: checked })}
           />

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -54,9 +54,9 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
     super(props);
     this.state = {
       tableWidth: null,
-      onlyShowParamDiff: false,
-      onlyShowTagDiff: false,
-      onlyShowMetricDiff: false,
+      onlyShowParamDiff: true,
+      onlyShowTagDiff: true,
+      onlyShowMetricDiff: true,
     };
     this.onResizeHandler = this.onResizeHandler.bind(this);
     this.onCompareRunTableScrollHandler = this.onCompareRunTableScrollHandler.bind(this);


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Gumichocopengin8/mlflow/pull/15070?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15070/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15070/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15070
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

https://github.com/mlflow/mlflow/pull/15012#discussion_r2002743371

### What changes are proposed in this pull request?

Enable show diff button by default in compare experiment page

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
