### PR TITLE
Fix infinite connection wait issue when exporting traces to Databricks

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -737,3 +737,24 @@ MLFLOW_MYSQL_SSL_CERT = _EnvironmentVariable("MLFLOW_MYSQL_SSL_CERT", str, None)
 #: Used when creating a SQLAlchemy engine for MySQL
 #: (default: ``None``)
 MLFLOW_MYSQL_SSL_KEY = _EnvironmentVariable("MLFLOW_MYSQL_SSL_KEY", str, None)
+
+
+#: Timeout in seconds for exporting traces to Databricks monitoring backend.
+#: (default: ``10``)
+MLFLOW_DATABRICKS_TRACE_EXPORT_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_DATABRICKS_TRACE_EXPORT_TIMEOUT", int, 10
+)
+
+#: Maximum allowed HTTP connection size for exporting traces to Databricks monitoring backend.
+#: The default value follows the recommendation in the httpx library https://www.python-httpx.org/advanced/resource-limits/
+#: (default: ``100``)
+MLFLOW_DATABRICKS_TRACE_EXPORT_MAX_CONNECTIONS = _EnvironmentVariable(
+    "MLFLOW_DATABRICKS_TRACE_EXPORT_MAX_CONNECTIONS", int, 100
+)
+
+#: Maximum allowed HTTP keep-alive pool size for exporting traces to Databricks monitoring backend.
+#: The default value follows the recommendation in the httpx library https://www.python-httpx.org/advanced/resource-limits/
+#: (default: ``20``)
+MLFLOW_DATABRICKS_TRACE_EXPORT_KEEP_ALIVE = _EnvironmentVariable(
+    "MLFLOW_DATABRICKS_TRACE_EXPORT_KEEP_ALIVE", int, 20
+)

--- a/mlflow/tracing/export/databricks.py
+++ b/mlflow/tracing/export/databricks.py
@@ -1,20 +1,21 @@
 import logging
 from typing import Sequence
 
+import httpx
 from google.protobuf.json_format import MessageToDict
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter
 
 from mlflow.entities.trace import Trace
-from mlflow.environment_variables import MLFLOW_HTTP_REQUEST_TIMEOUT
+from mlflow.environment_variables import (
+    MLFLOW_DATABRICKS_TRACE_EXPORT_KEEP_ALIVE,
+    MLFLOW_DATABRICKS_TRACE_EXPORT_MAX_CONNECTIONS,
+    MLFLOW_HTTP_REQUEST_TIMEOUT,
+)
 from mlflow.protos.databricks_trace_server_pb2 import CreateTrace, DatabricksTracingServerService
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.utils.databricks_utils import get_databricks_host_creds
-from mlflow.utils.rest_utils import (
-    _REST_API_PATH_PREFIX,
-    extract_api_info_for_service,
-    http_request,
-)
+from mlflow.utils.rest_utils import _REST_API_PATH_PREFIX, extract_api_info_for_service
 
 _logger = logging.getLogger(__name__)
 
@@ -24,10 +25,23 @@ _METHOD_TO_INFO = extract_api_info_for_service(
 )
 
 
+# NB: Set shorter timeout than the default timeout for MLflow HTTP request (120 sec)
+# because we don't want to block the application for too long when exporting traces.
+# Once we switch to asynchronous trace logging, we can increase this timeout.
+_DEFAULT_REQUEST_TIMEOUT = 10
+
+
 class DatabricksSpanExporter(SpanExporter):
     """
     An exporter implementation that logs the traces to Databricks Tracing Server.
     """
+
+    def __init__(self):
+        limits = httpx.Limits(
+            max_keepalive_connections=MLFLOW_DATABRICKS_TRACE_EXPORT_MAX_CONNECTIONS.get(),
+            max_connections=MLFLOW_DATABRICKS_TRACE_EXPORT_KEEP_ALIVE.get(),
+        )
+        self.client = httpx.Client(limits=limits)
 
     def export(self, spans: Sequence[ReadableSpan]):
         """
@@ -52,17 +66,15 @@ class DatabricksSpanExporter(SpanExporter):
     def _log_trace(self, trace: Trace):
         """Create a new Trace record in the Databricks Tracing Server."""
         request_body = MessageToDict(trace.to_proto(), preserving_proto_field_name=True)
-        endpoint, method = _METHOD_TO_INFO[CreateTrace]
 
-        res = http_request(
-            host_creds=get_databricks_host_creds(),
-            endpoint=endpoint,
-            method=method,
-            timeout=MLFLOW_HTTP_REQUEST_TIMEOUT.get(),
-            # Not doing reties here because trace export is currently running synchronously
-            # and we don't want to bottleneck the application by retrying.
+        creds = get_databricks_host_creds()
+        endpoint, _ = _METHOD_TO_INFO[CreateTrace]
+
+        res = self.client.post(
+            url=f"{creds.host}{endpoint}",
             json=request_body,
+            timeout=MLFLOW_HTTP_REQUEST_TIMEOUT.get_raw() or _DEFAULT_REQUEST_TIMEOUT,
+            headers={"Authorization": f"Bearer {creds.token}"},
         )
-
         if res.status_code != 200:
             _logger.warning(f"Failed to log trace to the trace server. Response: {res.text}")

--- a/tests/tracing/export/test_databricks_exporter.py
+++ b/tests/tracing/export/test_databricks_exporter.py
@@ -158,5 +158,5 @@ def test_export_override_configs(monkeypatch):
 
     mock_http.post.assert_called_once()
     mock_httpx_init.assert_called_once_with(
-        limits=httpx.Limits(max_keepalive_connections=10, max_connections=5)
+        limits=httpx.Limits(max_keepalive_connections=5, max_connections=10)
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15122?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15122/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15122/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15122
```

</p>
</details>

### What changes are proposed in this pull request?

We faced weird hanging issue during testing trace export to the Databricks trace server. After close look, the hang happens at [this line](https://github.com/mlflow/mlflow/blob/master/mlflow/tracing/export/databricks.py#L57) and the eventual root cause is that the connection pool is exhausted and new request waits forever to get it [here](https://github.com/urllib3/urllib3/blob/3e8f2db735dcaced6a3b777aa1966f40c018af7c/src/urllib3/connectionpool.py#L766). We seems to be hitting incorrect pool handling or configuration in Databricks SDK.

Switching to `httpx` solved this problem. For trace exporting specifically, we just use Databricks SDK as HTTP wrapper. 

Consequently, this PR adds `httpx` as a core dependency, but it should be fine given the package size (~600KB including dependencies).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
