### PR TITLE
Explicitly set python that `reticulate` uses

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -94,4 +94,5 @@ jobs:
           LINTR_COMMENT_BOT: false
         run: |
           cd tests
+          export RETICULATE_PYTHON_BIN=$(which python)
           Rscript -e 'source("../.run-tests.R", echo=TRUE)'

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -14,7 +14,4 @@ devtools::install_git("https://github.com/smurching/Rd2md", ref = "mlflow-patche
 devtools::install_version("roxygen2", "7.1.2")
 # The latest version of git2r (0.35.0) doesn't work with the rocker/r-ver:4.2.1 docker image
 devtools::install_version("git2r", "0.33.0")
-# In reticulate 1.41.0, `py_module_import` doesn't work.
-# See https://github.com/mlflow/mlflow/pull/14734 for the full traceback.
-devtools::install_version("reticulate", "1.40.0")
 install.packages("rmarkdown", repos = "https://cloud.r-project.org")

--- a/mlflow/R/mlflow/tests/testthat.R
+++ b/mlflow/R/mlflow/tests/testthat.R
@@ -18,8 +18,10 @@ mlflow_load_flavor.mlflow_flavor_trivial <- function(flavor, model_path) {
 
 library(testthat)
 library(mlflow)
+library(reticulate)
 
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   message("Current working directory: ", getwd())
   test_check("mlflow", reporter = ProgressReporter)
+  use_python(Sys.getenv("RETICULATE_PYTHON_BIN", "python"))
 }

--- a/mlflow/R/mlflow/tests/testthat.R
+++ b/mlflow/R/mlflow/tests/testthat.R
@@ -18,10 +18,8 @@ mlflow_load_flavor.mlflow_flavor_trivial <- function(flavor, model_path) {
 
 library(testthat)
 library(mlflow)
-library(reticulate)
 
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   message("Current working directory: ", getwd())
   test_check("mlflow", reporter = ProgressReporter)
-  use_python(Sys.getenv("RETICULATE_PYTHON_BIN", "python"))
 }

--- a/mlflow/R/mlflow/tests/testthat/test-keras-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-keras-model.R
@@ -1,8 +1,13 @@
 context("Model")
 
 library("keras")
+library("reticulate")
 
 testthat_model_dir <- tempfile("model_")
+
+setup({
+    use_python(Sys.getenv("RETICULATE_PYTHON_BIN", "python"))
+})
 
 teardown({
   mlflow_clear_test_dir(testthat_model_dir)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15303?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15303/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15303/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15303
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

For for the following error. Upgrades `reticulate` to latest and set the python bin to use.

```
Installing package into ‘/home/runner/work/_temp/Library’
(as ‘lib’ is unspecified)
* installing *source* package ‘reticulate’ ...
** this is package ‘reticulate’ version ‘1.40.0’
** package ‘reticulate’ successfully unpacked and MD5 sums checked
** using staged installation
** libs
using C++ compiler: ‘g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
g++ -std=gnu++17 -I"/opt/R/4.5.0/lib/R/include" -DNDEBUG  -I'/home/runner/work/_temp/Library/Rcpp/include' -I/usr/local/include    -fpic  -g -O2   -c RcppExports.cpp -o RcppExports.o
g++ -std=gnu++17 -I"/opt/R/4.5.0/lib/R/include" -DNDEBUG  -I'/home/runner/work/_temp/Library/Rcpp/include' -I/usr/local/include    -fpic  -g -O2   -c event_loop.cpp -o event_loop.o
g++ -std=gnu++17 -I"/opt/R/4.5.0/lib/R/include" -DNDEBUG  -I'/home/runner/work/_temp/Library/Rcpp/include' -I/usr/local/include    -fpic  -g -O2   -c libpython.cpp -o libpython.o
g++ -std=gnu++17 -I"/opt/R/4.5.0/lib/R/include" -DNDEBUG  -I'/home/runner/work/_temp/Library/Rcpp/include' -I/usr/local/include    -fpic  -g -O2   -c output.cpp -o output.o
g++ -std=gnu++17 -I"/opt/R/4.5.0/lib/R/include" -DNDEBUG  -I'/home/runner/work/_temp/Library/Rcpp/include' -I/usr/local/include    -fpic  -g -O2   -c pending_py_calls_notifier.cpp -o pending_py_calls_notifier.o
In file included from /opt/R/4.5.0/lib/R/include/R.h:73,
                 from pending_py_calls_notifier.cpp:14:
/opt/R/4.5.0/lib/R/include/R_ext/Error.h:58:19: error: function ‘void Rf_error(const char*, ...)’ declared ‘[[noreturn]]’ but its first declaration was not
   58 | [[noreturn]] void Rf_error(const char *, ...) R_PRINTF_FORMAT(1, 2);
      |                   ^~~~~~~~
In file included from pending_py_calls_notifier.cpp:11:
tinythread.h:33:17: note: previous declaration of ‘void Rf_error(const char*, ...)’
   33 | extern "C" void Rf_error(const char* fmt, ...);
      |                 ^~~~~~~~
make: *** [/opt/R/4.5.0/lib/R/etc/Makeconf:211: pending_py_calls_notifier.o] Error 1
ERROR: compilation failed for package ‘reticulate’
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
