### PR TITLE
Close connection when exporting traces to Databricks

### DIFF
--- a/mlflow/tracing/export/databricks.py
+++ b/mlflow/tracing/export/databricks.py
@@ -63,10 +63,15 @@ class DatabricksSpanExporter(SpanExporter):
             host_creds=get_databricks_host_creds(),
             endpoint=endpoint,
             method=method,
-            timeout=MLFLOW_HTTP_REQUEST_TIMEOUT.get_raw() or _DEFAULT_TRACE_EXPORT_TIMEOUT,
+            timeout=self._get_timeout(),
             # Not doing reties here because trace export is currently running synchronously
             # and we don't want to bottleneck the application by retrying.
             json=request_body,
         ) as res:
             if res.status_code != 200:
                 _logger.warning(f"Failed to log trace to the trace server. Response: {res.text}")
+
+    def _get_timeout(self) -> int:
+        if MLFLOW_HTTP_REQUEST_TIMEOUT.get_raw() is not None:
+            return int(MLFLOW_HTTP_REQUEST_TIMEOUT.get_raw())
+        return _DEFAULT_TRACE_EXPORT_TIMEOUT

--- a/tests/tracing/export/test_databricks_exporter.py
+++ b/tests/tracing/export/test_databricks_exporter.py
@@ -40,6 +40,7 @@ def test_export(experiment_id, monkeypatch):
     assert call_args.kwargs["host_creds"] is not None
     assert call_args.kwargs["endpoint"] == "/api/2.0/tracing/traces"
     assert call_args.kwargs["method"] == "POST"
+    assert call_args.kwargs["timeout"] == 5
 
     trace = call_args.kwargs["json"]
     trace_id = trace["info"]["trace_id"]

--- a/tests/tracing/export/test_databricks_exporter.py
+++ b/tests/tracing/export/test_databricks_exporter.py
@@ -20,9 +20,13 @@ def _predict(x: str) -> str:
 
 
 @pytest.mark.parametrize("experiment_id", [None, _EXPERIMENT_ID])
-def test_export(experiment_id, monkeypatch):
+@pytest.mark.parametrize("timeout", [None, "100"])
+def test_export(experiment_id, timeout, monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
+
+    if timeout is not None:
+        monkeypatch.setenv("MLFLOW_HTTP_REQUEST_TIMEOUT", timeout)
 
     mlflow.tracing.set_destination(Databricks(experiment_id=experiment_id))
 
@@ -40,7 +44,7 @@ def test_export(experiment_id, monkeypatch):
     assert call_args.kwargs["host_creds"] is not None
     assert call_args.kwargs["endpoint"] == "/api/2.0/tracing/traces"
     assert call_args.kwargs["method"] == "POST"
-    assert call_args.kwargs["timeout"] == 5
+    assert call_args.kwargs["timeout"] == (int(timeout) if timeout is not None else 5)
 
     trace = call_args.kwargs["json"]
     trace_id = trace["info"]["trace_id"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15124?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15124/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15124/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15124
```

</p>
</details>

### What changes are proposed in this pull request?

The HTTP response is not closed and keep holding connection, which caused indefinite hanging when exporting traces.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified concurrently writing 100> traces works.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
