### PR TITLE
Support linking traces in evaluate to active model

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -8,7 +8,7 @@ import signal
 import urllib
 import urllib.parse
 from abc import ABCMeta, abstractmethod
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from inspect import Parameter, Signature
 from types import FunctionType
@@ -29,7 +29,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.utils.models import _parse_model_id_if_present
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.client import MlflowClient
-from mlflow.tracking.fluent import _maybe_set_active_model_id
+from mlflow.tracking.fluent import _set_active_model
 from mlflow.utils import _get_fully_qualified_class_name
 from mlflow.utils.annotations import developer_stable, experimental
 from mlflow.utils.class_utils import _get_class_from_string
@@ -1724,10 +1724,9 @@ def evaluate(  # noqa: D417
     # Use specified model_id if provided, otherwise use derived model_id
     model_id = specified_model_id if specified_model_id is not None else model_id
     # If none of the model_id and model is specified, use the active model_id
-    if model_id is None:
-        model_id = mlflow.get_active_model_id()
+    model_id = model_id or mlflow.get_active_model_id()
     # model_id could be None
-    with _maybe_set_active_model_id(model_id=model_id):
+    with _set_active_model(model_id=model_id) if model_id else nullcontext():
         evaluators: list[EvaluatorBundle] = resolve_evaluators_and_configs(
             evaluators, evaluator_config, model_type
         )

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3228,3 +3228,12 @@ def _update_active_model_id_env_var(value):
         MLFLOW_ACTIVE_MODEL_ID.unset()
     else:
         MLFLOW_ACTIVE_MODEL_ID.set(value)
+
+
+@contextlib.contextmanager
+def _maybe_set_active_model_id(model_id: Optional[str]):
+    if model_id is None:
+        yield
+    else:
+        with _set_active_model(model_id=model_id):
+            yield

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3228,12 +3228,3 @@ def _update_active_model_id_env_var(value):
         MLFLOW_ACTIVE_MODEL_ID.unset()
     else:
         MLFLOW_ACTIVE_MODEL_ID.set(value)
-
-
-@contextlib.contextmanager
-def _maybe_set_active_model_id(model_id: Optional[str]):
-    if model_id is None:
-        yield
-    else:
-        with _set_active_model(model_id=model_id):
-            yield

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -53,7 +53,7 @@ from mlflow.models.evaluation.base import (
 from mlflow.models.evaluation.evaluator_registry import _model_evaluation_registry
 from mlflow.pyfunc import _ServedPyFuncModel
 from mlflow.pyfunc.scoring_server.client import ScoringServerClient
-from mlflow.tracing.constant import TraceMetadataKey
+from mlflow.tracing.constant import SpanAttributeKey, TraceMetadataKey
 from mlflow.tracking.artifact_utils import get_artifact_uri
 from mlflow.utils.file_utils import TempDir
 
@@ -383,9 +383,11 @@ def test_pyfunc_evaluate_logs_traces():
             targets="ground_truth",
             extra_metrics=[mlflow.metrics.exact_match()],
         )
-    assert len(get_traces()) == 1
-    assert len(get_traces()[0].data.spans) == 2
-    assert run.info.run_id == get_traces()[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
+    traces = get_traces()
+    assert len(traces) == 1
+    assert len(traces[0].data.spans) == 2
+    assert run.info.run_id == traces[0].info.request_metadata[TraceMetadataKey.SOURCE_RUN]
+    assert traces[0].info.request_metadata[SpanAttributeKey.MODEL_ID] == model_info.model_id
 
 
 def test_classifier_evaluate(multiclass_logistic_regressor_model_uri, iris_dataset):
@@ -2265,3 +2267,117 @@ def test_evaluate_model_id_consistency_check(multiclass_logistic_regressor_model
             targets=iris_dataset._constructor_args["targets"],
             model_type="classifier",
         )
+
+
+def test_evaluate_log_metrics_to_active_model(iris_dataset):
+    # Set active model
+    mlflow.set_active_model(name="my-model")
+    active_model_id = mlflow.get_active_model_id()
+
+    model = sklearn.linear_model.LogisticRegression()
+    model.fit(iris_dataset._constructor_args["data"], iris_dataset._constructor_args["targets"])
+    eval_df = pd.DataFrame(
+        {
+            "inputs": iris_dataset._constructor_args["data"].tolist(),
+            "targets": iris_dataset._constructor_args["targets"],
+            "predictions": model.predict(iris_dataset._constructor_args["data"]),
+        }
+    )
+
+    eval_dataset = mlflow.data.from_pandas(
+        df=eval_df,
+        name="eval_dataset",
+        targets="targets",
+        predictions="predictions",
+    )
+
+    # Evaluate the model with the specified model ID
+    with mlflow.start_run():
+        result = evaluate(
+            data=eval_dataset,
+            model_type="classifier",
+        )
+
+        # Verify metrics were logged
+        assert result.metrics is not None
+        assert len(result.metrics) > 0
+
+        # Verify metrics are linked to the active model ID
+        logged_model = mlflow.get_logged_model(active_model_id)
+        assert logged_model is not None
+        assert logged_model.model_id == active_model_id
+
+        # Convert metrics list to a dictionary for easier lookup
+        logged_metrics = {metric.key: metric.value for metric in logged_model.metrics}
+
+        # Verify each metric from the evaluation result matches the logged model metrics
+        for metric_name, metric_value in result.metrics.items():
+            assert metric_name in logged_metrics, (
+                f"Metric {metric_name} not found in logged model metrics"
+            )
+            assert logged_metrics[metric_name] == metric_value, (
+                f"Metric {metric_name} value mismatch: "
+                f"expected {metric_value}, got {logged_metrics[metric_name]}"
+            )
+
+
+def test_mlflow_evaluate_logs_traces_to_active_model():
+    eval_data = pd.DataFrame(
+        {
+            "inputs": [
+                "What is MLflow?",
+                "What is Spark?",
+            ],
+            "ground_truth": ["What is MLflow?", "Not what is Spark?"],
+        }
+    )
+
+    @mlflow.trace
+    def model(inputs):
+        return inputs
+
+    # no model_id used when no active model is set or passed
+    evaluate(model, eval_data, targets="ground_truth", extra_metrics=[mlflow.metrics.exact_match()])
+    traces = get_traces()
+    assert len(traces) == 1
+    assert SpanAttributeKey.MODEL_ID not in traces[0].info.request_metadata
+
+    # set active model
+    active_model = mlflow.set_active_model(name="my-model")
+    model_id = active_model.model_id
+    evaluate(model, eval_data, targets="ground_truth", extra_metrics=[mlflow.metrics.exact_match()])
+    traces = get_traces()
+    assert len(traces) == 2
+    assert traces[0].info.request_metadata[SpanAttributeKey.MODEL_ID] == model_id
+
+    # pass model_id explicitly takes precedence over active model
+    assert mlflow.get_active_model_id() is not None
+    another_model_id = mlflow.create_external_model(name="another-model").model_id
+    evaluate(
+        model,
+        eval_data,
+        targets="ground_truth",
+        extra_metrics=[mlflow.metrics.exact_match()],
+        model_id=another_model_id,
+    )
+    traces = get_traces()
+    assert len(traces) == 3
+    assert traces[0].info.request_metadata[SpanAttributeKey.MODEL_ID] == another_model_id
+
+    # model_id of the passed model takes precedence over active model
+    assert mlflow.get_active_model_id() is not None
+    model_info = mlflow.pyfunc.log_model(
+        "model",
+        python_model=model,
+        input_example="What is MLflow?",
+    )
+    evaluate(
+        model_info.model_uri,
+        eval_data,
+        targets="ground_truth",
+        extra_metrics=[mlflow.metrics.exact_match()],
+    )
+    traces = get_traces()
+    assert len(traces) == 4
+    assert traces[0].info.request_metadata[SpanAttributeKey.MODEL_ID] == model_info.model_id
+    # TODO: test registered ModelVersion's model_id works after it's supported


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15377?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15377/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15377/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15377
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
There are several places model_id could be derived in `mlflow.evaluate`, and we follow below order to decide which model_id to link metrics/traces to:
1. model_id derived from the `model` parameter if it's a model_uri
2. model_id passed to the `mlflow.evaluate` call (if both 1 and 2 exist, they should match)
3. active_model_id that was set before evaluate call if any


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
