### PR TITLE
Load context when infering signature from type hints

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3128,15 +3128,8 @@ def save_model(
             model_for_signature_inference = python_model
             predict_func = python_model.predict
         # Load context before calling predict to ensure necessary artifacts are available
-        try:
-            context = PythonModelContext(artifacts, model_config)
-            model_for_signature_inference.load_context(context)
-        except Exception as e:
-            _logger.warning(
-                "Failed to load context for Python model. This may affect the "
-                f"signature inference process. Error: {e}"
-            )
-
+        context = PythonModelContext(artifacts, model_config)
+        model_for_signature_inference.load_context(context)
         type_hint_from_example = _is_type_hint_from_example(type_hints.input)
         if type_hint_from_example:
             should_infer_signature_from_type_hints = False

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3136,6 +3136,8 @@ def save_model(
                 not _signature_cannot_be_inferred_from_type_hint(type_hints.input)
             )
             if should_infer_signature_from_type_hints:
+                context = PythonModelContext(artifacts, model_config)
+                model_for_signature_inference.load_context(context)
                 signature_from_type_hints = _infer_signature_from_type_hints(
                     func=predict_func,
                     type_hints=type_hints,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3128,6 +3128,8 @@ def save_model(
             model_for_signature_inference = python_model
             predict_func = python_model.predict
 
+        context = PythonModelContext(artifacts, model_config)
+        model_for_signature_inference.load_context(context)
         type_hint_from_example = _is_type_hint_from_example(type_hints.input)
         if type_hint_from_example:
             should_infer_signature_from_type_hints = False
@@ -3136,8 +3138,6 @@ def save_model(
                 not _signature_cannot_be_inferred_from_type_hint(type_hints.input)
             )
             if should_infer_signature_from_type_hints:
-                context = PythonModelContext(artifacts, model_config)
-                model_for_signature_inference.load_context(context)
                 signature_from_type_hints = _infer_signature_from_type_hints(
                     func=predict_func,
                     type_hints=type_hints,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3127,9 +3127,16 @@ def save_model(
             type_hints = python_model.predict_type_hints
             model_for_signature_inference = python_model
             predict_func = python_model.predict
+        # Load context before calling predict to ensure necessary artifacts are available
+        try:
+            context = PythonModelContext(artifacts, model_config)
+            model_for_signature_inference.load_context(context)
+        except Exception as e:
+            _logger.warning(
+                "Failed to load context for Python model. This may affect the "
+                f"signature inference process. Error: {e}"
+            )
 
-        context = PythonModelContext(artifacts, model_config)
-        model_for_signature_inference.load_context(context)
         type_hint_from_example = _is_type_hint_from_example(type_hints.input)
         if type_hint_from_example:
             should_infer_signature_from_type_hints = False
@@ -3150,8 +3157,6 @@ def save_model(
             if saved_example is not None:
                 _logger.info("Inferring model signature from input example")
                 try:
-                    context = PythonModelContext(artifacts, model_config)
-                    model_for_signature_inference.load_context(context)
                     mlflow_model.signature = _infer_signature_from_input_example(
                         saved_example,
                         _PythonModelPyfuncWrapper(model_for_signature_inference, None, None),

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1142,7 +1142,10 @@ def test_load_context_type_hint():
                 input_example=input_example,
                 signature=signature,
             )
-        assert not any("Failed to run the predict function on input example" in call[0][0] for call in mock_warning.call_args_list)
+        assert not any(
+            "Failed to run the predict function on input example" in call[0][0]
+            for call in mock_warning.call_args_list
+        )
         model_uri = f"runs:/{run.info.run_id}/model"
 
     pyfunc_model = mlflow.pyfunc.load_model(model_uri)

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1142,16 +1142,15 @@ def test_load_context_type_hint():
                 input_example=input_example,
                 signature=signature,
             )
-        for call in mock_warning.call_args_list:
-            assert "Failed to run the predict function on input example" not in call[0][0]
+        assert not any("Failed to run the predict function on input example" in call[0][0] for call in mock_warning.call_args_list)
         model_uri = f"runs:/{run.info.run_id}/model"
 
     pyfunc_model = mlflow.pyfunc.load_model(model_uri)
     underlying_model = pyfunc_model._model_impl.python_model
-    assert getattr(underlying_model, "context_loaded", False) is True, (
+    assert getattr(underlying_model, "context_loaded", False), (
         "load_context was not called as expected."
     )
 
     new_data = ["New", "Data"]
     prediction = pyfunc_model.predict(new_data)
-    assert prediction == new_data, "The model did not return the expected output."
+    assert prediction == new_data

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1120,3 +1120,38 @@ def test_type_hint_warning_not_shown_for_builtin_subclasses(mock_warning):
             pass
 
     assert mock_warning.call_count == 0
+
+
+def test_load_context_type_hint():
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def load_context(self, context):
+            self.context_loaded = True
+
+        def predict(self, model_input: list[str], params=None) -> list[str]:
+            assert getattr(self, "context_loaded", False), "load_context was not executed"
+            return model_input
+
+    input_example = ["Hello", "World"]
+    signature = infer_signature(input_example, input_example)
+
+    with mlflow.start_run() as run:
+        with mock.patch("mlflow.models.signature._logger.warning") as mock_warning:
+            mlflow.pyfunc.log_model(
+                "model",
+                python_model=MyModel(),
+                input_example=input_example,
+                signature=signature,
+            )
+        for call in mock_warning.call_args_list:
+            assert "Failed to run the predict function on input example" not in call[0][0]
+        model_uri = f"runs:/{run.info.run_id}/model"
+
+    pyfunc_model = mlflow.pyfunc.load_model(model_uri)
+    underlying_model = pyfunc_model._model_impl.python_model
+    assert getattr(underlying_model, "context_loaded", False) is True, (
+        "load_context was not called as expected."
+    )
+
+    new_data = ["New", "Data"]
+    prediction = pyfunc_model.predict(new_data)
+    assert prediction == new_data, "The model did not return the expected output."


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/15074?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15074/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15074/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15074
```

</p>
</details>

### Related Issues/PRs

Fix for #15068 

### What changes are proposed in this pull request?

Load context when infering signature from type hints

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integration

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
