### PR TITLE
Exhaust stream and close connection when making an HTTP request with databricks SDK

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -85,7 +85,7 @@ def _read_log_model_allowlist_from_file(allowlist_file):
             username=url_parsed.username,
             password=url_parsed.password,
         )
-        response = http_request(host_creds=host_creds, endpoint=path, method="GET")
+        response = http_request(host_creds=host_creds, endpoint=path, method="GET", stream=True)
         augmented_raise_for_status(response)
         return _parse_allowlist_file(response.iter_lines(decode_unicode=True))
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -113,6 +113,9 @@ def http_request(
                 files=kwargs.get("files"),
                 data=kwargs.get("data"),
             )
+            if kwargs.get("stream", False):
+                return raw_response["contents"]._response
+
             with raw_response["contents"]._response as resp:
                 # Exhaust the stream before closing the response
                 # https://github.com/psf/requests/blob/1764cc938efc3cc9720188dfa6c3852c45211aa0/src/requests/models.py#L890-L907

--- a/tests/deployments/databricks/test_databricks.py
+++ b/tests/deployments/databricks/test_databricks.py
@@ -1,4 +1,6 @@
+import json
 import os
+from dataclasses import dataclass
 from unittest import mock
 
 import pytest
@@ -18,12 +20,34 @@ def test_get_deploy_client():
     get_deploy_client("databricks://scope:prefix")
 
 
+@dataclass
+class MockResponse:
+    url: str
+    status_code: int
+    content: str
+
+    def json(self):
+        return json.loads(self.content)
+
+    @property
+    def ok(self):
+        return self.status_code == 200
+
+    def raise_for_status(self):
+        assert self.ok
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
 def test_create_endpoint():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"name": "test"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"name": "test"})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.create_endpoint(
             name="test",
@@ -49,10 +73,9 @@ def test_create_endpoint():
 
 def test_create_endpoint_config_only():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"name": "test"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"name": "test"})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.create_endpoint(
             config={
@@ -84,10 +107,9 @@ def test_create_endpoint_name_match():
     Should emit a deprecation warning about using name parameter.
     """
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"name": "test"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"name": "test"})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         with pytest.warns(
             UserWarning,
@@ -124,10 +146,9 @@ def test_create_endpoint_name_mismatch():
     Should raise an MlflowException.
     """
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"name": "test"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"name": "test"})
+    )
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         with pytest.raises(
@@ -165,10 +186,9 @@ def test_create_endpoint_route_optimized_match():
     Should emit a deprecation warning.
     """
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"name": "test"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"name": "test"})
+    )
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         with pytest.warns(
@@ -208,10 +228,9 @@ def test_create_endpoint_route_optimized_mismatch():
     Should raise an MlflowException.
     """
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"name": "test"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"name": "test"})
+    )
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         with pytest.raises(
@@ -251,10 +270,9 @@ def test_create_endpoint_named_name():
     Should emit a deprecation warning about the old format.
     """
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"name": "test"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"name": "test"})
+    )
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         with pytest.warns(
@@ -290,10 +308,9 @@ def test_create_endpoint_named_route_optimized():
     Should emit a deprecation warning about the old format.
     """
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"name": "test"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"name": "test"})
+    )
 
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         with pytest.warns(
@@ -327,10 +344,9 @@ def test_create_endpoint_named_route_optimized():
 
 def test_get_endpoint():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"name": "test"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"name": "test"})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.get_endpoint(endpoint="test")
         mock_request.assert_called_once()
@@ -339,10 +355,11 @@ def test_get_endpoint():
 
 def test_list_endpoints():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"endpoints": [{"name": "test"}]}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"],
+        status_code=200,
+        content=json.dumps({"endpoints": [{"name": "test"}]}),
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.list_endpoints()
         mock_request.assert_called_once()
@@ -351,10 +368,9 @@ def test_list_endpoints():
 
 def test_update_endpoint():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         with pytest.warns(
             UserWarning,
@@ -386,10 +402,9 @@ def test_update_endpoint():
 
 def test_update_endpoint_config():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.update_endpoint_config(
             endpoint="test",
@@ -415,10 +430,9 @@ def test_update_endpoint_config():
 
 def test_update_endpoint_tags():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.update_endpoint_tags(
             endpoint="test",
@@ -430,10 +444,9 @@ def test_update_endpoint_tags():
 
 def test_update_endpoint_rate_limits():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.update_endpoint_rate_limits(
             endpoint="test",
@@ -445,10 +458,9 @@ def test_update_endpoint_rate_limits():
 
 def test_update_endpoint_ai_gateway():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.update_endpoint_ai_gateway(
             endpoint="test",
@@ -467,10 +479,9 @@ def test_update_endpoint_ai_gateway():
 
 def test_delete_endpoint():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.delete_endpoint(endpoint="test")
         mock_request.assert_called_once()
@@ -479,10 +490,9 @@ def test_delete_endpoint():
 
 def test_predict():
     client = get_deploy_client("databricks")
-    mock_resp = mock.Mock()
-    mock_resp.json.return_value = {"foo": "bar"}
-    mock_resp.url = os.environ["DATABRICKS_HOST"]
-    mock_resp.status_code = 200
+    mock_resp = MockResponse(
+        url=os.environ["DATABRICKS_HOST"], status_code=200, content=json.dumps({"foo": "bar"})
+    )
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         resp = client.predict(endpoint="test", inputs={})
         mock_request.assert_called_once()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15155?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15155/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15155/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15155
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

We pass `raw=True` to databricks SDK to get the raw response in `http_request`. `raw=True` is equivalent to `stream=True`, which can cause a hang when the response is not closed (#15124). This PR fixes this issue.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
