### PR TITLE
Stop parsing list or dict input in dspy.Example

### DIFF
--- a/mlflow/dspy/util.py
+++ b/mlflow/dspy/util.py
@@ -92,13 +92,15 @@ def _flatten_dspy_module_state(
                 continue
             new_key = f"{parent_key}{sep}{k}" if parent_key else k
             if isinstance(v, Example):
-                v = v.toDict()
+                # Don't flatten Example objects further even if it has dict or list values
+                v = {key: str(value) for key, value in v.items()}
             items.update(_flatten_dspy_module_state(v, new_key, sep))
     elif isinstance(d, list):
         for i, v in enumerate(d):
             new_key = f"{parent_key}{sep}{i}" if parent_key else str(i)
             if isinstance(v, Example):
-                v = v.toDict()
+                # Don't flatten Example objects further even if it has dict or list values
+                v = {key: str(value) for key, value in v.items()}
             items.update(_flatten_dspy_module_state(v, new_key, sep))
     else:
         if d is not None:

--- a/tests/dspy/test_dspy_util.py
+++ b/tests/dspy/test_dspy_util.py
@@ -30,7 +30,12 @@ def test_save_dspy_module_state(tmp_path):
 
 
 def test_log_dspy_module_state_params():
-    program = dspy.Predict("question -> answer")
+    program = dspy.Predict("question -> answer: list[str]")
+    program.demos = [
+        dspy.Example(question="What are cities in Japan?", answer=["Tokyo", "Osaka"]).with_inputs(
+            "question"
+        ),
+    ]
 
     with mlflow.start_run() as run:
         log_dspy_module_params(program)
@@ -42,6 +47,8 @@ def test_log_dspy_module_state_params():
         "Predict.signature.fields.1.description": "${answer}",
         "Predict.signature.fields.1.prefix": "Answer:",
         "Predict.signature.instructions": "Given the fields `question`, produce the fields `answer`.",  # noqa: E501
+        "Predict.demos.0.answer": "['Tokyo', 'Osaka']",
+        "Predict.demos.0.question": "What are cities in Japan?",
     }
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15186?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15186/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15186/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15186
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?
This PR is for avoiding logging individual tokens as separate params when the example has list values such as extraction task.

<img width="819" alt="image" src="https://github.com/user-attachments/assets/66492c15-a58e-4a99-bf48-8cdd1e394f24" />



### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
