### PR TITLE
Retry when request to `huggingface_hub` fails with 429

### DIFF
--- a/mlflow/transformers/hub_utils.py
+++ b/mlflow/transformers/hub_utils.py
@@ -4,6 +4,7 @@ import os
 import time
 from typing import Optional
 
+from mlflow.environment_variables import _MLFLOW_TESTING
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 
@@ -32,10 +33,13 @@ def get_latest_commit_for_repo(repo: str) -> str:
     from huggingface_hub.errors import HfHubHTTPError
 
     api = hub.HfApi()
-    for i in range(5):
+    for i in range(7):
         try:
             return api.model_info(repo).sha
         except HfHubHTTPError as e:
+            if not _MLFLOW_TESTING.get():
+                raise
+
             # Retry on rate limit error
             if e.response.status_code == 429:
                 _logger.warning(

--- a/mlflow/transformers/hub_utils.py
+++ b/mlflow/transformers/hub_utils.py
@@ -38,6 +38,12 @@ def get_latest_commit_for_repo(repo: str) -> str:
         except HfHubHTTPError as e:
             # Retry on rate limit error
             if e.response.status_code == 429:
+                _logger.warning(
+                    "Rate limit exceeded while fetching commit hash for repo %s. "
+                    "Retrying in %d seconds. Error: %s",
+                    repo,
+                    2**i,
+                )
                 time.sleep(2**i)
                 continue
             raise

--- a/mlflow/transformers/hub_utils.py
+++ b/mlflow/transformers/hub_utils.py
@@ -39,10 +39,8 @@ def get_latest_commit_for_repo(repo: str) -> str:
             # Retry on rate limit error
             if e.response.status_code == 429:
                 _logger.warning(
-                    "Rate limit exceeded while fetching commit hash for repo %s. "
-                    "Retrying in %d seconds. Error: %s",
-                    repo,
-                    2**i,
+                    f"Rate limit exceeded while fetching commit hash for repo {repo}. "
+                    f"Retrying in {2**i} seconds. Error: {e}",
                 )
                 time.sleep(2**i)
                 continue


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15275?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15275/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15275/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15275
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix the following error where a request to fetch the model info fails with 429. This started happening recently.

https://github.com/mlflow/mlflow/actions/runs/14351699969/job/40231810420

```
...
                raise _format(HfHubHTTPError, message, response) from e
    
            # Convert `HTTPError` into a `HfHubHTTPError` to display request information
            # as well (request id and/or server error message)
>           raise _format(HfHubHTTPError, str(e), response) from e
E           huggingface_hub.errors.HfHubHTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/api/models/dandelin/vilt-b32-finetuned-vqa

endpoint_name = None
error_code = None
error_message = None
response   = <Response [429]>

/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/huggingface_hub/utils/_http.py:482: HfHubHTTPError
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
