### PR TITLE
Set `exclude_unset=False` to fix groq tests

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -149,7 +149,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install mlflow & test dependencies
         run: |
-          pip install wheel
+          pip install -U pip wheel setuptools
           pip install .[extras]
           pip install -r requirements/test-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -196,7 +196,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install mlflow & test dependencies
         run: |
-          pip install wheel
+          pip install -U pip wheel setuptools
           pip install .[extras]
           pip install -r requirements/test-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}

--- a/tests/groq/test_groq_autolog.py
+++ b/tests/groq/test_groq_autolog.py
@@ -81,7 +81,7 @@ def test_chat_completion_autolog():
     assert span.name == "Completions"
     assert span.span_type == SpanType.CHAT_MODEL
     assert span.inputs == DUMMY_CHAT_COMPLETION_REQUEST
-    assert span.outputs == DUMMY_CHAT_COMPLETION_RESPONSE.to_dict()
+    assert span.outputs == DUMMY_CHAT_COMPLETION_RESPONSE.to_dict(exclude_unset=False)
 
     mlflow.groq.autolog(disable=True)
     client = groq.Groq()
@@ -168,11 +168,11 @@ def test_tool_calling_autolog():
     assert span.name == "Completions"
     assert span.span_type == SpanType.CHAT_MODEL
     assert span.inputs == DUMMY_TOOL_CALL_REQUEST
-    assert span.outputs == DUMMY_TOOL_CALL_RESPONSE.to_dict()
+    assert span.outputs == DUMMY_TOOL_CALL_RESPONSE.to_dict(exclude_unset=False)
     assert span.get_attribute("mlflow.chat.tools") == TOOLS
     assert span.get_attribute("mlflow.chat.messages") == [
         *DUMMY_TOOL_CALL_REQUEST["messages"],
-        DUMMY_TOOL_CALL_RESPONSE.choices[0].message.to_dict(),
+        DUMMY_TOOL_CALL_RESPONSE.choices[0].message.to_dict(exclude_unset=False),
     ]
 
 
@@ -238,10 +238,10 @@ def test_tool_response_autolog():
     assert span.name == "Completions"
     assert span.span_type == SpanType.CHAT_MODEL
     assert span.inputs == DUMMY_TOOL_RESPONSE_REQUEST
-    assert span.outputs == DUMMY_TOOL_RESPONSE_RESPONSE.to_dict()
+    assert span.outputs == DUMMY_TOOL_RESPONSE_RESPONSE.to_dict(exclude_unset=False)
     assert span.get_attribute("mlflow.chat.messages") == [
         *DUMMY_TOOL_RESPONSE_REQUEST["messages"],
-        DUMMY_TOOL_RESPONSE_RESPONSE.choices[0].message.to_dict(),
+        DUMMY_TOOL_RESPONSE_RESPONSE.choices[0].message.to_dict(exclude_unset=False),
     ]
 
 
@@ -272,7 +272,7 @@ def test_audio_transcription_autolog():
     assert span.inputs["file"][0] == DUMMY_AUDIO_TRANSCRIPTION_REQUEST["file"][0]
     assert span.inputs["file"][1] == str(DUMMY_AUDIO_TRANSCRIPTION_REQUEST["file"][1])
     assert span.inputs["model"] == DUMMY_AUDIO_TRANSCRIPTION_REQUEST["model"]
-    assert span.outputs == DUMMY_AUDIO_TRANSCRIPTION_RESPONSE.to_dict()
+    assert span.outputs == DUMMY_AUDIO_TRANSCRIPTION_RESPONSE.to_dict(exclude_unset=False)
 
     mlflow.groq.autolog(disable=True)
     client = groq.Groq()
@@ -310,7 +310,7 @@ def test_audio_translation_autolog():
     assert span.inputs["file"][0] == DUMMY_AUDIO_TRANSLATION_REQUEST["file"][0]
     assert span.inputs["file"][1] == str(DUMMY_AUDIO_TRANSLATION_REQUEST["file"][1])
     assert span.inputs["model"] == DUMMY_AUDIO_TRANSLATION_REQUEST["model"]
-    assert span.outputs == DUMMY_AUDIO_TRANSLATION_RESPONSE.to_dict()
+    assert span.outputs == DUMMY_AUDIO_TRANSLATION_RESPONSE.to_dict(exclude_unset=False)
 
     mlflow.groq.autolog(disable=True)
     client = groq.Groq()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15268?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15268/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15268/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15268
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://github.com/mlflow-automation/mlflow/actions/runs/14334804638/job/40202293981. Set `exclude_unset=False` to include unset fields in the `to_dict` result.

```
Full diff:
    {
        'choices': [
            {
                'finish_reason': 'stop',
                'index': 0,
                'logprobs': None,
                'message': {
                    'content': 'The result of the calculation is 110',
  +                 'executed_tools': None,
                    'function_call': None,
                    'reasoning': None,
                    'role': 'assistant',
                    'tool_calls': None,
                },
            },
        ],
        'created': 1733574047,
        'id': 'chatcmpl-test-id',
        'model': 'llama3-8b-8192',
        'object': 'chat.completion',
        'system_fingerprint': 'fp_test',
        'usage': {
            'completion_time': 0.54,
            'completion_tokens': 648,
            'prompt_time': 0.000181289,
            'prompt_tokens': 20,
            'queue_time': 0.012770949,
            'total_time': 0.[540](https://github.com/mlflow-automation/mlflow/actions/runs/14334804638/job/40202293981#step:12:541)181289,
            'total_tokens': 668,
        },
  +     'usage_breakdown': None,
        'x_groq': {
            'id': 'req_test',
        },
    }
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
