### PR TITLE
Add download_spans option to client.search_traces API

### DIFF
--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -320,6 +320,7 @@ class TrackingServiceClient:
         order_by: Optional[list[str]] = None,
         page_token: Optional[str] = None,
         run_id: Optional[str] = None,
+        download_spans: bool = True,
     ) -> PagedList[Trace]:
         def download_trace_extra_fields(trace_info: TraceInfo) -> Optional[Trace]:
             """
@@ -333,6 +334,10 @@ class TrackingServiceClient:
                     trace_info.request_id, should_query_v3=True
                 )
                 trace_info.assessments = trace_info_with_assessments.assessments
+
+            if not download_spans:
+                return Trace(trace_info, TraceData(spans=[]))
+
             try:
                 trace_data = self._download_trace_data(trace_info)
             except MlflowTraceDataException as e:

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -320,7 +320,7 @@ class TrackingServiceClient:
         order_by: Optional[list[str]] = None,
         page_token: Optional[str] = None,
         run_id: Optional[str] = None,
-        download_spans: bool = True,
+        include_spans: bool = True,
     ) -> PagedList[Trace]:
         def download_trace_extra_fields(trace_info: TraceInfo) -> Optional[Trace]:
             """
@@ -335,7 +335,7 @@ class TrackingServiceClient:
                 )
                 trace_info.assessments = trace_info_with_assessments.assessments
 
-            if not download_spans:
+            if not include_spans:
                 return Trace(trace_info, TraceData(spans=[]))
 
             try:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -870,7 +870,7 @@ class MlflowClient:
         order_by: Optional[list[str]] = None,
         page_token: Optional[str] = None,
         run_id: Optional[str] = None,
-        download_spans: bool = True,
+        include_spans: bool = True,
     ) -> PagedList[Trace]:
         """
         Return traces that match the given list of search expressions within the experiments.
@@ -885,7 +885,7 @@ class MlflowClient:
             run_id: A run id to scope the search. When a trace is created under an active run,
                 it will be associated with the run and you can filter on the run id to retrieve
                 the trace.
-            download_spans: If ``True``, include spans in the returned traces. Otherwise, only
+            include_spans: If ``True``, include spans in the returned traces. Otherwise, only
                 the trace metadata is returned, e.g., trace ID, start time, end time, etc,
                 without any spans.
 
@@ -904,7 +904,7 @@ class MlflowClient:
             order_by=order_by,
             page_token=page_token,
             run_id=run_id,
-            download_spans=download_spans,
+            include_spans=include_spans,
         )
 
     def start_trace(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -870,6 +870,7 @@ class MlflowClient:
         order_by: Optional[list[str]] = None,
         page_token: Optional[str] = None,
         run_id: Optional[str] = None,
+        download_spans: bool = True,
     ) -> PagedList[Trace]:
         """
         Return traces that match the given list of search expressions within the experiments.
@@ -884,6 +885,9 @@ class MlflowClient:
             run_id: A run id to scope the search. When a trace is created under an active run,
                 it will be associated with the run and you can filter on the run id to retrieve
                 the trace.
+            download_spans: If ``True``, include spans in the returned traces. Otherwise, only
+                the trace metadata is returned, e.g., trace ID, start time, end time, etc,
+                without any spans.
 
         Returns:
             A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
@@ -900,6 +904,7 @@ class MlflowClient:
             order_by=order_by,
             page_token=page_token,
             run_id=run_id,
+            download_spans=download_spans,
         )
 
     def start_trace(

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -281,11 +281,10 @@ def test_client_search_traces(mock_store, mock_artifact_repo, download_spans):
         order_by=None,
         page_token=None,
     )
+    assert len(results) == 2
     if download_spans:
-        assert len(results) == 2
         mock_artifact_repo.download_trace_data.assert_called()
     else:
-        assert len(results) == 2
         mock_artifact_repo.download_trace_data.assert_not_called()
 
     # The TraceInfo is already fetched prior to the upload_trace_data call,

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -248,7 +248,8 @@ def test_client_get_trace_throws_for_missing_or_corrupted_data(mock_store, mock_
         MlflowClient().get_trace("1234567")
 
 
-def test_client_search_traces(mock_store, mock_artifact_repo):
+@pytest.mark.parametrize("download_spans", [True, False])
+def test_client_search_traces(mock_store, mock_artifact_repo, download_spans):
     mock_traces = [
         TraceInfo(
             request_id="1234567",
@@ -269,7 +270,9 @@ def test_client_search_traces(mock_store, mock_artifact_repo):
     ]
     mock_store.search_traces.return_value = (mock_traces, None)
     mock_artifact_repo.download_trace_data.return_value = {}
-    MlflowClient().search_traces(experiment_ids=["1", "2", "3"])
+    results = MlflowClient().search_traces(
+        experiment_ids=["1", "2", "3"], download_spans=download_spans
+    )
 
     mock_store.search_traces.assert_called_once_with(
         experiment_ids=["1", "2", "3"],
@@ -278,13 +281,20 @@ def test_client_search_traces(mock_store, mock_artifact_repo):
         order_by=None,
         page_token=None,
     )
-    mock_artifact_repo.download_trace_data.assert_called()
+    if download_spans:
+        assert len(results) == 2
+        mock_artifact_repo.download_trace_data.assert_called()
+    else:
+        assert len(results) == 2
+        mock_artifact_repo.download_trace_data.assert_not_called()
+
     # The TraceInfo is already fetched prior to the upload_trace_data call,
     # so we should not call _get_trace_info again
     mock_store.get_trace_info.assert_not_called()
 
 
-def test_client_search_traces_trace_data_download_error(mock_store):
+@pytest.mark.parametrize("download_spans", [True, False])
+def test_client_search_traces_trace_data_download_error(mock_store, download_spans):
     class CustomArtifactRepository(ArtifactRepository):
         def log_artifact(self, local_file, artifact_path=None):
             raise NotImplementedError("Should not be called")
@@ -313,8 +323,15 @@ def test_client_search_traces_trace_data_download_error(mock_store):
             ),
         ]
         mock_store.search_traces.return_value = (mock_traces, None)
-        assert MlflowClient().search_traces(experiment_ids=["1"]) == []
-        mock_get_artifact_repository.assert_called()
+        traces = MlflowClient().search_traces(experiment_ids=["1"], download_spans=download_spans)
+
+        if download_spans:
+            assert traces == []
+            mock_get_artifact_repository.assert_called()
+        else:
+            assert len(traces) == 1
+            assert traces[0].info.request_id == "1234567"
+            mock_get_artifact_repository.assert_not_called()
 
 
 def test_client_delete_traces(mock_store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -248,8 +248,8 @@ def test_client_get_trace_throws_for_missing_or_corrupted_data(mock_store, mock_
         MlflowClient().get_trace("1234567")
 
 
-@pytest.mark.parametrize("download_spans", [True, False])
-def test_client_search_traces(mock_store, mock_artifact_repo, download_spans):
+@pytest.mark.parametrize("include_spans", [True, False])
+def test_client_search_traces(mock_store, mock_artifact_repo, include_spans):
     mock_traces = [
         TraceInfo(
             request_id="1234567",
@@ -271,7 +271,7 @@ def test_client_search_traces(mock_store, mock_artifact_repo, download_spans):
     mock_store.search_traces.return_value = (mock_traces, None)
     mock_artifact_repo.download_trace_data.return_value = {}
     results = MlflowClient().search_traces(
-        experiment_ids=["1", "2", "3"], download_spans=download_spans
+        experiment_ids=["1", "2", "3"], include_spans=include_spans
     )
 
     mock_store.search_traces.assert_called_once_with(
@@ -282,7 +282,7 @@ def test_client_search_traces(mock_store, mock_artifact_repo, download_spans):
         page_token=None,
     )
     assert len(results) == 2
-    if download_spans:
+    if include_spans:
         mock_artifact_repo.download_trace_data.assert_called()
     else:
         mock_artifact_repo.download_trace_data.assert_not_called()
@@ -292,8 +292,8 @@ def test_client_search_traces(mock_store, mock_artifact_repo, download_spans):
     mock_store.get_trace_info.assert_not_called()
 
 
-@pytest.mark.parametrize("download_spans", [True, False])
-def test_client_search_traces_trace_data_download_error(mock_store, download_spans):
+@pytest.mark.parametrize("include_spans", [True, False])
+def test_client_search_traces_trace_data_download_error(mock_store, include_spans):
     class CustomArtifactRepository(ArtifactRepository):
         def log_artifact(self, local_file, artifact_path=None):
             raise NotImplementedError("Should not be called")
@@ -322,9 +322,9 @@ def test_client_search_traces_trace_data_download_error(mock_store, download_spa
             ),
         ]
         mock_store.search_traces.return_value = (mock_traces, None)
-        traces = MlflowClient().search_traces(experiment_ids=["1"], download_spans=download_spans)
+        traces = MlflowClient().search_traces(experiment_ids=["1"], include_spans=include_spans)
 
-        if download_spans:
+        if include_spans:
             assert traces == []
             mock_get_artifact_repository.assert_called()
         else:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15300?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15300/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15300/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15300
```

</p>
</details>

### What changes are proposed in this pull request?

Adding an option to run `search_traces` API but without downloading spans for an internal use case that only require TraceInfo but no spans.

This PR only introduce the argument to the low-level client API `MlflowClient().search_traces()` because we haven't heard any request from users. We shouldn't complicate the fluent API for a particular internal use case.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
