### PR TITLE
Migrate the legacy `mlflow.evaluation.Assessment` to the new `mlflow.entity.Assessment`

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -176,9 +176,6 @@ class Assessment(_MlflowObject):
             "span_id": self.span_id,
         }
 
-    def _get_current_time_ms(self):
-        return int(time.time() * 1000)
-
 
 @experimental
 @dataclass

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -37,7 +37,7 @@ class Assessment(_MlflowObject):
         Feedback can come from different sources, such as human judges, heuristic scorers,
         or LLM-as-a-Judge.
 
-    You can log an assessment to a trace using the :py:func:`mlflow.log_expectation`or
+    You can log an assessment to a trace using the :py:func:`mlflow.log_expectation` or
     :py:func:`mlflow.log_feedback` functions.
 
     Args:

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Optional, Union
 
@@ -28,9 +29,7 @@ AssessmentValueType = Union[PbValueType, dict[str, PbValueType], list[PbValueTyp
 @dataclass
 class Assessment(_MlflowObject):
     """
-    Assessment object associated with a trace.
-
-    Assessment are an abstraction for annotating two different types of labels on traces:
+    An abstraction for annotating a trace. An Assessment should be one of the following types:
 
     - Expectations: A label that represents the expected value for a particular operation.
         For example, an expected answer for a user question from a chatbot.
@@ -38,16 +37,14 @@ class Assessment(_MlflowObject):
         Feedback can come from different sources, such as human judges, heuristic scorers,
         or LLM-as-a-Judge.
 
-    To create an assessment with these labels, use the :py:func:`mlflow.log_expectation`
-    or :py:func:`mlflow.log_feedback` functions. Do **not** create an assessment object
-    directly using the constructor.
+    You can log an assessment to a trace using the :py:func:`mlflow.log_expectation`or
+    :py:func:`mlflow.log_feedback` functions.
 
     Args:
-        trace_id: The ID of the trace associated with the assessment.
         name: The name of the assessment.
         source: The source of the assessment.
-        create_time_ms: The creation time of the assessment in milliseconds.
-        last_update_time_ms: The last update time of the assessment in milliseconds.
+        trace_id: The ID of the trace associated with the assessment. If unset, the assessment
+            is not associated with any trace yet.
         expectation: The expectation value of the assessment.
         feedback: The feedback value of the assessment. Only one of `expectation`, `feedback`
             or `error` should be specified.
@@ -57,34 +54,33 @@ class Assessment(_MlflowObject):
             If this is set, the assessment should not contain `expectation` or `feedback`.
         span_id: The ID of the span associated with the assessment, if the assessment should
             be associated with a particular span in the trace.
-        _assessment_id: The ID of the assessment. This must be generated in the backend.
+        create_time_ms: The creation time of the assessment in milliseconds. If unset, the
+            current time is used.
+        last_update_time_ms: The last update time of the assessment in milliseconds.
+            If unset, the current time is used.
+        assessment_id: The ID of the assessment. This must be generated in the backend.
     """
 
-    trace_id: str
     name: str
     source: AssessmentSource
-    create_time_ms: int
-    last_update_time_ms: int
+    # NB: The trace ID is optional because the assessment object itself may be created
+    #   standalone. For example, a custom metric function returns an assessment object
+    #   without a trace ID. That said, the trace ID is required when logging the
+    #   assessment to a trace in the backend eventually.
+    #   https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/custom-metrics#-metric-decorator
+    trace_id: Optional[str] = None
     expectation: Optional[Expectation] = None
     feedback: Optional[Feedback] = None
     rationale: Optional[str] = None
     metadata: Optional[dict[str, str]] = None
     error: Optional[AssessmentError] = None
     span_id: Optional[str] = None
+    create_time_ms: Optional[int] = None
+    last_update_time_ms: Optional[int] = None
     # NB: The assessment ID should always be generated in the backend. The CreateAssessment
     #   backend API asks for an incomplete Assessment object without an ID and returns a
     #   complete one with assessment_id, so the ID is Optional in the constructor here.
-    _assessment_id: Optional[str] = None
-
-    @property
-    def assessment_id(self) -> str:
-        if self._assessment_id is None:
-            raise ValueError(
-                "Assessment ID is not set. The assessment object might not be "
-                "properly created. Please use the `mlflow.log_expectation` or "
-                "the `mlflow.log_feedback` API to create an assessment."
-            )
-        return self._assessment_id
+    assessment_id: Optional[str] = None
 
     def __post_init__(self):
         if (self.expectation is not None) + (self.feedback is not None) != 1:
@@ -95,6 +91,13 @@ class Assessment(_MlflowObject):
             raise MlflowException.invalid_parameter_value(
                 "Expectations cannot have `error` specified.",
             )
+
+        # Set timestamp if not provided
+        current_time = int(time.time() * 1000)  # milliseconds
+        if self.create_time_ms is None:
+            self.create_time_ms = current_time
+        if self.last_update_time_ms is None:
+            self.last_update_time_ms = current_time
 
     def to_proto(self):
         assessment = ProtoAssessment()
@@ -111,7 +114,7 @@ class Assessment(_MlflowObject):
             assessment.span_id = self.span_id
         if self.rationale is not None:
             assessment.rationale = self.rationale
-        if self._assessment_id is not None:
+        if self.assessment_id is not None:
             assessment.assessment_id = self.assessment_id
         if self.error is not None:
             assessment.error.CopyFrom(self.error.to_proto())
@@ -143,7 +146,7 @@ class Assessment(_MlflowObject):
         metadata = dict(proto.metadata) if proto.metadata else None
 
         return cls(
-            _assessment_id=proto.assessment_id or None,
+            assessment_id=proto.assessment_id or None,
             trace_id=proto.trace_id,
             name=proto.assessment_name,
             source=AssessmentSource.from_proto(proto.source),
@@ -159,7 +162,7 @@ class Assessment(_MlflowObject):
 
     def to_dictionary(self):
         return {
-            "assessment_id": self._assessment_id,
+            "assessment_id": self.assessment_id,
             "trace_id": self.trace_id,
             "name": self.name,
             "source": self.source.to_dictionary(),
@@ -172,6 +175,9 @@ class Assessment(_MlflowObject):
             "error": self.error.to_dictionary() if self.error else None,
             "span_id": self.span_id,
         }
+
+    def _get_current_time_ms(self):
+        return int(time.time() * 1000)
 
 
 @experimental

--- a/mlflow/entities/assessment_source.py
+++ b/mlflow/entities/assessment_source.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import asdict, dataclass
 from typing import Any, Optional
 
@@ -53,6 +54,7 @@ class AssessmentSource(_MlflowObject):
 class AssessmentSourceType:
     SOURCE_TYPE_UNSPECIFIED = "SOURCE_TYPE_UNSPECIFIED"
     LLM_JUDGE = "LLM_JUDGE"
+    AI_JUDGE = "AI_JUDGE"  # Deprecated, use LLM_JUDGE instead
     HUMAN = "HUMAN"
     CODE = "CODE"
     _SOURCE_TYPES = [SOURCE_TYPE_UNSPECIFIED, LLM_JUDGE, HUMAN, CODE]
@@ -63,6 +65,15 @@ class AssessmentSourceType:
     @staticmethod
     def _parse(source_type: str) -> str:
         source_type = source_type.upper()
+
+        # Backwards compatibility shim for mlflow.evaluations.AssessmentSourceType
+        if source_type == AssessmentSourceType.AI_JUDGE:
+            warnings.warn(
+                "AI_JUDGE is deprecated. Use LLM_JUDGE instead.",
+                DeprecationWarning,
+            )
+            source_type = AssessmentSourceType.LLM_JUDGE
+
         if source_type not in AssessmentSourceType._SOURCE_TYPES:
             raise MlflowException(
                 message=(

--- a/mlflow/evaluation/assessment.py
+++ b/mlflow/evaluation/assessment.py
@@ -11,7 +11,7 @@ from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.utils.annotations import deprecated, experimental
+from mlflow.utils.annotations import experimental
 
 
 @experimental
@@ -195,11 +195,6 @@ class AssessmentEntity(_MlflowObject):
         )
 
 
-@deprecated(
-    alternative="mlflow.entities.Assessment",
-    since="2.22.0",
-    impact="This class will be removed in MLflow 3.0.",
-)
 @experimental
 class Assessment(_MlflowObject):
     """

--- a/mlflow/evaluation/assessment.py
+++ b/mlflow/evaluation/assessment.py
@@ -8,104 +8,10 @@ import time
 from typing import Any, Optional, Union
 
 from mlflow.entities._mlflow_object import _MlflowObject
+from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.utils.annotations import experimental
-
-
-@experimental
-class AssessmentSourceType:
-    AI_JUDGE = "AI_JUDGE"
-    HUMAN = "HUMAN"
-    CODE = "CODE"
-    _SOURCE_TYPES = [AI_JUDGE, HUMAN, CODE]
-
-    def __init__(self, source_type: str):
-        self._source_type = AssessmentSourceType._parse(source_type)
-
-    @staticmethod
-    def _parse(source_type: str) -> str:
-        source_type = source_type.upper()
-        if source_type not in AssessmentSourceType._SOURCE_TYPES:
-            raise MlflowException(
-                message=(
-                    f"Invalid assessment source type: {source_type}. "
-                    f"Valid source types: {AssessmentSourceType._SOURCE_TYPES}"
-                ),
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-        return source_type
-
-    def __str__(self):
-        return self._source_type
-
-    @staticmethod
-    def _standardize(source_type: str) -> str:
-        return str(AssessmentSourceType(source_type))
-
-
-@experimental
-class AssessmentSource(_MlflowObject):
-    """
-    Source of an assessment (human, LLM as a judge with GPT-4, etc).
-    """
-
-    def __init__(self, source_type: str, source_id: str, metadata: Optional[dict[str, Any]] = None):
-        """Construct a new mlflow.evaluation.AssessmentSource instance.
-
-        Args:
-            source_type: The type of the assessment source (AssessmentSourceType).
-            source_id: An identifier for the source, e.g. user ID or LLM judge ID.
-            metadata: Additional metadata about the source, e.g. human-readable name, inlined LLM
-                judge parameters, etc.
-        """
-        self._source_type = AssessmentSourceType._standardize(source_type)
-        self._source_id = source_id
-        self._metadata = metadata or {}
-
-    @property
-    def source_type(self) -> str:
-        """The type of the assessment source."""
-        return self._source_type
-
-    @property
-    def source_id(self) -> str:
-        """The identifier for the source."""
-        return self._source_id
-
-    @property
-    def metadata(self) -> dict[str, Any]:
-        """The additional metadata about the source."""
-        return self._metadata
-
-    def __eq__(self, __o):
-        if isinstance(__o, self.__class__):
-            return self.to_dictionary() == __o.to_dictionary()
-
-        return False
-
-    def to_dictionary(self) -> dict[str, Any]:
-        return {
-            "source_type": self.source_type,
-            "source_id": self.source_id,
-            "metadata": self.metadata,
-        }
-
-    @classmethod
-    def from_dictionary(cls, source_dict: dict[str, Any]) -> "AssessmentSource":
-        """
-        Create a AssessmentSource object from a dictionary.
-
-        Args:
-            source_dict (dict): Dictionary containing assessment source information.
-
-        Returns:
-            AssessmentSource: The AssessmentSource object created from the dictionary.
-        """
-        source_type = source_dict["source_type"]
-        source_id = source_dict["source_id"]
-        metadata = source_dict.get("metadata")
-        return cls(source_type=source_type, source_id=source_id, metadata=metadata)
+from mlflow.utils.annotations import deprecated, experimental
 
 
 @experimental
@@ -124,9 +30,10 @@ class AssessmentEntity(_MlflowObject):
         numeric_value: Optional[float] = None,
         string_value: Optional[str] = None,
         rationale: Optional[str] = None,
-        metadata: Optional[dict[str, Any]] = None,
+        metadata: Optional[dict[str, str]] = None,
         error_code: Optional[str] = None,
         error_message: Optional[str] = None,
+        span_id: Optional[str] = None,
     ):
         """Construct a new mlflow.evaluation.AssessmentEntity instance.
 
@@ -144,6 +51,10 @@ class AssessmentEntity(_MlflowObject):
             error_code: An error code representing any issues encountered during the assessment.
             error_message: A descriptive error message representing any issues encountered during
                 the assessment.
+            span_id: The span ID of the span within the Trace, that the assessment is evaluating,
+                     e.g. if you are evaluating a retrieval span for document recall, you can
+                     specify the span ID of the retrieval span here. This field is only supported
+                     by mlflow.log_feedback.
         """
         self._evaluation_id = evaluation_id
         self._name = name
@@ -156,6 +67,7 @@ class AssessmentEntity(_MlflowObject):
         self._metadata = metadata or {}
         self._error_code = error_code
         self._error_message = error_message
+        self._span_id = span_id
 
         if error_message is not None and (
             boolean_value is not None or numeric_value is not None or string_value is not None
@@ -230,6 +142,11 @@ class AssessmentEntity(_MlflowObject):
         """The error message."""
         return self._error_message
 
+    @property
+    def span_id(self) -> Optional[str]:
+        """The span ID of the span within the Trace, that the assessment is evaluating."""
+        return self._span_id
+
     def __eq__(self, __o):
         if isinstance(__o, self.__class__):
             return self.to_dictionary() == __o.to_dictionary()
@@ -248,6 +165,7 @@ class AssessmentEntity(_MlflowObject):
             "metadata": self.metadata,
             "error_code": self.error_code,
             "error_message": self.error_message,
+            "span_id": self.span_id,
         }
 
     @classmethod
@@ -273,9 +191,15 @@ class AssessmentEntity(_MlflowObject):
             metadata=assessment_dict.get("metadata"),
             error_code=assessment_dict.get("error_code"),
             error_message=assessment_dict.get("error_message"),
+            span_id=assessment_dict.get("span_id"),
         )
 
 
+@deprecated(
+    alternative="mlflow.entities.Assessment",
+    since="2.22.0",
+    impact="This class will be removed in MLflow 3.0.",
+)
 @experimental
 class Assessment(_MlflowObject):
     """
@@ -333,7 +257,10 @@ class Assessment(_MlflowObject):
             )
 
         self._name = name
-        self._source = source
+        self._source = source or AssessmentSource(
+            source_type=AssessmentSourceType.SOURCE_TYPE_UNSPECIFIED,
+            source_id="unknown",
+        )
         self._value = value
         self._rationale = rationale
         self._metadata = metadata or {}
@@ -366,7 +293,7 @@ class Assessment(_MlflowObject):
         return self._rationale
 
     @property
-    def source(self) -> Optional[AssessmentSource]:
+    def source(self) -> AssessmentSource:
         """The source of the assessment."""
         return self._source
 

--- a/mlflow/evaluation/utils.py
+++ b/mlflow/evaluation/utils.py
@@ -124,6 +124,7 @@ def _get_assessments_dataframe_schema() -> dict[str, str]:
         "metadata": "object",
         "error_code": "object",
         "error_message": "object",
+        "span_id": "object",
     }
 
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -12,7 +12,6 @@ import posixpath
 import re
 import sys
 import tempfile
-import time
 import urllib
 import uuid
 import warnings
@@ -1470,15 +1469,11 @@ class MlflowClient:
         metadata: Optional[dict[str, Any]] = None,
         span_id: Optional[str] = None,
     ) -> Assessment:
-        timestamp = int(time.time() * 1000)  # milliseconds
-
         assessment = Assessment(
             # assessment_id must be None when creating a new assessment
             trace_id=trace_id,
             name=name,
             source=source,
-            create_time_ms=timestamp,
-            last_update_time_ms=timestamp,
             expectation=expectation,
             feedback=feedback,
             error=error,

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -26,7 +26,7 @@ def test_assessment_creation():
         "metadata": {"key1": "value1"},
         "error": None,
         "span_id": "span_id",
-        "_assessment_id": "assessment_id",
+        "assessment_id": "assessment_id",
     }
 
     assessment = Assessment(**default_params)
@@ -204,7 +204,7 @@ def test_assessment_conversion(expectation, feedback, error, source, metadata):
     assert result == assessment
 
     dict = assessment.to_dictionary()
-    assert dict["assessment_id"] == assessment._assessment_id
+    assert dict["assessment_id"] == assessment.assessment_id
     assert dict["trace_id"] == assessment.trace_id
     assert dict["name"] == assessment.name
     assert dict["source"] == {

--- a/tests/entities/test_assessment_source.py
+++ b/tests/entities/test_assessment_source.py
@@ -42,7 +42,8 @@ def test_assessment_source_type_validation():
     AssessmentSource(source_type="LLM_JUDGE", source_id="judge_1")
 
     # Deprecated source type for backward compatibility
-    AssessmentSource(source_type="AI_JUDGE", source_id="ai_1")
+    source = AssessmentSource(source_type="AI_JUDGE", source_id="ai_1")
+    assert source.source_type == "LLM_JUDGE"
 
     # Invalid source type
     with pytest.raises(MlflowException, match="Invalid assessment source type"):

--- a/tests/entities/test_assessment_source.py
+++ b/tests/entities/test_assessment_source.py
@@ -41,6 +41,9 @@ def test_assessment_source_type_validation():
     AssessmentSource(source_type="HUMAN", source_id="user_1")
     AssessmentSource(source_type="LLM_JUDGE", source_id="judge_1")
 
+    # Deprecated source type for backward compatibility
+    AssessmentSource(source_type="AI_JUDGE", source_id="ai_1")
+
     # Invalid source type
     with pytest.raises(MlflowException, match="Invalid assessment source type"):
         AssessmentSource(source_type="ROBOT", source_id="robot_1")

--- a/tests/evaluate/logging/test_assessment.py
+++ b/tests/evaluate/logging/test_assessment.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
+from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.evaluation import Assessment
 from mlflow.evaluation.assessment import AssessmentSource
 from mlflow.exceptions import MlflowException
@@ -320,18 +321,7 @@ def test_assessment_without_source():
         value=0.9,
     )
 
-    assert assessment.source is None
+    assert assessment.source.source_type == AssessmentSourceType.SOURCE_TYPE_UNSPECIFIED
 
-
-def test_assessment_to_entity_fail_without_source():
-    assessment = Assessment(
-        name="relevance",
-        value=0.9,
-    )
-
-    evaluation_id = "evaluation_1"
-    with pytest.raises(
-        MlflowException,
-        match="Assessment source must be specified.",
-    ):
-        assessment._to_entity(evaluation_id)
+    entity = assessment._to_entity("evaluation_1")
+    assert entity.source.source_type == AssessmentSourceType.SOURCE_TYPE_UNSPECIFIED

--- a/tests/evaluate/logging/test_assessment_entity.py
+++ b/tests/evaluate/logging/test_assessment_entity.py
@@ -111,6 +111,7 @@ def test_assessment_to_from_dictionary():
         "metadata": {"key1": "value1"},
         "error_code": None,
         "error_message": None,
+        "span_id": None,
     }
     assert assessment_dict == expected_dict
 

--- a/tests/evaluate/logging/test_fluent.py
+++ b/tests/evaluate/logging/test_fluent.py
@@ -58,7 +58,6 @@ def test_log_evaluations_with_all_params():
                     "source": {
                         "source_type": "HUMAN",
                         "source_id": "user_1",
-                        "metadata": {"sourcekey1": "sourcevalue1"},
                     },
                 },
                 {
@@ -67,7 +66,6 @@ def test_log_evaluations_with_all_params():
                     "source": {
                         "source_type": "HUMAN",
                         "source_id": "user_1",
-                        "metadata": {"sourcekey2": "sourcevalue2"},
                     },
                 },
             ],
@@ -88,7 +86,6 @@ def test_log_evaluations_with_all_params():
                     source=AssessmentSource(
                         source_type=AssessmentSourceType.HUMAN,
                         source_id="user-1",
-                        metadata={"sourcekey3": "sourcevalue3"},
                     ),
                 )
             ],

--- a/tests/evaluate/logging/test_utils.py
+++ b/tests/evaluate/logging/test_utils.py
@@ -133,6 +133,7 @@ def test_evaluations_to_dataframes_empty():
         "metadata",
         "error_code",
         "error_message",
+        "span_id",
     ]
     expected_tags_columns = ["evaluation_id", "key", "value"]
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Taking over https://github.com/mlflow/mlflow/pull/15191. 

The `mlflow.evaluation.Assessment` will be deprecated in favor of the new `mlflow.entity.Assessment`. However, we cannot remove it in 2.x because there are some important usage in DBX such as Agent Evaluation. Therefore, this PR make non-breaking adjustments so that those use cases can migrate to 3.x smoothly.

Also, the `trace_id` and timestamp fields in the new `mlflow.entity.Assessment` entity becomes optional, so that users can create a stand-alone Assessment object. This is a valid use case of Agent Evaluation, so supporting it is necessary to make migration happen. For example, [a custom metric definition](https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/custom-metrics) that returns a stand-alone Assessment object (which will be later logged to backend by evaluator).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Deprecate `mlflow.evaluation.Assessment` class in favor of the new `mlflow.entityt.Assessment` class.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
