### PR TITLE
Remove deprecated code_path argument in MLflow 3

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -411,7 +411,6 @@ import sys
 import tempfile
 import threading
 import uuid
-import warnings
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Iterator, Optional, Tuple, Union

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2791,7 +2791,6 @@ def save_model(
     path,
     loader_module=None,
     data_path=None,
-    code_path=None,  # deprecated
     code_paths=None,
     infer_code_paths=False,
     conda_env=None,
@@ -2831,11 +2830,9 @@ def save_model(
             - The MLflow library.
             - Package(s) listed in the model's Conda environment, specified by
               the ``conda_env`` parameter.
-            - One or more of the files specified by the ``code_path`` parameter.
+            - One or more of the files specified by the ``code_paths`` parameter.
 
         data_path: Path to a file or directory containing model data.
-        code_path: **Deprecated** The legacy argument for defining dependent code. This argument is
-            replaced by ``code_paths`` and will be removed in a future version of MLflow.
         code_paths: {{ code_paths_pyfunc }}
         infer_code_paths: {{ infer_code_paths }}
         conda_env: {{ conda_env }}
@@ -2852,7 +2849,7 @@ def save_model(
             - The MLflow library.
             - Package(s) listed in the model's Conda environment, specified by the ``conda_env``
               parameter.
-            - One or more of the files specified by the ``code_path`` parameter.
+            - One or more of the files specified by the ``code_paths`` parameter.
 
             Note: If the class is imported from another module, as opposed to being defined in the
             ``__main__`` scope, the defining module should also be included in one of the listed
@@ -3023,22 +3020,9 @@ def save_model(
     if len(kwargs) > 0:
         raise TypeError(f"save_model() got unexpected keyword arguments: {kwargs}")
 
-    if code_path is not None and code_paths is not None:
-        raise MlflowException(
-            "Both `code_path` and `code_paths` have been specified, which is not permitted."
-        )
-    if code_path is not None:
-        # Alias for `code_path` deprecation
-        code_paths = code_path
-        warnings.warn(
-            "The `code_path` argument is replaced by `code_paths` and is deprecated "
-            "as of MLflow version 2.12.0. This argument will be removed in a future "
-            "release of MLflow."
-        )
-
     if code_paths is not None:
         if not isinstance(code_paths, list):
-            raise TypeError(f"Argument code_path should be a list, not {type(code_paths)}")
+            raise TypeError(f"Argument code_paths should be a list, not {type(code_paths)}")
 
     first_argument_set = {
         "loader_module": loader_module,
@@ -3338,7 +3322,6 @@ def log_model(
     artifact_path=None,
     loader_module=None,
     data_path=None,
-    code_path=None,  # deprecated
     code_paths=None,
     infer_code_paths=False,
     conda_env=None,
@@ -3384,11 +3367,9 @@ def log_model(
             - The MLflow library.
             - Package(s) listed in the model's Conda environment, specified by
               the ``conda_env`` parameter.
-            - One or more of the files specified by the ``code_path`` parameter.
+            - One or more of the files specified by the ``code_paths`` parameter.
 
         data_path: Path to a file or directory containing model data.
-        code_path: **Deprecated** The legacy argument for defining dependent code. This argument is
-            replaced by ``code_paths`` and will be removed in a future version of MLflow.
         code_paths: {{ code_paths_pyfunc }}
         infer_code_paths: {{ infer_code_paths }}
         conda_env: {{ conda_env }}
@@ -3403,7 +3384,7 @@ def log_model(
             - The MLflow library.
             - Package(s) listed in the model's Conda environment, specified by the ``conda_env``
               parameter.
-            - One or more of the files specified by the ``code_path`` parameter.
+            - One or more of the files specified by the ``code_paths`` parameter.
 
             Note: If the class is imported from another module, as opposed to being defined in the
             ``__main__`` scope, the defining module should also be included in one of the listed
@@ -3575,7 +3556,6 @@ def log_model(
         flavor=mlflow.pyfunc,
         loader_module=loader_module,
         data_path=data_path,
-        code_path=code_path,  # deprecated
         code_paths=code_paths,
         python_model=python_model,
         artifacts=artifacts,

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -180,7 +180,7 @@ def _infer_and_copy_code_paths(flavor, path, default_subpath="code"):
     # It only picks necessary files, because:
     #  1. Reduce risk of logging files containing user credentials to MLflow
     #     artifact repository.
-    #  2. In databricks runtime, notebook files might exist under a code_path directory,
+    #  2. In databricks runtime, notebook files might exist under a code_paths directory,
     #     if logging the whole directory to MLflow artifact repository, these
     #     notebook files are not accessible and trigger exceptions. On the other
     #     hand, these notebook files are not used as code_paths modules because

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1129,14 +1129,6 @@ def test_model_with_code_path_containing_main(tmp_path):
     assert "__main__" in sys.modules
 
 
-def test_deprecation_warning_for_code_path(tmp_path):
-    pyfunc_model_path = tmp_path.joinpath("pyfunc_model")
-    directory = tmp_path.joinpath("model_with_main")
-    directory.mkdir()
-    main = directory.joinpath("__main__.py")
-    main.write_text("# empty main")
-
-
 def test_model_save_load_with_metadata(tmp_path):
     pyfunc_model_path = os.path.join(tmp_path, "pyfunc_model")
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1136,30 +1136,6 @@ def test_deprecation_warning_for_code_path(tmp_path):
     main = directory.joinpath("__main__.py")
     main.write_text("# empty main")
 
-    with pytest.warns(UserWarning, match="The `code_path` argument is replaced by `code_paths`"):
-        mlflow.pyfunc.save_model(
-            path=pyfunc_model_path,
-            code_path=[str(directory)],
-            python_model=mlflow.pyfunc.model.PythonModel(),
-        )
-
-
-def test_error_when_both_code_path_and_code_paths_specified():
-    error_msg = "Both `code_path` and `code_paths` have been specified"
-    with pytest.raises(MlflowException, match=error_msg):
-        mlflow.pyfunc.save_model(
-            path="some_path",
-            code_path="some_code_path",
-            code_paths=["some_code_path"],
-        )
-    with pytest.raises(MlflowException, match=error_msg):
-        with mlflow.start_run():
-            mlflow.pyfunc.log_model(
-                "some_path",
-                code_path="some_code_path",
-                code_paths=["some_code_path"],
-            )
-
 
 def test_model_save_load_with_metadata(tmp_path):
     pyfunc_model_path = os.path.join(tmp_path, "pyfunc_model")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/15368?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15368/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15368/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15368
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Remove deprecated code_path argument in MLflow 3
### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Remove deprecated code_path argument in MLflow 3
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
