### PR TITLE
Log params for openai autolog

### DIFF
--- a/mlflow/models/evaluation/utils/trace.py
+++ b/mlflow/models/evaluation/utils/trace.py
@@ -66,7 +66,9 @@ def configure_autologging_for_evaluation(enable_tracing: bool = True):
                     new_config = {
                         k: False if k.startswith("log_") else v for k, v in original_config.items()
                     }
-                    new_config |= {"log_traces": True, "silent": True}
+                    # log_models needs to be disabled
+                    # so we don't init LoggedModels during eval for some GenAI flavors
+                    new_config |= {"log_traces": True, "silent": True, "log_models": False}
                     _kwargs_safe_invoke(autolog, new_config)
 
                     global _SHOWN_TRACE_MESSAGE_BEFORE

--- a/mlflow/openai/_openai_autolog.py
+++ b/mlflow/openai/_openai_autolog.py
@@ -94,11 +94,13 @@ def patched_call(original, self, *args, **kwargs):
 
     model_id = None
     task = mlflow.openai._get_task_name(self.__class__)
-    model_identity = _generate_model_identity({"task": task, **kwargs})
+    model_dict = {"task": task, **kwargs}
+    model_identity = _generate_model_identity(model_dict)
     model_id = _MODEL_TRACKER.get(model_identity)
     if config.log_traces:
         if model_id is None and config.log_models:
-            logged_model = mlflow.create_external_model(name="openai")
+            params = _generate_model_params_dict(model_dict)
+            logged_model = mlflow.create_external_model(name="openai", params=params)
             _MODEL_TRACKER.set(model_identity, logged_model.model_id)
             model_id = logged_model.model_id
 
@@ -125,11 +127,13 @@ async def async_patched_call(original, self, *args, **kwargs):
     mlflow_client = mlflow.MlflowClient()
 
     task = mlflow.openai._get_task_name(self.__class__)
-    model_identity = _generate_model_identity({"task": task, **kwargs})
+    model_dict = {"task": task, **kwargs}
+    model_identity = _generate_model_identity(model_dict)
     model_id = _MODEL_TRACKER.get(model_identity)
     if config.log_traces:
         if model_id is None and config.log_models:
-            logged_model = mlflow.create_external_model(name="openai")
+            params = _generate_model_params_dict(model_dict)
+            logged_model = mlflow.create_external_model(name="openai", params=params)
             _MODEL_TRACKER.set(model_identity, logged_model.model_id)
             model_id = logged_model.model_id
         span = _start_span(mlflow_client, self, kwargs, run_id, model_id)
@@ -304,6 +308,23 @@ def patched_swarm_run(original, self, *args, **kwargs):
     """
     traced_fn = mlflow.trace(original, span_type=SpanType.AGENT)
     return traced_fn(self, *args, **kwargs)
+
+
+def _generate_model_params_dict(model_dict: dict[str, Any]) -> dict[str, str]:
+    # drop input fields
+    exclude_fields = {
+        "messages",
+        "prompt",
+        "input",
+    }
+    return {
+        k: (
+            model_dict[k]
+            if isinstance(model_dict[k], str)
+            else json.dumps(model_dict[k], default=str)
+        )
+        for k in sorted(model_dict.keys() - exclude_fields)
+    }
 
 
 def _generate_model_identity(model_dict) -> int:

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -923,6 +923,11 @@ async def test_autolog_log_models_and_link_traces(client, log_models):
     )
     if log_models:
         assert len(logged_models) == 1
+        logged_model = logged_models[0]
+        assert logged_model.params["model"] == "gpt-4o-mini"
+        assert logged_model.params["task"] == "chat.completions"
+        assert logged_model.params["temperature"] == "0.1"
+        assert "messages" not in logged_model.params
         logged_model_id = logged_models[0].model_id
         for i in range(3):
             assert (


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15223?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15223/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15223/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15223
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
1. Log params to the LoggedModel in openai autolog
2. Avoid creating new LoggedModel if autologging is turned on inside evaluate
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
