### PR TITLE
Fix tracing for Anthropic and Langchain combination

### DIFF
--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -55,7 +55,7 @@ def convert_lc_message_to_chat_message(lc_message: Union[BaseMessage]) -> ChatMe
             content = lc_message.content
             # For Anthropic model tool calls are returned twice so we need to filter them out from content
             if isinstance(content, list):
-                content = filter(lambda c: c['type'] != 'tool_use', content)
+                content = [c for c in content if c["type"] != "tool_use"]
             return ChatMessage(
                 role="assistant",
                 # If tool calls present, content null value should be None not empty string

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -53,7 +53,7 @@ def convert_lc_message_to_chat_message(lc_message: Union[BaseMessage]) -> ChatMe
     if isinstance(lc_message, AIMessage):
         if tool_calls := _get_tool_calls_from_ai_message(lc_message):
             content = lc_message.content
-            # For Anthropic model tool calls are returned twice so we need to filter them out from content
+            # For Anthropic model tool calls are returned twice so we need to filter them out
             if isinstance(content, list):
                 content = [c for c in content if c["type"] != "tool_use"]
             return ChatMessage(
@@ -261,7 +261,9 @@ def try_transform_response_iter_to_chat_format(chunk_iter):
     return map(_convert, chunk_iter)
 
 
-def _convert_chat_request_or_throw(chat_request: dict[str, Any]) -> list[Union[BaseMessage]]:
+def _convert_chat_request_or_throw(
+    chat_request: dict[str, Any],
+) -> list[Union[BaseMessage]]:
     model = ChatCompletionRequest.validate_compat(chat_request)
     return [_chat_model_to_langchain_message(message) for message in model.messages]
 
@@ -377,7 +379,9 @@ def parse_token_usage(
     return dict(aggregated) if aggregated else None
 
 
-def _parse_token_usage_from_generation(generation: Generation) -> Optional[dict[str, int]]:
+def _parse_token_usage_from_generation(
+    generation: Generation,
+) -> Optional[dict[str, int]]:
     message = getattr(generation, "message", None)
     if not message:
         return None

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -52,12 +52,16 @@ def convert_lc_message_to_chat_message(lc_message: Union[BaseMessage]) -> ChatMe
     """
     if isinstance(lc_message, AIMessage):
         if tool_calls := _get_tool_calls_from_ai_message(lc_message):
+            content = lc_message.content
+            # For Anthropic model tool calls are returned twice so we need to filter them out from content
+            if isinstance(content, list):
+                content = filter(lambda c: c['type'] != 'tool_use', content)
             return ChatMessage(
                 role="assistant",
                 # If tool calls present, content null value should be None not empty string
                 # according to the OpenAI spec, which ChatMessage is following
                 # Ref: https://github.com/langchain-ai/langchain/blob/32917a0b98cb8edcfb8d0e84f0878434e1c3f192/libs/partners/openai/langchain_openai/chat_models/base.py#L116-L117
-                content=lc_message.content or None,
+                content=content or None,
                 tool_calls=tool_calls,
             )
         else:

--- a/tests/langchain/test_chat_utils.py
+++ b/tests/langchain/test_chat_utils.py
@@ -34,6 +34,26 @@ from mlflow.types.chat import ToolCall as _ToolCall
             ChatMessage(role="assistant", content="foo", id="123"),
         ),
         (
+            AIMessage(
+                content=[
+                    {"type": "text", "text": "Response text"},
+                    {"type": "tool_use", "id": "123", "name": "tool"},
+                ],
+                tool_calls=[{"id": "123", "name": "tool", "args": {}, "type": "tool_call"}],
+            ),
+            ChatMessage(
+                role="assistant",
+                content=[{"type": "text", "text": "Response text"}],
+                tool_calls=[
+                    _ToolCall(
+                        id="123",
+                        type="function",
+                        function=Function(name="tool", arguments="{}"),
+                    )
+                ],
+            ),
+        ),
+        (
             ToolMessage(content="foo", tool_call_id="123"),
             ChatMessage(role="tool", content="foo", tool_call_id="123"),
         ),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/maver1ck/mlflow/pull/15151?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15151/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15151/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15151
```

</p>
</details>

### Related Issues/PRs

Fixes: https://github.com/mlflow/mlflow/issues/15150

### What changes are proposed in this pull request?

Workaround for exception when doing tracing of Anthropic Langchain AIMessage with tool_use

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
