### PR TITLE
fix: switch `enum` to `object literal`

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentSourceTypeIcon.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentSourceTypeIcon.tsx
@@ -8,7 +8,7 @@ export const ExperimentSourceTypeIcon = ({
   sourceType,
   className,
 }: {
-  sourceType: SourceType | string;
+  sourceType: typeof SourceType[keyof typeof SourceType] | string;
   className?: string;
 }) => {
   if (sourceType === SourceType.NOTEBOOK) {

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/hooks/useEvaluationArtifactTableData.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/hooks/useEvaluationArtifactTableData.test.tsx
@@ -218,12 +218,12 @@ describe('useEvaluationArtifactTableData', () => {
   });
 
   describe('properly pulls and generates data for multiple data tables and columns', () => {
-    enum TestColumns {
-      StaticData = 'StaticData',
-      ValueVaryingPerTable = 'ValueVaryingPerTable',
-      ValueVaryingPerRun = 'ValueVaryingPerRun',
-      ValueVaryingPerRunAndTable = 'ValueVaryingPerRunAndTable',
-    }
+    const TestColumns = {
+      StaticData: 'StaticData',
+      ValueVaryingPerTable: 'ValueVaryingPerTable',
+      ValueVaryingPerRun: 'ValueVaryingPerRun',
+      ValueVaryingPerRunAndTable: 'ValueVaryingPerRunAndTable',
+    } as const;
 
     // Prepare ten run UUIDS: run_0, run_1, run_2 etc.
     const RUN_IDS = new Array(10).fill(0).map((_, i) => `run_${i + 1}`);

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
@@ -36,8 +36,8 @@ import { RunsChartsSetHighlightContextProvider } from '../../../runs-charts/hook
 export interface ExperimentViewRunsOwnProps {
   isLoading: boolean;
   experiments: ExperimentEntity[];
-  modelVersionFilter?: MODEL_VERSION_FILTER;
-  lifecycleFilter?: LIFECYCLE_FILTER;
+  modelVersionFilter?: typeof MODEL_VERSION_FILTER[keyof typeof MODEL_VERSION_FILTER];
+  lifecycleFilter?: typeof LIFECYCLE_FILTER[keyof typeof LIFECYCLE_FILTER];
   datasetsFilter?: DatasetSummary[];
   onMaximizedChange?: (newIsMaximized: boolean) => void;
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsGroupBySelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsGroupBySelector.tsx
@@ -141,7 +141,7 @@ const GroupBySelectorBody = ({
   const hasAnyResults = filteredTagNames.length > 0 || filteredParamNames.length > 0 || attributesMatchFilter;
 
   const groupByToggle = useCallback(
-    (mode: RunGroupingMode, groupByData: string, checked: boolean) => {
+    (mode: typeof RunGroupingMode[keyof typeof RunGroupingMode], groupByData: string, checked: boolean) => {
       if (checked) {
         // Scenario #1: user selected new grouping key
         const newGroupByKeys = [...groupByKeys];
@@ -175,13 +175,14 @@ const GroupBySelectorBody = ({
 
   const aggregateFunctionChanged = (aggregateFunctionString: string) => {
     if (values<string>(RunGroupingAggregateFunction).includes(aggregateFunctionString)) {
-      const newFunction = aggregateFunctionString as RunGroupingAggregateFunction;
+      const newFunction =
+        aggregateFunctionString as typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction];
       const newGroupBy: RunsGroupByConfig = { ...groupBy, aggregateFunction: newFunction };
       onChange(newGroupBy);
     }
   };
 
-  const isGroupedBy = (mode: RunGroupingMode, groupByData: string) => {
+  const isGroupedBy = (mode: typeof RunGroupingMode[keyof typeof RunGroupingMode], groupByData: string) => {
     return groupByKeys.some((key) => key.mode === mode && key.groupByData === groupByData);
   };
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTableHeaderContext.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTableHeaderContext.tsx
@@ -1,7 +1,20 @@
 import React, { useMemo } from 'react';
 import { RUNS_VISIBILITY_MODE } from '../../models/ExperimentPageUIState';
 
-const ExperimentViewRunsTableHeaderContext = React.createContext({
+type ExperimentViewRunsTableHeaderContextType = {
+  runsHiddenMode: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE];
+  useGroupedValuesInCharts?: boolean;
+  /**
+   * Whether the user is using custom visibility settings (at least one row is configured manually)
+   */
+  usingCustomVisibility?: boolean;
+  /**
+   * Whether all runs are hidden
+   */
+  allRunsHidden?: boolean;
+};
+
+const ExperimentViewRunsTableHeaderContext = React.createContext<ExperimentViewRunsTableHeaderContextType>({
   runsHiddenMode: RUNS_VISIBILITY_MODE.FIRST_10_RUNS,
   useGroupedValuesInCharts: true,
   usingCustomVisibility: false,
@@ -21,19 +34,7 @@ export const ExperimentViewRunsTableHeaderContextProvider = ({
   useGroupedValuesInCharts,
   usingCustomVisibility,
   allRunsHidden,
-}: {
-  children: React.ReactNode;
-  runsHiddenMode: RUNS_VISIBILITY_MODE;
-  useGroupedValuesInCharts?: boolean;
-  /**
-   * Whether the user is using custom visibility settings (at least one row is configured manually)
-   */
-  usingCustomVisibility?: boolean;
-  /**
-   * Whether all runs are hidden
-   */
-  allRunsHidden?: boolean;
-}) => {
+}: ExperimentViewRunsTableHeaderContextType & { children: React.ReactNode }) => {
   const contextValue = useMemo(
     () => ({
       runsHiddenMode,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RowActionsCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RowActionsCellRenderer.tsx
@@ -78,7 +78,10 @@ export const RowActionsCellRenderer = React.memo(
     data: RunRowType;
     value: { pinned: boolean; hidden: boolean };
     onTogglePin: (runUuid: string) => void;
-    onToggleVisibility: (runUuidOrToggle: string | RUNS_VISIBILITY_MODE, runUuid?: string) => void;
+    onToggleVisibility: (
+      runUuidOrToggle: string | typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE],
+      runUuid?: string,
+    ) => void;
   }) => {
     const updateUIState = useUpdateExperimentViewUIState();
     const { theme } = useDesignSystemTheme();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RowActionsHeaderCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RowActionsHeaderCellRenderer.tsx
@@ -13,7 +13,10 @@ const RowActionsHeaderCellRendererV2 = React.memo(
   ({
     onToggleVisibility,
   }: {
-    onToggleVisibility: (mode: RUNS_VISIBILITY_MODE | string, runOrGroupUuid?: string) => void;
+    onToggleVisibility: (
+      mode: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE] | string,
+      runOrGroupUuid?: string,
+    ) => void;
   }) => {
     const { theme } = useDesignSystemTheme();
     const intl = useIntl();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RunVisibilityControlButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RunVisibilityControlButton.tsx
@@ -11,7 +11,11 @@ interface RunVisibilityControlButtonProps {
   rowHidden: boolean;
   buttonHidden: boolean;
   disabled: boolean;
-  onClick: (runUuidOrToggle: string | RUNS_VISIBILITY_MODE, runUuid?: string, isRowVisible?: boolean) => void;
+  onClick: (
+    runUuidOrToggle: string | typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE],
+    runUuid?: string,
+    isRowVisible?: boolean,
+  ) => void;
   label: React.ReactNode;
 }
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useToggleRowVisibilityCallback.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useToggleRowVisibilityCallback.tsx
@@ -16,7 +16,11 @@ export const useToggleRowVisibilityCallback = (tableRows: RunRowType[], useGroup
   immediateTableRows.current = tableRows;
 
   const toggleRowUsingVisibilityMap = useCallback(
-    (mode: RUNS_VISIBILITY_MODE, groupOrRunUuid?: string, isCurrentlyVisible?: boolean) => {
+    (
+      mode: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE],
+      groupOrRunUuid?: string,
+      isCurrentlyVisible?: boolean,
+    ) => {
       updateUIState((currentUIState) => {
         // If user has toggled a run or a group manually, we need to update the visibility map
         if (mode === RUNS_VISIBILITY_MODE.CUSTOM && groupOrRunUuid) {
@@ -51,12 +55,10 @@ export const useToggleRowVisibilityCallback = (tableRows: RunRowType[], useGroup
         // Otherwise, we're toggling a predefined visibility mode
         // and clearing the visibility map
         if (
-          [
-            RUNS_VISIBILITY_MODE.SHOWALL,
-            RUNS_VISIBILITY_MODE.HIDEALL,
-            RUNS_VISIBILITY_MODE.FIRST_10_RUNS,
-            RUNS_VISIBILITY_MODE.FIRST_20_RUNS,
-          ].includes(mode)
+          RUNS_VISIBILITY_MODE.SHOWALL === mode ||
+          RUNS_VISIBILITY_MODE.HIDEALL === mode ||
+          RUNS_VISIBILITY_MODE.FIRST_10_RUNS === mode ||
+          RUNS_VISIBILITY_MODE.FIRST_20_RUNS === mode
         ) {
           return {
             ...currentUIState,
@@ -77,7 +79,7 @@ export const useToggleRowVisibilityCallback = (tableRows: RunRowType[], useGroup
    * This one should be removed after ramping up `runsVisibility` field.
    */
   const toggleRowVisibility = useCallback(
-    (mode: RUNS_VISIBILITY_MODE, groupOrRunUuid?: string) => {
+    (mode: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE], groupOrRunUuid?: string) => {
       updateUIState((currentUIState) => {
         if (mode === RUNS_VISIBILITY_MODE.SHOWALL) {
           // Case #1: Showing all runs

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageSearchFacetsState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageSearchFacetsState.tsx
@@ -36,7 +36,7 @@ export interface ExperimentPageSearchFacetsState {
   /**
    * Lifecycle filter of runs to display
    */
-  lifecycleFilter: LIFECYCLE_FILTER;
+  lifecycleFilter: typeof LIFECYCLE_FILTER[keyof typeof LIFECYCLE_FILTER];
 
   /**
    * Datasets filter of runs to display
@@ -46,7 +46,7 @@ export interface ExperimentPageSearchFacetsState {
   /**
    * Filter of model versions to display
    */
-  modelVersionFilter: MODEL_VERSION_FILTER;
+  modelVersionFilter: typeof MODEL_VERSION_FILTER[keyof typeof MODEL_VERSION_FILTER];
 }
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
@@ -38,13 +38,13 @@ const getDefaultSelectedColumns = () => {
   return result;
 };
 
-export enum RUNS_VISIBILITY_MODE {
-  SHOWALL = 'SHOW_ALL',
-  HIDEALL = 'HIDE_ALL',
-  FIRST_10_RUNS = 'FIRST_10_RUNS',
-  FIRST_20_RUNS = 'FIRST_20_RUNS',
-  CUSTOM = 'CUSTOM',
-}
+export const RUNS_VISIBILITY_MODE = {
+  SHOWALL: 'SHOW_ALL',
+  HIDEALL: 'HIDE_ALL',
+  FIRST_10_RUNS: 'FIRST_10_RUNS',
+  FIRST_20_RUNS: 'FIRST_20_RUNS',
+  CUSTOM: 'CUSTOM',
+} as const;
 
 export type RunsChartsGlobalLineChartConfig = Partial<
   Pick<RunsChartsLineCardConfig, 'selectedXAxisMetricKey' | 'xAxisKey' | 'lineSmoothness'>
@@ -115,7 +115,7 @@ export interface ExperimentPageUIState extends ExperimentRunsChartsUIConfigurati
   /**
    * Determines default visibility mode for runs which are not explicitly specified by "runsVisibilityMap" field
    */
-  runsHiddenMode: RUNS_VISIBILITY_MODE;
+  runsHiddenMode: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE];
 
   /**
    * Object mapping run UUIDs (strings) to booleans, where a boolean value of true indicates that

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
@@ -146,7 +146,7 @@ export interface UseRunsColumnDefinitionsParams {
   onTogglePin: (runUuid: string) => void;
   onToggleVisibility:
     | ((runUuidOrToggle: string) => void)
-    | ((mode: RUNS_VISIBILITY_MODE, runOrGroupUuid: string) => void);
+    | ((mode: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE], runOrGroupUuid: string) => void);
   compareExperiments: boolean;
   metricKeyList: string[];
   paramKeyList: string[];
@@ -157,7 +157,7 @@ export interface UseRunsColumnDefinitionsParams {
   expandRows?: boolean;
   allRunsHidden?: boolean;
   usingCustomVisibility?: boolean;
-  runsHiddenMode?: RUNS_VISIBILITY_MODE;
+  runsHiddenMode?: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE];
 }
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.common-row-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.common-row-utils.ts
@@ -5,7 +5,7 @@ import { RUNS_VISIBILITY_MODE } from '../models/ExperimentPageUIState';
 // Utility function that determines if a particular table run should be hidden,
 // based on the selected mode, position on the list and current state of manually hidden runs array.
 export const determineIfRowIsHidden = (
-  runsHiddenMode: RUNS_VISIBILITY_MODE,
+  runsHiddenMode: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE],
   /**
    * @deprecated Use "runsVisibilityMap" field instead which has better control over visibility
    */

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.group-row-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.group-row-utils.ts
@@ -24,9 +24,9 @@ type AggregableParamEntity = { key: string; value: string };
 type AggregableMetricEntity = { key: string; value: number; step: number; min?: number; max?: number };
 
 export type RunsGroupByConfig = {
-  aggregateFunction: RunGroupingAggregateFunction;
+  aggregateFunction: typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction];
   groupByKeys: {
-    mode: RunGroupingMode;
+    mode: typeof RunGroupingMode[keyof typeof RunGroupingMode];
     groupByData: string;
   }[];
 };
@@ -36,9 +36,9 @@ export type RunsGroupByConfig = {
  * E.g. {mode: "tags", groupByData: "some_tag", aggregateFunction: "min"} -> "tags.some_tag.min"
  */
 export const createRunsGroupByKey = (
-  mode: RunGroupingMode | undefined,
+  mode: typeof RunGroupingMode[keyof typeof RunGroupingMode] | undefined,
   groupByData: string,
-  aggregateFunction: RunGroupingAggregateFunction,
+  aggregateFunction: typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction],
 ) => (mode ? [mode, aggregateFunction, groupByData].join('.') : '');
 
 const createGroupValueId = ({ groupByData, mode, value }: RunGroupByGroupingValue) =>
@@ -71,10 +71,11 @@ export const normalizeRunsGroupByKey = (groupBy?: string | RunsGroupByConfig | n
   }
 
   return {
-    aggregateFunction: aggregateFunction as RunGroupingAggregateFunction,
+    aggregateFunction:
+      aggregateFunction as typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction],
     groupByKeys: [
       {
-        mode: mode as RunGroupingMode,
+        mode: mode as typeof RunGroupingMode[keyof typeof RunGroupingMode],
         groupByData: groupByData,
       },
     ],
@@ -85,7 +86,7 @@ const createGroupRenderMetadata = (
   groupId: string,
   expanded: boolean,
   runsInGroup: SingleRunData[],
-  aggregateFunction: RunGroupingAggregateFunction,
+  aggregateFunction: typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction],
   isRemainingRowsGroup: boolean,
   groupingKeys: RunGroupByGroupingValue[],
 ): (RowRenderMetadata | RowGroupRenderMetadata)[] => {
@@ -146,12 +147,12 @@ const createGroupRenderMetadataV2 = ({
   groupId: string;
   expanded: boolean;
   runsInGroup: SingleRunData[];
-  aggregateFunction: RunGroupingAggregateFunction;
+  aggregateFunction: typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction];
   isRemainingRowsGroup: boolean;
   groupingKeys: RunGroupByGroupingValue[];
   runsHidden: string[];
   runsVisibilityMap: Record<string, boolean>;
-  runsHiddenMode: RUNS_VISIBILITY_MODE;
+  runsHiddenMode: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE];
   rowCounter: { value: number };
   useGroupedValuesInCharts?: boolean;
 }): (RowRenderMetadata | RowGroupRenderMetadata)[] => {
@@ -254,7 +255,7 @@ const getDatasetHash = ({ dataset }: RunDatasetWithTags) => `${dataset.name}.${d
  */
 const aggregateValues = <T extends AggregableParamEntity | AggregableMetricEntity>(
   valuesByRun: T[][],
-  aggregateFunction: RunGroupingAggregateFunction,
+  aggregateFunction: typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction],
 ) => {
   if (
     aggregateFunction === RunGroupingAggregateFunction.Min ||
@@ -547,7 +548,7 @@ export const getGroupedRowRenderMetadata = ({
   searchFacetsState?: Readonly<ExperimentPageSearchFacetsState>;
   runsHidden?: string[];
   runsVisibilityMap?: Record<string, boolean>;
-  runsHiddenMode?: RUNS_VISIBILITY_MODE;
+  runsHiddenMode?: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE];
   useGroupedValuesInCharts?: boolean;
 }) => {
   // First, make sure we have a valid "group by" configuration.

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-types.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-types.ts
@@ -9,20 +9,20 @@ import type {
 /**
  * Represents how eye icon should be displayed for a particular row in runs table.
  */
-export enum RunRowVisibilityControl {
+export const RunRowVisibilityControl = {
   /**
    * Eye icon button is enabled and visible.
    */
-  Enabled = 0,
+  Enabled: 0,
   /**
    * Eye icon button is disabled but visible.
    */
-  Disabled = 1,
+  Disabled: 1,
   /**
    * Eye icon button is hidden.
    */
-  Hidden = 2,
-}
+  Hidden: 2,
+} as const;
 
 /**
  * Represents a single ag-grid compatible row used in Experiment View runs table.
@@ -50,7 +50,7 @@ export interface RunRowType {
   defaultColor?: string;
   tags?: Record<string, { key: string; value: string }>;
   params?: KeyValueEntity[];
-  visibilityControl?: RunRowVisibilityControl;
+  visibilityControl?: typeof RunRowVisibilityControl[keyof typeof RunRowVisibilityControl];
 
   /**
    * Contains information about run's date, timing and hierarchy. Empty for group rows.
@@ -111,17 +111,18 @@ export interface RunRowDateAndNestInfo {
   level: number;
 }
 
-export enum RunGroupingMode {
-  Dataset = 'dataset',
-  Tag = 'tag',
-  Param = 'param',
-}
+export const RunGroupingMode = {
+  Dataset: 'dataset',
+  Tag: 'tag',
+  Param: 'param',
+} as const;
 
-export enum RunGroupingAggregateFunction {
-  Min = 'min',
-  Average = 'average',
-  Max = 'max',
-}
+export const RunGroupingAggregateFunction = {
+  Min: 'min',
+  Average: 'average',
+  Max: 'max',
+} as const;
+
 export type RunGroupByValueType =
   | string
   | {
@@ -130,7 +131,7 @@ export type RunGroupByValueType =
     };
 
 export type RunGroupByGroupingValue = {
-  mode: RunGroupingMode;
+  mode: typeof RunGroupingMode[keyof typeof RunGroupingMode];
   groupByData: any;
   value: RunGroupByValueType | null;
 };
@@ -147,7 +148,7 @@ export interface RunGroupParentInfo {
   runUuidsForAggregation?: string[];
   aggregatedMetricData: Record<string, { key: string; value: number; maxStep: number }>;
   aggregatedParamData: Record<string, { key: string; value: number }>;
-  aggregateFunction?: RunGroupingAggregateFunction;
+  aggregateFunction?: typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction];
 }
 
 /**
@@ -173,7 +174,7 @@ export interface RowRenderMetadata {
   isGroup?: false;
   rowUuid: string;
   hidden?: boolean;
-  visibilityControl?: RunRowVisibilityControl;
+  visibilityControl?: typeof RunRowVisibilityControl[keyof typeof RunRowVisibilityControl];
 }
 
 export interface RowGroupRenderMetadata {
@@ -193,10 +194,10 @@ export interface RowGroupRenderMetadata {
     key: string;
     value: number;
   }[];
-  aggregateFunction: RunGroupingAggregateFunction;
+  aggregateFunction: typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction];
   groupingValues: RunGroupByGroupingValue[];
   isRemainingRunsGroup: boolean;
   hidden?: boolean;
   allRunsHidden?: boolean;
-  visibilityControl?: RunRowVisibilityControl;
+  visibilityControl?: typeof RunRowVisibilityControl[keyof typeof RunRowVisibilityControl];
 }

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-utils.ts
@@ -485,7 +485,7 @@ export const useExperimentRunRows = ({
 const determineVisibleRuns = (
   runs: RunRowType[],
   runsHidden: string[],
-  runsHiddenMode: RUNS_VISIBILITY_MODE,
+  runsHiddenMode: typeof RUNS_VISIBILITY_MODE[keyof typeof RUNS_VISIBILITY_MODE],
   runsVisibilityMap: Record<string, boolean> = {},
 ): RunRowType[] => {
   // In the new visibility model, we will count rows that can change visibility (groups and ungrouped runs)

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentRuns.selector.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentRuns.selector.ts
@@ -78,8 +78,8 @@ export type ExperimentRunsSelectorResult = {
 export type ExperimentRunsSelectorParams = {
   experiments: ExperimentEntity[];
   experimentIds?: string[];
-  lifecycleFilter?: LIFECYCLE_FILTER;
-  modelVersionFilter?: MODEL_VERSION_FILTER;
+  lifecycleFilter?: typeof LIFECYCLE_FILTER[keyof typeof LIFECYCLE_FILTER];
+  modelVersionFilter?: typeof MODEL_VERSION_FILTER[keyof typeof MODEL_VERSION_FILTER];
   datasetsFilter?: DatasetSummary[];
 };
 

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
@@ -108,7 +108,7 @@ const RunViewMetricChartsImpl = ({
 
   const reorderCharts = useReorderRunsChartsFn();
 
-  const addNewChartCard = (metricSectionId: string) => (type: RunsChartType) =>
+  const addNewChartCard = (metricSectionId: string) => (type: typeof RunsChartType[keyof typeof RunsChartType]) =>
     setConfiguredCardConfig(RunsChartsCardConfig.getEmptyChartCardByType(type, false, undefined, metricSectionId));
 
   const insertCharts = useInsertRunsChartsFn();

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
@@ -18,14 +18,14 @@ export const RunViewModeSwitch = () => {
   const { experimentId, runUuid } = useParams<{ runUuid: string; experimentId: string }>();
   const navigate = useNavigate();
   const currentTab = useRunViewActiveTab();
-  const [removeTabMargin, setRemoveTabMargin] = useState(TABS_WITHOUT_MARGIN.includes(currentTab));
+  const [removeTabMargin, setRemoveTabMargin] = useState((TABS_WITHOUT_MARGIN as string[]).includes(currentTab));
 
   const onTabChanged = (newTabKey: string) => {
     if (!experimentId || !runUuid || currentTab === newTabKey) {
       return;
     }
 
-    setRemoveTabMargin(TABS_WITHOUT_MARGIN.includes(newTabKey as RunPageTabName));
+    setRemoveTabMargin((TABS_WITHOUT_MARGIN as string[]).includes(newTabKey));
 
     if (newTabKey === RunPageTabName.OVERVIEW) {
       navigate(Routes.getRunPageRoute(experimentId, runUuid));

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/useRunViewActiveTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/useRunViewActiveTab.tsx
@@ -7,7 +7,7 @@ import { RunPageTabName } from '../../constants';
  * - Supports multi-slash artifact paths (hence '*' catch-all param)
  * - Supports both new (/artifacts/...) and previous (/artifactPath/...) routes
  */
-export const useRunViewActiveTab = (): RunPageTabName => {
+export const useRunViewActiveTab = (): typeof RunPageTabName[keyof typeof RunPageTabName] => {
   const { '*': tabParam } = useParams<{ '*': string }>();
   if (tabParam === 'model-metrics') {
     return RunPageTabName.MODEL_METRIC_CHARTS;

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsCharts.common.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsCharts.common.ts
@@ -145,7 +145,10 @@ export interface RunsChartsRunData {
    * Set for run groups, contains aggregated metrics history for each run group.
    * It's keyed by a metric name, then by an aggregate function (min, max, average).
    */
-  aggregatedMetricsHistory?: Record<string, Record<RunGroupingAggregateFunction, MetricEntity[]>>;
+  aggregatedMetricsHistory?: Record<
+    string,
+    Record<typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction], MetricEntity[]>
+  >;
   /**
    * Object containing run's params by key
    */
@@ -386,7 +389,7 @@ export const getLineChartLegendData = (
   runsData: Pick<RunsChartsRunData, 'runInfo' | 'color' | 'metricsHistory' | 'displayName' | 'uuid'>[],
   selectedMetricKeys: string[] | undefined,
   metricKey: string,
-  yAxisKey: RunsChartsLineChartYAxisType,
+  yAxisKey: typeof RunsChartsLineChartYAxisType[keyof typeof RunsChartsLineChartYAxisType],
   yAxisExpressions: RunsChartsLineChartExpression[],
 ): LegendLabelData[] =>
   runsData.flatMap((runEntry): LegendLabelData[] => {
@@ -444,15 +447,20 @@ export const createFadedTraceColor = (hexColor?: string, alpha = 0.1) => {
  * Enum for X axis types for line charts. Defined here to
  * avoid circular imports from runs-charts.types.ts
  */
-export enum RunsChartsLineChartXAxisType {
-  STEP = 'step',
-  TIME = 'time',
-  TIME_RELATIVE = 'time-relative',
-  TIME_RELATIVE_HOURS = 'time-relative-hours',
-  METRIC = 'metric',
-}
+export const RunsChartsLineChartXAxisType = {
+  STEP: 'step',
+  TIME: 'time',
+  TIME_RELATIVE: 'time-relative',
+  TIME_RELATIVE_HOURS: 'time-relative-hours',
+  METRIC: 'metric',
+} as const;
 
-const axisKeyToLabel = defineMessages<Exclude<RunsChartsLineChartXAxisType, RunsChartsLineChartXAxisType.METRIC>>({
+const axisKeyToLabel = defineMessages<
+  Exclude<
+    typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType],
+    typeof RunsChartsLineChartXAxisType.METRIC
+  >
+>({
   [RunsChartsLineChartXAxisType.TIME]: {
     defaultMessage: 'Time',
     description: 'Label for the time axis on the runs compare chart',
@@ -472,7 +480,10 @@ const axisKeyToLabel = defineMessages<Exclude<RunsChartsLineChartXAxisType, Runs
 });
 
 export const getChartAxisLabelDescriptor = (
-  axisKey: Exclude<RunsChartsLineChartXAxisType, RunsChartsLineChartXAxisType.METRIC>,
+  axisKey: Exclude<
+    typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType],
+    typeof RunsChartsLineChartXAxisType.METRIC
+  >,
 ) => {
   return axisKeyToLabel[axisKey];
 };

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsAddChartMenu.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsAddChartMenu.tsx
@@ -13,12 +13,13 @@ import { shouldEnableDifferenceViewCharts } from '@mlflow/mlflow/src/common/util
 import { FormattedMessage } from 'react-intl';
 
 export interface RunsChartsAddChartMenuProps {
-  onAddChart: (type: RunsChartType) => void;
-  supportedChartTypes?: RunsChartType[];
+  onAddChart: (type: typeof RunsChartType[keyof typeof RunsChartType]) => void;
+  supportedChartTypes?: typeof RunsChartType[keyof typeof RunsChartType][];
 }
 
 export const RunsChartsAddChartMenu = ({ onAddChart, supportedChartTypes }: RunsChartsAddChartMenuProps) => {
-  const isChartTypeSupported = (type: RunsChartType) => !supportedChartTypes || supportedChartTypes.includes(type);
+  const isChartTypeSupported = (type: typeof RunsChartType[keyof typeof RunsChartType]) =>
+    !supportedChartTypes || supportedChartTypes.includes(type);
   return (
     <DropdownMenu.Root modal={false}>
       <DropdownMenu.Trigger asChild>

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsConfigureModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsConfigureModal.tsx
@@ -50,7 +50,7 @@ import { RunsChartsConfigureScatterChartWithDatasets } from './config/RunsCharts
 import { DifferenceViewPlot } from './charts/DifferenceViewPlot';
 
 const previewComponentsMap: Record<
-  RunsChartType,
+  typeof RunsChartType[keyof typeof RunsChartType],
   React.FC<{
     previewData: RunsChartsRunData[];
     cardConfig: any;
@@ -92,17 +92,18 @@ export const RunsChartsConfigureModal = ({
   onCancel: () => void;
   groupBy: RunsGroupByConfig | null;
   onSubmit: (formData: Partial<RunsChartsCardConfig>) => void;
-  supportedChartTypes?: RunsChartType[] | undefined;
+  supportedChartTypes?: typeof RunsChartType[keyof typeof RunsChartType][] | undefined;
   globalLineChartConfig?: RunsChartsGlobalLineChartConfig;
 }) => {
-  const isChartTypeSupported = (type: RunsChartType) => !supportedChartTypes || supportedChartTypes.includes(type);
+  const isChartTypeSupported = (type: typeof RunsChartType[keyof typeof RunsChartType]) =>
+    !supportedChartTypes || supportedChartTypes.includes(type);
   const { theme } = useDesignSystemTheme();
   const borderStyle = `1px solid ${theme.colors.actionDefaultBorderDefault}`;
   const [currentFormState, setCurrentFormState] = useState<RunsChartsCardConfig>(config);
 
   const isEditing = Boolean(currentFormState.uuid);
 
-  const updateChartType = useCallback((type?: RunsChartType) => {
+  const updateChartType = useCallback((type?: typeof RunsChartType[keyof typeof RunsChartType]) => {
     if (!type) {
       return;
     }
@@ -124,7 +125,7 @@ export const RunsChartsConfigureModal = ({
     return Array.from(imageKeys).sort();
   }, [previewData]);
 
-  const renderConfigOptionsforChartType = (type?: RunsChartType) => {
+  const renderConfigOptionsforChartType = (type?: typeof RunsChartType[keyof typeof RunsChartType]) => {
     if (type === RunsChartType.BAR) {
       return (
         <RunsChartsConfigureBarChart
@@ -208,7 +209,7 @@ export const RunsChartsConfigureModal = ({
     return null;
   };
 
-  const renderPreviewChartType = (type?: RunsChartType) => {
+  const renderPreviewChartType = (type?: typeof RunsChartType[keyof typeof RunsChartType]) => {
     if (!type) {
       return null;
     }
@@ -307,7 +308,7 @@ export const RunsChartsConfigureModal = ({
                 css={{ width: '100%' }}
                 value={currentFormState.type}
                 onChange={({ target }) => {
-                  const chartType = target.value as RunsChartType;
+                  const chartType = target.value as typeof RunsChartType[keyof typeof RunsChartType];
                   Object.values(RunsChartType).includes(chartType) && updateChartType(chartType);
                 }}
               >

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -137,7 +137,7 @@ const normalizeRelativeTimeChartTooltipValue = (value: string | number) => {
 
 const getTooltipXValue = (
   hoverData: RunsMetricsSingleTraceTooltipData | undefined,
-  xAxisKey: RunsChartsLineChartXAxisType,
+  xAxisKey: typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType],
 ) => {
   if (xAxisKey === RunsChartsLineChartXAxisType.METRIC) {
     return hoverData?.xValue ?? '';

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
@@ -188,7 +188,7 @@ const getBandTraceForRun = ({
   runEntry: Omit<RunsChartsRunData, 'metrics' | 'params' | 'tags' | 'images'>;
   metricKey: RunsMetricsLinePlotProps['metricKey'];
   lineShape: RunsMetricsLinePlotProps['lineShape'];
-  xAxisKey: RunsChartsLineChartXAxisType;
+  xAxisKey: typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType];
   selectedXAxisMetricKey: RunsMetricsLinePlotProps['selectedXAxisMetricKey'];
   xAxisScaleType?: 'linear' | 'log';
 }): LineChartTraceData => {
@@ -297,7 +297,7 @@ export interface RunsCompareMultipleTracesTooltipData {
     value?: string | number;
   }[];
   xValue: string | number;
-  xAxisKey: RunsChartsLineChartXAxisType;
+  xAxisKey: typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType];
   xAxisKeyLabel: string;
   hoveredDataPoint?: RunsMetricsSingleTraceTooltipData;
 }
@@ -338,12 +338,12 @@ export interface RunsMetricsLinePlotProps extends RunsPlotsCommonProps {
   /**
    * Choose X axis mode - numeric step or absolute time
    */
-  xAxisKey?: RunsChartsLineChartXAxisType;
+  xAxisKey?: typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType];
 
   /**
    * Choose Y axis mode - metric or expressions
    */
-  yAxisKey?: RunsChartsLineChartYAxisType;
+  yAxisKey?: typeof RunsChartsLineChartYAxisType[keyof typeof RunsChartsLineChartYAxisType];
 
   /**
    * Array of expressions to evaluate
@@ -465,9 +465,9 @@ const prepareXAxisDataForMetricType = (
 };
 
 const getXAxisPlotlyType = (
-  xAxisKey: RunsChartsLineChartXAxisType,
+  xAxisKey: typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType],
   xAxisScaleType: 'linear' | 'log',
-  dynamicXAxisKey: RunsChartsLineChartXAxisType,
+  dynamicXAxisKey: typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType],
 ) => {
   if (
     xAxisKey === RunsChartsLineChartXAxisType.TIME ||

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/ChartCard.common.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/ChartCard.common.tsx
@@ -22,10 +22,10 @@ export const DRAGGABLE_CARD_HANDLE_CLASS = 'drag-handle';
 export const DRAGGABLE_CARD_TRANSITION_NAME = '--drag-transform';
 export const DRAGGABLE_CARD_TRANSITION_VAR = `var(${DRAGGABLE_CARD_TRANSITION_NAME})`;
 
-export enum RunsChartsChartsDragGroup {
-  PARALLEL_CHARTS_AREA = 'PARALLEL_CHARTS_AREA',
-  GENERAL_AREA = 'GENERAL_AREA',
-}
+export const RunsChartsChartsDragGroup = {
+  PARALLEL_CHARTS_AREA: 'PARALLEL_CHARTS_AREA',
+  GENERAL_AREA: 'GENERAL_AREA',
+} as const;
 
 export interface RunsChartCardReorderProps {
   onReorderWith: (draggedKey: string, targetDropKey: string) => void;
@@ -69,7 +69,7 @@ export interface ChartCardWrapperProps extends RunsChartCardReorderProps, RunsCh
   onDelete: () => void;
   tooltip?: React.ReactNode;
   uuid?: string;
-  dragGroupKey: RunsChartsChartsDragGroup;
+  dragGroupKey: typeof RunsChartsChartsDragGroup[keyof typeof RunsChartsChartsDragGroup];
   additionalMenuContent?: React.ReactNode;
   toggleFullScreenChart?: () => void;
   toggles?: ChartCardToggleProps[];

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/DifferenceViewPlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/DifferenceViewPlot.tsx
@@ -118,65 +118,72 @@ export const DifferenceViewPlot = ({
 
   const dataRows = useMemo<DifferencePlotDataRow[]>(
     () =>
-      cardConfig.compareGroups.reduce((acc: DifferencePlotDataRow[], group: DifferenceCardConfigCompareGroup) => {
-        switch (group) {
-          case DifferenceCardConfigCompareGroup.MODEL_METRICS:
-            acc.push({
-              [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
-                defaultMessage: `Model Metrics`,
-                description:
-                  'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > model metrics heading',
-              }),
-              children: [...modelMetrics],
-              key: 'modelMetrics',
-            });
-            break;
-          case DifferenceCardConfigCompareGroup.SYSTEM_METRICS:
-            acc.push({
-              [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
-                defaultMessage: `System Metrics`,
-                description:
-                  'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > system metrics heading',
-              }),
-              children: [...systemMetrics],
-              key: 'systemMetrics',
-            });
-            break;
-          case DifferenceCardConfigCompareGroup.PARAMETERS:
-            acc.push({
-              [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
-                defaultMessage: `Parameters`,
-                description:
-                  'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > parameters heading',
-              }),
-              children: getDifferencePlotJSONRows(parameters),
-              key: 'parameters',
-            });
-            break;
-          case DifferenceCardConfigCompareGroup.ATTRIBUTES:
-            acc.push({
-              [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
-                defaultMessage: `Attributes`,
-                description:
-                  'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > attributes heading',
-              }),
-              children: [...attributes],
-              key: 'attributes',
-            });
-            break;
-          case DifferenceCardConfigCompareGroup.TAGS:
-            acc.push({
-              [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
-                defaultMessage: `Tags`,
-                description: 'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > tags heading',
-              }),
-              children: [...tags],
-              key: 'tags',
-            });
-            break;
-        }
-        return acc;
-      }, []),
+      cardConfig.compareGroups.reduce(
+        (
+          acc: DifferencePlotDataRow[],
+          group: typeof DifferenceCardConfigCompareGroup[keyof typeof DifferenceCardConfigCompareGroup],
+        ) => {
+          switch (group) {
+            case DifferenceCardConfigCompareGroup.MODEL_METRICS:
+              acc.push({
+                [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
+                  defaultMessage: `Model Metrics`,
+                  description:
+                    'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > model metrics heading',
+                }),
+                children: [...modelMetrics],
+                key: 'modelMetrics',
+              });
+              break;
+            case DifferenceCardConfigCompareGroup.SYSTEM_METRICS:
+              acc.push({
+                [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
+                  defaultMessage: `System Metrics`,
+                  description:
+                    'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > system metrics heading',
+                }),
+                children: [...systemMetrics],
+                key: 'systemMetrics',
+              });
+              break;
+            case DifferenceCardConfigCompareGroup.PARAMETERS:
+              acc.push({
+                [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
+                  defaultMessage: `Parameters`,
+                  description:
+                    'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > parameters heading',
+                }),
+                children: getDifferencePlotJSONRows(parameters),
+                key: 'parameters',
+              });
+              break;
+            case DifferenceCardConfigCompareGroup.ATTRIBUTES:
+              acc.push({
+                [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
+                  defaultMessage: `Attributes`,
+                  description:
+                    'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > attributes heading',
+                }),
+                children: [...attributes],
+                key: 'attributes',
+              });
+              break;
+            case DifferenceCardConfigCompareGroup.TAGS:
+              acc.push({
+                [DIFFERENCE_PLOT_HEADING_COLUMN_ID]: formatMessage({
+                  defaultMessage: `Tags`,
+                  description:
+                    'Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > tags heading',
+                }),
+                children: [...tags],
+                key: 'tags',
+              });
+              break;
+          }
+          return acc;
+        },
+        [],
+      ),
     [modelMetrics, systemMetrics, parameters, tags, attributes, cardConfig.compareGroups, formatMessage],
   );
 

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/DifferenceViewPlot.utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/DifferenceViewPlot.utils.tsx
@@ -1,7 +1,13 @@
 import { ArrowDownIcon, ArrowUpIcon, DashIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { DifferenceChartCellDirection } from '../../utils/differenceView';
 
-export const CellDifference = ({ label, direction }: { label: string; direction: DifferenceChartCellDirection }) => {
+export const CellDifference = ({
+  label,
+  direction,
+}: {
+  label: string;
+  direction: typeof DifferenceChartCellDirection[keyof typeof DifferenceChartCellDirection];
+}) => {
   const { theme } = useDesignSystemTheme();
   let paragraphColor = undefined;
   let icon = null;

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/difference-view-plot/DifferencePlotDataCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/difference-view-plot/DifferencePlotDataCell.tsx
@@ -7,7 +7,13 @@ import {
 import { type CellContext } from '@tanstack/react-table';
 import { DifferencePlotDataColumnDef, type DifferencePlotDataRow } from '../DifferenceViewPlot';
 
-const CellDifference = ({ label, direction }: { label: string; direction: DifferenceChartCellDirection }) => {
+const CellDifference = ({
+  label,
+  direction,
+}: {
+  label: string;
+  direction: typeof DifferenceChartCellDirection[keyof typeof DifferenceChartCellDirection];
+}) => {
   const { theme } = useDesignSystemTheme();
   let paragraphColor = undefined;
   let icon = null;

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/config/RunsChartsConfigureDifferenceChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/config/RunsChartsConfigureDifferenceChart.tsx
@@ -38,7 +38,7 @@ export const RunsChartsConfigureDifferenceChart = ({
    * Callback for updating compare groups
    */
   const updateCompareGroups = useCallback(
-    (compareGroup: DifferenceCardConfigCompareGroup) => {
+    (compareGroup: typeof DifferenceCardConfigCompareGroup[keyof typeof DifferenceCardConfigCompareGroup]) => {
       onStateChange((current) => {
         const currentConfig = current as RunsChartsDifferenceCardConfig;
         const compareGroups = currentConfig.compareGroups;
@@ -92,7 +92,7 @@ export const RunsChartsConfigureDifferenceChart = ({
       >
         <Checkbox.Group id="checkbox-group" defaultValue={state.compareGroups}>
           {Object.values(DifferenceCardConfigCompareGroup).map((group) => {
-            const groupedCondition = groupBy ? DISABLED_GROUP_WHEN_GROUPBY.includes(group) : false;
+            const groupedCondition = groupBy ? (DISABLED_GROUP_WHEN_GROUPBY as string[]).includes(group) : false;
             return (
               <div css={{ display: 'inline-flex', alignItems: 'center' }} key={group}>
                 <Checkbox

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
@@ -77,12 +77,12 @@ export interface RunsChartsSectionAccordionProps {
   isMetricHistoryLoading?: boolean;
   startEditChart: (chartCard: RunsChartsCardConfig) => void;
   removeChart: (configToDelete: RunsChartsCardConfig) => void;
-  addNewChartCard: (metricSectionId: string) => (type: RunsChartType) => void;
+  addNewChartCard: (metricSectionId: string) => (type: typeof RunsChartType[keyof typeof RunsChartType]) => void;
   search: string;
   groupBy: RunsGroupByConfig | null;
   autoRefreshEnabled?: boolean;
   hideEmptyCharts?: boolean;
-  supportedChartTypes?: RunsChartType[] | undefined;
+  supportedChartTypes?: typeof RunsChartType[keyof typeof RunsChartType][] | undefined;
   setFullScreenChart: RunsChartCardSetFullscreenFn;
   globalLineChartConfig?: RunsChartsGlobalLineChartConfig;
   noRunsSelectedEmptyState?: React.ReactElement;

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionHeader.tsx
@@ -23,7 +23,7 @@ export interface RunsChartsSectionHeaderProps {
   index: number;
   section: ChartSectionConfig;
   sectionChartsLength: number;
-  addNewChartCard: (metricSectionId: string) => (type: RunsChartType) => void;
+  addNewChartCard: (metricSectionId: string) => (type: typeof RunsChartType[keyof typeof RunsChartType]) => void;
   onDeleteSection: (sectionId: string) => void;
   onAddSection: (sectionId: string, above: boolean) => void;
   editSection: number;
@@ -31,7 +31,7 @@ export interface RunsChartsSectionHeaderProps {
   onSetSectionName: (sectionId: string, name: string) => void;
   onSectionReorder: (sourceSectionId: string, targetSectionId: string) => void;
   isExpanded: boolean;
-  supportedChartTypes?: RunsChartType[] | undefined;
+  supportedChartTypes?: typeof RunsChartType[keyof typeof RunsChartType][] | undefined;
   /**
    * Set to "true" to hide various controls (e.g. edit, add, delete) in the section header.
    */

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useCompareRunChartSelectedRange.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useCompareRunChartSelectedRange.tsx
@@ -17,7 +17,7 @@ import { RunsChartsLineCardConfig } from '../runs-charts.types';
  */
 export const useCompareRunChartSelectedRange = (
   config: RunsChartsLineCardConfig,
-  xAxisKey: RunsChartsLineChartXAxisType,
+  xAxisKey: typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType],
   metricKey: string,
   sampledMetricsByRunUuid: SampledMetricsByRunUuidState,
   runUuids: string[],

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsChartTraceHighlight.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsChartTraceHighlight.ts
@@ -155,18 +155,26 @@ export const useRenderRunsChartTraceHighlight = (
   };
 };
 
-export enum ChartsTraceHighlightSource {
-  NONE,
-  CHART,
-  TABLE,
-}
+export const ChartsTraceHighlightSource = {
+  NONE: 'NONE',
+  CHART: 'CHART',
+  TABLE: 'TABLE',
+} as const;
 
 interface RunsChartsSetHighlightContextType {
   highlightDataTrace: (
     traceUuid: string | null,
-    options?: { source?: ChartsTraceHighlightSource; shouldBlock?: boolean },
+    options?: {
+      source?: typeof ChartsTraceHighlightSource[keyof typeof ChartsTraceHighlightSource];
+      shouldBlock?: boolean;
+    },
   ) => void;
-  onHighlightChange: (fn: (traceUuid: string | null, source?: ChartsTraceHighlightSource) => void) => () => void;
+  onHighlightChange: (
+    fn: (
+      traceUuid: string | null,
+      source?: typeof ChartsTraceHighlightSource[keyof typeof ChartsTraceHighlightSource],
+    ) => void,
+  ) => () => void;
 }
 
 const RunsChartsSetHighlightContext = createContext<RunsChartsSetHighlightContextType>({
@@ -175,7 +183,12 @@ const RunsChartsSetHighlightContext = createContext<RunsChartsSetHighlightContex
 });
 
 export const RunsChartsSetHighlightContextProvider = ({ children }: PropsWithChildren<unknown>) => {
-  const highlightListenerFns = useRef<((traceUuid: string | null, source?: ChartsTraceHighlightSource) => void)[]>([]);
+  const highlightListenerFns = useRef<
+    ((
+      traceUuid: string | null,
+      source?: typeof ChartsTraceHighlightSource[keyof typeof ChartsTraceHighlightSource],
+    ) => void)[]
+  >([]);
   const block = useRef(false);
 
   // Stable and memoized context value
@@ -188,7 +201,10 @@ export const RunsChartsSetHighlightContextProvider = ({ children }: PropsWithChi
       };
     }
 
-    const notifyListeners = (traceUuid: string | null, source?: ChartsTraceHighlightSource) => {
+    const notifyListeners = (
+      traceUuid: string | null,
+      source?: typeof ChartsTraceHighlightSource[keyof typeof ChartsTraceHighlightSource],
+    ) => {
       for (const fn of highlightListenerFns.current) {
         fn(traceUuid, source);
       }
@@ -196,7 +212,13 @@ export const RunsChartsSetHighlightContextProvider = ({ children }: PropsWithChi
 
     const highlightDataTrace = (
       traceUuid: string | null,
-      { shouldBlock, source }: { source?: ChartsTraceHighlightSource; shouldBlock?: boolean } = {},
+      {
+        shouldBlock,
+        source,
+      }: {
+        source?: typeof ChartsTraceHighlightSource[keyof typeof ChartsTraceHighlightSource];
+        shouldBlock?: boolean;
+      } = {},
     ) => {
       if (!isUndefined(shouldBlock)) {
         block.current = shouldBlock;
@@ -206,7 +228,12 @@ export const RunsChartsSetHighlightContextProvider = ({ children }: PropsWithChi
       notifyListeners(traceUuid, source);
     };
 
-    const onHighlightChange = (listener: (traceUuid: string | null, source?: ChartsTraceHighlightSource) => void) => {
+    const onHighlightChange = (
+      listener: (
+        traceUuid: string | null,
+        source?: typeof ChartsTraceHighlightSource[keyof typeof ChartsTraceHighlightSource],
+      ) => void,
+    ) => {
       highlightListenerFns.current.push(listener);
       return () => {
         highlightListenerFns.current = highlightListenerFns.current.filter((fn) => fn !== listener);

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsChartsMultipleTracesTooltip.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsChartsMultipleTracesTooltip.tsx
@@ -53,7 +53,7 @@ export const useRunsMultipleTracesTooltipData = ({
   containsMultipleMetricKeys?: boolean;
   xAxisKeyLabel: string;
   disabled?: boolean;
-  xAxisKey: RunsChartsLineChartXAxisType;
+  xAxisKey: typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType];
   setHoveredPointIndex: (value: number) => void;
   xAxisScaleType?: 'linear' | 'log';
   positionInSection?: number;

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsChartsTooltip.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsChartsTooltip.tsx
@@ -15,7 +15,7 @@ export interface RunsChartsTooltipBodyProps<TContext = any, TChartData = any, TH
   contextData: TContext;
   closeContextMenu: () => void;
   isHovering?: boolean;
-  mode: RunsChartsTooltipMode;
+  mode: typeof RunsChartsTooltipMode[keyof typeof RunsChartsTooltipMode];
 }
 
 export interface RunsChartsChartMouseEvent {
@@ -24,10 +24,10 @@ export interface RunsChartsChartMouseEvent {
   originalEvent?: MouseEvent;
 }
 
-export enum RunsChartsTooltipMode {
-  Simple = 1,
-  MultipleTracesWithScanline = 2,
-}
+export const RunsChartsTooltipMode = {
+  Simple: 1,
+  MultipleTracesWithScanline: 2,
+} as const;
 
 export type RunsChartsTooltipBodyComponent<C = any, T = any> = React.ComponentType<RunsChartsTooltipBodyProps<C, T>>;
 
@@ -38,18 +38,18 @@ const RunsChartsTooltipContext = React.createContext<{
   destroyTooltip: () => void;
   updateTooltip: (
     runUuid: string,
-    mode: RunsChartsTooltipMode,
+    mode: typeof RunsChartsTooltipMode[keyof typeof RunsChartsTooltipMode],
     chartData?: any,
     event?: RunsChartsChartMouseEvent,
     additionalData?: any,
   ) => void;
 } | null>(null);
 
-export enum ContextMenuVisibility {
-  HIDDEN,
-  HOVER,
-  VISIBLE,
-}
+const ContextMenuVisibility = {
+  HIDDEN: 'HIDDEN',
+  HOVER: 'HOVER',
+  VISIBLE: 'VISIBLE',
+} as const;
 
 export const containsMultipleRunsTooltipData = (
   hoverData: RunsMetricsBarPlotHoverData | RunsMetricsSingleTraceTooltipData | RunsCompareMultipleTracesTooltipData,
@@ -109,10 +109,14 @@ export const RunsChartsTooltipWrapper = <
   // Used instead of `currentPos` when the tooltip is in the "multiple runs" mode
   const currentSnappedCoordinates = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
 
-  const [mode, setMode] = useState<RunsChartsTooltipMode>(RunsChartsTooltipMode.Simple);
+  const [mode, setMode] = useState<typeof RunsChartsTooltipMode[keyof typeof RunsChartsTooltipMode]>(
+    RunsChartsTooltipMode.Simple,
+  );
 
   // Current visibility of the tooltip/context-menu
-  const [contextMenuShown, setContextMenuShown] = useState<ContextMenuVisibility>(ContextMenuVisibility.HIDDEN);
+  const [contextMenuShown, setContextMenuShown] = useState<
+    typeof ContextMenuVisibility[keyof typeof ContextMenuVisibility]
+  >(ContextMenuVisibility.HIDDEN);
 
   const [tooltipDisplayParams, setTooltipDisplayParams] = useState<any | null>(null);
   const [hoveredRunUuid, setHoveredRunUuid] = useState<string>('');
@@ -124,7 +128,8 @@ export const RunsChartsTooltipWrapper = <
   const focusedRunData = useRef<{ x: number; y: number; runUuid: string } | null>(null);
 
   // Mutable version of certain state values, used in processes outside the React event lifecycle
-  const mutableContextMenuShownRef = useRef<ContextMenuVisibility>(contextMenuShown);
+  const mutableContextMenuShownRef =
+    useRef<typeof ContextMenuVisibility[keyof typeof ContextMenuVisibility]>(contextMenuShown);
   const mutableHoveredRunUuid = useRef(hoveredRunUuid);
   const mutableTooltipDisplayParams = useRef(tooltipDisplayParams);
   const mutableAdditionalAxisData = useRef(additionalAxisData);
@@ -226,7 +231,7 @@ export const RunsChartsTooltipWrapper = <
   const updateTooltip = useCallback(
     (
       runUuid: string,
-      mode: RunsChartsTooltipMode,
+      mode: typeof RunsChartsTooltipMode[keyof typeof RunsChartsTooltipMode],
       chartData?: any,
       event?: RunsChartsChartMouseEvent,
       additionalRunData?: any,
@@ -488,7 +493,7 @@ export const useRunsChartsTooltip = <
   TAxisData = any,
 >(
   chartData?: TChart,
-  mode = RunsChartsTooltipMode.Simple,
+  mode: typeof RunsChartsTooltipMode[keyof typeof RunsChartsTooltipMode] = RunsChartsTooltipMode.Simple,
 ) => {
   const contextValue = useContext(RunsChartsTooltipContext);
 

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsHighlightTableRow.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsHighlightTableRow.tsx
@@ -30,7 +30,7 @@ export const useRunsHighlightTableRow = (
    * Listener function that highlights a row in the table by adding a class to it.
    */
   const highlightFn = useCallback(
-    (rowUuid: string | null, source?: ChartsTraceHighlightSource) => {
+    (rowUuid: string | null, source?: typeof ChartsTraceHighlightSource[keyof typeof ChartsTraceHighlightSource]) => {
       // First, quickly remove the highlight class from the previous highlighted row
       const existingHighlightedRowElement = containerElementRef.current?.querySelector(`.${highlightedClassName}`);
 

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
@@ -15,15 +15,15 @@ import { customMetricBehaviorDefs } from '../experiment-page/utils/customMetricB
 /**
  * Enum for all recognized chart types used in runs charts
  */
-export enum RunsChartType {
-  BAR = 'BAR',
-  LINE = 'LINE',
-  SCATTER = 'SCATTER',
-  CONTOUR = 'CONTOUR',
-  PARALLEL = 'PARALLEL',
-  DIFFERENCE = 'DIFFERENCE',
-  IMAGE = 'IMAGE',
-}
+export const RunsChartType = {
+  BAR: 'BAR',
+  LINE: 'LINE',
+  SCATTER: 'SCATTER',
+  CONTOUR: 'CONTOUR',
+  PARALLEL: 'PARALLEL',
+  DIFFERENCE: 'DIFFERENCE',
+  IMAGE: 'IMAGE',
+};
 
 const MIN_NUMBER_OF_STEP_FOR_LINE_COMPARISON = 1;
 
@@ -45,7 +45,7 @@ const dataTraceMetricsContainMultipleEpochs = (dataTrace: RunsChartsRunData, met
  */
 export abstract class RunsChartsCardConfig {
   uuid?: string;
-  type: RunsChartType = RunsChartType.BAR;
+  type: typeof RunsChartType[keyof typeof RunsChartType] = RunsChartType.BAR;
   runsCountToCompare?: number = 10;
   metricSectionId?: string = '';
   deleted = false;
@@ -76,7 +76,12 @@ export abstract class RunsChartsCardConfig {
    * Creates empty chart (card) config basing on a type.
    * TODO: consume visible run set and determine best configuration of metrics, params etc.
    */
-  static getEmptyChartCardByType(type: RunsChartType, isGenerated: boolean, uuid?: string, metricSectionId?: string) {
+  static getEmptyChartCardByType(
+    type: typeof RunsChartType[keyof typeof RunsChartType],
+    isGenerated: boolean,
+    uuid?: string,
+    metricSectionId?: string,
+  ) {
     if (type === RunsChartType.BAR) {
       return new RunsChartsBarCardConfig(isGenerated, uuid, metricSectionId);
     } else if (type === RunsChartType.SCATTER) {
@@ -446,7 +451,7 @@ export abstract class RunsChartsCardConfig {
 
 // TODO: add configuration fields relevant to scatter chart
 export class RunsChartsScatterCardConfig extends RunsChartsCardConfig {
-  type: RunsChartType.SCATTER = RunsChartType.SCATTER;
+  type: typeof RunsChartType.SCATTER = RunsChartType.SCATTER;
   xaxis: RunsChartAxisDef = { key: '', type: 'METRIC' };
   yaxis: RunsChartAxisDef = { key: '', type: 'METRIC' };
   runsCountToCompare = 100;
@@ -459,10 +464,10 @@ export interface ChartRange {
   yMax?: number;
 }
 
-export enum RunsChartsLineChartYAxisType {
-  METRIC = 'metric',
-  EXPRESSION = 'expression',
-}
+export const RunsChartsLineChartYAxisType = {
+  METRIC: 'metric',
+  EXPRESSION: 'expression',
+} as const;
 
 export interface RunsChartsLineChartExpression {
   // The expression parsed in Reverse Polish Notation
@@ -475,7 +480,7 @@ export interface RunsChartsLineChartExpression {
 
 // TODO: add configuration fields relevant to line chart
 export class RunsChartsLineCardConfig extends RunsChartsCardConfig {
-  type: RunsChartType.LINE = RunsChartType.LINE;
+  type: typeof RunsChartType.LINE = RunsChartType.LINE;
 
   /**
    * A metric key used for chart's X axis
@@ -516,7 +521,8 @@ export class RunsChartsLineCardConfig extends RunsChartsCardConfig {
   /**
    * Choose X axis mode - numeric step, relative time in seconds or absolute time value
    */
-  xAxisKey: RunsChartsLineChartXAxisType = RunsChartsLineChartXAxisType.STEP;
+  xAxisKey: typeof RunsChartsLineChartXAxisType[keyof typeof RunsChartsLineChartXAxisType] =
+    RunsChartsLineChartXAxisType.STEP;
 
   /**
    * Name of the metric to use for the X axis. Used when xAxisKey is set to 'metric'
@@ -532,7 +538,8 @@ export class RunsChartsLineCardConfig extends RunsChartsCardConfig {
   /**
    * Show metrics directly or custom expressions on metrics
    */
-  yAxisKey?: RunsChartsLineChartYAxisType = RunsChartsLineChartYAxisType.METRIC;
+  yAxisKey?: typeof RunsChartsLineChartYAxisType[keyof typeof RunsChartsLineChartYAxisType] =
+    RunsChartsLineChartYAxisType.METRIC;
 
   /**
    * Custom expressions for Y axis
@@ -558,7 +565,7 @@ export class RunsChartsLineCardConfig extends RunsChartsCardConfig {
 
 // TODO: add configuration fields relevant to bar chart
 export class RunsChartsBarCardConfig extends RunsChartsCardConfig {
-  type: RunsChartType.BAR = RunsChartType.BAR;
+  type: typeof RunsChartType.BAR = RunsChartType.BAR;
 
   /**
    * A metric key used for chart's X axis
@@ -578,7 +585,7 @@ export class RunsChartsBarCardConfig extends RunsChartsCardConfig {
 
 // TODO: add configuration fields relevant to contour chart
 export class RunsChartsContourCardConfig extends RunsChartsCardConfig {
-  type: RunsChartType.CONTOUR = RunsChartType.CONTOUR;
+  type: typeof RunsChartType.CONTOUR = RunsChartType.CONTOUR;
   xaxis: RunsChartAxisDef = { key: '', type: 'METRIC' };
   yaxis: RunsChartAxisDef = { key: '', type: 'METRIC' };
   zaxis: RunsChartAxisDef = { key: '', type: 'METRIC' };
@@ -586,19 +593,19 @@ export class RunsChartsContourCardConfig extends RunsChartsCardConfig {
 
 // TODO: add configuration fields relevant to parallel coords chart
 export class RunsChartsParallelCardConfig extends RunsChartsCardConfig {
-  type: RunsChartType.PARALLEL = RunsChartType.PARALLEL;
+  type: typeof RunsChartType.PARALLEL = RunsChartType.PARALLEL;
   selectedParams: string[] = [];
   selectedMetrics: string[] = [];
   showAllRuns?: boolean = false;
 }
 
-export enum DifferenceCardConfigCompareGroup {
-  MODEL_METRICS = 'Model metrics',
-  SYSTEM_METRICS = 'System metrics',
-  PARAMETERS = 'Parameters',
-  ATTRIBUTES = 'Attributes',
-  TAGS = 'Tags',
-}
+export const DifferenceCardConfigCompareGroup = {
+  MODEL_METRICS: 'Model metrics',
+  SYSTEM_METRICS: 'System metrics',
+  PARAMETERS: 'Parameters',
+  ATTRIBUTES: 'Attributes',
+  TAGS: 'Tags',
+} as const;
 
 export const DISABLED_GROUP_WHEN_GROUPBY = [
   DifferenceCardConfigCompareGroup.PARAMETERS,
@@ -606,17 +613,17 @@ export const DISABLED_GROUP_WHEN_GROUPBY = [
   DifferenceCardConfigCompareGroup.ATTRIBUTES,
 ];
 
-export enum DifferenceCardAttributes {
-  USER = 'User',
-  SOURCE = 'Source',
-  VERSION = 'Version',
-  MODELS = 'Models',
-}
+export const DifferenceCardAttributes = {
+  USER: 'User',
+  SOURCE: 'Source',
+  VERSION: 'Version',
+  MODELS: 'Models',
+} as const;
 
 // TODO: add configuration fields relevant to difference view chart
 export class RunsChartsDifferenceCardConfig extends RunsChartsCardConfig {
-  type: RunsChartType = RunsChartType.DIFFERENCE;
-  compareGroups: DifferenceCardConfigCompareGroup[] = [];
+  type: typeof RunsChartType[keyof typeof RunsChartType] = RunsChartType.DIFFERENCE;
+  compareGroups: typeof DifferenceCardConfigCompareGroup[keyof typeof DifferenceCardConfigCompareGroup][] = [];
   chartName = 'Runs difference view';
   showChangeFromBaseline = true;
   showDifferencesOnly = true;
@@ -624,7 +631,7 @@ export class RunsChartsDifferenceCardConfig extends RunsChartsCardConfig {
 }
 
 export class RunsChartsImageCardConfig extends RunsChartsCardConfig {
-  type: RunsChartType = RunsChartType.IMAGE;
+  type: typeof RunsChartType.IMAGE = RunsChartType.IMAGE;
   // image keys to show
   imageKeys: string[] = [];
   step = 0;

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/utils/differenceView.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/utils/differenceView.ts
@@ -21,11 +21,11 @@ export const getDifferenceChartDisplayedValue = (val: any, places = 2) => {
   }
 };
 
-export enum DifferenceChartCellDirection {
-  POSITIVE,
-  NEGATIVE,
-  SAME,
-}
+export const DifferenceChartCellDirection = {
+  POSITIVE: 'POSITIVE',
+  NEGATIVE: 'NEGATIVE',
+  SAME: 'SAME',
+} as const;
 export const differenceView = (a: any, b: any) => {
   if (typeof a !== 'number' || typeof b !== 'number') {
     return undefined;

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.test.tsx
@@ -1204,7 +1204,7 @@ describe.each(testCases)('RunsCompare $description', ({ setup: testCaseSetup }) 
         uuid: 'chart-difference',
         runsCountToCompare: 10,
         metricSectionId: 'metric-section-1',
-        compareGroups: [] as DifferenceCardConfigCompareGroup[],
+        compareGroups: [] as typeof DifferenceCardConfigCompareGroup[keyof typeof DifferenceCardConfigCompareGroup][],
         chartName: 'Runs difference view',
         showDifferencesOnly: true,
         deleted: false,

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
@@ -187,7 +187,7 @@ const RunsCompareImpl = ({
   >(undefined);
 
   const addNewChartCard = (metricSectionId: string) => {
-    return (type: RunsChartType) => {
+    return (type: typeof RunsChartType[keyof typeof RunsChartType]) => {
       // TODO: pass existing runs data and get pre-configured initial setup for every chart type
       setConfiguredCardConfig(RunsChartsCardConfig.getEmptyChartCardByType(type, false, undefined, metricSectionId));
     };

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/hooks/useGroupedChartRunData.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/hooks/useGroupedChartRunData.tsx
@@ -17,7 +17,7 @@ import type { MetricHistoryByName } from '../../../types';
 export interface UseGroupedChartRunDataParams {
   ungroupedRunsData: RunsChartsRunData[];
   enabled: boolean;
-  aggregateFunction?: RunGroupingAggregateFunction;
+  aggregateFunction?: typeof RunGroupingAggregateFunction[keyof typeof RunGroupingAggregateFunction];
   metricKeys: string[];
   sampledDataResultsByRunUuid: Dictionary<SampledMetricsByRun>;
   selectedXAxisMetricKey?: string;

--- a/mlflow/server/js/src/experiment-tracking/components/traces/TracesView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TracesView.tsx
@@ -37,7 +37,7 @@ export const TracesView = ({
    * Columns that should be disabled in the table.
    * Disabled columns are hidden and are not available to be toggled at all.
    */
-  disabledColumns?: ExperimentViewTracesTableColumns[];
+  disabledColumns?: typeof ExperimentViewTracesTableColumns[keyof typeof ExperimentViewTracesTableColumns][];
 }) => {
   const timeoutRef = useRef<number | undefined>(undefined);
   const [filter, setFilter] = useState<string>('');

--- a/mlflow/server/js/src/experiment-tracking/components/traces/TracesView.utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TracesView.utils.ts
@@ -64,21 +64,24 @@ export const EXPERIMENT_TRACES_SORTABLE_COLUMNS = ['timestamp_ms'];
 // we don't users to be able to control its visibility
 export const TRACE_TABLE_CHECKBOX_COLUMN_ID = 'select';
 
-export enum ExperimentViewTracesTableColumns {
-  requestId = 'request_id',
-  traceName = 'traceName',
-  timestampMs = 'timestamp_ms',
-  inputs = 'inputs',
-  outputs = 'outputs',
-  runName = 'runName',
-  totalTokens = 'total_tokens',
-  source = 'source',
-  latency = 'latency',
-  tags = 'tags',
-  status = 'status',
-}
+export const ExperimentViewTracesTableColumns = {
+  requestId: 'request_id',
+  traceName: 'traceName',
+  timestampMs: 'timestamp_ms',
+  inputs: 'inputs',
+  outputs: 'outputs',
+  runName: 'runName',
+  totalTokens: 'total_tokens',
+  source: 'source',
+  latency: 'latency',
+  tags: 'tags',
+  status: 'status',
+} as const;
 
-export const ExperimentViewTracesTableColumnLabels: Record<ExperimentViewTracesTableColumns, MessageDescriptor> = {
+export const ExperimentViewTracesTableColumnLabels: Record<
+  typeof ExperimentViewTracesTableColumns[keyof typeof ExperimentViewTracesTableColumns],
+  MessageDescriptor
+> = {
   [ExperimentViewTracesTableColumns.requestId]: defineMessage({
     defaultMessage: 'Request ID',
     description: 'Experiment page > traces table > request id column header',

--- a/mlflow/server/js/src/experiment-tracking/constants.ts
+++ b/mlflow/server/js/src/experiment-tracking/constants.ts
@@ -43,16 +43,16 @@ export const COLUMN_SORT_BY_ASC = 'ASCENDING';
 export const COLUMN_SORT_BY_DESC = 'DESCENDING';
 export const SORT_DELIMITER_SYMBOL = '***';
 
-export enum LIFECYCLE_FILTER {
-  ACTIVE = 'Active',
-  DELETED = 'Deleted',
-}
+export const LIFECYCLE_FILTER = {
+  ACTIVE: 'Active',
+  DELETED: 'Deleted',
+} as const;
 
-export enum MODEL_VERSION_FILTER {
-  WITH_MODEL_VERSIONS = 'With Model Versions',
-  WTIHOUT_MODEL_VERSIONS = 'Without Model Versions',
-  ALL_RUNS = 'All Runs',
-}
+const MODEL_VERSION_FILTER = {
+  WITH_MODEL_VERSIONS: 'With Model Versions',
+  WTIHOUT_MODEL_VERSIONS: 'Without Model Versions',
+  ALL_RUNS: 'All Runs',
+} as const;
 
 export const DEFAULT_ORDER_BY_KEY = ATTRIBUTE_COLUMN_SORT_KEY.DATE;
 export const DEFAULT_ORDER_BY_ASC = false;
@@ -85,20 +85,20 @@ export const MLFLOW_RUN_TYPE_VALUE_EVALUATION = 'evaluation';
 
 export const MLFLOW_RUN_GIT_SOURCE_BRANCH_TAG = 'mlflow.source.git.branch';
 
-export enum MLflowRunSourceType {
-  PROMPT_ENGINEERING = 'PROMPT_ENGINEERING',
-}
+export const MLflowRunSourceType = {
+  PROMPT_ENGINEERING: 'PROMPT_ENGINEERING',
+} as const;
 
 export const MLFLOW_PROMPT_ENGINEERING_ARTIFACT_NAME = 'eval_results_table.json';
 
-export enum RunPageTabName {
-  OVERVIEW = 'overview',
-  TRACES = 'traces',
-  MODEL_METRIC_CHARTS = 'model-metrics',
-  SYSTEM_METRIC_CHARTS = 'system-metrics',
-  ARTIFACTS = 'artifacts',
-  EVALUATIONS = 'evaluations',
-}
+export const RunPageTabName = {
+  OVERVIEW: 'overview',
+  TRACES: 'traces',
+  MODEL_METRIC_CHARTS: 'model-metrics',
+  SYSTEM_METRIC_CHARTS: 'system-metrics',
+  ARTIFACTS: 'artifacts',
+  EVALUATIONS: 'evaluations',
+} as const;
 
 export const MLFLOW_SYSTEM_METRIC_PREFIX = 'system/';
 
@@ -131,9 +131,9 @@ export const EPOCH_RELATIVE_TIME = 28800000;
 export const LINE_CHART_RELATIVE_TIME_THRESHOLD = 1000 * 60 * 60 * 24; // 1 day
 export const HOUR_IN_MILLISECONDS = 1000 * 60 * 60; // 1 hour
 
-export enum ExperimentPageTabName {
-  Models = 'models',
-  EvaluationMonitoring = 'evaluation-monitoring',
-  Datasets = 'datasets',
-  LabelingSessions = 'labeling-sessions',
-}
+export const ExperimentPageTabName = {
+  Models: 'models',
+  EvaluationMonitoring: 'evaluation-monitoring',
+  Datasets: 'datasets',
+  LabelingSessions: 'labeling-sessions',
+} as const;

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -90,7 +90,9 @@ const PromptsDetailsPage = () => {
   const isEmptyVersions = !isLoading && !promptDetailsData?.versions.length;
 
   const showPreviewPane =
-    !isLoading && !isEmptyVersions && [PromptVersionsTableMode.PREVIEW, PromptVersionsTableMode.COMPARE].includes(mode);
+    !isLoading &&
+    !isEmptyVersions &&
+    (PromptVersionsTableMode.PREVIEW === mode || PromptVersionsTableMode.COMPARE === mode);
 
   const selectedVersionEntity = promptDetailsData?.versions.find(
     ({ version }) => version === viewState.selectedVersion,

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionsTable.tsx
@@ -39,7 +39,7 @@ export const PromptVersionsTable = ({
   comparedVersion?: string;
   onUpdateSelectedVersion: (version: string) => void;
   onUpdateComparedVersion: (version: string) => void;
-  mode: PromptVersionsTableMode;
+  mode: typeof PromptVersionsTableMode[keyof typeof PromptVersionsTableMode];
   registeredPrompt?: RegisteredPrompt;
   showEditAliasesModal?: (versionNumber: string) => void;
   aliasesByVersion: Record<string, string[]>;
@@ -138,13 +138,13 @@ export const PromptVersionsTable = ({
         ) : (
           table.getRowModel().rows.map((row) => {
             const isSelectedSingle =
-              [PromptVersionsTableMode.PREVIEW].includes(mode) && selectedVersion === row.original.version;
+              PromptVersionsTableMode.PREVIEW === mode && selectedVersion === row.original.version;
 
             const isSelectedFirstToCompare =
-              [PromptVersionsTableMode.COMPARE].includes(mode) && selectedVersion === row.original.version;
+              PromptVersionsTableMode.COMPARE === mode && selectedVersion === row.original.version;
 
             const isSelectedSecondToCompare =
-              [PromptVersionsTableMode.COMPARE].includes(mode) && comparedVersion === row.original.version;
+              PromptVersionsTableMode.COMPARE === mode && comparedVersion === row.original.version;
 
             const getColor = () => {
               if (isSelectedSingle) {

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -8,10 +8,10 @@ import { getPromptContentTagValue } from '../utils';
 import { CollapsibleSection } from '@mlflow/mlflow/src/common/components/CollapsibleSection';
 import { EditableTagsTableView } from '@mlflow/mlflow/src/common/components/EditableTagsTableView';
 
-export enum CreatePromptModalMode {
-  CreatePrompt = 'CreatePrompt',
-  CreatePromptVersion = 'CreatePromptVersion',
-}
+export const CreatePromptModalMode = {
+  CreatePrompt: 'CreatePrompt',
+  CreatePromptVersion: 'CreatePromptVersion',
+} as const;
 
 export const useCreatePromptModal = ({
   mode = CreatePromptModalMode.CreatePromptVersion,
@@ -19,7 +19,7 @@ export const useCreatePromptModal = ({
   latestVersion,
   onSuccess,
 }: {
-  mode: CreatePromptModalMode;
+  mode: typeof CreatePromptModalMode[keyof typeof CreatePromptModalMode];
   registeredPrompt?: RegisteredPrompt;
   latestVersion?: RegisteredPromptVersion;
   onSuccess?: (result: { promptName: string; promptVersion?: string }) => void | Promise<any>;

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/usePromptDetailsPageViewState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/usePromptDetailsPageViewState.tsx
@@ -5,7 +5,7 @@ import { RegisteredPromptDetailsResponse } from '../types';
 
 const promptDetailsViewStateReducer = (
   state: {
-    mode: PromptVersionsTableMode;
+    mode: typeof PromptVersionsTableMode[keyof typeof PromptVersionsTableMode];
     selectedVersion?: string;
     comparedVersion?: string;
   },

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
@@ -15,11 +15,11 @@ export type PromptsVersionsTableMetadata = {
   registeredPrompt: RegisteredPrompt;
 };
 
-export enum PromptVersionsTableMode {
-  TABLE = 'table',
-  PREVIEW = 'preview',
-  COMPARE = 'compare',
-}
+export const PromptVersionsTableMode = {
+  TABLE: 'table',
+  PREVIEW: 'preview',
+  COMPARE: 'compare',
+} as const;
 
 export const getPromptContentTagValue = (promptVersion: RegisteredPromptVersion) => {
   return promptVersion?.tags?.find((tag) => tag.key === REGISTERED_PROMPT_CONTENT_TAG_KEY)?.value;

--- a/mlflow/server/js/src/experiment-tracking/reducers/ModelGatewayReducer.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ModelGatewayReducer.ts
@@ -53,8 +53,7 @@ const modelGatewayRoutes = (
         return state;
       }
       const compatibleGatewayEndpoints = payload.endpoints.filter(
-        ({ endpoint_type }) =>
-          endpoint_type && compatibleEndpointTypes.includes(endpoint_type as ModelGatewayRouteTask),
+        ({ endpoint_type }) => endpoint_type && (compatibleEndpointTypes as string[]).includes(endpoint_type),
       );
       return compatibleGatewayEndpoints.reduce((newState, deploymentEndpoint) => {
         return {
@@ -64,7 +63,7 @@ const modelGatewayRoutes = (
             key: `mlflow_deployment_endpoint:${deploymentEndpoint.name}`,
             name: deploymentEndpoint.name,
             mlflowDeployment: deploymentEndpoint,
-            task: deploymentEndpoint.endpoint_type as ModelGatewayRouteTask,
+            task: deploymentEndpoint.endpoint_type,
           },
         };
       }, state);

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowEnums.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowEnums.ts
@@ -7,21 +7,22 @@
  *   place these generated enums in the correct location shortly.
  */
 
-export enum SourceType {
-  NOTEBOOK = 'NOTEBOOK',
-  JOB = 'JOB',
-  PROJECT = 'PROJECT',
-  LOCAL = 'LOCAL',
-  UNKNOWN = 'UNKNOWN',
-}
+export const SourceType = {
+  NOTEBOOK: 'NOTEBOOK',
+  JOB: 'JOB',
+  PROJECT: 'PROJECT',
+  LOCAL: 'LOCAL',
+  UNKNOWN: 'UNKNOWN',
+} as const;
 
 export const ViewType = {
   ACTIVE_ONLY: 'ACTIVE_ONLY',
   DELETED_ONLY: 'DELETED_ONLY',
   ALL: 'ALL',
-};
-export enum ModelGatewayRouteTask {
-  LLM_V1_COMPLETIONS = 'llm/v1/completions',
-  LLM_V1_CHAT = 'llm/v1/chat',
-  LLM_V1_EMBEDDINGS = 'llm/v1/embeddings',
-}
+} as const;
+
+export const ModelGatewayRouteTask = {
+  LLM_V1_COMPLETIONS: 'llm/v1/completions',
+  LLM_V1_CHAT: 'llm/v1/chat',
+  LLM_V1_EMBEDDINGS: 'llm/v1/embeddings',
+} as const;

--- a/mlflow/server/js/src/experiment-tracking/sdk/ModelGatewayService.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/ModelGatewayService.ts
@@ -16,7 +16,9 @@ export interface ModelGatewayQueryPayload {
   };
 }
 
-export interface ModelGatewayResponseMetadata<T extends ModelGatewayRouteTask> {
+export interface ModelGatewayResponseMetadata<
+  T extends typeof ModelGatewayRouteTask[keyof typeof ModelGatewayRouteTask],
+> {
   mode: string;
   route_type: T;
   total_tokens: number;
@@ -32,7 +34,7 @@ export interface ModelGatewayCompletionsResponseType {
     };
   }[];
 
-  metadata: ModelGatewayResponseMetadata<ModelGatewayRouteTask.LLM_V1_COMPLETIONS>;
+  metadata: ModelGatewayResponseMetadata<typeof ModelGatewayRouteTask.LLM_V1_COMPLETIONS>;
 }
 
 export interface ModelGatewayChatResponseType {
@@ -43,7 +45,7 @@ export interface ModelGatewayChatResponseType {
     };
   }[];
 
-  metadata: ModelGatewayResponseMetadata<ModelGatewayRouteTask.LLM_V1_CHAT>;
+  metadata: ModelGatewayResponseMetadata<typeof ModelGatewayRouteTask.LLM_V1_CHAT>;
 }
 
 export type ModelGatewayResponseType = ModelGatewayCompletionsResponseType | ModelGatewayChatResponseType;
@@ -101,7 +103,7 @@ export interface ModelGatewayRouteLegacy {
   /**
    * Type of route (e.g., embedding, text generation, etc.)
    */
-  route_type: ModelGatewayRouteTask;
+  route_type: typeof ModelGatewayRouteTask[keyof typeof ModelGatewayRouteTask];
   /**
    * Underlying ML model that can be accessed via this route. Could add other types of resources in the future.
    */
@@ -110,7 +112,7 @@ export interface ModelGatewayRouteLegacy {
 
 export interface MlflowDeploymentsEndpoint {
   name: string;
-  endpoint_type: ModelGatewayRouteTask;
+  endpoint_type: typeof ModelGatewayRouteTask[keyof typeof ModelGatewayRouteTask];
   endpoint_url: string;
   model: ModelGatewayModelInfo;
 }
@@ -128,7 +130,7 @@ export interface ModelGatewayRoute {
   /**
    * Type of route (e.g., embedding, text generation, etc.)
    */
-  task: ModelGatewayRouteTask;
+  task: typeof ModelGatewayRouteTask[keyof typeof ModelGatewayRouteTask];
   /**
    * MLflow deployments URL of the endpoint
    */
@@ -156,7 +158,10 @@ const gatewayErrorHandler = ({
 };
 
 export class ModelGatewayService {
-  static createEvaluationTextPayload(inputText: string, task: ModelGatewayRouteTask) {
+  static createEvaluationTextPayload(
+    inputText: string,
+    task: typeof ModelGatewayRouteTask[keyof typeof ModelGatewayRouteTask],
+  ) {
     switch (task) {
       case ModelGatewayRouteTask.LLM_V1_COMPLETIONS: {
         return { prompt: inputText };

--- a/mlflow/server/js/src/experiment-tracking/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/types.ts
@@ -272,16 +272,16 @@ export interface ExperimentStoreEntities {
   colorByRunUuid: Record<string, string>;
 }
 
-export enum LIFECYCLE_FILTER {
-  ACTIVE = 'Active',
-  DELETED = 'Deleted',
-}
+export const LIFECYCLE_FILTER = {
+  ACTIVE: 'Active',
+  DELETED: 'Deleted',
+} as const;
 
-export enum MODEL_VERSION_FILTER {
-  WITH_MODEL_VERSIONS = 'With Model Versions',
-  WTIHOUT_MODEL_VERSIONS = 'Without Model Versions',
-  ALL_RUNS = 'All Runs',
-}
+export const MODEL_VERSION_FILTER = {
+  WITH_MODEL_VERSIONS: 'With Model Versions',
+  WTIHOUT_MODEL_VERSIONS: 'Without Model Versions',
+  ALL_RUNS: 'All Runs',
+} as const;
 
 export type ExperimentCategorizedUncheckedKeys = {
   attributes: string[];
@@ -299,16 +299,16 @@ export type UpdateExperimentViewStateFn = (newPartialViewState: Partial<Experime
 /**
  * Enum representing the different types of dataset sources.
  */
-export enum DatasetSourceTypes {
-  DELTA = 'delta_table',
-  EXTERNAL = 'external',
-  CODE = 'code',
-  LOCAL = 'local',
-  HTTP = 'http',
-  S3 = 's3',
-  HUGGING_FACE = 'hugging_face',
-  UC = 'uc_volume',
-}
+export const DatasetSourceTypes = {
+  DELTA: 'delta_table',
+  EXTERNAL: 'external',
+  CODE: 'code',
+  LOCAL: 'local',
+  HTTP: 'http',
+  S3: 's3',
+  HUGGING_FACE: 'hugging_face',
+  UC: 'uc_volume',
+} as const;
 
 /**
  * Describes a single entry in the text evaluation artifact
@@ -343,16 +343,16 @@ export interface EvaluationArtifactTable {
 /**
  * Known artifact types that are useful for the evaluation purposes
  */
-export enum RunLoggedArtifactType {
-  TABLE = 'table',
-}
+export const RunLoggedArtifactType = {
+  TABLE: 'table',
+} as const;
 
 /**
  * Shape of the contents of "mlflow.loggedArtifacts" tag
  */
 export type RunLoggedArtifactsDeclaration = {
   path: string;
-  type: RunLoggedArtifactType;
+  type: typeof RunLoggedArtifactType[keyof typeof RunLoggedArtifactType];
 }[];
 
 // "MODELS", "EVAL_RESULTS", "DATASETS", and "LABELING_SESSIONS" are the not real legacy view modes, they are used to navigate to the

--- a/mlflow/server/js/src/experiment-tracking/utils/LLMGatewayUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/LLMGatewayUtils.ts
@@ -17,7 +17,7 @@ export class GatewayErrorWrapper extends ErrorWrapper {
 }
 export const parseEndpointEvaluationResponse = (
   response: EndpointModelGatewayResponseType,
-  task: ModelGatewayRouteTask,
+  task: typeof ModelGatewayRouteTask[keyof typeof ModelGatewayRouteTask],
 ) => {
   // We're supporting completions and chat responses for the time being
   if (task === ModelGatewayRouteTask.LLM_V1_COMPLETIONS) {

--- a/mlflow/server/js/src/model-registry/components/ModelStageTransitionFormModal.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelStageTransitionFormModal.tsx
@@ -17,12 +17,12 @@ export interface ModelStageTransitionFormModalValues {
   archiveExistingVersions: boolean;
 }
 
-export enum ModelStageTransitionFormModalMode {
-  RequestOrDirect,
-  Approve,
-  Reject,
-  Cancel,
-}
+export const ModelStageTransitionFormModalMode = {
+  RequestOrDirect: 'RequestOrDirect',
+  Approve: 'Approve',
+  Reject: 'Reject',
+  Cancel: 'Cancel',
+} as const;
 
 export const ModelStageTransitionFormModal = ({
   visible,
@@ -37,7 +37,7 @@ export const ModelStageTransitionFormModal = ({
   transitionDescription: React.ReactNode;
   allowArchivingExistingVersions?: boolean;
   onConfirm?: (values: ModelStageTransitionFormModalValues) => void;
-  mode?: ModelStageTransitionFormModalMode;
+  mode?: typeof ModelStageTransitionFormModalMode[keyof typeof ModelStageTransitionFormModalMode];
 } & Pick<ModalProps, 'visible' | 'onCancel'>) => {
   const { theme } = useDesignSystemTheme();
   const form = useForm<ModelStageTransitionFormModalValues>({

--- a/mlflow/server/js/src/model-registry/constants.tsx
+++ b/mlflow/server/js/src/model-registry/constants.tsx
@@ -42,7 +42,7 @@ export const StageTagComponents = {
 export interface ModelVersionActivity {
   creation_timestamp?: number;
   user_id?: string;
-  activity_type: ActivityTypes;
+  activity_type: typeof ActivityTypes[keyof typeof ActivityTypes];
   comment?: string;
   last_updated_timestamp?: number;
   from_stage?: string;
@@ -51,18 +51,18 @@ export interface ModelVersionActivity {
   id?: string;
 }
 
-export enum ActivityTypes {
-  APPLIED_TRANSITION = 'APPLIED_TRANSITION',
-  REQUESTED_TRANSITION = 'REQUESTED_TRANSITION',
-  SYSTEM_TRANSITION = 'SYSTEM_TRANSITION',
-  CANCELLED_REQUEST = 'CANCELLED_REQUEST',
-  APPROVED_REQUEST = 'APPROVED_REQUEST',
-  REJECTED_REQUEST = 'REJECTED_REQUEST',
-  NEW_COMMENT = 'NEW_COMMENT',
-}
+export const ActivityTypes = {
+  APPLIED_TRANSITION: 'APPLIED_TRANSITION',
+  REQUESTED_TRANSITION: 'REQUESTED_TRANSITION',
+  SYSTEM_TRANSITION: 'SYSTEM_TRANSITION',
+  CANCELLED_REQUEST: 'CANCELLED_REQUEST',
+  APPROVED_REQUEST: 'APPROVED_REQUEST',
+  REJECTED_REQUEST: 'REJECTED_REQUEST',
+  NEW_COMMENT: 'NEW_COMMENT',
+} as const;
 
 export interface PendingModelVersionActivity {
-  type: ActivityTypes;
+  type: typeof ActivityTypes[keyof typeof ActivityTypes];
   to_stage: string;
 }
 

--- a/mlflow/server/js/src/shared/web-shared/errors/ErrorLogType.ts
+++ b/mlflow/server/js/src/shared/web-shared/errors/ErrorLogType.ts
@@ -1,9 +1,9 @@
-export enum ErrorLogType {
-  UserInputError = 'UserInputError',
-  UnexpectedSystemStateError = 'UnexpectedSystemStateError',
-  ServerError = 'ServerError',
-  SessionError = 'SessionError',
-  NetworkError = 'NetworkError',
-  ApplicationError = 'ApplicationError',
-  UnknownError = 'UnknownError',
-}
+export const ErrorLogType = {
+  UserInputError: 'UserInputError',
+  UnexpectedSystemStateError: 'UnexpectedSystemStateError',
+  ServerError: 'ServerError',
+  SessionError: 'SessionError',
+  NetworkError: 'NetworkError',
+  ApplicationError: 'ApplicationError',
+  UnknownError: 'UnknownError',
+} as const;

--- a/mlflow/server/js/src/shared/web-shared/errors/ErrorName.ts
+++ b/mlflow/server/js/src/shared/web-shared/errors/ErrorName.ts
@@ -1,14 +1,14 @@
-export enum ErrorName {
-  BadRequestError = 'BadRequestError',
-  FormValidationError = 'FormInputError',
-  GenericNetworkRequestError = 'GenericNetworkRequestError',
-  GraphQLGenericError = 'GraphQLGenericError',
-  InternalServerError = 'InternalServerError',
-  NotFoundError = 'NotFoundError',
-  PermissionError = 'PermissionError',
-  RateLimitedError = 'RateLimitedError',
-  RouteNotFoundError = 'RouteNotFoundError',
-  ServiceUnavailableError = 'ServiceUnavailableError',
-  UnauthorizedError = 'UnauthorizedError',
-  UnknownError = 'UnknownError',
-}
+export const ErrorName = {
+  BadRequestError: 'BadRequestError',
+  FormValidationError: 'FormInputError',
+  GenericNetworkRequestError: 'GenericNetworkRequestError',
+  GraphQLGenericError: 'GraphQLGenericError',
+  InternalServerError: 'InternalServerError',
+  NotFoundError: 'NotFoundError',
+  PermissionError: 'PermissionError',
+  RateLimitedError: 'RateLimitedError',
+  RouteNotFoundError: 'RouteNotFoundError',
+  ServiceUnavailableError: 'ServiceUnavailableError',
+  UnauthorizedError: 'UnauthorizedError',
+  UnknownError: 'UnknownError',
+} as const;

--- a/mlflow/server/js/src/shared/web-shared/errors/PredefinedErrors.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/errors/PredefinedErrors.test.tsx
@@ -1,19 +1,10 @@
-import type { ErrorLogType } from './ErrorLogType';
-import type { ErrorName } from './ErrorName';
 import {
-  PredefinedError,
   matchPredefinedError,
   NotFoundError,
   PermissionError,
   UnauthorizedError,
   UnknownError,
 } from './PredefinedErrors';
-
-class GenericError extends PredefinedError {
-  errorLogType = 'GenericError' as ErrorLogType;
-  errorName = 'GenericError' as ErrorName;
-  displayMessage = 'Generic Message';
-}
 
 describe('PredefinedErrors', () => {
   describe('matchPredefinedError', () => {

--- a/mlflow/server/js/src/shared/web-shared/errors/PredefinedErrors.tsx
+++ b/mlflow/server/js/src/shared/web-shared/errors/PredefinedErrors.tsx
@@ -11,8 +11,8 @@ export type HandleableError = Error | string | Record<string, unknown> | Predefi
 export type CausableError = Error | string | Record<string, unknown>;
 
 export abstract class PredefinedError extends Error {
-  abstract errorLogType: ErrorLogType;
-  abstract errorName: ErrorName;
+  abstract errorLogType: typeof ErrorLogType[keyof typeof ErrorLogType];
+  abstract errorName: typeof ErrorName[keyof typeof ErrorName];
   abstract displayMessage: React.ReactNode;
   isUserError = false;
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -1,24 +1,24 @@
 export { ModelTraceExplorerFrameRenderer } from './ModelTraceExplorerFrameRenderer';
 
-export enum ModelSpanType {
-  LLM = 'LLM',
-  CHAIN = 'CHAIN',
-  AGENT = 'AGENT',
-  TOOL = 'TOOL',
-  FUNCTION = 'FUNCTION',
-  CHAT_MODEL = 'CHAT_MODEL',
-  RETRIEVER = 'RETRIEVER',
-  PARSER = 'PARSER',
-  EMBEDDING = 'EMBEDDING',
-  RERANKER = 'RERANKER',
-  UNKNOWN = 'UNKNOWN',
-}
+export const ModelSpanType = {
+  LLM: 'LLM',
+  CHAIN: 'CHAIN',
+  AGENT: 'AGENT',
+  TOOL: 'TOOL',
+  FUNCTION: 'FUNCTION',
+  CHAT_MODEL: 'CHAT_MODEL',
+  RETRIEVER: 'RETRIEVER',
+  PARSER: 'PARSER',
+  EMBEDDING: 'EMBEDDING',
+  RERANKER: 'RERANKER',
+  UNKNOWN: 'UNKNOWN',
+} as const;
 
-export enum ModelIconType {
-  MODELS = 'models',
-  DOCUMENT = 'document',
-  CONNECT = 'connect',
-}
+export const ModelIconType = {
+  MODELS: 'models',
+  DOCUMENT: 'document',
+  CONNECT: 'connect',
+} as const;
 
 /**
  * Represents a single model trace span.
@@ -34,7 +34,7 @@ export type ModelTraceSpan = {
   parent_span_id?: string | null;
   parent_id?: string | null;
   /* deprecated, contained in attributes['mlflow.spanType'] */
-  span_type?: ModelSpanType | string;
+  span_type?: typeof ModelSpanType[keyof typeof ModelSpanType] | string;
   /* deprecated, migrated to `status_code` and `status_message` */
   status?: ModelTraceStatus;
   status_code?: string;
@@ -47,7 +47,7 @@ export type ModelTraceSpan = {
   outputs?: any;
   attributes?: Record<string, any>;
   /* metadata for ui usage logging */
-  type: ModelSpanType;
+  type: typeof ModelSpanType[keyof typeof ModelSpanType];
 };
 
 export type ModelTraceEvent = {
@@ -104,18 +104,18 @@ export type ModelTraceStatusInProgress = {
   status_code: 3;
 };
 
-export enum ModelTraceSpanType {
-  LLM = 'LLM',
-  CHAIN = 'CHAIN',
-  AGENT = 'AGENT',
-  TOOL = 'TOOL',
-  CHAT_MODEL = 'CHAT_MODEL',
-  RETRIEVER = 'RETRIEVER',
-  PARSER = 'PARSER',
-  EMBEDDING = 'EMBEDDING',
-  RERANKER = 'RERANKER',
-  UNKNOWN = 'UNKNOWN',
-}
+export const ModelTraceSpanType = {
+  LLM: 'LLM',
+  CHAIN: 'CHAIN',
+  AGENT: 'AGENT',
+  TOOL: 'TOOL',
+  CHAT_MODEL: 'CHAT_MODEL',
+  RETRIEVER: 'RETRIEVER',
+  PARSER: 'PARSER',
+  EMBEDDING: 'EMBEDDING',
+  RERANKER: 'RERANKER',
+  UNKNOWN: 'UNKNOWN',
+} as const;
 
 export type ModelTraceStatus =
   | ModelTraceStatusUnset
@@ -123,20 +123,20 @@ export type ModelTraceStatus =
   | ModelTraceStatusError
   | ModelTraceStatusInProgress;
 
-export enum ModelTraceChildToParentFrameMessage {
-  Ready = 'READY',
-}
+export const ModelTraceChildToParentFrameMessage = {
+  Ready: 'READY',
+} as const;
 
 type ModelTraceFrameReadyMessage = {
-  type: ModelTraceChildToParentFrameMessage.Ready;
+  type: typeof ModelTraceChildToParentFrameMessage.Ready;
 };
 
-export enum ModelTraceParentToChildFrameMessage {
-  UpdateTrace = 'UPDATE_TRACE',
-}
+export const ModelTraceParentToChildFrameMessage = {
+  UpdateTrace: 'UPDATE_TRACE',
+} as const;
 
 type ModelTraceFrameUpdateTraceMessage = {
-  type: ModelTraceParentToChildFrameMessage.UpdateTrace;
+  type: typeof ModelTraceParentToChildFrameMessage.UpdateTrace;
   traceData: ModelTrace;
 };
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Gumichocopengin8/mlflow/pull/15112?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15112/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15112/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15112
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Typescript `enum` has issues. 
For example, 
- It won't be tree shook because `enum` becomes `IIFE` after transpile
- Bundle size might get bigger
- If JS support `enum` in the future, we might need to migrate the code
- Not good DX like this
```ts
enum StringEnum {
  Meow = "meow",
}
const foo1: StringEnum = StringEnum.Meow; // compiled
const foo2: StringEnum = "meow";          // not compiled, but we expect it to be compiled
```

Therefore, use `object literal` instead of `enum`

I couldn't find good ESLint rules to bad `enum`, so if we merge this PR, code review should be the way to detect `enum`

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

<img width="308" alt="image" src="https://github.com/user-attachments/assets/ba525989-d115-42c6-9c65-b50237dcfe9a" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
