### PR TITLE
Performance: refactor _get_run_inputs to make a single database call

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5,6 +5,7 @@ import random
 import threading
 import time
 import uuid
+from collections import defaultdict
 from functools import reduce
 from typing import Optional
 
@@ -548,46 +549,31 @@ class SqlAlchemyStore(AbstractStore):
         return runs[0]
 
     def _get_run_inputs(self, session, run_uuids):
-        datasets = (
+        datasets_with_tags = (
             session.query(
                 SqlInput.input_uuid,
                 SqlInput.destination_id.label("run_uuid"),
                 SqlDataset,
-            )
-            .select_from(SqlDataset)
-            .join(SqlInput, SqlInput.source_id == SqlDataset.dataset_uuid)
-            .filter(
-                SqlInput.destination_type == "RUN",
-                SqlInput.destination_id.in_(run_uuids),
-            )
-            .order_by("run_uuid")
-        ).all()
-        input_uuids = [dataset.input_uuid for dataset in datasets]
-        input_tags = (
-            session.query(
-                SqlInput.input_uuid,
-                SqlInput.destination_id.label("run_uuid"),
                 SqlInputTag,
             )
-            .join(SqlInput, (SqlInput.input_uuid == SqlInputTag.input_uuid))
-            .filter(SqlInput.input_uuid.in_(input_uuids))
+            .select_from(SqlInput)
+            .join(SqlDataset, SqlInput.source_id == SqlDataset.dataset_uuid)
+            .outerjoin(SqlInputTag, SqlInputTag.input_uuid == SqlInput.input_uuid)
+            .filter(SqlInput.destination_type == "RUN", SqlInput.destination_id.in_(run_uuids))
             .order_by("run_uuid")
         ).all()
 
-        all_dataset_inputs = []
-        for run_uuid in run_uuids:
-            dataset_inputs = []
-            for input_uuid, dataset_run_uuid, dataset_sql in datasets:
-                if run_uuid == dataset_run_uuid:
-                    dataset_entity = dataset_sql.to_mlflow_entity()
-                    tags = []
-                    for tag_input_uuid, tag_run_uuid, tag_sql in input_tags:
-                        if input_uuid == tag_input_uuid and run_uuid == tag_run_uuid:
-                            tags.append(tag_sql.to_mlflow_entity())
-                    dataset_input_entity = DatasetInput(dataset=dataset_entity, tags=tags)
-                    dataset_inputs.append(dataset_input_entity)
-            all_dataset_inputs.append(dataset_inputs)
-        return all_dataset_inputs
+        dataset_inputs_per_run = defaultdict(dict)
+        for input_uuid, run_uuid, dataset_sql, tag_sql in datasets_with_tags:
+            dataset_inputs = dataset_inputs_per_run[run_uuid]
+            dataset_uuid = dataset_sql.dataset_uuid
+            dataset_input = dataset_inputs.get(dataset_uuid)
+            if dataset_input is None:
+                dataset_entity = dataset_sql.to_mlflow_entity()
+                dataset_input = DatasetInput(dataset=dataset_entity, tags=[])
+                dataset_inputs[dataset_uuid] = dataset_input
+            dataset_input.tags.append(tag_sql.to_mlflow_entity())
+        return [list(dataset_inputs_per_run[run_uuid].values()) for run_uuid in run_uuids]
 
     @staticmethod
     def _get_eager_run_query_options():

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -572,7 +572,8 @@ class SqlAlchemyStore(AbstractStore):
                 dataset_entity = dataset_sql.to_mlflow_entity()
                 dataset_input = DatasetInput(dataset=dataset_entity, tags=[])
                 dataset_inputs[dataset_uuid] = dataset_input
-            dataset_input.tags.append(tag_sql.to_mlflow_entity())
+            if tag_sql is not None:
+                dataset_input.tags.append(tag_sql.to_mlflow_entity())
         return [list(dataset_inputs_per_run[run_uuid].values()) for run_uuid in run_uuids]
 
     @staticmethod

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4613,3 +4613,88 @@ def test_delete_traces_raises_error(store):
         MlflowException, match=r"`max_traces` must be a positive integer, received 0"
     ):
         store.delete_traces(exp_id, 100, max_traces=0)
+
+
+@pytest.mark.parametrize("tags_count", [0, 1, 2])
+def test_get_run_inputs(store, tags_count):
+    run = _run_factory(store)
+
+    dataset = entities.Dataset(
+        name="name1",
+        digest="digest1",
+        source_type="st1",
+        source="source1",
+        schema="schema1",
+        profile="profile1",
+    )
+
+    tags = [entities.InputTag(key=f"foo{i}", value=f"bar{i}") for i in range(tags_count)]
+
+    dataset_inputs = [entities.DatasetInput(dataset, tags)]
+
+    store.log_inputs(run.info.run_id, dataset_inputs)
+
+    with store.ManagedSessionMaker() as session:
+        actual = store._get_run_inputs(session, [run.info.run_id])
+
+    assert len(actual) == 1
+    assert_dataset_inputs_equal(actual[0], dataset_inputs)
+
+
+def test_get_run_inputs_run_order(store):
+    exp_id = _create_experiments(store, "test_get_run_inputs_run_order")
+    config = _get_run_configs(exp_id)
+
+    run_with_one_input = _run_factory(store, config)
+    run_with_no_inputs = _run_factory(store, config)
+    run_with_two_inputs = _run_factory(store, config)
+
+    dataset1 = entities.Dataset(
+        name="name1",
+        digest="digest1",
+        source_type="st1",
+        source="source1",
+        schema="schema1",
+        profile="profile1",
+    )
+
+    dataset2 = entities.Dataset(
+        name="name2",
+        digest="digest2",
+        source_type="st2",
+        source="source2",
+        schema="schema2",
+        profile="profile2",
+    )
+
+    tags_1 = [entities.InputTag(key="foo1", value="bar1")]
+
+    tags_2 = [
+        entities.InputTag(key="foo2", value="bar2"),
+        entities.InputTag(key="foo3", value="bar3"),
+    ]
+
+    tags_3 = [
+        entities.InputTag(key="foo4", value="bar4"),
+        entities.InputTag(key="foo5", value="bar5"),
+        entities.InputTag(key="foo6", value="bar6"),
+    ]
+
+    dataset_inputs_1 = [entities.DatasetInput(dataset1, tags_1)]
+    dataset_inputs_2 = [
+        entities.DatasetInput(dataset2, tags_2),
+        entities.DatasetInput(dataset1, tags_3),
+    ]
+
+    store.log_inputs(run_with_one_input.info.run_id, dataset_inputs_1)
+    store.log_inputs(run_with_two_inputs.info.run_id, dataset_inputs_2)
+
+    expected = [dataset_inputs_1, [], dataset_inputs_2]
+
+    runs = [run_with_one_input, run_with_no_inputs, run_with_two_inputs]
+    run_uuids = [run.info.run_id for run in runs]
+    with store.ManagedSessionMaker() as session:
+        actual = store._get_run_inputs(session, run_uuids)
+
+    for expected_i, actual_i in zip(expected, actual):
+        assert_dataset_inputs_equal(expected_i, actual_i)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4693,8 +4693,10 @@ def test_get_run_inputs_run_order(store):
 
     runs = [run_with_one_input, run_with_no_inputs, run_with_two_inputs]
     run_uuids = [run.info.run_id for run in runs]
+
     with store.ManagedSessionMaker() as session:
         actual = store._get_run_inputs(session, run_uuids)
 
+    assert len(expected) == len(actual)
     for expected_i, actual_i in zip(expected, actual):
         assert_dataset_inputs_equal(expected_i, actual_i)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kbolashev/mlflow/pull/15232?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15232/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15232/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15232
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #15231

### What changes are proposed in this pull request?

This PR refactors the `_get_run_inputs()` function, changing it to use a left outer join to fetch the InputTags, instead of a second query.

Performance info copied from the issue:


Running with a synthetic benchmark that reuses one dataset over and over.

Code to generate experiments:
```python
def generate_experiments():
    dataset_source_url = "https://raw.githubusercontent.com/mlflow/mlflow/master/tests/datasets/winequality-white.csv"
    raw_data = pd.read_csv(dataset_source_url, delimiter=";")

    run_count = 10
    input_counts = [1, 10, 100, 1000]

    for datasets_per_run in input_counts:
        experiment_id = mlflow.create_experiment(f"_ManyInputsExperiment_{run_count}x{datasets_per_run}")
        for run_i in range(run_count):
            with mlflow.start_run(run_name=f"run_{run_i}", experiment_id=experiment_id):
                for i in range(datasets_per_run):
                    # Create an instance of a PandasDataset
                    dataset = mlflow.data.from_pandas(
                        raw_data, source=dataset_source_url, name=f"wine quality - white - {i}", targets="quality"
                    )
                    mlflow.log_input(dataset, context="training", tags={"key": f"{i}"})
```

Benchmarking test:
```python
def search_runs_of_experiment(experiment_id):
    return mlflow.search_runs([experiment_id])


@pytest.mark.parametrize(
    "experiment_name",
    [
        "_ManyInputsExperiment_10x1",
        "_ManyInputsExperiment_10x10",
        "_ManyInputsExperiment_10x100",
        "_ManyInputsExperiment_10x1000",
    ],
)
def test_benchmark_search_runs(benchmark, experiment_name):
    mlflow.set_tracking_uri("http://localhost:5000")
    experiment_id = mlflow.get_experiment_by_name(experiment_name).experiment_id
    res = benchmark(search_runs_of_experiment, experiment_id)
    assert len(res) == 10
```

To benchmark using `pytest-benchmark` (if benchmark code saved in `many_inputs.py`):
```
pip install pytest-benchmark
pytest many_inputs.py::test_benchmark_search_runs --benchmark-save=base
pytest many_inputs.py::test_benchmark_search_runs --benchmark-compare
```

Results when running it on an M1 Mac Pro, with the DB backend being a docker-hosted PostgreSQL:

```
---------------------------------------------------------------------------------------------------------------------- benchmark: 8 tests ---------------------------------------------------------------------------------------------------------------------
Name (time in ms)                                                                 Min                    Max                   Mean              StdDev                 Median                   IQR            Outliers      OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_search_runs[_ManyInputsExperiment_10x1] (NOW)                  20.3232 (1.0)         146.5042 (1.90)         41.0288 (1.09)      46.6047 (4.70)         22.9480 (1.0)          5.9432 (1.19)          1;1  24.3731 (0.92)          7           1
test_benchmark_search_runs[_ManyInputsExperiment_10x1] (0001_base)            21.5706 (1.06)         81.3058 (1.06)         37.5818 (1.0)       15.7172 (1.59)         32.1795 (1.40)         7.1041 (1.42)          3;2  26.6087 (1.0)          13           1
test_benchmark_search_runs[_ManyInputsExperiment_10x10] (NOW)                 36.2185 (1.78)         76.9996 (1.0)          47.4742 (1.26)       9.9138 (1.0)          44.9491 (1.96)         6.6604 (1.33)          3;2  21.0641 (0.79)         18           1
test_benchmark_search_runs[_ManyInputsExperiment_10x10] (0001_base)           36.8074 (1.81)        163.0088 (2.12)         52.1107 (1.39)      28.0670 (2.83)         46.9836 (2.05)         4.9971 (1.0)           1;2  19.1899 (0.72)         18           1
test_benchmark_search_runs[_ManyInputsExperiment_10x100] (NOW)               189.8313 (9.34)        472.6290 (6.14)        252.2470 (6.71)     123.2836 (12.44)       201.0443 (8.76)        74.1424 (14.84)         1;1   3.9644 (0.15)          5           1
test_benchmark_search_runs[_ManyInputsExperiment_10x100] (0001_base)         305.3586 (15.03)       449.1591 (5.83)        368.4358 (9.80)      73.5583 (7.42)        326.7477 (14.24)      137.2496 (27.47)         2;0   2.7142 (0.10)          5           1
test_benchmark_search_runs[_ManyInputsExperiment_10x1000] (NOW)            1,951.1430 (96.01)     2,068.3531 (26.86)     2,021.1253 (53.78)     44.0042 (4.44)      2,030.2596 (88.47)       51.5835 (10.32)         2;0   0.4948 (0.02)          5           1
test_benchmark_search_runs[_ManyInputsExperiment_10x1000] (0001_base)     13,751.4782 (676.64)   15,673.3222 (203.55)   14,703.7937 (391.25)   805.7551 (81.28)    14,837.1900 (646.56)   1,381.0476 (276.37)        2;0   0.0680 (0.00)          5           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```


### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [X] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
