### PR TITLE
Include source information as tags when logged models are created 

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2032,11 +2032,12 @@ def create_logged_model(
     if source_run_id is None and (run := active_run()):
         source_run_id = run.info.run_id
     experiment_id = experiment_id if experiment_id is not None else _get_experiment_id()
+    resolved_tags = context_registry.resolve_tags(tags)
     model = MlflowClient().create_logged_model(
         experiment_id=experiment_id,
         name=name,
         source_run_id=source_run_id,
-        tags=tags,
+        tags=resolved_tags,
         params=params,
         model_type=model_type,
     )

--- a/tests/store/tracking/test_file_store_logged_model.py
+++ b/tests/store/tracking/test_file_store_logged_model.py
@@ -44,7 +44,11 @@ def assert_logged_model_attributes(
         assert logged_model.source_run_id is None
     else:
         assert logged_model.source_run_id == source_run_id
-    assert logged_model.tags == (tags or {})
+    # NB: In many cases, there are default tags populated from the context in which a model
+    # is created, such as the notebook ID or git hash. We don't want to assert that these
+    # tags are present in the model's tags field (because it's complicated and already tested
+    # elsewhere), so we only check that the tags we specify are present
+    assert (tags or {}).items() <= logged_model.tags.items()
     assert logged_model.params == (params or {})
     assert logged_model.model_type == model_type
     assert logged_model.status == status

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1727,7 +1727,7 @@ def test_last_logged_model():
 
     client = MlflowClient()
     client.set_logged_model_tags(model.model_id, {"tag": "value"})
-    assert mlflow.last_logged_model().tags == {"tag": "value"}
+    assert mlflow.last_logged_model().tags.get("tag") == "value"
 
     client.delete_logged_model_tag(model.model_id, "tag")
     assert "tag" not in mlflow.last_logged_model().tags

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1730,7 +1730,7 @@ def test_last_logged_model():
     assert mlflow.last_logged_model().tags == {"tag": "value"}
 
     client.delete_logged_model_tag(model.model_id, "tag")
-    assert mlflow.last_logged_model().tags == {}
+    assert "tag" not in mlflow.last_logged_model().tags
 
     another_model = mlflow.create_logged_model()
     assert mlflow.last_logged_model().model_id == another_model.model_id

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1716,9 +1716,7 @@ def test_create_logged_model_tags_from_context():
         source_version_patch,
     ):
         model = mlflow.create_logged_model()
-    assert (
-        expected_tags.items() <= mlflow.MlflowClient().get_logged_model(model.model_id).tags.items()
-    )
+        assert expected_tags.items() <= model.tags.items()
 
 
 def test_last_logged_model():

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1697,26 +1697,25 @@ def test_create_logged_model_tags_from_context():
         mlflow_tags.MLFLOW_GIT_COMMIT: "1234",
     }
 
-    source_name_patch = mock.patch(
-        "mlflow.tracking.context.default_context._get_source_name",
-        return_value=expected_tags[mlflow_tags.MLFLOW_SOURCE_NAME],
-    )
-    source_type_patch = mock.patch(
-        "mlflow.tracking.context.default_context._get_source_type",
-        return_value=SourceType.from_string(expected_tags[mlflow_tags.MLFLOW_SOURCE_TYPE]),
-    )
-    source_version_patch = mock.patch(
-        "mlflow.tracking.context.git_context._get_source_version",
-        return_value=expected_tags[mlflow_tags.MLFLOW_GIT_COMMIT],
-    )
-
-    with multi_context(
-        source_name_patch,
-        source_type_patch,
-        source_version_patch,
+    with (
+        mock.patch(
+            "mlflow.tracking.context.default_context._get_source_name",
+            return_value=expected_tags[mlflow_tags.MLFLOW_SOURCE_NAME],
+        ) as m_get_source_name,
+        mock.patch(
+            "mlflow.tracking.context.default_context._get_source_type",
+            return_value=SourceType.from_string(expected_tags[mlflow_tags.MLFLOW_SOURCE_TYPE]),
+        ) as m_get_source_type,
+        mock.patch(
+            "mlflow.tracking.context.git_context._get_source_version",
+            return_value=expected_tags[mlflow_tags.MLFLOW_GIT_COMMIT],
+        ) as m_get_source_version,
     ):
         model = mlflow.create_logged_model()
         assert expected_tags.items() <= model.tags.items()
+        m_get_source_name.assert_called_once()
+        m_get_source_type.assert_called_once()
+        m_get_source_version.assert_called_once()
 
 
 def test_last_logged_model():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/15100?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15100/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15100/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15100
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Include source information as tags when logged models are created 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
