### PR TITLE
fix: disable delete button for the default experiment

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, fireEvent, renderWithIntl } from '../../common/utils/TestUtils.react18';
 import { BrowserRouter } from '../../common/utils/RoutingUtils';
@@ -84,10 +83,27 @@ test('If button to create experiment is pressed then open CreateExperimentModal'
   expect(screen.getByText('Create Experiment')).toBeInTheDocument();
 });
 
+test('should be disabled to delete the default experiment', () => {
+  const localExperiments = [
+    Fixtures.createExperiment(),
+    Fixtures.createExperiment({ experimentId: '1', name: 'Test' }),
+  ];
+  mountComponent({ experiments: localExperiments, activeExperimentIds: ['0', '1'] });
+  const selected = screen.getAllByTestId('active-experiment-list-item');
+  expect(selected.length).toEqual(2);
+  expect(screen.getAllByTestId('delete-experiment-button')[0]).toBeDisabled();
+});
+
 test('If button to delete experiment is pressed then open DeleteExperimentModal', async () => {
-  mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
-  await userEvent.click(screen.getAllByTestId('delete-experiment-button')[0]);
-  expect(screen.getByText(`Delete Experiment "${Fixtures.experiments[0].name}"`)).toBeInTheDocument();
+  const localExperiments = [
+    Fixtures.createExperiment(),
+    Fixtures.createExperiment({ experimentId: '1', name: 'Test' }),
+  ];
+  mountComponent({ experiments: localExperiments, activeExperimentIds: ['0', '1'] });
+  const selected = screen.getAllByTestId('active-experiment-list-item');
+  expect(selected.length).toEqual(2);
+  await userEvent.click(screen.getAllByTestId('delete-experiment-button')[1]);
+  expect(screen.getByText(`Delete Experiment "${localExperiments[1].name}"`)).toBeInTheDocument();
 });
 
 test('If button to edit experiment is pressed then open RenameExperimentModal', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
@@ -15,13 +15,14 @@ import {
 } from '@databricks/design-system';
 import { List as VList, AutoSizer, ListRowRenderer } from 'react-virtualized';
 import 'react-virtualized/styles.css';
-import { Link, NavigateFunction } from '../../common/utils/RoutingUtils';
+import { Link } from '../../common/utils/RoutingUtils';
 import Routes from '../routes';
 import { CreateExperimentModal } from './modals/CreateExperimentModal';
 import { DeleteExperimentModal } from './modals/DeleteExperimentModal';
 import { RenameExperimentModal } from './modals/RenameExperimentModal';
 import { withRouterNext, WithRouterNextProps } from '../../common/utils/withRouterNext';
 import { ExperimentEntity } from '../types';
+import { DEFAULT_EXPERIMENT_ID } from '../constants';
 
 type Props = {
   activeExperimentIds: string[];
@@ -50,7 +51,7 @@ export class ExperimentListView extends Component<Props, State> {
     showCreateExperimentModal: false,
     showDeleteExperimentModal: false,
     showRenameExperimentModal: false,
-    selectedExperimentId: '0',
+    selectedExperimentId: DEFAULT_EXPERIMENT_ID,
     selectedExperimentName: '',
   };
 
@@ -159,6 +160,7 @@ export class ExperimentListView extends Component<Props, State> {
     const { activeExperimentIds } = this.props;
     const isActive = activeExperimentIds.includes(item.experimentId);
     const dataTestId = isActive ? 'active-experiment-list-item' : 'experiment-list-item';
+    const isDefaultExperiment = item.experimentId === DEFAULT_EXPERIMENT_ID;
     const { theme } = this.props.designSystemThemeApi;
     // Clicking the link removes all checks and marks other experiments
     // as not active.
@@ -167,10 +169,9 @@ export class ExperimentListView extends Component<Props, State> {
         css={{
           display: 'flex',
           alignItems: 'center',
-          // gap: theme.spacing.xs,
           paddingLeft: theme.spacing.xs,
           paddingRight: theme.spacing.xs,
-          borderLeft: isActive ? `solid ${theme.colors.primary}` : 'solid transparent',
+          borderLeft: isActive ? `solid ${theme.colors.actionPrimaryBackgroundDefault}` : 'solid transparent',
           borderLeftWidth: 4,
           backgroundColor: isActive ? theme.colors.actionDefaultBackgroundPress : 'transparent',
           fontSize: theme.typography.fontSizeBase,
@@ -211,9 +212,13 @@ export class ExperimentListView extends Component<Props, State> {
             size="small"
           />
         </Tooltip>
-        <Tooltip componentId="mlflow.experiment_list_view.delete_experiment_button.tooltip" content="Delete experiment">
+        <Tooltip
+          componentId="mlflow.experiment_list_view.delete_experiment_button.tooltip"
+          content={isDefaultExperiment ? 'Default experiment cannot be deleted' : 'Delete experiment'}
+        >
           <Button
             type="link"
+            disabled={isDefaultExperiment}
             componentId="mlflow.experiment_list_view.delete_experiment_button"
             icon={<TrashIcon />}
             onClick={this.handleDeleteExperiment(item.experimentId, item.name)}

--- a/mlflow/server/js/src/experiment-tracking/constants.ts
+++ b/mlflow/server/js/src/experiment-tracking/constants.ts
@@ -137,3 +137,5 @@ export enum ExperimentPageTabName {
   Datasets = 'datasets',
   LabelingSessions = 'labeling-sessions',
 }
+
+export const DEFAULT_EXPERIMENT_ID = '0';

--- a/mlflow/server/js/src/experiment-tracking/utils/test-utils/Fixtures.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/test-utils/Fixtures.ts
@@ -1,7 +1,8 @@
+import { DEFAULT_EXPERIMENT_ID } from '../../constants';
 import { ExperimentEntity, RunInfoEntity } from '../../types';
 
 const createExperiment = ({
-  experimentId = '0',
+  experimentId = DEFAULT_EXPERIMENT_ID,
   name = 'Default',
   artifactLocation = 'dbfs:/databricks/mlflow/0',
   lifecycleStage = 'active',
@@ -21,7 +22,7 @@ const createExperiment = ({
 const createRunInfo = (): RunInfoEntity => {
   return {
     runUuid: '0',
-    experimentId: '0',
+    experimentId: DEFAULT_EXPERIMENT_ID,
     artifactUri: '',
     endTime: 0,
     status: 'RUNNING',


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Gumichocopengin8/mlflow/pull/15142?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15142/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15142/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15142
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

It is prohibited to delete the default experiment, but the delete button is active even if API sends `unable to delete the default experiment` error. For the better UX, let's disable the delete button for the default experiment. 

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

<img width="337" alt="image" src="https://github.com/user-attachments/assets/bee97e4d-0adf-476a-bba0-e05d6d3c4d7f" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
