### PR TITLE
Always create a run for dspy eval

### DIFF
--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -56,7 +56,6 @@ class MlflowCallback(BaseCallback):
         self.optimizer_stack_level = 0
         # call_id: (key, step)
         self._call_id_to_metric_key: dict[str, tuple[str, int]] = {}
-        self._call_id_to_run_id: dict[str, str] = {}
         self._evaluation_counter = defaultdict(int)
 
     def set_dependencies_schema(self, dependencies_schema: dict[str, Any]):
@@ -227,23 +226,19 @@ class MlflowCallback(BaseCallback):
         if not get_autologging_config(FLAVOR_NAME, "log_evals"):
             return
 
+        key = "eval"
+        if callback_metadata := inputs.get("callback_metadata"):
+            if "metric_key" in callback_metadata:
+                key = callback_metadata["metric_key"]
         if self.optimizer_stack_level > 0:
-            key = "eval"
-            if callback_metadata := inputs.get("callback_metadata"):
-                if "metric_key" in callback_metadata:
-                    key = callback_metadata["metric_key"]
             with _lock:
                 # we may want to include optimizer_stack_level in the key
                 # to handle nested optimization
                 step = self._evaluation_counter[key]
                 self._evaluation_counter[key] += 1
-            run = mlflow.start_run(run_name=f"{key}_{step}", nested=True)
-            self._call_id_to_metric_key[call_id] = (key, step)
-            self._call_id_to_run_id[call_id] = run.info.run_id
+            mlflow.start_run(run_name=f"{key}_{step}", nested=True)
         else:
-            if mlflow.active_run() is None:
-                run = mlflow.start_run()
-                self._call_id_to_run_id[call_id] = run.info.run_id
+            mlflow.start_run(run_name=key, nested=True)
         if program := inputs.get("program"):
             save_dspy_module_state(program, "model.json")
             log_dspy_module_params(program)
@@ -278,8 +273,8 @@ class MlflowCallback(BaseCallback):
         if score is not None:
             mlflow.log_metric("eval", score)
 
-        if self._call_id_to_run_id.pop(call_id, None):
-            mlflow.end_run()
+        mlflow.end_run()
+        # Log the evaluation score to the parent run if called inside optimization
         if self.optimizer_stack_level > 0 and mlflow.active_run() is not None:
             if call_id not in self._call_id_to_metric_key:
                 return
@@ -293,7 +288,6 @@ class MlflowCallback(BaseCallback):
 
     def reset(self):
         self._call_id_to_metric_key: dict[str, tuple[str, int]] = {}
-        self._call_id_to_run_id: dict[str, str] = {}
         self._evaluation_counter = defaultdict(int)
 
     def _start_span(

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -236,6 +236,7 @@ class MlflowCallback(BaseCallback):
                 # to handle nested optimization
                 step = self._evaluation_counter[key]
                 self._evaluation_counter[key] += 1
+            self._call_id_to_metric_key[call_id] = (key, step)
             mlflow.start_run(run_name=f"{key}_{step}", nested=True)
         else:
             mlflow.start_run(run_name=key, nested=True)

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -764,15 +764,11 @@ def test_autolog_nested_evals():
         evaluator(program, devset=examples[:1])
         evaluator(program, devset=examples[1:])
 
-    # root run
-    root_run = mlflow.last_active_run()
-    assert root_run is not None
-
     # children runs
     client = MlflowClient()
     child_runs = client.search_runs(
-        root_run.info.experiment_id,
-        filter_string=f"tags.mlflow.parentRunId = '{root_run.info.run_id}'",
+        run.info.experiment_id,
+        filter_string=f"tags.mlflow.parentRunId = '{run.info.run_id}'",
         order_by=["attributes.start_time ASC"],
     )
     assert len(child_runs) == 2
@@ -825,7 +821,6 @@ def test_autolog_log_compile_with_evals():
     callback = dspy.settings.callbacks[0]
     assert callback.optimizer_stack_level == 0
     assert callback._call_id_to_metric_key == {}
-    assert callback._call_id_to_run_id == {}
     assert callback._evaluation_counter == {}
 
     # root run

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -744,6 +744,54 @@ def test_autolog_log_evals(
         assert run is None
 
 
+def test_autolog_nested_evals():
+    lm = DummyLM(
+        {
+            "What is 1 + 1?": {"answer": "2"},
+            "What is 2 + 2?": {"answer": "4"},
+        }
+    )
+    dspy.settings.configure(lm=lm)
+    examples = [
+        Example(question="What is 1 + 1?", answer="2").with_inputs("question"),
+        Example(question="What is 2 + 2?", answer="2").with_inputs("question"),
+    ]
+    program = Predict("question -> answer")
+    evaluator = Evaluate(devset=examples, metric=answer_exact_match)
+
+    mlflow.dspy.autolog(log_evals=True)
+    with mlflow.start_run() as run:
+        evaluator(program, devset=examples[:1])
+        evaluator(program, devset=examples[1:])
+
+    # root run
+    root_run = mlflow.last_active_run()
+    assert root_run is not None
+
+    # children runs
+    client = MlflowClient()
+    child_runs = client.search_runs(
+        root_run.info.experiment_id,
+        filter_string=f"tags.mlflow.parentRunId = '{root_run.info.run_id}'",
+        order_by=["attributes.start_time ASC"],
+    )
+    assert len(child_runs) == 2
+    for i, run in enumerate(child_runs):
+        if i == 0:
+            assert run.data.metrics == {"eval": 100.0}
+        else:
+            assert run.data.metrics == {"eval": 0}
+        assert run.data.params == {
+            "Predict.signature.fields.0.description": "${question}",
+            "Predict.signature.fields.0.prefix": "Question:",
+            "Predict.signature.fields.1.description": "${answer}",
+            "Predict.signature.fields.1.prefix": "Answer:",
+            "Predict.signature.instructions": "Given the fields `question`, produce the fields `answer`.",  # noqa: E501
+        }
+        artifacts = (x.path for x in client.list_artifacts(run.info.run_id))
+        assert "model.json" in artifacts
+
+
 @skip_if_evaluate_callback_unavailable
 def test_autolog_log_compile_with_evals():
     class EvalOptimizer(dspy.teleprompt.Teleprompter):

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -744,6 +744,7 @@ def test_autolog_log_evals(
         assert run is None
 
 
+@skip_if_evaluate_callback_unavailable
 def test_autolog_nested_evals():
     lm = DummyLM(
         {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15256?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15256/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15256/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15256
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR changes the behavior of dspy auto logging and always creates a mlflow run for each dspy.Evaluate execution. This is for solving an issue that run metrics are not easy to understand when multiple evals are executed under the same mlflow run.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
