### PR TITLE
Add base_image argument to mlflow models CLI API

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -210,6 +210,7 @@ def prepare_env(
 @cli_args.INSTALL_JAVA
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
+@cli_args.BASE_IMAGE
 def generate_dockerfile(
     model_uri,
     output_directory,
@@ -218,6 +219,7 @@ def generate_dockerfile(
     install_java,
     install_mlflow,
     enable_mlserver,
+    base_image,
 ):
     """
     Generates a directory with Dockerfile whose default entrypoint serves an MLflow model at port
@@ -238,6 +240,7 @@ def generate_dockerfile(
             install_java=install_java,
             install_mlflow=install_mlflow,
             enable_mlserver=enable_mlserver,
+            base_image=base_image,
         )
         _logger.info("Generated Dockerfile in directory %s", output_directory)
     else:
@@ -256,6 +259,7 @@ def generate_dockerfile(
 @cli_args.INSTALL_JAVA
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
+@cli_args.BASE_IMAGE
 def build_docker(**kwargs):
     """
     Builds a Docker image whose default entrypoint serves an MLflow model at port 8080, using the

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -247,3 +247,17 @@ INSTALL_JAVA = click.option(
     "Note: This option only works with the UBUNTU base image; "
     "Python base images do not support Java installation.",
 )
+
+BASE_IMAGE = click.option(
+    "--base-image",
+    is_flag=False,
+    default=None,
+    metavar="BASE_IMAGE",
+    help="""
+Base image for the Docker image. If not specified, the default image is either
+``UBUNTU_BASE_IMAGE = "ubuntu:20.04"`` or ``PYTHON_SLIM_BASE_IMAGE = "python:{version}-slim"``
+Note: If custom image is used, there are no guarantees that the image will work. You
+may find greater compatibility by building your image on top of the ubuntu images. In
+addition, you must install Java and virtualenv to have the image work properly.
+""",
+)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<Resolve> #11770 </Resolve>

### What changes are proposed in this pull request?

Implement CLI argument `--base-image` for `mlflow model generate-dockerfile` and `mlflow model build-docker` 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes
Implement CLI argument `--base-image` for `mlflow model generate-dockerfile` and `mlflow model build-docker` 

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Now you can set the base image for generating Dockerfiles and building container images using the mlflow CLI

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
