### PR TITLE
Remove `set_pb_value` and `parse_pb_value`

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -15,7 +15,6 @@ from mlflow.protos.assessments_pb2 import Assessment as ProtoAssessment
 from mlflow.protos.assessments_pb2 import Expectation as ProtoExpectation
 from mlflow.protos.assessments_pb2 import Feedback as ProtoFeedback
 from mlflow.utils.annotations import experimental
-from mlflow.utils.proto_json_utils import parse_pb_value, set_pb_value
 
 # Assessment value should be one of the following types:
 # - float
@@ -129,7 +128,7 @@ class Assessment(_MlflowObject):
             assessment.assessment_id = self.assessment_id
 
         if self.expectation is not None:
-            set_pb_value(assessment.expectation.value, self.expectation.value)
+            assessment.expectation.CopyFrom(self.expectation.to_proto())
         elif self.feedback is not None:
             assessment.feedback.CopyFrom(self.feedback.to_proto())
 
@@ -141,7 +140,7 @@ class Assessment(_MlflowObject):
     @classmethod
     def from_proto(cls, proto):
         if proto.WhichOneof("value") == "expectation":
-            expectation = Expectation(parse_pb_value(proto.expectation.value))
+            expectation = Expectation.from_proto(proto.expectation)
             feedback = None
         elif proto.WhichOneof("value") == "feedback":
             expectation = None
@@ -194,9 +193,11 @@ class Expectation(_MlflowObject):
     value: AssessmentValueType
 
     def to_proto(self):
-        expectation = ProtoExpectation()
-        expectation.value = self.value
-        return expectation
+        return ProtoExpectation(value=ParseDict(self.value, Value()))
+
+    @classmethod
+    def from_proto(cls, proto) -> "Expectation":
+        return cls(value=MessageToDict(proto.value))
 
     def to_dictionary(self):
         return {"value": self.value}
@@ -221,7 +222,7 @@ class Feedback(_MlflowObject):
         )
 
     @classmethod
-    def from_proto(self, proto):
+    def from_proto(self, proto) -> "Feedback":
         return Feedback(
             value=MessageToDict(proto.value),
             error=AssessmentError.from_proto(proto.error) if proto.HasField("error") else None,

--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -76,7 +76,7 @@ class SpanEvent(_MlflowObject):
         return ProtoSpan.Event(
             name=self.name,
             time_unix_nano=self.timestamp,
-            attributes={key: ParseDict(value, Value()) for key, value in self.attributes.items()},
+            attributes={k: ParseDict(v, Value()) for k, v in self.attributes.items()},
         )
 
 

--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -5,11 +5,12 @@ import traceback
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from google.protobuf.json_format import ParseDict
+from google.protobuf.struct_pb2 import Value
 from opentelemetry.util.types import AttributeValue
 
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.databricks_trace_server_pb2 import Span as ProtoSpan
-from mlflow.utils.proto_json_utils import set_pb_value
 
 
 @dataclass
@@ -72,14 +73,11 @@ class SpanEvent(_MlflowObject):
 
     def to_proto(self):
         """Convert into OTLP compatible proto object to sent to the Databricks Trace Server."""
-        proto = ProtoSpan.Event(
+        return ProtoSpan.Event(
             name=self.name,
             time_unix_nano=self.timestamp,
+            attributes={key: ParseDict(value, Value()) for key, value in self.attributes.items()},
         )
-        # Trace server's proto uses map<string, google.protobuf.Value> for attributes
-        for key, value in self.attributes.items():
-            set_pb_value(proto.attributes[key], value)
-        return proto
 
 
 class CustomEncoder(json.JSONEncoder):

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -48,7 +48,7 @@ from mlflow.protos.service_pb2 import (
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.store.tracking.abstract_store import AbstractStore
-from mlflow.utils.proto_json_utils import message_to_json, set_pb_value
+from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import (
     _REST_API_PATH_PREFIX,
     call_endpoint,
@@ -470,7 +470,7 @@ class RestStore(AbstractStore):
             assessment.assessment_name = name
             mask.paths.append("assessment_name")
         if expectation is not None:
-            set_pb_value(assessment.expectation.value, expectation.value)
+            assessment.expectation.CopyFrom(expectation.to_proto())
             mask.paths.append("expectation")
         if feedback is not None:
             assessment.feedback.CopyFrom(feedback.to_proto())

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -12,7 +12,6 @@ from typing import Any, Optional
 import pydantic
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.json_format import MessageToJson, ParseDict
-from google.protobuf.struct_pb2 import NULL_VALUE, Value
 
 from mlflow.exceptions import MlflowException
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
@@ -158,45 +157,6 @@ def parse_dict(js_dict, message):
     """Parses a JSON dictionary into a message proto, ignoring unknown fields in the JSON."""
     _stringify_all_experiment_ids(js_dict)
     ParseDict(js_dict=js_dict, message=message, ignore_unknown_fields=True)
-
-
-def set_pb_value(proto: Value, value: Any):
-    """Set a value to the google.protobuf.Value object."""
-    if isinstance(value, dict):
-        for key, val in value.items():
-            set_pb_value(proto.struct_value.fields[key], val)
-    elif isinstance(value, list):
-        for idx, val in enumerate(value):
-            pb = Value()
-            set_pb_value(pb, val)
-            proto.list_value.values.append(pb)
-    elif isinstance(value, bool):
-        proto.bool_value = value
-    elif isinstance(value, (int, float)):
-        proto.number_value = value
-    elif isinstance(value, str):
-        proto.string_value = value
-    elif value is None:
-        proto.null_value = NULL_VALUE
-
-    else:
-        raise ValueError(f"Unsupported value type: {type(value)}")
-
-
-def parse_pb_value(proto: Value) -> Optional[Any]:
-    """Extract a value from the google.protobuf.Value object."""
-    if proto.HasField("struct_value"):
-        return {key: parse_pb_value(val) for key, val in proto.struct_value.fields.items()}
-    elif proto.HasField("list_value"):
-        return [parse_pb_value(val) for val in proto.list_value.values]
-    elif proto.HasField("bool_value"):
-        return proto.bool_value
-    elif proto.HasField("number_value"):
-        return proto.number_value
-    elif proto.HasField("string_value"):
-        return proto.string_value
-
-    return None
 
 
 class NumpyEncoder(JSONEncoder):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15315?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15315/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15315/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15315
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Remove `set_pb_value` and `parse_pb_value`. `ParseDict` or `MessageToDict` can be used instead. The following code ensures they are equivalent.

```python
from google.protobuf.struct_pb2 import NULL_VALUE, Value
from google.protobuf.json_format import ParseDict, MessageToDict
from mlflow.utils.proto_json_utils import set_pb_value, parse_pb_value


for val in [
    "str",
    0,
    0.0,
    True,
    None,
    [1, 2, 3],
    {"foo": "bar"},
    {"foo": ["bar", "baz"]},
]:
    x = ParseDict(val, Value())
    y = Value()
    set_pb_value(y, val)
    print(x, y)

    assert x == y

    xx = MessageToDict(x)
    yy = parse_pb_value(y)
    print(xx, yy)
    assert xx == yy

```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->



### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
