### PR TITLE
Log metrics to model id after eval

### DIFF
--- a/examples/mlflow-3/evaluate_example.py
+++ b/examples/mlflow-3/evaluate_example.py
@@ -40,15 +40,3 @@ with mlflow.start_run() as run:
         evaluators=["default"],
     )
     print(mlflow.get_logged_model(model_info.model_id))
-
-metrics_run = mlflow.get_run(run.info.run_id).data.metrics
-metrics_model_list = mlflow.get_logged_model(model_info.model_id).metrics
-metrics_model = {metric.key: metric.value for metric in metrics_model_list}
-
-# Ensure metrics are the same
-assert metrics_run == metrics_model, "Metrics for the run and model do not match."
-
-# Validate that all metrics have model_id in their metadata
-assert all(model_info.model_id == metric.model_id for metric in metrics_model_list), (
-    "Some metrics are missing model_id in metadata."
-)

--- a/examples/mlflow-3/evaluate_example.py
+++ b/examples/mlflow-3/evaluate_example.py
@@ -40,3 +40,15 @@ with mlflow.start_run() as run:
         evaluators=["default"],
     )
     print(mlflow.get_logged_model(model_info.model_id))
+
+metrics_run = mlflow.get_run(run.info.run_id).data.metrics
+metrics_model_list = mlflow.get_logged_model(model_info.model_id).metrics
+metrics_model = {metric.key: metric.value for metric in metrics_model_list}
+
+# Ensure metrics are the same
+assert metrics_run == metrics_model, "Metrics for the run and model do not match."
+
+# Validate that all metrics have model_id in their metadata
+assert all(model_info.model_id == metric.model_id for metric in metrics_model_list), (
+    "Some metrics are missing model_id in metadata."
+)

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1784,9 +1784,7 @@ def evaluate(  # noqa: D417
 
         # if model_id is specified log metrics to the eval run and logged model
         if model_id is not None:
-            from mlflow import log_metrics
-
-            log_metrics(metrics=evaluate_result.metrics, dataset=data, model_id=model_id)
+            mlflow.log_metrics(metrics=evaluate_result.metrics, dataset=data, model_id=model_id)
 
     # TODO: Remove this block in a future release when we
     # remove the deprecated arguments.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1782,6 +1782,12 @@ def evaluate(  # noqa: D417
             if isinstance(model, _ServedPyFuncModel):
                 os.kill(model.pid, signal.SIGTERM)
 
+        # if model_id is specified log metrics to the eval run and logged model
+        if model_id is not None:
+            from mlflow import log_metrics
+
+            log_metrics(metrics=evaluate_result.metrics, dataset=data, model_id=model_id)
+
     # TODO: Remove this block in a future release when we
     # remove the deprecated arguments.
     if baseline_model is not None and validation_thresholds is not None:

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -2153,7 +2153,7 @@ def test_metrics_logged_to_model_on_evaluation(
     with mlflow.start_run():
         # Log the model and retrieve its model_id
         model_info = mlflow.sklearn.log_model(
-            mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri), artifact_path="model"
+            mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri), "model"
         )
         model_id = model_info.model_id
 
@@ -2170,11 +2170,7 @@ def test_metrics_logged_to_model_on_evaluation(
         logged_model_metrics = mlflow.get_logged_model(model_id).metrics
 
         # Ensure metrics are logged to the model
-        assert eval_result.metrics == {
-            metric.key: metric.value for metric in logged_model_metrics
-        }, "Metrics logged to the model do not match evaluation results."
+        assert eval_result.metrics == {metric.key: metric.value for metric in logged_model_metrics}
 
         # Validate that all metrics have the correct model_id in their metadata
-        assert all(metric.model_id == model_id for metric in logged_model_metrics), (
-            "Some metrics are missing model_id in metadata."
-        )
+        assert all(metric.model_id == model_id for metric in logged_model_metrics)

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -2145,3 +2145,36 @@ def test_env_manager_set_on_served_pyfunc_model(multiclass_logistic_regressor_mo
     served_model_1 = _ServedPyFuncModel(model_meta=model.metadata, client=client, server_pid=1)
     served_model_1.env_manager = "virtualenv"
     assert served_model_1.env_manager == "virtualenv"
+
+
+def test_metrics_logged_to_model_on_evaluation(
+    multiclass_logistic_regressor_model_uri, iris_dataset
+):
+    with mlflow.start_run():
+        # Log the model and retrieve its model_id
+        model_info = mlflow.sklearn.log_model(
+            mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri), artifact_path="model"
+        )
+        model_id = model_info.model_id
+
+        # Evaluate the model using its model_id
+        eval_result = mlflow.evaluate(
+            model=model_info.model_uri,
+            data=iris_dataset._constructor_args["data"],
+            model_type="classifier",
+            targets=iris_dataset._constructor_args["targets"],
+            evaluators=["default"],
+        )
+
+        # Retrieve metrics logged to the model
+        logged_model_metrics = mlflow.get_logged_model(model_id).metrics
+
+        # Ensure metrics are logged to the model
+        assert eval_result.metrics == {
+            metric.key: metric.value for metric in logged_model_metrics
+        }, "Metrics logged to the model do not match evaluation results."
+
+        # Validate that all metrics have the correct model_id in their metadata
+        assert all(metric.model_id == model_id for metric in logged_model_metrics), (
+            "Some metrics are missing model_id in metadata."
+        )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/15241?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15241/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15241/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15241
```

</p>
</details>

### What changes are proposed in this pull request?
To improve user CUJ, log metrics to model id after a successful eval run.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
  - [x] [Dogfood notebook](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/3556892743510424?o=6051921418418893) shows metrics are automatically logged to model-id after eval run

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
To improve user CUJ, log metrics to model id after a successful eval run.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
