### PR TITLE
use requests_aws4auth lib to fix error with signing buffer in request body

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -158,7 +158,7 @@ def build(package_type: PackageType) -> None:
                     # Required to log artifacts and models to HDFS artifact locations
                     "pyarrow",
                     # Required to sign outgoing request with SigV4 signature
-                    "requests-auth-aws-sigv4",
+                    "requests-aws4auth",
                     # Required to log artifacts and models to AWS S3 artifact locations
                     "boto3",
                     "botocore",

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -169,9 +169,19 @@ def http_request(
 
     if host_creds.aws_sigv4:
         # will overwrite the Authorization header
-        from requests_auth_aws_sigv4 import AWSSigV4
+        from requests_aws4auth import AWS4Auth
+        import boto3
 
-        kwargs["auth"] = AWSSigV4("execute-api")
+        session = boto3.Session()
+        credentials = session.get_credentials()
+
+        kwargs["auth"] = AWS4Auth(
+            credentials.access_key,
+            credentials.secret_key,
+            session.region_name,
+            "execute-api",
+            session_token=credentials.token
+        )
     elif host_creds.auth:
         from mlflow.tracking.request_auth.registry import fetch_auth
 

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -55,7 +55,7 @@ file = "LICENSE.txt"
 [project.optional-dependencies]
 extras = [
   "pyarrow",
-  "requests-auth-aws-sigv4",
+  "requests-aws4auth",
   "boto3",
   "botocore",
   "google-cloud-storage>=1.30.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ file = "LICENSE.txt"
 [project.optional-dependencies]
 extras = [
   "pyarrow",
-  "requests-auth-aws-sigv4",
+  "requests-aws4auth",
   "boto3",
   "botocore",
   "google-cloud-storage>=1.30.0",

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -137,9 +137,9 @@ def test_http_request_with_basic_auth(request):
 
 @mock.patch("requests.Session.request")
 def test_http_request_with_aws_sigv4(request, monkeypatch):
-    """This test requires the "requests_auth_aws_sigv4" package to be installed"""
+    """This test requires the "requests_aws4auth" package to be installed"""
 
-    from requests_auth_aws_sigv4 import AWSSigV4
+    from requests_aws4auth import AWS4Auth
 
     monkeypatch.setenvs(
         {
@@ -156,7 +156,7 @@ def test_http_request_with_aws_sigv4(request, monkeypatch):
 
     class AuthMatcher:
         def __eq__(self, other):
-            return isinstance(other, AWSSigV4)
+            return isinstance(other, AWS4Auth)
 
     request.assert_called_once_with(
         "GET",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/agathanatasha/mlflow/pull/15089?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15089/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15089/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15089
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #15051 

### What changes are proposed in this pull request?

Use requests_aws4auth for signing aws auth

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
