### PR TITLE
streamline boto3 aws authentication for bedrock client

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -211,8 +211,8 @@ class AWSRole(AWSBaseConfig):
 
 
 class AWSIdAndKey(AWSBaseConfig):
-    aws_access_key_id: str
-    aws_secret_access_key: str
+    aws_access_key_id: Optional[str] = None
+    aws_secret_access_key: Optional[str] = None
     aws_session_token: Optional[str] = None
 
 

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -197,8 +197,9 @@ class AmazonBedrockProvider(BaseProvider):
             return self._client
 
         try:
-            self._client = boto3.client('bedrock-runtime',
-                                        self.bedrock_config.aws_config.aws_region)
+            self._client = boto3.client(
+                "bedrock-runtime", self.bedrock_config.aws_config.aws_region
+            )
             return self._client
         except botocore.exceptions.NoCredentialsError as e:
             raise AIGatewayConfigException(

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -197,7 +197,7 @@ class AmazonBedrockProvider(BaseProvider):
             return self._client
 
         try:
-            self._client = boto3.client('bedrock-runtime', 
+            self._client = boto3.client('bedrock-runtime',
                                         self.bedrock_config.aws_config.aws_region)
             return self._client
         except botocore.exceptions.NoCredentialsError as e:
@@ -207,7 +207,7 @@ class AmazonBedrockProvider(BaseProvider):
                 "Otherwise likely missing credentials or accessing account to "
                 "Amazon Bedrock Private"
             ) from e
-        
+
         session = boto3.Session(**self._construct_session_args())
 
         try:
@@ -285,7 +285,7 @@ class AmazonBedrockProvider(BaseProvider):
 
         if self._client is None:
             self.get_bedrock_client()
-            
+
         try:
             response = self._client.invoke_model(
                 body=json.dumps(body).encode(),

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -195,18 +195,18 @@ class AmazonBedrockProvider(BaseProvider):
 
         if self._client is not None and not self._client_expired():
             return self._client
-        else:
-            try:
-                self._client = boto3.client('bedrock-runtime', 
-                                            self.bedrock_config.aws_config.aws_region)
-                return self._client
-            except botocore.exceptions.NoCredentialsError as e:
-                raise AIGatewayConfigException(
-                    "Cannot create Amazon Bedrock client; ensure boto3/botocore "
-                    "linked from the Amazon Bedrock user guide are installed. "
-                    "Otherwise likely missing credentials or accessing account to "
-                    "Amazon Bedrock Private"
-                ) from e
+
+        try:
+            self._client = boto3.client('bedrock-runtime', 
+                                        self.bedrock_config.aws_config.aws_region)
+            return self._client
+        except botocore.exceptions.NoCredentialsError as e:
+            raise AIGatewayConfigException(
+                "Cannot create Amazon Bedrock client; ensure boto3/botocore "
+                "linked from the Amazon Bedrock user guide are installed. "
+                "Otherwise likely missing credentials or accessing account to "
+                "Amazon Bedrock Private"
+            ) from e
         
         session = boto3.Session(**self._construct_session_args())
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sciarrilli/mlflow/pull/15096?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15096/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15096/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15096
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<Resolve> #15098 15098

### What changes are proposed in this pull request?

improve authentication for bedrock client with boto3

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

1. Tested llm-as-a-judge for bedrock claude with ~/.aws/credentials file
2. Tested llm-as-a-judge for bedrock claude with an instance profile (assumed role on ec2)
3. Tested llm-as-a-judge for bedrock claude with env variables for aws id, aws key, and aws region

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Boto3 includes logic to search for aws credentials. It looks for a credentials file at ~/.aws/credentials and also looks for an ec2 assumed role (instance profile). This is useful if running on ec2 or sagemaker training job then explicit credentials are not required.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
