### PR TITLE
Implement async export for Databricks trace export and make it default

### DIFF
--- a/docs/docs/tracing/api/how-to.mdx
+++ b/docs/docs/tracing/api/how-to.mdx
@@ -205,3 +205,11 @@ with mlflow.start_span(name="foo") as span:
 ```
 
 Note that the async logging does not fully eliminate the performance overhead. Some backend calls still need to be made synchronously and there are other factors such as data serialization. However, async logging can significantly reduce the overall overhead of logging traces, empirically about ~80% for typical workloads.
+
+The following configurations are available for async logging:
+
+| Environment Variable | Description | Default Value |
+|----------------------|-------------|---------------|
+|`MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS`|The maximum number of worker threads to use for async trace logging.|`10`|
+|`MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE`|The maximum number of traces that can be queued for logging. Traces will be discarded if the queue is full.|`1000`|
+|`MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`|Timeout in seconds for retrying failed trace logging. Namely, failed traces will be retried up to this timeout with backoff, after which they will be discarded.|`60`|

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -742,6 +742,13 @@ MLFLOW_MYSQL_SSL_CERT = _EnvironmentVariable("MLFLOW_MYSQL_SSL_CERT", str, None)
 MLFLOW_MYSQL_SSL_KEY = _EnvironmentVariable("MLFLOW_MYSQL_SSL_KEY", str, None)
 
 
+#: Specifies whether to enable async trace logging to Databricks Tracing Server.
+#: TODO: Update OSS MLflow Server to logging async by default
+#: Default: ``True``.
+MLFLOW_ENABLE_ASYNC_TRACE_LOGGING = _BooleanEnvironmentVariable(
+    "MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", True
+)
+
 #: Maximum number of worker threads to use for async trace logging.
 #: (default: ``10``)
 MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS = _EnvironmentVariable(

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -32,6 +32,9 @@ class _EnvironmentVariable:
     def unset(self):
         os.environ.pop(self.name, None)
 
+    def is_set(self):
+        return self.name in os.environ
+
     def get(self):
         """
         Reads the value of the environment variable if it exists and converts it to the desired
@@ -737,3 +740,24 @@ MLFLOW_MYSQL_SSL_CERT = _EnvironmentVariable("MLFLOW_MYSQL_SSL_CERT", str, None)
 #: Used when creating a SQLAlchemy engine for MySQL
 #: (default: ``None``)
 MLFLOW_MYSQL_SSL_KEY = _EnvironmentVariable("MLFLOW_MYSQL_SSL_KEY", str, None)
+
+
+#: Maximum number of worker threads to use for async trace logging.
+#: (default: ``10``)
+MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS = _EnvironmentVariable(
+    "MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS", int, 10
+)
+
+#: Maximum number of export tasks to queue for async trace logging.
+#: When the queue is full, new export tasks will be dropped.
+#: (default: ``1000``)
+MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE = _EnvironmentVariable(
+    "MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE", int, 1000
+)
+
+
+#: Timeout seconds for retrying async trace logging.
+#: (default: ``60``)
+MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", int, 60
+)

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -1,0 +1,167 @@
+import atexit
+import logging
+import threading
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from dataclasses import dataclass
+from queue import Empty, Queue
+from queue import Full as queue_Full
+from typing import Callable, Sequence
+
+from mlflow.environment_variables import (
+    MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE,
+    MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS,
+)
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Task:
+    """A dataclass to represent a simple task."""
+
+    handler: Callable
+    args: Sequence
+    error_msg: str = ""
+
+    def handle(self) -> None:
+        """Handle the task execution. This method must not raise any exception."""
+        try:
+            self.handler(*self.args)
+        except Exception as e:
+            _logger.warning(
+                f"{self.error_msg} Error: {e}.",
+                exc_info=_logger.isEnabledFor(logging.DEBUG),
+            )
+
+
+class AsyncTraceExportQueue:
+    """A queue-based asynchronous tracing export processor."""
+
+    def __init__(self):
+        self._queue: Queue[Task] = Queue(maxsize=MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE.get())
+        self._lock = threading.RLock()
+        self._max_workers = MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS.get()
+
+        # Thread event that indicates the queue should stop processing tasks
+        self._stop_event = threading.Event()
+        self._is_active = False
+        self._atexit_callback_registered = False
+
+        self._active_tasks = set()
+
+    def put(self, task: Task):
+        """Put a new task to the queue for processing."""
+        if not self.is_active():
+            self.activate()
+
+        # If stop event is set, wait for the queue to be drained before putting the task
+        if self._stop_event.is_set():
+            self._stop_event.wait()
+
+        try:
+            # Do not block if the queue is full, it will block the main application
+            self._queue.put(task, block=False)
+        except queue_Full:
+            _logger.warning(
+                "Trace export queue is full, trace will be discarded. "
+                "Consider increasing the queue size or number of workers."
+            )
+
+    def _consumer_loop(self) -> None:
+        while not self._stop_event.is_set():
+            self._dispatch_task()
+
+        # Drain remaining tasks when stopping
+        while not self._queue.empty():
+            self._dispatch_task()
+
+    def _dispatch_task(self) -> None:
+        """Dispatch a task from the queue to the worker thread pool."""
+        # NB: Monitor number of active tasks being processed by the workers. If the all
+        #   workers are busy, wait for one of them to finish before draining a new task
+        #   from the queue. This is because ThreadPoolExecutor does not have a built-in
+        #   mechanism to limit the number of pending tasks in the internal queue.
+        #   This ruins the purpose of having a size bound for self._queue, because the
+        #   TPE's internal queue can grow indefinitely and potentially run out of memory.
+        #   Therefore, we should only dispatch a new task when there is a worker available,
+        #   and pend the new tasks in the self._queue which has a size bound.
+        if len(self._active_tasks) >= self._max_workers:
+            _, self._active_tasks = wait(self._active_tasks, return_when=FIRST_COMPLETED)
+
+        try:
+            task = self._queue.get(timeout=1)
+        except Empty:
+            return
+
+        def _handle(task):
+            task.handle()
+            self._queue.task_done()
+
+        future = self._worker_threadpool.submit(_handle, task)
+        self._active_tasks.add(future)
+
+    def activate(self) -> None:
+        """Activate the async queue to accept and handle incoming tasks."""
+        with self._lock:
+            if self._is_active:
+                return
+
+            self._set_up_threads()
+
+            # Callback to ensure remaining tasks are processed before program exit
+            if not self._atexit_callback_registered:
+                atexit.register(self._at_exit_callback)
+                self._atexit_callback_registered = True
+
+            self._is_active = True
+
+    def is_active(self) -> bool:
+        return self._is_active
+
+    def _set_up_threads(self) -> None:
+        """Set up the consumer and worker threads."""
+        with self._lock:
+            self._worker_threadpool = ThreadPoolExecutor(
+                max_workers=self._max_workers,
+                thread_name_prefix="MlflowTraceLoggingWorker",
+            )
+            self._consumer_thread = threading.Thread(
+                target=self._consumer_loop,
+                name="MLflowTraceLoggingConsumer",
+                daemon=True,
+            )
+            self._consumer_thread.start()
+
+    def _at_exit_callback(self) -> None:
+        """Callback function executed when the program is exiting."""
+        try:
+            _logger.info("Flushing the async trace logging queue before program exit. "
+                         "This may take a while...")
+            self.flush(terminate=True)
+        except Exception as e:
+            _logger.error(f"Error while finishing trace export requests: {e}")
+
+    def flush(self, terminate=False) -> None:
+        """
+        Flush the async logging queue.
+
+        Args:
+            terminate: If True, shut down the logging threads after flushing.
+        """
+        if not self.is_active():
+            return
+
+        self._stop_event.set()
+        self._consumer_thread.join()
+
+        # Wait for all tasks to be processed
+        self._queue.join()
+
+        self._worker_threadpool.shutdown(wait=True)
+        self._is_active = False
+        # Restart threads to listen to incoming requests after flushing, if not terminating
+        if not terminate:
+            self._stop_event.clear()
+            self.activate()

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -137,8 +137,10 @@ class AsyncTraceExportQueue:
     def _at_exit_callback(self) -> None:
         """Callback function executed when the program is exiting."""
         try:
-            _logger.info("Flushing the async trace logging queue before program exit. "
-                         "This may take a while...")
+            _logger.info(
+                "Flushing the async trace logging queue before program exit. "
+                "This may take a while..."
+            )
             self.flush(terminate=True)
         except Exception as e:
             _logger.error(f"Error while finishing trace export requests: {e}")

--- a/mlflow/tracing/export/databricks.py
+++ b/mlflow/tracing/export/databricks.py
@@ -8,7 +8,7 @@ from opentelemetry.sdk.trace.export import SpanExporter
 from mlflow.entities.trace import Trace
 from mlflow.environment_variables import (
     MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT,
-    MLFLOW_ENABLE_ASYNC_LOGGING,
+    MLFLOW_ENABLE_ASYNC_TRACE_LOGGING,
 )
 from mlflow.protos.databricks_trace_server_pb2 import CreateTrace, DatabricksTracingServerService
 from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task
@@ -34,12 +34,7 @@ class DatabricksSpanExporter(SpanExporter):
     """
 
     def __init__(self):
-        # Default to async logging when MLFLOW_ENABLE_ASYNC_LOGGING is not explicitly
-        # set to False.
-        self._is_async = True
-        if MLFLOW_ENABLE_ASYNC_LOGGING.is_set():
-            self._is_async = MLFLOW_ENABLE_ASYNC_LOGGING.get()
-
+        self._is_async = MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
         if self._is_async:
             _logger.info("MLflow is configured to log traces asynchronously.")
             self._async_queue = AsyncTraceExportQueue()

--- a/mlflow/tracing/export/databricks.py
+++ b/mlflow/tracing/export/databricks.py
@@ -6,8 +6,12 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter
 
 from mlflow.entities.trace import Trace
-from mlflow.environment_variables import MLFLOW_HTTP_REQUEST_TIMEOUT
+from mlflow.environment_variables import (
+    MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT,
+    MLFLOW_ENABLE_ASYNC_LOGGING,
+)
 from mlflow.protos.databricks_trace_server_pb2 import CreateTrace, DatabricksTracingServerService
+from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.rest_utils import (
@@ -23,15 +27,22 @@ _METHOD_TO_INFO = extract_api_info_for_service(
     DatabricksTracingServerService, _REST_API_PATH_PREFIX
 )
 
-# NB: Setting lower default timeout for trace export to avoid blocking the application
-# We can increase this value when the trace export is updated to async.
-_DEFAULT_TRACE_EXPORT_TIMEOUT = 5
-
 
 class DatabricksSpanExporter(SpanExporter):
     """
     An exporter implementation that logs the traces to Databricks Tracing Server.
     """
+
+    def __init__(self):
+        # Default to async logging when MLFLOW_ENABLE_ASYNC_LOGGING is not explicitly
+        # set to False.
+        self._is_async = True
+        if MLFLOW_ENABLE_ASYNC_LOGGING.is_set():
+            self._is_async = MLFLOW_ENABLE_ASYNC_LOGGING.get()
+
+        if self._is_async:
+            _logger.info("MLflow is configured to log traces asynchronously.")
+            self._async_queue = AsyncTraceExportQueue()
 
     def export(self, spans: Sequence[ReadableSpan]):
         """
@@ -51,27 +62,35 @@ class DatabricksSpanExporter(SpanExporter):
                 _logger.debug(f"Trace for span {span} not found. Skipping export.")
                 continue
 
-            self._log_trace(trace)
+            if self._is_async:
+                self._async_queue.put(
+                    task=Task(
+                        handler=self._log_trace,
+                        args=(trace,),
+                        error_msg="Failed to log trace to the trace server.",
+                    )
+                )
+            else:
+                self._log_trace(trace)
 
     def _log_trace(self, trace: Trace):
         """Create a new Trace record in the Databricks Tracing Server."""
         request_body = MessageToDict(trace.to_proto(), preserving_proto_field_name=True)
         endpoint, method = _METHOD_TO_INFO[CreateTrace]
 
+        # NB: Using Databricks SDK's built-in retry logic, which simply retries until the timeout
+        #    is reached, with linearly increasing backoff. Since it doesn't expose additional
+        #    configuration options, we might want to implement our own retry logic in the future.
+        # NB: If async logging is disabled, we don't retry to avoid blocking the application.
+        timeout = MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT.get() if self._is_async else 0
+
         # Use context manager to ensure the request is closed properly
         with http_request(
             host_creds=get_databricks_host_creds(),
             endpoint=endpoint,
             method=method,
-            timeout=self._get_timeout(),
-            # Not doing reties here because trace export is currently running synchronously
-            # and we don't want to bottleneck the application by retrying.
             json=request_body,
+            retry_timeout_seconds=timeout,
         ) as res:
             if res.status_code != 200:
                 _logger.warning(f"Failed to log trace to the trace server. Response: {res.text}")
-
-    def _get_timeout(self) -> int:
-        if MLFLOW_HTTP_REQUEST_TIMEOUT.get_raw() is not None:
-            return int(MLFLOW_HTTP_REQUEST_TIMEOUT.get_raw())
-        return _DEFAULT_TRACE_EXPORT_TIMEOUT

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -1,9 +1,5 @@
-import atexit
 import logging
-import threading
-from concurrent.futures import ThreadPoolExecutor
-from queue import Empty, Queue
-from typing import Callable, Optional, Sequence
+from typing import Optional, Sequence
 
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter
@@ -13,6 +9,7 @@ from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_LOGGING
 from mlflow.tracing.constant import TraceTagKey
 from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.display.display_handler import IPythonTraceDisplayHandler
+from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task
 from mlflow.tracing.fluent import _EVAL_REQUEST_ID_TO_TRACE_ID, _set_last_active_trace_id
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import maybe_get_request_id
@@ -45,7 +42,7 @@ class MlflowSpanExporter(SpanExporter):
         self._client = client or MlflowClient()
         self._display_handler = display_handler or get_display_handler()
         self._trace_manager = InMemoryTraceManager.get_instance()
-        self._async_queue = AsyncTraceExportQueue(self._client)
+        self._async_queue = AsyncTraceExportQueue()
 
     def export(self, spans: Sequence[ReadableSpan]):
         """
@@ -99,133 +96,3 @@ class MlflowSpanExporter(SpanExporter):
         else:
             upload_trace_data_task.handle()
             upload_ended_trace_info_task.handle()
-
-
-class Task:
-    """A dataclass to represent a task to be processed by the async trace export queue."""
-
-    def __init__(self, handler: Callable, args: Sequence, error_msg: str = ""):
-        self._handler = handler
-        self._args = args
-        self._error_msg = error_msg
-
-    def handle(self):
-        """Handle the task. This method must not raise any exception."""
-        try:
-            self._handler(*self._args)
-        except Exception as e:
-            _logger.warning(
-                f"{self._error_msg} Error: {e}. For full traceback, set logging level to debug.",
-                exc_info=_logger.isEnabledFor(logging.DEBUG),
-            )
-
-
-class AsyncTraceExportQueue:
-    """
-    This is a queue based run data processor that queue incoming data and process it using a single
-    worker thread. This class is used to process traces saving in async fashion.
-    """
-
-    def __init__(self, client) -> None:
-        self._queue: Queue[Task] = Queue()
-        self._client = client
-        self._lock = threading.RLock()
-
-        # A thread event that indicates the logging queue stop processing task.
-        self._stop_event = threading.Event()
-        self._is_activated = False
-        self._unprocessed_tasks = set()
-        self._atexit_callback_registered = False
-
-    def put(self, task: Task) -> None:
-        """Put a new task to the queue for processing."""
-        if not self.is_active():
-            self.activate()
-
-        # If stop event is set, we should wait for the queue to be drained before putting the task.
-        if self._stop_event.is_set():
-            self._stop_event.wait()
-
-        self._unprocessed_tasks.add(task)
-        self._queue.put(task)
-
-    def _logging_loop(self) -> None:
-        """
-        Continuously process incoming tasks in the queue until the stop event is set.
-        When the stop event is set, the loop will drain the remaining tasks in the queue.
-        """
-        while not self._stop_event.is_set():
-            self._handle_task()
-        while not self._queue.empty() or self._unprocessed_tasks:
-            self._handle_task()
-
-    def _handle_task(self) -> None:
-        """Process the given task in the running runs queues."""
-        try:
-            task = self._queue.get(timeout=1)
-        except Empty:
-            return
-
-        def _handle(task):
-            task.handle()
-            self._unprocessed_tasks.discard(task)
-
-        self._trace_logging_worker_threadpool.submit(_handle, task)
-
-    def activate(self) -> None:
-        """Activates the async logging queue"""
-        with self._lock:
-            if self._is_activated:
-                return
-
-            self._set_up_logging_thread()
-            # Registering an atexit callback to ensure that any remaining log data
-            # is flushed before the program exits.
-            if not self._atexit_callback_registered:
-                atexit.register(self._at_exit_callback)
-                self._atexit_callback_registered = True
-            self._is_activated = True
-
-    def is_active(self) -> bool:
-        return self._is_activated
-
-    def _set_up_logging_thread(self) -> None:
-        """Sets up the logging thread."""
-        with self._lock:
-            self._trace_logging_thread = threading.Thread(
-                target=self._logging_loop,
-                name="MLflowTraceLoggingLoop",
-                daemon=True,
-            )
-            self._trace_logging_worker_threadpool = ThreadPoolExecutor(
-                max_workers=5,
-                thread_name_prefix="MLflowTraceLoggingWorkerPool",
-            )
-            self._trace_logging_thread.start()
-
-    def _at_exit_callback(self) -> None:
-        """Callback function to be executed when the program is exiting."""
-        try:
-            self.flush(terminate=True)
-        except Exception as e:
-            _logger.error(f"Encountered error while trying to finish logging: {e}")
-
-    def flush(self, terminate=False) -> None:
-        """
-        Flush the async logging queue.
-
-        Args:
-            terminate: If True, shut down the logging threads after flushing.
-        """
-        if not self.is_active():
-            return
-
-        self._stop_event.set()
-        self._trace_logging_thread.join()
-        self._trace_logging_worker_threadpool.shutdown(wait=True)
-        self._is_activated = False
-
-        # Restart the thread to listen to incoming data after flushing.
-        if not terminate:
-            self._stop_event.clear()
-            self.activate()

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -90,6 +90,8 @@ class MlflowSpanExporter(SpanExporter):
             error_msg="Failed to log trace to MLflow backend.",
         )
 
+        # TODO: Use MLFLOW_ENABLE_ASYNC_TRACE_LOGGING instead and default to async
+        # logging once the async logging implementation becomes stable.
         if MLFLOW_ENABLE_ASYNC_LOGGING.get():
             self._async_queue.put(upload_trace_data_task)
             self._async_queue.put(upload_ended_trace_info_task)

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -54,6 +54,7 @@ def http_request(
     timeout=None,
     raise_on_status=True,
     respect_retry_after_header=None,
+    retry_timeout_seconds=None,
     **kwargs,
 ):
     """Makes an HTTP request with the specified method to the specified hostname/endpoint. Transient
@@ -79,6 +80,7 @@ def http_request(
             in retry_codes range and retries have been exhausted.
         respect_retry_after_header: Whether to respect Retry-After header on status codes defined
             as Retry.RETRY_AFTER_STATUS_CODES or not.
+        retry_timeout_seconds: Timeout for retires. Only effective when using Databricks SDK.
         kwargs: Additional keyword arguments to pass to `requests.Session.request()`
 
     Returns:
@@ -95,6 +97,7 @@ def http_request(
             host_creds.host,
             host_creds.token,
             host_creds.databricks_auth_profile,
+            retry_timeout_seconds=retry_timeout_seconds,
         )
         try:
             # Databricks SDK `APIClient.do` API is for making request using
@@ -205,7 +208,13 @@ def http_request(
 
 
 @lru_cache(maxsize=1)
-def get_workspace_client(use_secret_scope_token, host, token, databricks_auth_profile):
+def get_workspace_client(
+    use_secret_scope_token,
+    host,
+    token,
+    databricks_auth_profile,
+    retry_timeout_seconds=None,
+):
     from databricks.sdk import WorkspaceClient
     from databricks.sdk.config import Config
 
@@ -215,7 +224,8 @@ def get_workspace_client(use_secret_scope_token, host, token, databricks_auth_pr
         kwargs = {"profile": databricks_auth_profile}
     config = Config(
         **kwargs,
-        retry_timeout_seconds=MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT.get(),
+        retry_timeout_seconds=retry_timeout_seconds
+        or MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT.get(),
     )
     # Note: If we use `config` param, all SDK configurations must be set in `config` object.
     return WorkspaceClient(config=config)

--- a/tests/tracing/export/test_async_export_queue.py
+++ b/tests/tracing/export/test_async_export_queue.py
@@ -1,0 +1,86 @@
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
+from unittest import mock
+
+from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task
+
+
+def test_async_queue_handle_tasks():
+    queue = AsyncTraceExportQueue()
+
+    counter = 0
+
+    def _increment(delta):
+        nonlocal counter
+        counter += delta
+
+    for _ in range(10):
+        task = Task(handler=_increment, args=(1,))
+        queue.put(task)
+
+    queue.flush(terminate=True)
+    assert counter == 10
+
+
+@mock.patch("atexit.register")
+def test_async_queue_activate_thread_safe(mock_atexit):
+    queue = AsyncTraceExportQueue()
+
+    def _count_threads():
+        main_thread = threading.main_thread()
+        return sum(
+            t.is_alive()
+            for t in threading.enumerate()
+            if t is not main_thread and t.getName().startswith("MLflowTraceLogging")
+        )
+
+    # 1. Validate activation
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        for _ in range(10):
+            executor.submit(queue.activate)
+
+    assert queue.is_active()
+    assert _count_threads() > 0  # Logging thread + max 5 worker threads
+    mock_atexit.assert_called_once()
+    mock_atexit.reset_mock()
+
+    # 2. Validate flush (continue)
+    queue.flush(terminate=False)
+    assert queue.is_active()
+    assert _count_threads() > 0  # New threads should be created
+    mock_atexit.assert_not_called()  # Exit callback should not be registered again
+
+    # 3. Validate flush with termination
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        for _ in range(10):
+            executor.submit(queue.flush(terminate=True))
+
+    assert not queue.is_active()
+    assert _count_threads() == 0
+
+
+def test_async_queue_drop_task_when_full(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE", "3")
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS", "1")
+
+    queue = AsyncTraceExportQueue()
+
+    processed_tasks = 0
+
+    # Create a slow handler to keep tasks in the queue
+    def slow_handler():
+        time.sleep(0.5)
+
+        nonlocal processed_tasks
+        processed_tasks += 1
+
+    for _ in range(10):
+        task = Task(handler=slow_handler, args=())
+        queue.put(task)
+
+    queue.flush(terminate=True)
+
+    # One more task than the queue size might be processed, because the first task
+    # can be drained from the queue immediately, which creates a slot for another task
+    assert processed_tasks <= 4

--- a/tests/tracing/export/test_async_export_queue.py
+++ b/tests/tracing/export/test_async_export_queue.py
@@ -1,6 +1,6 @@
-from concurrent.futures import ThreadPoolExecutor
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
 from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task

--- a/tests/tracing/export/test_databricks_exporter.py
+++ b/tests/tracing/export/test_databricks_exporter.py
@@ -33,7 +33,7 @@ def _flush_async_logging():
 def test_export(experiment_id, is_async, monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
-    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", str(is_async))
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", str(is_async))
     monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", "3")
 
     mlflow.tracing.set_destination(Databricks(experiment_id=experiment_id))
@@ -138,7 +138,7 @@ def test_export(experiment_id, is_async, monkeypatch):
 def test_export_catch_failure(is_async, monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
-    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", str(is_async))
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", str(is_async))
     monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", "3")
 
     mlflow.tracing.set_destination(Databricks(experiment_id=_EXPERIMENT_ID))
@@ -165,7 +165,7 @@ def test_export_catch_failure(is_async, monkeypatch):
 def test_async_bulk_export(monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
-    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", "True")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "True")
     monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", "3")
     monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", "3")
 

--- a/tests/tracing/export/test_databricks_exporter.py
+++ b/tests/tracing/export/test_databricks_exporter.py
@@ -1,4 +1,6 @@
 import base64
+import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
 import pytest
@@ -6,6 +8,7 @@ import pytest
 import mlflow
 from mlflow.entities.span_event import SpanEvent
 from mlflow.tracing.destination import Databricks
+from mlflow.tracing.provider import _get_trace_exporter
 
 _EXPERIMENT_ID = "dummy-experiment-id"
 
@@ -19,14 +22,19 @@ def _predict(x: str) -> str:
     return x + "!"
 
 
+def _flush_async_logging():
+    exporter = _get_trace_exporter()
+    assert hasattr(exporter, "_async_queue"), "Async queue is not initialized"
+    exporter._async_queue.flush(terminate=True)
+
+
+@pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
 @pytest.mark.parametrize("experiment_id", [None, _EXPERIMENT_ID])
-@pytest.mark.parametrize("timeout", [None, "100"])
-def test_export(experiment_id, timeout, monkeypatch):
+def test_export(experiment_id, is_async, monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
-
-    if timeout is not None:
-        monkeypatch.setenv("MLFLOW_HTTP_REQUEST_TIMEOUT", timeout)
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", str(is_async))
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", "3")
 
     mlflow.tracing.set_destination(Databricks(experiment_id=experiment_id))
 
@@ -39,12 +47,15 @@ def test_export(experiment_id, timeout, monkeypatch):
     ) as mock_http:
         _predict("hello")
 
+        if is_async:
+            _flush_async_logging()
+
     mock_http.assert_called_once()
     call_args = mock_http.call_args
     assert call_args.kwargs["host_creds"] is not None
     assert call_args.kwargs["endpoint"] == "/api/2.0/tracing/traces"
     assert call_args.kwargs["method"] == "POST"
-    assert call_args.kwargs["timeout"] == (int(timeout) if timeout is not None else 5)
+    assert call_args.kwargs["retry_timeout_seconds"] == (3 if is_async else 0)
 
     trace = call_args.kwargs["json"]
     trace_id = trace["info"]["trace_id"]
@@ -123,9 +134,12 @@ def test_export(experiment_id, timeout, monkeypatch):
     }
 
 
-def test_export_catch_failure(monkeypatch):
+@pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
+def test_export_catch_failure(is_async, monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", str(is_async))
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", "3")
 
     mlflow.tracing.set_destination(Databricks(experiment_id=_EXPERIMENT_ID))
 
@@ -141,5 +155,42 @@ def test_export_catch_failure(monkeypatch):
     ):
         _predict("hello")
 
+        if is_async:
+            _flush_async_logging()
+
     mock_http.assert_called_once()
     mock_logger.warning.assert_called_once()
+
+
+def test_async_bulk_export(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", "True")
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", "3")
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", "3")
+
+    mlflow.tracing.set_destination(Databricks(experiment_id=0))
+
+    def _mock_http(*args, **kwargs):
+        # Simulate a slow response
+        time.sleep(0.1)
+        response = mock.MagicMock()
+        response.status_code = 200
+        response.text = "{}"
+        return response
+
+    with mock.patch(
+        "mlflow.tracing.export.databricks.http_request", side_effect=_mock_http
+    ) as mock_http:
+        # Log many traces
+        start_time = time.time()
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            for _ in range(1000):
+                executor.submit(_predict, "hello")
+
+        # Trace logging should not block the main thread
+        assert time.time() - start_time < 1
+
+        _flush_async_logging()
+
+    assert mock_http.call_count == 1000

--- a/tests/tracing/export/test_databricks_exporter.py
+++ b/tests/tracing/export/test_databricks_exporter.py
@@ -189,7 +189,7 @@ def test_async_bulk_export(monkeypatch):
                 executor.submit(_predict, "hello")
 
         # Trace logging should not block the main thread
-        assert time.time() - start_time < 1
+        assert time.time() - start_time < 3
 
         _flush_async_logging()
 

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -1,10 +1,7 @@
-import threading
-from concurrent.futures import ThreadPoolExecutor
-from unittest import mock
 from unittest.mock import MagicMock
 
 from mlflow.entities import LiveSpan
-from mlflow.tracing.export.mlflow import AsyncTraceExportQueue, MlflowSpanExporter, Task
+from mlflow.tracing.export.mlflow import MlflowSpanExporter
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 
 from tests.tracing.helper import create_mock_otel_span, create_test_trace_info
@@ -66,60 +63,3 @@ def test_export(async_logging_enabled):
     assert trace_info == logged_trace_info
     assert len(logged_trace_data.spans) == 2
     mock_client._upload_ended_trace_info.assert_called_once_with(trace_info)
-
-
-def test_async_queue_handle_tasks():
-    mock_client = MagicMock()
-    queue = AsyncTraceExportQueue(mock_client)
-
-    counter = 0
-
-    def _increment(delta):
-        nonlocal counter
-        counter += delta
-
-    for _ in range(10):
-        task = Task(handler=_increment, args=(1,))
-        queue.put(task)
-
-    queue.flush(terminate=True)
-    assert counter == 10
-    assert len(queue._unprocessed_tasks) == 0
-
-
-@mock.patch("atexit.register")
-def test_async_queue_activate_thread_safe(mock_atexit):
-    mock_client = MagicMock()
-    queue = AsyncTraceExportQueue(mock_client)
-
-    def _count_threads():
-        main_thread = threading.main_thread()
-        return sum(
-            t.is_alive()
-            for t in threading.enumerate()
-            if t is not main_thread and t.getName().startswith("MLflowTraceLogging")
-        )
-
-    # 1. Validate activation
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        for _ in range(10):
-            executor.submit(queue.activate)
-
-    assert queue.is_active()
-    assert _count_threads() > 0  # Logging thread + max 5 worker threads
-    mock_atexit.assert_called_once()
-    mock_atexit.reset_mock()
-
-    # 2. Validate flush (continue)
-    queue.flush(terminate=False)
-    assert queue.is_active()
-    assert _count_threads() > 0  # New threads should be created
-    mock_atexit.assert_not_called()  # Exit callback should not be registered again
-
-    # 3. Validate flush with termination
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        for _ in range(10):
-            executor.submit(queue.flush(terminate=True))
-
-    assert not queue.is_active()
-    assert _count_threads() == 0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15163?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15163/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15163/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15163
```

</p>
</details>

### What changes are proposed in this pull request?

Enable async trace logging when exporting to Databricks trace server. This will be a default behavior and can opt-out by setting `MLFLOW_ENABLE_ASYNC_LOGGING` to `False` explicitly.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

I will add more documentation about Databricks external monitoring to https://www.mlflow.org/docs/latest/tracing/production in follow-up.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Suport async trace export to Databricks and make it default behavior.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
