### PR TITLE
Stringify non-string tags and enforce length limits on v3 TraceInfo

### DIFF
--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -53,8 +53,6 @@ class TraceInfo(_MlflowObject):
         return False
 
     def to_proto(self):
-        from mlflow.tracing.constant import MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
-
         proto = ProtoTraceInfo()
         proto.request_id = self.request_id
         proto.experiment_id = self.experiment_id
@@ -66,18 +64,18 @@ class TraceInfo(_MlflowObject):
         proto.status = self.status.to_proto()
 
         request_metadata = []
-        for key, value in self.request_metadata.items():
+        for key, value in _truncate_dict_keys_and_values(self.request_metadata).items():
             attr = ProtoTraceRequestMetadata()
-            attr.key = key[:MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS]
-            attr.value = str(value)[:MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS]
+            attr.key = key
+            attr.value = value
             request_metadata.append(attr)
         proto.request_metadata.extend(request_metadata)
 
         tags = []
-        for key, value in self.tags.items():
+        for key, value in _truncate_dict_keys_and_values(self.tags).items():
             tag = ProtoTraceTag()
-            tag.key = key[:MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS]
-            tag.value = str(value)[:MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS]
+            tag.key = key
+            tag.value = str(value)
             tags.append(tag)
 
         proto.tags.extend(tags)

--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.assessment import Assessment
@@ -9,6 +9,17 @@ from mlflow.protos.service_pb2 import TraceInfo as ProtoTraceInfo
 from mlflow.protos.service_pb2 import TraceLocation as ProtoTraceLocation
 from mlflow.protos.service_pb2 import TraceRequestMetadata as ProtoTraceRequestMetadata
 from mlflow.protos.service_pb2 import TraceTag as ProtoTraceTag
+
+
+def _truncate_dict_keys_and_values(d: dict[str, Any]) -> dict[str, str]:
+    from mlflow.tracing.constant import MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+
+    return {
+        k[:MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS]: str(v)[
+            :MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+        ]
+        for k, v in d.items()
+    }
 
 
 @dataclass
@@ -121,9 +132,9 @@ class TraceInfo(_MlflowObject):
             proto.execution_duration.FromMilliseconds(self.execution_time_ms)
 
         if self.request_metadata:
-            proto.trace_metadata.update(self.request_metadata)
+            proto.trace_metadata.update(_truncate_dict_keys_and_values(self.request_metadata))
 
         if self.tags:
-            proto.tags.update(self.tags)
+            proto.tags.update(_truncate_dict_keys_and_values(self.tags))
 
         return proto

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -812,10 +812,15 @@ def update_current_trace(
     if isinstance(tags, dict):
         non_string_items = {k: v for k, v in tags.items() if not isinstance(v, str)}
         if non_string_items:
+            none_values_present = any(v is None for v in non_string_items.values())
+            null_tag_advice = (
+                "Consider dropping None values from the tag dict prior to updating the trace."
+                if none_values_present
+                else ""
+            )
             _logger.warning(
                 "Found non-string values in tags. Please note that non-string tag values will "
-                "automatically be stringified when the trace is logged. Consider dropping None "
-                "values from the tag dict prior to updating the trace.\n\n"
+                f"automatically be stringified when the trace is logged. {null_tag_advice}\n\n"
                 f"Non-string items: {non_string_items}"
             )
 

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -809,6 +809,16 @@ def update_current_trace(
             error_code=BAD_REQUEST,
         )
 
+    if isinstance(tags, dict):
+        non_string_items = {k: v for k, v in tags.items() if not isinstance(v, str)}
+        if non_string_items:
+            _logger.warning(
+                "Found non-string values in tags. Please note that non-string tag values will "
+                "be automatically stringified when the trace is logged. Consider dropping None "
+                "values from the tag dict prior to updating the trace.\n\n"
+                f"Non-string keys and values: {non_string_items}"
+            )
+
     # Update tags for the trace stored in-memory rather than directly updating the
     # backend store. The in-memory trace will be exported when it is ended. By doing
     # this, we can avoid unnecessary server requests for each tag update.

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -814,9 +814,9 @@ def update_current_trace(
         if non_string_items:
             _logger.warning(
                 "Found non-string values in tags. Please note that non-string tag values will "
-                "be automatically stringified when the trace is logged. Consider dropping None "
+                "automatically be stringified when the trace is logged. Consider dropping None "
                 "values from the tag dict prior to updating the trace.\n\n"
-                f"Non-string keys and values: {non_string_items}"
+                f"Non-string items: {non_string_items}"
             )
 
     # Update tags for the trace stored in-memory rather than directly updating the

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1410,6 +1410,12 @@ class MlflowClient:
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
+        if not isinstance(value, str):
+            _logger.warning(
+                "Received non-string value for trace tag. Please note that non-string tag values"
+                "will automatically be stringified when the trace is logged."
+            )
+
         # Trying to set the tag on the active trace first
         with InMemoryTraceManager.get_instance().get_trace(request_id) as trace:
             if trace:

--- a/tests/entities/test_trace_info.py
+++ b/tests/entities/test_trace_info.py
@@ -1,4 +1,6 @@
 import pytest
+from google.protobuf.duration_pb2 import Duration
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from mlflow.entities import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
@@ -133,3 +135,19 @@ def test_trace_info_serialization_deserialization(trace_info_proto):
     assert TraceInfo.from_dict(trace_info_as_dict) == trace_info
     # TraceInfo -> trace info proto
     assert trace_info.to_proto() == trace_info_proto
+
+
+def test_trace_info_v3(trace_info):
+    v3_proto = trace_info.to_v3_proto("request", "response")
+    assert v3_proto.request == "request"
+    assert v3_proto.response == "response"
+    assert v3_proto.trace_id == "request_id"
+    assert isinstance(v3_proto.request_time, Timestamp)
+    assert v3_proto.request_time.ToSeconds() == 0
+    assert isinstance(v3_proto.execution_duration, Duration)
+    assert v3_proto.execution_duration.ToMilliseconds() == 1
+    assert v3_proto.state == 1
+    assert v3_proto.trace_metadata["foo"] == "bar"
+    assert v3_proto.trace_metadata["k" * 250] == "v" * 250
+    assert v3_proto.tags["baz"] == "qux"
+    assert v3_proto.tags["k" * 250] == "v" * 250


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As title, update the v3 to_proto function to be consistent with v2 behavior. Also add a warning when attempting to set non-string trace tags.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
