### PR TITLE
Remove module reload usage in test

### DIFF
--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -34,9 +34,6 @@ class FuncInfo(NamedTuple):
     input_param_name: str
 
 
-class TypeHintWarning(UserWarning): ...
-
-
 def pyfunc(func):
     """
     A decorator that forces data validation against type hint of the input data
@@ -179,7 +176,7 @@ def _get_func_info_if_type_hint_supported(func) -> Optional[FuncInfo]:
                 "Remove the type hint to disable this warning. "
                 "To enable validation for the input data, specify input example "
                 "or model signature when logging the model. ",
-                category=TypeHintWarning,
+                category=UserWarning,
                 stacklevel=3,
                 color="red",
             )
@@ -193,7 +190,7 @@ def _get_func_info_if_type_hint_supported(func) -> Optional[FuncInfo]:
             " for more details.",
             stacklevel=1,
             color="yellow",
-            category=TypeHintWarning,
+            category=UserWarning,
         )
 
 

--- a/mlflow/pyfunc/utils/data_validation.py
+++ b/mlflow/pyfunc/utils/data_validation.py
@@ -34,6 +34,9 @@ class FuncInfo(NamedTuple):
     input_param_name: str
 
 
+class TypeHintWarning(UserWarning): ...
+
+
 def pyfunc(func):
     """
     A decorator that forces data validation against type hint of the input data
@@ -176,7 +179,7 @@ def _get_func_info_if_type_hint_supported(func) -> Optional[FuncInfo]:
                 "Remove the type hint to disable this warning. "
                 "To enable validation for the input data, specify input example "
                 "or model signature when logging the model. ",
-                category=UserWarning,
+                category=TypeHintWarning,
                 stacklevel=3,
                 color="red",
             )
@@ -190,6 +193,7 @@ def _get_func_info_if_type_hint_supported(func) -> Optional[FuncInfo]:
             " for more details.",
             stacklevel=1,
             color="yellow",
+            category=TypeHintWarning,
         )
 
 

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1118,6 +1118,9 @@ def test_type_hint_warning_not_shown_for_builtin_subclasses(mock_warning):
     assert mock_warning.call_count == 0
 
     # Check import does not trigger any warning (from builtin sub-classes)
+    # Note: DO NOT USE importlib.reload as classes in the reloaded
+    # module are different than original ones, which could cause unintended
+    # side effects in other tests.
     subprocess.check_call(
         [
             sys.executable,

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1116,6 +1116,18 @@ def test_type_hint_warning_not_shown_for_builtin_subclasses(mock_warning):
             pass
 
     assert mock_warning.call_count == 0
+    # from mlflow.pyfunc.utils.data_validation import TypeHintWarning
+
+    # Check import does not trigger any warning (from builtin sub-classes)
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-W",
+            "error::UserWarning:mlflow.pyfunc.model",
+            "-c",
+            "import mlflow.pyfunc.model",
+        ]
+    )
 
     # Check import does not trigger any warning (from builtin sub-classes)
     subprocess.check_call(

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1116,7 +1116,6 @@ def test_type_hint_warning_not_shown_for_builtin_subclasses(mock_warning):
             pass
 
     assert mock_warning.call_count == 0
-    # from mlflow.pyfunc.utils.data_validation import TypeHintWarning
 
     # Check import does not trigger any warning (from builtin sub-classes)
     subprocess.check_call(
@@ -1127,11 +1126,6 @@ def test_type_hint_warning_not_shown_for_builtin_subclasses(mock_warning):
             "-c",
             "import mlflow.pyfunc.model",
         ]
-    )
-
-    # Check import does not trigger any warning (from builtin sub-classes)
-    subprocess.check_call(
-        [sys.executable, "-W", "error::TypeHintWarning", "-c", "import mlflow.pyfunc"]
     )
 
 

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -1,7 +1,7 @@
 import datetime
-import importlib
 import json
 import os
+import subprocess
 import sys
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 from unittest import mock
@@ -1098,10 +1098,6 @@ def test_type_hint_warning_not_shown_for_builtin_subclasses(mock_warning):
     _FunctionPythonModel.__init_subclass__()
     assert mock_warning.call_count == 0
 
-    # Check import does not trigger any warning (from builtin sub-classes)
-    importlib.reload(mlflow.pyfunc.model)
-    assert mock_warning.call_count == 0
-
     # Subclass of ChatModel should not warn (exception to the rule)
     class ChatModelSubclass(ChatModel):
         def predict(self, model_input: list[ChatMessage], params: Optional[ChatParams] = None):
@@ -1120,6 +1116,11 @@ def test_type_hint_warning_not_shown_for_builtin_subclasses(mock_warning):
             pass
 
     assert mock_warning.call_count == 0
+
+    # Check import does not trigger any warning (from builtin sub-classes)
+    subprocess.check_call(
+        [sys.executable, "-W", "error::TypeHintWarning", "-c", "import mlflow.pyfunc"]
+    )
 
 
 def test_load_context_type_hint():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15379?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15379/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15379/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15379
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
The test uses `importlib.reload` could have side impact on other tests, this PR fixes it by removing the part and check warning inside subprocess instead.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
