### PR TITLE
Allow log_model() with existing model_id

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -979,7 +979,7 @@ class Model:
                 )
 
             model_is_external = model.tags.get(MLFLOW_MODEL_IS_EXTERNAL, "false").lower() == "true"
-            if LoggedModelStatus.is_finalized(model.status) and model_is_external:
+            if LoggedModelStatus.is_finalized(model.status) and not model_is_external:
                 raise MlflowException(
                     f"Model with id {model.model_id} has the status '{model.status}', "
                     f"so its artifacts cannot be modified.",

--- a/tests/pyfunc/test_logged_models.py
+++ b/tests/pyfunc/test_logged_models.py
@@ -105,6 +105,10 @@ def test_log_model_finalizes_existing_pending_model():
     assert updated_model.status == LoggedModelStatus.READY
 
 
+def test_log_model_permits_logging_model_artifacts_to_external_models(tmp_path):
+    pass
+
+
 def test_log_model_does_not_update_artifacts_or_status_for_finalized_models(tmp_path):
     model = mlflow.create_external_model(name="testmodel")
     assert model.status == LoggedModelStatus.READY

--- a/tests/pyfunc/test_logged_models.py
+++ b/tests/pyfunc/test_logged_models.py
@@ -135,10 +135,10 @@ def test_log_model_permits_logging_model_artifacts_to_external_models(tmp_path):
     mlflow.artifacts.download_artifacts(f"models:/{model.model_id}", dst_path=dst_dir_1)
     mlflow_model: Model = Model.load(os.path.join(dst_dir_1, "MLmodel"))
 
-    mlflow.pyfunc.log_model(python_model=DummyModel(), model_id=model.model_id)
+    model_info = mlflow.pyfunc.log_model(python_model=DummyModel(), model_id=model.model_id)
 
     # Verify that the model can now be loaded and is no longer tagged as external
-    mlflow.pyfunc.load_model(f"models:/{model.model_id}")
+    mlflow.pyfunc.load_model(model_info.model_uri)
     assert MLFLOW_MODEL_IS_EXTERNAL not in mlflow.get_logged_model(model.model_id).tags
     dst_dir_2 = os.path.join(tmp_path, "dst_2")
     mlflow.artifacts.download_artifacts(f"models:/{model.model_id}", dst_path=dst_dir_2)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/15247?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15247/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15247/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15247
```

</p>
</details>

### What changes are proposed in this pull request?

Allow `log_model()` with existing model_id

Motivation:

- Customers should be able to create an external logged model with GenAI autologging (LangChain / OpenAI / etc.) and then add model artifacts to it later

- If customers make a mistake when logging files to their model prior to registration, they should be able to overwrite the files

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
