### PR TITLE
Fix spark ML save model error in Databricks shared or serverless cluster

### DIFF
--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -713,7 +713,7 @@ def _check_databricks_uc_volume_tmpdir_availability(dfs_tmpdir):
                 "UC volume path must be provided to save, log or load SparkML models "
                 "in Databricks shared or serverless clusters. "
                 "Specify environment variable 'MLFLOW_DFS_TMP' "
-                "or 'dfs_tmpdir' argument to a UC volume path like '/Volumes/...' "
+                "or 'dfs_tmpdir' argument that uses a UC volume path starting with '/Volumes/...' "
                 "when saving, logging or loading a model."
             )
 

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -336,18 +336,8 @@ def log_model(
             append_to_uri_path(run_root_artifact_uri, artifact_path),
         )
     ):
-        if (
-            databricks_utils.is_in_databricks_serverless_runtime()
-            or databricks_utils.is_in_databricks_shared_cluster_runtime()
-        ):
-            dfs_tmpdir = dfs_tmpdir or MLFLOW_DFS_TMP.get()
-            if not dfs_tmpdir or not _is_uc_volume_uri(dfs_tmpdir):
-                raise MlflowException(
-                    "UC volume path must be provided to log SparkML models In Databricks "
-                    "shared or serverless clusters. Specify environment variable 'MLFLOW_DFS_TMP' "
-                    "or 'dfs_tmpdir' argument to a UC volume path like '/Volumes/...' "
-                    "when logging a model."
-                )
+        dfs_tmpdir = dfs_tmpdir or MLFLOW_DFS_TMP.get()
+        _check_databricks_uc_volume_tmpdir_availability(dfs_tmpdir)
         return Model.log(
             artifact_path=artifact_path,
             flavor=mlflow.spark,
@@ -713,6 +703,21 @@ def _is_uc_volume_uri(url):
     return parsed_url.scheme in ["", "dbfs"] and parsed_url.path.startswith("/Volumes")
 
 
+def _check_databricks_uc_volume_tmpdir_availability(dfs_tmpdir):
+    if (
+        databricks_utils.is_in_databricks_serverless_runtime()
+        or databricks_utils.is_in_databricks_shared_cluster_runtime()
+    ):
+        if not dfs_tmpdir or not _is_uc_volume_uri(dfs_tmpdir):
+            raise MlflowException(
+                "UC volume path must be provided to save, log or load SparkML models "
+                "in Databricks shared or serverless clusters. "
+                "Specify environment variable 'MLFLOW_DFS_TMP' "
+                "or 'dfs_tmpdir' argument to a UC volume path like '/Volumes/...' "
+                "when saving, logging or loading a model."
+            )
+
+
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="pyspark"))
 def save_model(
     spark_model,
@@ -821,6 +826,8 @@ def save_model(
         # Save it to a DFS temp dir first and copy it to local path
         if dfs_tmpdir is None:
             dfs_tmpdir = MLFLOW_DFS_TMP.get()
+
+        _check_databricks_uc_volume_tmpdir_availability(dfs_tmpdir)
         tmp_path = generate_tmp_dfs_path(dfs_tmpdir)
         spark_model.save(tmp_path)
 
@@ -886,17 +893,11 @@ def _load_model(model_uri, dfs_tmpdir_base=None, local_model_path=None):
 
     dfs_tmpdir = generate_tmp_dfs_path(dfs_tmpdir_base or MLFLOW_DFS_TMP.get())
 
+    _check_databricks_uc_volume_tmpdir_availability(dfs_tmpdir)
     if (
         databricks_utils.is_in_databricks_serverless_runtime()
         or databricks_utils.is_in_databricks_shared_cluster_runtime()
     ):
-        if not _is_uc_volume_uri(dfs_tmpdir):
-            raise MlflowException(
-                "UC volume path must be provided to load SparkML models In Databricks "
-                "shared or serverless clusters. Specify environment variable 'MLFLOW_DFS_TMP' "
-                "or 'dfs_tmpdir' argument to a UC volume path like '/Volumes/...' "
-                "when loading a model."
-            )
         return _load_model_databricks_uc_volume(
             dfs_tmpdir, local_model_path or _download_artifact_from_uri(model_uri)
         )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/15198?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15198/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15198/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15198
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?


This PR fixes the following error when invoking `mlflow.spark.save_model` in DBR runtime 17 shared / serverless cluster:
![image](https://github.com/user-attachments/assets/beeafca3-38ef-459a-9cb1-fcdfb53b7514)


### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
