### PR TITLE
Fix `Model.load` slowness

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import posixpath
 import shutil
 import uuid
 import warnings
@@ -686,6 +685,8 @@ class Model:
             res.pop("artifact_path", None)
         if self.run_id is None:
             res.pop("run_id", None)
+        if self.env_vars is not None:
+            res["env_vars"] = self.env_vars
         return res
 
     def to_yaml(self, stream=None) -> str:
@@ -743,22 +744,6 @@ class Model:
         mlmodel_local_path = _download_artifact_from_uri(artifact_uri=mlmodel_file_path)
         with open(mlmodel_local_path) as f:
             model_dict = yaml.safe_load(f)
-        env_var_path = (
-            f"{path}/{ENV_VAR_FILE_NAME}"
-            if is_model_dir
-            else posixpath.join(posixpath.dirname(path), ENV_VAR_FILE_NAME)
-        )
-
-        try:
-            env_var_path = _download_artifact_from_uri(env_var_path)
-        except Exception:
-            env_var_path = None
-        env_vars = None
-        if env_var_path is not None:
-            # comments start with `#` such as ENV_VAR_FILE_HEADER
-            lines = Path(env_var_path).read_text().splitlines()
-            env_vars = [line for line in lines if line and not line.startswith("#")]
-        model_dict["env_vars"] = env_vars
         return cls.from_dict(model_dict)
 
     @classmethod
@@ -907,6 +892,8 @@ class Model:
                         or None
                     )
             if env_vars:
+                # Keep the environment variable file as it serves as a check
+                # for displaying tips in Databricks serving endpoint
                 env_var_path = Path(local_path, ENV_VAR_FILE_NAME)
                 env_var_path.write_text(ENV_VAR_FILE_HEADER + "\n".join(env_vars) + "\n")
                 if len(env_vars) <= 3:
@@ -921,7 +908,9 @@ class Model:
                     "model. To disable this message, set environment variable "
                     f"`{MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name}` to `false`."
                 )
-            mlflow_model.env_vars = env_vars
+                mlflow_model.env_vars = env_vars
+                # mlflow_model is updated, rewrite the MLmodel file
+                mlflow_model.save(os.path.join(local_path, MLMODEL_FILE_NAME))
 
             # Associate prompts to the model Run
             if prompts:

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -942,7 +942,6 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
     )
     if size := get_total_file_size(path):
         mlflow_model.model_size_bytes = size
-    mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
     saved_code_subpath = _validate_infer_and_copy_code_paths(
         code_paths,
@@ -952,7 +951,6 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
     )
     mlflow_model.flavors[mlflow.pyfunc.FLAVOR_NAME][mlflow.pyfunc.CODE] = saved_code_subpath
 
-    # `mlflow_model.code` is updated, re-generate `MLmodel` file.
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
     if conda_env is None:

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -942,6 +942,9 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
     )
     if size := get_total_file_size(path):
         mlflow_model.model_size_bytes = size
+    # `mlflow_model.save` must be called before _validate_infer_and_copy_code_paths as it
+    # internally infers dependency, and MLmodel file is required to successfully load the model
+    mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
     saved_code_subpath = _validate_infer_and_copy_code_paths(
         code_paths,
@@ -951,6 +954,7 @@ def _save_model_with_class_artifacts_params(  # noqa: D417
     )
     mlflow_model.flavors[mlflow.pyfunc.FLAVOR_NAME][mlflow.pyfunc.CODE] = saved_code_subpath
 
+    # `mlflow_model.code` is updated, re-generate `MLmodel` file.
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
     if conda_env is None:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15292?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15292/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15292/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15292
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #15273

### What changes are proposed in this pull request?
As explained in the linked issue, `Model.load` appears to be slow since it tries to fetch a non-existing file (env_variable.txt)
This PR simplifies the process by saving env vars directly into the MLmodel file, so we don't need to fetch another file when loading. It's fine to keep it in MLmodel file since normally the env vars won't be too long as we restricted the format of the detected env vars.
NB: I'm still keeping the env_variables.txt file since it's used as a check in databricks serving to determine whether to show up a tip or not, we can clean up later.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
