### PR TITLE
Added allow_missing parameter in load_prompt

### DIFF
--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -427,7 +427,9 @@ def register_prompt(
 
 @experimental
 @require_prompt_registry
-def load_prompt(name_or_uri: str, version: Optional[int] = None) -> Prompt:
+def load_prompt(
+    name_or_uri: str, version: Optional[int] = None, allow_missing: bool = False
+) -> Prompt:
     """
     Load a :py:class:`Prompt <mlflow.entities.Prompt>` from the MLflow Prompt Registry.
 
@@ -436,6 +438,8 @@ def load_prompt(name_or_uri: str, version: Optional[int] = None) -> Prompt:
     Args:
         name_or_uri: The name of the prompt, or the URI in the format "prompts:/name/version".
         version: The version of the prompt. If not specified, the latest version will be loaded.
+        allow_missing: If True, return None instead of raising Exception if the specified prompt
+            is not found.
 
     Example:
 
@@ -457,7 +461,9 @@ def load_prompt(name_or_uri: str, version: Optional[int] = None) -> Prompt:
 
     """
     client = MlflowClient()
-    prompt = client.load_prompt(name_or_uri=name_or_uri, version=version)
+    prompt = client.load_prompt(
+        name_or_uri=name_or_uri, version=version, allow_missing=allow_missing
+    )
 
     # If there is an active MLflow run, associate the prompt with the run
     if run := active_run():

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -555,7 +555,9 @@ class MlflowClient:
     @experimental
     @require_prompt_registry
     @translate_prompt_exception
-    def load_prompt(self, name_or_uri: str, version: Optional[int] = None) -> Prompt:
+    def load_prompt(
+        self, name_or_uri: str, version: Optional[int] = None, allow_missing: bool = False
+    ) -> Prompt:
         """
         Load a :py:class:`Prompt <mlflow.entities.Prompt>` from the MLflow Prompt Registry.
 
@@ -581,6 +583,8 @@ class MlflowClient:
         Args:
             name_or_uri: The name of the prompt, or the URI in the format "prompts:/name/version".
             version: The version of the prompt. If not specified, the latest version will be loaded.
+            allow_missing: If True, return None instead of raising Exception if the specified prompt
+                is not found.
         """
         if name_or_uri.startswith("prompts:/"):
             if version is not None:
@@ -593,10 +597,16 @@ class MlflowClient:
             name = name_or_uri
 
         registry_client = self._get_registry_client()
-        if version is None:
-            mv = registry_client.get_latest_versions(name, stages=ALL_STAGES)[0]
-        else:
-            mv = registry_client.get_model_version(name, version)
+        try:
+            mv = (
+                registry_client.get_latest_versions(name, stages=ALL_STAGES)[0]
+                if version is None
+                else registry_client.get_model_version(name, version)
+            )
+        except MlflowException as exc:
+            if allow_missing and exc.error_code == "RESOURCE_DOES_NOT_EXIST":
+                return None
+            raise
 
         # Fetch the prompt-level tags from the registered model
         prompt_tags = registry_client.get_registered_model(name)._tags

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -150,6 +150,12 @@ def test_crud_prompts(tmp_path):
     with pytest.raises(MlflowException, match=r"Prompt \(name=prompt_1, version=2\) not found"):
         mlflow.load_prompt("prompt_1", version=2)
 
+    with pytest.raises(MlflowException, match=r"Prompt \(name=prompt_1, version=2\) not found"):
+        mlflow.load_prompt("prompt_1", version=2, allow_missing=False)
+
+    assert mlflow.load_prompt("prompt_1", version=2, allow_missing=True) is None
+    assert mlflow.load_prompt("does_not_exist", allow_missing=True) is None
+
     mlflow.delete_prompt("prompt_1", version=1)
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1653,6 +1653,9 @@ def test_crud_prompts(tracking_uri):
     with pytest.raises(MlflowException, match=r"Prompt \(name=prompt_1, version=2\) not found"):
         client.load_prompt("prompt_1", version=2)
 
+    assert mlflow.load_prompt("prompt_1", version=2, allow_missing=True) is None
+    assert mlflow.load_prompt("does_not_exist", allow_missing=True) is None
+
     client.delete_prompt("prompt_1", version=1)
 
 
@@ -1766,6 +1769,9 @@ def test_load_prompt_error(tracking_uri):
     with pytest.raises(MlflowException, match=error_msg):
         client.load_prompt("test", version=2)
 
+    with pytest.raises(MlflowException, match=error_msg):
+        client.load_prompt("test", version=2, allow_missing=False)
+
     # Load prompt with a model name
     client.create_registered_model("model")
     client.create_model_version("model", "source")
@@ -1775,6 +1781,12 @@ def test_load_prompt_error(tracking_uri):
 
     with pytest.raises(MlflowException, match=r"Name `model` is registered as a model"):
         client.load_prompt("model", version=1)
+
+    with pytest.raises(MlflowException, match=r"Name `model` is registered as a model"):
+        client.load_prompt("model", allow_missing=False)
+
+    with pytest.raises(MlflowException, match=r"Name `model` is registered as a model"):
+        client.load_prompt("model", version=1, allow_missing=False)
 
 
 def test_delete_prompt_error(tracking_uri):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/15371?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15371/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15371/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15371
```

</p>
</details>

### Related Issues/PRs

Fix #15280 

### What changes are proposed in this pull request?

Added an extra parameter `allow_missing` in mlfllow.load_prompt which when enabled would silence the error and return None when the resource does not exists. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introducing a new parameter `allow_missing` in mlflow.load_prompt which when enabled return None instead of raising Exception allowing developers to handle None and register the prompt if it doesnt exist in mlflow database.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations


<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
