### PR TITLE
Replace `mlflow-automation` with `mlflow-app[bot]`

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -81,8 +81,8 @@ jobs:
       # Merge the base branch (which is usually master) to apply formatting using the latest configurations.
       - name: Merge base branch
         run: |
-          git config user.name 'mlflow-automation'
-          git config user.email 'mlflow-automation@users.noreply.github.com'
+          git config user.name 'mlflow-app[bot]'
+          git config user.email 'mlflow-app[bot]@users.noreply.github.com'
           git remote add base https://github.com/${{ needs.check-comment.outputs.base_repo }}.git
           git fetch base ${{ needs.check-comment.outputs.base_ref }}
           git merge base/${{ needs.check-comment.outputs.base_ref }}
@@ -191,8 +191,8 @@ jobs:
           BASE_REPO: ${{ needs.check-comment.outputs.base_repo }}
           BASE_REF: ${{ needs.check-comment.outputs.base_ref }}
         run: |
-          git config user.name 'mlflow-automation'
-          git config user.email 'mlflow-automation@users.noreply.github.com'
+          git config user.name 'mlflow-app[bot]'
+          git config user.email 'mlflow-app[bot]@users.noreply.github.com'
           git remote add base https://github.com/${BASE_REPO}.git
           git fetch base $BASE_REF
           git merge base/${BASE_REF}

--- a/.github/workflows/release-note.js
+++ b/.github/workflows/release-note.js
@@ -26,7 +26,7 @@ async function validateLabeled({ core, context, github }) {
   const { number: issue_number } = context.issue;
 
   // Skip validation on pull requests created by the automation bot
-  if (user.login === "mlflow-automation") {
+  if (user.login === "mlflow-app[bot]") {
     console.log("This pull request was created by the automation bot, skipping");
     return;
   }
@@ -81,7 +81,7 @@ async function postMerge({ context, github }) {
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
 
-  if (user.login === "mlflow-automation") {
+  if (user.login === "mlflow-app[bot]") {
     console.log("This PR was created by the automation bot, skipping");
     return;
   }

--- a/.github/workflows/sync.py
+++ b/.github/workflows/sync.py
@@ -49,9 +49,9 @@ def main():
             page += 1
 
     # Fetch master and mlflow-3 branches
-    subprocess.check_call(["git", "config", "user.name", "mlflow-automation"])
+    subprocess.check_call(["git", "config", "user.name", "mlflow-app[bot]"])
     subprocess.check_call(
-        ["git", "config", "user.email", "mlflow-automation@users.noreply.github.com"]
+        ["git", "config", "user.email", "mlflow-app[bot]@users.noreply.github.com"]
     )
     subprocess.check_call(["git", "fetch", "origin", "master"])
     subprocess.check_call(["git", "fetch", "origin", MLFLOW_3_BRANCH_NAME])

--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -143,7 +143,7 @@ def main(prev_version, release_version, remote):
     author_to_prs = defaultdict(list)
     unlabelled_prs = []
     for pr in prs:
-        if pr.author in ["mlflow-automation", "mlflow-app[bot]"]:
+        if pr.author == "mlflow-app[bot]":
             continue
 
         if len(pr.release_note_labels) == 0:

--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -126,7 +126,7 @@ def main(prev_version, release_version, remote):
         print(f"Fetching PR #{pr_num}...")
         resp = requests.get(
             f"https://api.github.com/repos/mlflow/mlflow/pulls/{pr_num}",
-            auth=("mlflow-automation", os.getenv("GITHUB_TOKEN")),
+            auth=("mlflow-app[bot]", os.getenv("GITHUB_TOKEN")),
         )
         resp.raise_for_status()
         pr = resp.json()
@@ -143,7 +143,7 @@ def main(prev_version, release_version, remote):
     author_to_prs = defaultdict(list)
     unlabelled_prs = []
     for pr in prs:
-        if pr.author == "mlflow-automation":
+        if pr.author in ["mlflow-automation", "mlflow-app[bot]"]:
             continue
 
         if len(pr.release_note_labels) == 0:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15236?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15236/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15236/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15236
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`mlflow-automation` is being migrated to `mlflow-app[bot]` to enhance security. This PR replaces `mlflow-automation` with `mlflow-app[bot]`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
