### PR TITLE
Fix for tuple return type of dspy.Evaluate

### DIFF
--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -264,9 +264,10 @@ class MlflowCallback(BaseCallback):
         if exception:
             mlflow.end_run(status=RunStatus.to_string(RunStatus.FAILED))
             return
+        score = None
         if isinstance(outputs, float):
             score = outputs
-        elif isinstance(outputs, list):
+        elif isinstance(outputs, tuple):
             score = outputs[0]
         elif isinstance(outputs, dspy.Prediction):
             score = float(outputs)
@@ -274,7 +275,8 @@ class MlflowCallback(BaseCallback):
                 mlflow.log_table(self._generate_result_table(outputs.outputs), "result_table.json")
             except Exception:
                 _logger.debug("Failed to log result table.", exc_info=True)
-        mlflow.log_metric("eval", score)
+        if score is not None:
+            mlflow.log_metric("eval", score)
 
         if self._call_id_to_run_id.pop(call_id, None):
             mlflow.end_run()
@@ -282,11 +284,12 @@ class MlflowCallback(BaseCallback):
             if call_id not in self._call_id_to_metric_key:
                 return
             key, step = self._call_id_to_metric_key.pop(call_id)
-            mlflow.log_metric(
-                key,
-                score,
-                step=step,
-            )
+            if score is not None:
+                mlflow.log_metric(
+                    key,
+                    score,
+                    step=step,
+                )
 
     def reset(self):
         self._call_id_to_metric_key: dict[str, tuple[str, int]] = {}

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -646,11 +646,12 @@ skip_if_evaluate_callback_unavailable = pytest.mark.skipif(
 
 
 # Evaluate.call starts to return dspy.Prediction since 2.7.0
-is_result_table_available = Version(importlib.metadata.version("dspy")) >= Version("2.7.0")
+is_2_7_or_newer = Version(importlib.metadata.version("dspy")) >= Version("2.7.0")
 
 
 @skip_if_evaluate_callback_unavailable
 @pytest.mark.parametrize("log_evals", [True, False])
+@pytest.mark.parametrize("return_outputs", [True, False])
 @pytest.mark.parametrize(
     ("lm", "examples", "expected_result_table"),
     [
@@ -702,10 +703,18 @@ is_result_table_available = Version(importlib.metadata.version("dspy")) >= Versi
         ),
     ],
 )
-def test_autolog_log_evals(tmp_path, log_evals, lm, examples, expected_result_table):
+def test_autolog_log_evals(
+    tmp_path, log_evals, return_outputs, lm, examples, expected_result_table
+):
     dspy.settings.configure(lm=lm)
     program = Predict("question -> answer")
-    evaluator = Evaluate(devset=examples, metric=answer_exact_match)
+    if is_2_7_or_newer:
+        evaluator = Evaluate(devset=examples, metric=answer_exact_match)
+    else:
+        # return_outputs arg does not exist after 2.7
+        evaluator = Evaluate(
+            devset=examples, metric=answer_exact_match, return_outputs=return_outputs
+        )
 
     mlflow.dspy.autolog(log_evals=log_evals)
     evaluator(program, devset=examples)
@@ -724,7 +733,7 @@ def test_autolog_log_evals(tmp_path, log_evals, lm, examples, expected_result_ta
         client = MlflowClient()
         artifacts = (x.path for x in client.list_artifacts(run.info.run_id))
         assert "model.json" in artifacts
-        if is_result_table_available:
+        if is_2_7_or_newer:
             assert "result_table.json" in artifacts
             client.download_artifacts(
                 run_id=run.info.run_id, path="result_table.json", dst_path=tmp_path


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15157?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15157/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15157/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15157
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This fixes a bug where scores are not logged correctly when dspy.Evaluate return a tuple

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
