### PR TITLE
Move optuna module to `mlflow/optuna`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -325,7 +325,7 @@ jobs:
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
-          pytest tests/pyspark/optuna/test_storage.py
+          pytest tests/optuna/test_storage.py
   pyfunc:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -95,7 +95,7 @@ jobs:
           source dev/setup-ssh.sh
           pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
             --ignore-flavors --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate \
-            --ignore=tests/deployments/server --ignore=tests/pyspark/optuna tests
+            --ignore=tests/deployments/server tests
 
   py310:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
@@ -446,7 +446,7 @@ jobs:
           export PATH=$PATH:$HADOOP_HOME/bin
           # Run Windows tests
           pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
-            --ignore-flavors --ignore=tests/projects --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate --ignore tests/deployments/server --ignore=tests/pyspark/optuna \
+            --ignore-flavors --ignore=tests/projects --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate --ignore tests/deployments/server --ignore=tests/optuna \
             tests
           # MLeap is incompatible on Windows with PySpark3.4 release.
           # Reinstate tests when MLeap has released a fix. [ML-30491]

--- a/mlflow/optuna/__init__.py
+++ b/mlflow/optuna/__init__.py
@@ -1,1 +1,3 @@
-from .storage import MlflowStorage
+from mlflow.optuna.storage import MlflowStorage
+
+__all__ = ["MlflowStorage"]

--- a/mlflow/optuna/__init__.py
+++ b/mlflow/optuna/__init__.py
@@ -1,0 +1,1 @@
+from .storage import MlflowStorage

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -26,7 +26,7 @@ try:
     from optuna.study._frozen import FrozenStudy
     from optuna.trial import FrozenTrial, TrialState
 except ImportError as e:
-    raise MlflowException(f"Importing 'mlflow.optuna module fails: {e}'")
+    raise ImportError("Install optuna to use `mlflow.optuna` module") from e
 
 optuna_mlflow_status_map = {
     TrialState.RUNNING: "RUNNING",

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -1,7 +1,6 @@
 import copy
 import datetime
 import json
-import sys
 import threading
 import time
 import uuid
@@ -9,8 +8,8 @@ from collections.abc import Container, Sequence
 from typing import Any, Optional
 
 from mlflow import MlflowClient
-from mlflow.exceptions import MlflowException
 from mlflow.entities import Metric, Param, RunTag
+from mlflow.exceptions import MlflowException
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
 
 try:

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -9,7 +9,6 @@ from typing import Any, Optional
 
 from mlflow import MlflowClient
 from mlflow.entities import Metric, Param, RunTag
-from mlflow.exceptions import MlflowException
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
 
 try:

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -9,6 +9,7 @@ from collections.abc import Container, Sequence
 from typing import Any, Optional
 
 from mlflow import MlflowClient
+from mlflow.exceptions import MlflowException
 from mlflow.entities import Metric, Param, RunTag
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
 
@@ -25,8 +26,8 @@ try:
     from optuna.study import StudyDirection
     from optuna.study._frozen import FrozenStudy
     from optuna.trial import FrozenTrial, TrialState
-except ImportError:
-    sys.exit()
+except ImportError as e:
+    raise MlflowException(f"Importing 'mlflow.optuna module fails: {e}'")
 
 optuna_mlflow_status_map = {
     TrialState.RUNNING: "RUNNING",

--- a/tests/optuna/test_storage.py
+++ b/tests/optuna/test_storage.py
@@ -18,7 +18,7 @@ from optuna.trial import FrozenTrial, TrialState
 
 import mlflow
 from mlflow.entities import Metric, Param, RunTag
-from mlflow.pyspark.optuna.storage import MlflowStorage
+from mlflow.optuna.storage import MlflowStorage
 
 ALL_STATES = list(TrialState)
 
@@ -168,7 +168,7 @@ def test_queue_batch_operation_appends_to_existing_queue(setup_storage):
 
 def test_flush_batch_sends_data_to_mlflow(setup_storage):
     """Test that _flush_batch properly sends data to MLflow client."""
-    with patch("mlflow.pyspark.optuna.storage.MlflowClient") as mock_client:
+    with patch("mlflow.optuna.storage.MlflowClient") as mock_client:
         storage = setup_storage
         run_id = "test-run-id"
         mock_client_instance = MagicMock()
@@ -199,7 +199,7 @@ def test_flush_batch_sends_data_to_mlflow(setup_storage):
 
 def test_flush_batch_does_nothing_for_empty_batch(setup_storage):
     """Test that _flush_batch does nothing when batch is empty."""
-    with patch("mlflow.pyspark.optuna.storage.MlflowClient") as mock_client:
+    with patch("mlflow.optuna.storage.MlflowClient") as mock_client:
         storage = setup_storage
         run_id = "test-run-id"
         # Create a mock instance that will be returned when MlflowClient is instantiated
@@ -220,7 +220,7 @@ def test_flush_batch_does_nothing_for_empty_batch(setup_storage):
 
 def test_flush_batch_handles_nonexistent_run(setup_storage):
     """Test that _flush_batch handles nonexistent run gracefully."""
-    with patch("mlflow.pyspark.optuna.storage.MlflowClient") as mock_client:
+    with patch("mlflow.optuna.storage.MlflowClient") as mock_client:
         storage = setup_storage
         run_id = "nonexistent-run"
         # Create a mock instance that will be returned when MlflowClient is instantiated


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/15357?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15357/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15357/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15357
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Move optuna module to `mlflow/optuna`
### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Move optuna module to `mlflow/optuna`
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
