### PR TITLE
[OpenAI] Drop log_models option in autolog and add test

### DIFF
--- a/mlflow/openai/_openai_autolog.py
+++ b/mlflow/openai/_openai_autolog.py
@@ -318,9 +318,11 @@ def _generate_model_identity(model_dict) -> int:
         "model",
     }
     model_dict = {
-        k: model_dict[k]
-        if isinstance(model_dict[k], str)
-        else json.dumps(model_dict[k], default=str)
+        k: (
+            model_dict[k]
+            if isinstance(model_dict[k], str)
+            else json.dumps(model_dict[k], default=str)
+        )
         for k in sorted(model_dict.keys() - exclude_fields)
     }
     model_str = model if isinstance(model, str) else str(id(model))

--- a/mlflow/openai/_openai_autolog.py
+++ b/mlflow/openai/_openai_autolog.py
@@ -1,16 +1,12 @@
 import functools
 import json
 import logging
-import os
-from contextlib import contextmanager
-from copy import deepcopy
 from typing import Any, AsyncIterator, Iterator, Optional
 
 from packaging.version import Version
 
 import mlflow
-from mlflow import MlflowException
-from mlflow.entities import RunTag, SpanType
+from mlflow.entities import SpanType
 from mlflow.entities.span import LiveSpan
 from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatusCode
@@ -30,59 +26,12 @@ from mlflow.tracing.utils import (
     end_client_span_or_trace,
     start_client_span_or_trace,
 )
-from mlflow.tracking.context import registry as context_registry
-from mlflow.tracking.fluent import _get_experiment_id
-from mlflow.utils.autologging_utils import disable_autologging, get_autologging_config
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
-from mlflow.utils.autologging_utils.safety import _resolve_extra_tags
 
 MIN_REQ_VERSION = Version(_ML_PACKAGE_VERSIONS["openai"]["autologging"]["minimum"])
 MAX_REQ_VERSION = Version(_ML_PACKAGE_VERSIONS["openai"]["autologging"]["maximum"])
 
 _logger = logging.getLogger(__name__)
-
-
-def _get_input_from_model(model, kwargs):
-    from openai.resources.chat.completions import Completions as ChatCompletions
-    from openai.resources.completions import Completions
-    from openai.resources.embeddings import Embeddings
-
-    model_class_param_name_mapping = {
-        ChatCompletions: "messages",
-        Completions: "prompt",
-        Embeddings: "input",
-    }
-    if param_name := model_class_param_name_mapping.get(model.__class__):
-        # openai tasks accept only keyword arguments
-        if param := kwargs.get(param_name):
-            return param
-        input_example_exc = MlflowException(
-            "Inference function signature changes, please contact MLflow team to "
-            "fix OpenAI autologging.",
-        )
-    else:
-        input_example_exc = MlflowException(
-            "Unsupported OpenAI task. Only support chat completions, completions and embeddings."
-        )
-    _logger.warning(
-        f"Failed to gather input example of model {model.__class__.__name__} "
-        f"due to error: {input_example_exc}"
-    )
-
-
-@contextmanager
-def _set_api_key_env_var(client):
-    """
-    Gets the API key from the client and temporarily set it as an environment variable
-    """
-    api_key = client.api_key
-    original = os.environ.get("OPENAI_API_KEY", None)
-    os.environ["OPENAI_API_KEY"] = api_key
-    yield
-    if original is not None:
-        os.environ["OPENAI_API_KEY"] = original
-    else:
-        os.environ.pop("OPENAI_API_KEY")
 
 
 def _get_span_type(task: type) -> str:
@@ -140,50 +89,11 @@ def _try_parse_raw_response(response: Any) -> Any:
 def patched_call(original, self, *args, **kwargs):
     config = AutoLoggingConfig.init(flavor_name=mlflow.openai.FLAVOR_NAME)
     active_run = mlflow.active_run()
-    run_id = _get_autolog_run_id(self, active_run)
+    run_id = active_run.info.run_id if active_run else None
     mlflow_client = mlflow.MlflowClient()
 
-    # If optional artifacts logging are enabled e.g. log_models, we need to create a run
-    if config.should_log_optional_artifacts():
-        run_id = _start_run_or_log_tag(mlflow_client, config, run_id)
-
-    input_example = None
     model_id = None
     task = mlflow.openai._get_task_name(self.__class__)
-    # TODO: drop log_models
-    if config.log_models and not hasattr(self, "_mlflow_model_logged"):
-        if config.log_input_examples:
-            input_example = deepcopy(_get_input_from_model(self, kwargs))
-            if not config.log_model_signatures:
-                _logger.info(
-                    "Signature is automatically generated for logged model if "
-                    "input_example is provided. To disable log_model_signatures, "
-                    "please also disable log_input_examples."
-                )
-
-        registered_model_name = get_autologging_config(
-            mlflow.openai.FLAVOR_NAME, "registered_model_name", None
-        )
-        try:
-            with disable_autologging():
-                # If the user is using `openai.OpenAI()` client,
-                # they do not need to set the "OPENAI_API_KEY" environment variable.
-                # This temporarily sets the API key as an environment variable
-                # so that the model can be logged.
-                with _set_api_key_env_var(self._client):
-                    logged_model = mlflow.openai.log_model(
-                        model=kwargs.get("model"),
-                        task=task,
-                        name="model",
-                        input_example=input_example,
-                        registered_model_name=registered_model_name,
-                        run_id=run_id,
-                    )
-                    model_id = logged_model.model_id
-        except Exception as e:
-            _logger.warning(f"Failed to log model due to error: {e}")
-        self._mlflow_model_logged = True
-
     model_identity = _generate_model_identity({"task": task, **kwargs})
     model_id = _MODEL_TRACKER.get(model_identity)
     # TODO: create LoggedModel if model_id is None and set into _MODEL_TRACKER
@@ -202,28 +112,14 @@ def patched_call(original, self, *args, **kwargs):
     if config.log_traces:
         _end_span_on_success(mlflow_client, span, kwargs, raw_result)
 
-    if config.should_log_optional_artifacts():
-        _log_optional_artifacts(config, run_id, self, kwargs)
-
-    # Even if the model is not logged, we keep a single run per model
-    self._mlflow_run_id = run_id
-
-    # Terminate the run if it is not managed by the user
-    if run_id is not None and (active_run is None or active_run.info.run_id != run_id):
-        mlflow_client.set_terminated(run_id)
-
     return raw_result
 
 
 async def async_patched_call(original, self, *args, **kwargs):
     config = AutoLoggingConfig.init(flavor_name=mlflow.openai.FLAVOR_NAME)
     active_run = mlflow.active_run()
-    run_id = _get_autolog_run_id(self, active_run)
+    run_id = active_run.info.run_id if active_run else None
     mlflow_client = mlflow.MlflowClient()
-
-    # If optional artifacts logging are enabled e.g. log_models, we need to create a run
-    if config.should_log_optional_artifacts():
-        run_id = _start_run_or_log_tag(mlflow_client, config, run_id)
 
     task = mlflow.openai._get_task_name(self.__class__)
     model_identity = _generate_model_identity({"task": task, **kwargs})
@@ -242,93 +138,7 @@ async def async_patched_call(original, self, *args, **kwargs):
     if config.log_traces:
         _end_span_on_success(mlflow_client, span, kwargs, raw_result)
 
-    if config.should_log_optional_artifacts():
-        _log_optional_artifacts(config, run_id, self, kwargs)
-
-    # Even if the model is not logged, we keep a single run per model
-    self._mlflow_run_id = run_id
-
-    # Terminate the run if it is not managed by the user
-    if run_id is not None and (active_run is None or active_run.info.run_id != run_id):
-        mlflow_client.set_terminated(run_id)
-
     return raw_result
-
-
-def _get_autolog_run_id(instance, active_run):
-    """
-    Get the run ID to use for logging artifacts and associate with the trace.
-
-    The run ID is determined as follows:
-    - If there is an active run (created by a user), use its run ID.
-    - If the model has a `_mlflow_run_id` attribute, use it. This is the run ID created
-        by autologging in a previous call to the same model.
-    """
-    return active_run.info.run_id if active_run else getattr(instance, "_mlflow_run_id", None)
-
-
-def _start_run_or_log_tag(
-    mlflow_client: MlflowClient, config: AutoLoggingConfig, run_id: Optional[str]
-) -> str:
-    """Start a new run or log models, or log extra tags if a run is already active."""
-    # include run context tags
-    resolved_tags = context_registry.resolve_tags(config.extra_tags)
-    tags = _resolve_extra_tags(mlflow.openai.FLAVOR_NAME, resolved_tags)
-    if run_id is not None:
-        mlflow_client.log_batch(
-            run_id=run_id,
-            tags=[RunTag(key, str(value)) for key, value in tags.items()],
-        )
-    else:
-        run = mlflow_client.create_run(
-            experiment_id=_get_experiment_id(),
-            tags=tags,
-        )
-        run_id = run.info.run_id
-    return run_id
-
-
-def _log_optional_artifacts(
-    config: AutoLoggingConfig, run_id: str, instance: Any, kwargs: dict[str, Any]
-):
-    if hasattr(instance, "_mlflow_model_logged"):
-        # Model is already logged for this instance, no need to log again
-        return
-
-    input_example = None
-    if config.log_input_examples:
-        input_example = deepcopy(_get_input_from_model(instance, kwargs))
-        if not config.log_model_signatures:
-            _logger.info(
-                "Signature is automatically generated for logged model if "
-                "input_example is provided. To disable log_model_signatures, "
-                "please also disable log_input_examples."
-            )
-
-    registered_model_name = get_autologging_config(
-        mlflow.openai.FLAVOR_NAME, "registered_model_name", None
-    )
-    try:
-        task = mlflow.openai._get_task_name(instance.__class__)
-        with disable_autologging():
-            # If the user is using `openai.OpenAI()` client,
-            # they do not need to set the "OPENAI_API_KEY" environment variable.
-            # This temporarily sets the API key as an environment variable
-            # so that the model can be logged.
-            with _set_api_key_env_var(instance._client):
-                mlflow.openai.log_model(
-                    kwargs.get("model"),
-                    task,
-                    "model",
-                    input_example=input_example,
-                    registered_model_name=registered_model_name,
-                    run_id=run_id,
-                )
-    except Exception as e:
-        _logger.warning(f"Failed to log model due to error: {e}")
-
-    # Even if the model is not logged, we keep a single run per model
-    instance._mlflow_model_logged = True
 
 
 def _start_span(
@@ -508,8 +318,10 @@ def _generate_model_identity(model_dict) -> int:
         "model",
     }
     model_dict = {
-        k: json.dumps(model_dict[k], default=str)
+        k: model_dict[k]
+        if isinstance(model_dict[k], str)
+        else json.dumps(model_dict[k], default=str)
         for k in sorted(model_dict.keys() - exclude_fields)
     }
     model_str = model if isinstance(model, str) else str(id(model))
-    return hash(model_str)
+    return hash(f"{model_str}-{model_dict}")

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -790,6 +790,7 @@ async def test_log_model_multiple_times_different_model_id(client):
     assert traces[0].data.spans[0].get_attribute(SpanAttributeKey.MODEL_ID) == logged_model_id
 
 
+# Used for testing model identity generation on same/different objects
 class DummyModel:
     def __init__(self, temperature):
         self.temperature = temperature

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -9,9 +9,9 @@ from packaging.version import Version
 from pydantic import BaseModel
 
 import mlflow
-from mlflow import MlflowClient
 from mlflow.entities.span import SpanType
 from mlflow.exceptions import MlflowException
+from mlflow.openai._openai_autolog import _generate_model_identity
 from mlflow.tracing.constant import STREAM_CHUNK_EVENT_VALUE_KEY, SpanAttributeKey, TraceMetadataKey
 
 from tests.openai.mock_openai import EMPTY_CHOICES
@@ -55,9 +55,8 @@ def client(request, monkeypatch, mock_openai):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("log_models", [True, False])
-async def test_chat_completions_autolog(client, log_models):
-    mlflow.openai.autolog(log_models=log_models)
+async def test_chat_completions_autolog(client):
+    mlflow.openai.autolog()
 
     messages = [{"role": "user", "content": "test"}]
     response = client.chat.completions.create(
@@ -82,20 +81,7 @@ async def test_chat_completions_autolog(client, log_models):
     assert span.attributes["model"] == "gpt-4o-mini"
     assert span.attributes["temperature"] == 0
 
-    if log_models:
-        run_id = client.chat.completions._mlflow_run_id
-        assert run_id is not None
-        assert trace.info.request_metadata[TraceMetadataKey.SOURCE_RUN] == run_id
-        loaded_model = mlflow.openai.load_model(f"runs:/{run_id}/model")
-        assert loaded_model == {
-            "model": "gpt-4o-mini",
-            "task": "chat.completions",
-        }
-        pyfunc_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
-        assert pyfunc_model.predict("test") == [json.dumps(messages)]
-
-    else:
-        assert TraceMetadataKey.SOURCE_RUN not in trace.info.request_metadata
+    assert TraceMetadataKey.SOURCE_RUN not in trace.info.request_metadata
 
 
 @pytest.mark.asyncio
@@ -284,9 +270,8 @@ async def test_chat_completions_streaming_empty_choices(client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("log_models", [True, False])
-async def test_completions_autolog(client, log_models):
-    mlflow.openai.autolog(log_models=log_models)
+async def test_completions_autolog(client):
+    mlflow.openai.autolog()
 
     response = client.completions.create(
         prompt="test",
@@ -306,19 +291,7 @@ async def test_completions_autolog(client, log_models):
     assert span.inputs == {"prompt": "test", "model": "gpt-4o-mini", "temperature": 0}
     assert span.outputs["id"] == "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7"
 
-    if log_models:
-        run_id = client.completions._mlflow_run_id
-        assert run_id is not None
-        assert trace.info.request_metadata[TraceMetadataKey.SOURCE_RUN] == run_id
-        loaded_model = mlflow.openai.load_model(f"runs:/{run_id}/model")
-        assert loaded_model == {
-            "model": "gpt-4o-mini",
-            "task": "completions",
-        }
-        pyfunc_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
-        assert pyfunc_model.predict("test") == ["test"]
-    else:
-        assert TraceMetadataKey.SOURCE_RUN not in trace.info.request_metadata
+    assert TraceMetadataKey.SOURCE_RUN not in trace.info.request_metadata
 
 
 @pytest.mark.asyncio
@@ -388,9 +361,8 @@ async def test_completions_autolog_streaming(client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("log_models", [True, False])
-async def test_embeddings_autolog(client, log_models):
-    mlflow.openai.autolog(log_models=log_models)
+async def test_embeddings_autolog(client):
+    mlflow.openai.autolog()
 
     response = client.embeddings.create(
         input="test",
@@ -409,44 +381,12 @@ async def test_embeddings_autolog(client, log_models):
     assert span.inputs == {"input": "test", "model": "text-embedding-ada-002"}
     assert span.outputs["data"][0]["embedding"] == list(range(1536))
 
-    if log_models:
-        run_id = client.embeddings._mlflow_run_id
-        assert run_id is not None
-        assert trace.info.request_metadata[TraceMetadataKey.SOURCE_RUN] == run_id
-        loaded_model = mlflow.openai.load_model(f"runs:/{run_id}/model")
-        assert loaded_model == {
-            "model": "text-embedding-ada-002",
-            "task": "embeddings",
-        }
-        pyfunc_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
-        output = pyfunc_model.predict("test")
-        assert len(output) == 1
-        assert len(output[0]) == 1536
-    else:
-        assert TraceMetadataKey.SOURCE_RUN not in trace.info.request_metadata
+    assert TraceMetadataKey.SOURCE_RUN not in trace.info.request_metadata
 
 
 @pytest.mark.asyncio
-async def test_autolog_with_registered_model_name(client):
-    registered_model_name = "test_model"
-    mlflow.openai.autolog(log_models=True, registered_model_name=registered_model_name)
-    response = client.chat.completions.create(
-        messages=[{"role": "user", "content": "test"}],
-        model="gpt-4o-mini",
-        temperature=0,
-    )
-
-    if client._is_async:
-        await response
-
-    registered_model = MlflowClient().get_registered_model(registered_model_name)
-    assert registered_model.name == registered_model_name
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("log_models", [True, False])
-def test_autolog_use_active_run_id(client, log_models):
-    mlflow.openai.autolog(log_models=log_models)
+def test_autolog_use_active_run_id(client):
+    mlflow.openai.autolog()
 
     messages = [{"role": "user", "content": "test"}]
 
@@ -459,22 +399,13 @@ def test_autolog_use_active_run_id(client, log_models):
     with mlflow.start_run() as run_1:
         _call_create()
 
-    assert client.chat.completions._mlflow_run_id == run_1.info.run_id
-
     with mlflow.start_run() as run_2:
         _call_create()
         _call_create()
 
-    assert client.chat.completions._mlflow_run_id == run_2.info.run_id
-
     with mlflow.start_run() as run_3:
-        mlflow.openai.autolog(
-            log_models=log_models,
-            extra_tags={"foo": "bar"},
-        )
+        mlflow.openai.autolog()
         _call_create()
-
-    assert client.chat.completions._mlflow_run_id == run_3.info.run_id
 
     traces = get_traces()[::-1]  # reverse order to sort by timestamp in ascending order
     assert len(traces) == 4
@@ -775,3 +706,196 @@ async def test_autolog_link_traces_to_original_model_after_logging(client):
     model_id = span.get_attribute(SpanAttributeKey.MODEL_ID)
     assert model_id == model_info.model_id
     assert span.inputs["messages"][0]["content"] == f"test {model_id}"
+
+
+@pytest.mark.asyncio
+async def test_new_model_logged_after_loaded(client):
+    mlflow.openai.autolog()
+
+    with mlflow.start_run():
+        model_info = mlflow.openai.log_model(
+            "gpt-4o-mini",
+            "chat.completions",
+            "model",
+            temperature=0.1,
+            messages=[{"role": "system", "content": "test"}],
+        )
+    loaded_model_id = model_info.model_id
+
+    response = client.chat.completions.create(
+        messages=[{"role": "user", "content": "test"}],
+        model="gpt-4o-mini",
+        temperature=0.1,
+    )
+    if client._is_async:
+        await response
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].data.spans[0].get_attribute(SpanAttributeKey.MODEL_ID) == loaded_model_id
+
+    with mlflow.start_run():
+        model_info = mlflow.openai.log_model(
+            "gpt-4o-mini",
+            "chat.completions",
+            "model",
+            temperature=0.1,
+            messages=[{"role": "system", "content": "test"}],
+        )
+    new_logged_model_id = model_info.model_id
+    assert new_logged_model_id != loaded_model_id
+
+    response = client.chat.completions.create(
+        messages=[{"role": "user", "content": "test again"}],
+        model="gpt-4o-mini",
+        temperature=0.1,
+    )
+    if client._is_async:
+        await response
+
+    traces = get_traces()
+    assert len(traces) == 2
+    assert traces[0].data.spans[0].get_attribute(SpanAttributeKey.MODEL_ID) == new_logged_model_id
+
+
+@pytest.mark.asyncio
+async def test_log_model_multiple_times_different_model_id(client):
+    mlflow.openai.autolog()
+
+    model_infos = []
+    for i in range(2):
+        with mlflow.start_run():
+            model_infos.append(
+                mlflow.openai.log_model(
+                    "gpt-4o-mini",
+                    "chat.completions",
+                    "model",
+                    temperature=0.1,
+                    messages=[{"role": "system", "content": "test"}],
+                )
+            )
+    assert model_infos[0].model_id != model_infos[1].model_id
+    logged_model_id = model_infos[-1].model_id
+
+    response = client.chat.completions.create(
+        messages=[{"role": "user", "content": "test again"}],
+        model="gpt-4o-mini",
+        temperature=0.1,
+    )
+    if client._is_async:
+        await response
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].data.spans[0].get_attribute(SpanAttributeKey.MODEL_ID) == logged_model_id
+
+
+class DummyModel:
+    def __init__(self, temperature):
+        self.temperature = temperature
+
+
+@pytest.mark.parametrize(
+    ("model_dict1", "model_dict2"),
+    [
+        (
+            {
+                "model": "gpt-4o-mini",
+                "task": "chat.completions",
+                "temperature": 0.1,
+                "messages": [{"role": "system", "content": "test"}],
+            },
+            {
+                "model": "gpt-4o-mini",
+                "task": "chat.completions",
+                "temperature": 0.1,
+                "messages": [{"role": "system", "content": "abc"}],
+            },
+        ),
+        (
+            {
+                "model": "gpt-4o-mini",
+                "task": "chat.completions",
+                "temperature": 0.1,
+            },
+            {
+                "task": "chat.completions",
+                "model": "gpt-4o-mini",
+                "temperature": 0.1,
+                "messages": "abc",
+            },
+        ),
+        (
+            {"model": DummyModel, "task": "chat.completions"},
+            {"model": DummyModel, "task": "chat.completions"},
+        ),
+    ],
+)
+def test_generate_model_identity_same(model_dict1, model_dict2):
+    assert _generate_model_identity(model_dict1) == _generate_model_identity(model_dict1)
+
+
+@pytest.mark.parametrize(
+    ("model_dict1", "model_dict2"),
+    [
+        (
+            {
+                "model": "gpt-4o-mini",
+                "task": "chat.completions",
+                "temperature": 0.1,
+            },
+            {
+                "model": "gpt-4o-mini",
+                "task": "chat.completions",
+                "temperature": 0.2,
+            },
+        ),
+        (
+            {
+                "model": "gpt-4o-mini",
+                "task": "chat.completions",
+                "temperature": 0.1,
+            },
+            {
+                "model": "gpt-4o-mini",
+                "task": "completions",
+                "temperature": 0.1,
+            },
+        ),
+        (
+            {
+                "model": "gpt-4o-mini",
+                "task": "completions",
+                "temperature": 0.1,
+            },
+            {
+                "model": "gpt-4o-mini",
+                "task": "completions",
+                "temperature": 0.1,
+                "xyz": "abc",
+            },
+        ),
+        (
+            {
+                "model": "test",
+                "task": "completions",
+                "temperature": 0.1,
+            },
+            {
+                "model": "gpt-4o-mini",
+                "task": "completions",
+                "temperature": 0.1,
+            },
+        ),
+        (
+            {"model": DummyModel, "task": "completions"},
+            {"model": DummyModel, "task": "chat.completions"},
+        ),
+        (
+            {"model": DummyModel(temperature=0.1), "task": "completions"},
+            {"model": DummyModel(temperature=0.1), "task": "completions"},
+        ),
+    ],
+)
+def test_generate_model_identity_different(model_dict1, model_dict2):
+    assert _generate_model_identity(model_dict1) != _generate_model_identity(model_dict2)

--- a/tests/openai/test_openai_evaluate.py
+++ b/tests/openai/test_openai_evaluate.py
@@ -40,8 +40,7 @@ def client(monkeypatch, mock_openai):
     [
         None,
         {"log_traces": False},
-        {"log_models": True},
-        {"log_traces": False, "log_models": False},
+        {"log_traces": True},
     ],
 )
 @pytest.mark.usefixtures("reset_autolog_state")
@@ -84,15 +83,11 @@ def test_openai_evaluate(client, config):
     purge_traces()
 
     # Test original autolog configs is restored
-    with mock.patch("mlflow.openai.log_model") as log_model_mock:
-        client.chat.completions.create(
-            messages=[{"role": "user", "content": "hi"}], model="gpt-4o-mini"
-        )
+    client.chat.completions.create(
+        messages=[{"role": "user", "content": "hi"}], model="gpt-4o-mini"
+    )
 
-        if config and config.get("log_models", False):
-            log_model_mock.assert_called_once()
-
-        assert len(get_traces()) == (1 if is_trace_enabled else 0)
+    assert len(get_traces()) == (1 if is_trace_enabled else 0)
 
 
 @pytest.mark.usefixtures("reset_autolog_state")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15101?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15101/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15101/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15101
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Drop log_models option in autolog and add some tests

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
