### PR TITLE
Fix databricks-connect inference

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -83,8 +83,6 @@ jobs:
           source ./dev/install-common-deps.sh --ml
           # transformers doesn't support Keras 3 yet. tf-keras needs to be installed as a workaround.
           pip install tf-keras
-          # for testing databricks-connect inference in pip requirements
-          pip install databricks-agents
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Import check
@@ -117,11 +115,13 @@ jobs:
         run: |
           source ./dev/install-common-deps.sh
           pip install .
+          # for testing databricks-connect inference in pip requirements
+          pip install databricks-agents
       - uses: ./.github/actions/show-versions
       - name: Run tests
         run: |
           python -c "import sys; assert sys.version_info[:2] == (3, 10), sys.version_info"
-          pytest tests/types/test_type_hints.py tests/pyfunc/test_pyfunc_model_with_type_hints.py
+          pytest tests/types/test_type_hints.py tests/pyfunc/test_pyfunc_model_with_type_hints.py tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
 
   database:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -83,6 +83,8 @@ jobs:
           source ./dev/install-common-deps.sh --ml
           # transformers doesn't support Keras 3 yet. tf-keras needs to be installed as a workaround.
           pip install tf-keras
+          # for testing databricks-connect inference in pip requirements
+          pip install databricks-agents
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Import check

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -115,13 +115,17 @@ jobs:
         run: |
           source ./dev/install-common-deps.sh
           pip install .
-          # for testing databricks-connect inference in pip requirements
-          pip install databricks-agents
       - uses: ./.github/actions/show-versions
       - name: Run tests
         run: |
           python -c "import sys; assert sys.version_info[:2] == (3, 10), sys.version_info"
-          pytest tests/types/test_type_hints.py tests/pyfunc/test_pyfunc_model_with_type_hints.py tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
+          pytest tests/types/test_type_hints.py tests/pyfunc/test_pyfunc_model_with_type_hints.py
+      - name: Run databricks-connect related tests
+        run: |
+          # this needs to be run in a separate job because installing databricks-connect could break other 
+          # tests that uses normal SparkSession instead of remote SparkSession
+          pip install databricks-agents
+          pytest tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
 
   database:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -238,6 +238,8 @@ def _prune_packages(packages):
     requires = {req for req in requires if not req.startswith("llama-index-")}
 
     # Do not exclude mlflow's dependencies
+    # Do not exclude databricks-connect since it conflicts with pyspark during execution time,
+    # and we need to determine if pyspark needs to be stripped based on the inferred packages
     return packages - (requires - set(_get_requires("mlflow")) - {"databricks-connect"})
 
 

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -238,7 +238,7 @@ def _prune_packages(packages):
     requires = {req for req in requires if not req.startswith("llama-index-")}
 
     # Do not exclude mlflow's dependencies
-    return packages - (requires - set(_get_requires("mlflow")))
+    return packages - (requires - set(_get_requires("mlflow")) - {"databricks-connect"})
 
 
 def _run_command(cmd, timeout_seconds, env=None):

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -11,6 +11,7 @@ import pytest
 import mlflow
 import mlflow.utils.requirements_utils
 from mlflow.exceptions import MlflowException
+from mlflow.pyfunc import _get_pip_requirements_from_model_path
 from mlflow.utils.environment import infer_pip_requirements
 from mlflow.utils.os import is_windows
 from mlflow.utils.requirements_utils import (
@@ -737,7 +738,7 @@ def test_capture_imported_modules_extra_env_vars(monkeypatch):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
-def test_infer_pip_requirements_on_databricks_agents():
+def test_infer_pip_requirements_on_databricks_agents(tmp_path):
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
             import databricks.agents  # noqa: F401
@@ -745,14 +746,13 @@ def test_infer_pip_requirements_on_databricks_agents():
 
             return model_input
 
-    with mlflow.start_run():
-        model_info = mlflow.pyfunc.log_model(
-            "model",
-            python_model=TestModel(),
-            input_example="test",
-        )
+    mlflow.pyfunc.save_model(
+        tmp_path,
+        python_model=TestModel(),
+        input_example="test",
+    )
 
-    requirements = infer_pip_requirements(model_info.model_uri, mlflow.pyfunc.FLAVOR_NAME)
+    requirements = _get_pip_requirements_from_model_path(tmp_path)
     packages = [req.split("==")[0] for req in requirements]
     assert "databricks-agents" in packages
     # databricks-connect should not be pruned even it's a dependency of databricks-agents

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -740,6 +740,7 @@ def test_infer_pip_requirements_on_databricks_agents():
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
             import databricks.agents  # noqa: F401
+            import pyspark  # noqa: F401
 
             return model_input
 
@@ -755,3 +756,5 @@ def test_infer_pip_requirements_on_databricks_agents():
     assert "databricks-agents" in packages
     # databricks-connect should not be pruned even it's a dependency of databricks-agents
     assert "databricks-connect" in packages
+    # pyspark should not exist because it conflicts with databricks-connect
+    assert "pyspark" not in packages

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -11,7 +11,6 @@ import pytest
 import mlflow
 import mlflow.utils.requirements_utils
 from mlflow.exceptions import MlflowException
-from mlflow.pyfunc import _get_pip_requirements_from_model_path
 from mlflow.utils.environment import infer_pip_requirements
 from mlflow.utils.os import is_windows
 from mlflow.utils.requirements_utils import (
@@ -739,6 +738,9 @@ def test_capture_imported_modules_extra_env_vars(monkeypatch):
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
 def test_infer_pip_requirements_on_databricks_agents(tmp_path):
+    # import here to avoid breaking this test suite on mlflow-skinny
+    from mlflow.pyfunc import _get_pip_requirements_from_model_path
+
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
             import databricks.agents  # noqa: F401

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -736,6 +736,7 @@ def test_capture_imported_modules_extra_env_vars(monkeypatch):
     )
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
 def test_infer_pip_requirements_on_databricks_agents():
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15251?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15251/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15251/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15251
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Include databricks-connect in pip requirements, since it has conflicts with pyspark during execution time.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
