### PR TITLE
Use `MessageToDict` to convert Assessment entity to dict to mirror its proto

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -153,6 +153,8 @@ class Assessment(_MlflowObject):
         )
 
     def to_dictionary(self):
+        # Note that MessageToDict excludes None fields. For example, if assessment_id is None,
+        # it won't be included in the resulting dictionary.
         return MessageToDict(self.to_proto(), preserving_proto_field_name=True)
 
 

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -153,19 +153,7 @@ class Assessment(_MlflowObject):
         )
 
     def to_dictionary(self):
-        return {
-            "assessment_id": self.assessment_id,
-            "trace_id": self.trace_id,
-            "name": self.name,
-            "source": self.source.to_dictionary(),
-            "create_time_ms": self.create_time_ms,
-            "last_update_time_ms": self.last_update_time_ms,
-            "expectation": self.expectation.to_dictionary() if self.expectation else None,
-            "feedback": self.feedback.to_dictionary() if self.feedback else None,
-            "rationale": self.rationale,
-            "metadata": self.metadata,
-            "span_id": self.span_id,
-        }
+        return MessageToDict(self.to_proto(), preserving_proto_field_name=True)
 
 
 @experimental

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -201,7 +201,4 @@ class Feedback(_MlflowObject):
         )
 
     def to_dictionary(self):
-        d = {"value": self.value}
-        if self.error:
-            d["error"] = self.error.to_dictionary()
-        return d
+        return MessageToDict(self.to_proto(), preserving_proto_field_name=True)

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -13,6 +13,7 @@ import pydantic
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.json_format import MessageToJson, ParseDict
 from google.protobuf.struct_pb2 import NULL_VALUE, Value
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from mlflow.exceptions import MlflowException
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
@@ -124,6 +125,15 @@ def message_to_json(message):
         json_dict_with_int64_fields_only, json_dict_with_int64_as_str
     )
     return json.dumps(json_dict_with_int64_as_numbers, indent=2)
+
+
+def proto_timestamp_to_milliseconds(timestamp: str) -> int:
+    """
+    Converts a timestamp string (e.g. "2025-04-15T08:49:18.699Z") to milliseconds.
+    """
+    t = Timestamp()
+    t.FromJsonString(timestamp)
+    return t.ToMilliseconds()
 
 
 def _stringify_all_experiment_ids(x):

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -199,7 +199,7 @@ def test_assessment_conversion(expectation, feedback, source, metadata):
     dict = assessment.to_dictionary()
     assert dict.get("assessment_id") == assessment.assessment_id
     assert dict["trace_id"] == assessment.trace_id
-    assert dict.get("assessment_name") == assessment.name
+    assert dict["assessment_name"] == assessment.name
     assert dict["source"].get("source_type") == source.source_type
     assert dict["source"].get("source_id") == source.source_id
     assert proto_timestamp_to_milliseconds(dict["create_time"]) == assessment.create_time_ms

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -11,6 +11,7 @@ from mlflow.entities.assessment import (
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.assessments_pb2 import Assessment as ProtoAssessment
+from mlflow.utils.proto_json_utils import proto_timestamp_to_milliseconds
 
 
 def test_assessment_creation():
@@ -196,17 +197,17 @@ def test_assessment_conversion(expectation, feedback, source, metadata):
     assert result == assessment
 
     dict = assessment.to_dictionary()
-    assert dict["assessment_id"] == assessment.assessment_id
+    assert dict.get("assessment_id") == assessment.assessment_id
     assert dict["trace_id"] == assessment.trace_id
-    assert dict["name"] == assessment.name
-    assert dict["source"] == {
-        "source_type": source.source_type,
-        "source_id": source.source_id,
-    }
-    assert dict["create_time_ms"] == assessment.create_time_ms
-    assert dict["last_update_time_ms"] == assessment.last_update_time_ms
-    assert dict["rationale"] == assessment.rationale
-    assert dict["metadata"] == metadata
+    assert dict.get("assessment_name") == assessment.name
+    assert dict["source"].get("source_type") == source.source_type
+    assert dict["source"].get("source_id") == source.source_id
+    assert proto_timestamp_to_milliseconds(dict["create_time"]) == assessment.create_time_ms
+    assert (
+        proto_timestamp_to_milliseconds(dict["last_update_time"]) == assessment.last_update_time_ms
+    )
+    assert dict.get("rationale") == assessment.rationale
+    assert dict.get("metadata") == metadata
 
     if expectation:
         assert dict["expectation"] == {"value": expectation.value}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15321?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15321/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15321/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15321
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `MessageToDict` to convert Assessment entity to dict to mirror proto. Addresses https://github.com/mlflow/mlflow/pull/15279#discussion_r2042984968.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
