### PR TITLE
Add `to_predict_fn` API to convert endpoint URI to a callable

### DIFF
--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -1,3 +1,3 @@
-from mlflow.genai.evaluation import evaluate
+from mlflow.genai.evaluation import evaluate, to_predict_fn
 
-__all__ = ["evaluate"]
+__all__ = ["evaluate", "to_predict_fn"]

--- a/mlflow/genai/evaluation/__init__.py
+++ b/mlflow/genai/evaluation/__init__.py
@@ -1,3 +1,3 @@
-from mlflow.genai.evaluation.base import evaluate
+from mlflow.genai.evaluation.base import evaluate, to_predict_fn
 
-__all__ = ["evaluate"]
+__all__ = ["evaluate", "to_predict_fn"]

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -142,6 +142,22 @@ def to_predict_fn(endpoint_uri: str) -> Callable:
 
     Returns:
         A predict function that can be used to make predictions.
+
+    Example:
+        .. code-block:: python
+
+            data = (
+                pd.DataFrame(
+                    {
+                        "inputs": ["What is MLflow?", "What is Spark?"],
+                    }
+                ),
+            )
+            predict_fn = mlflow.genai.to_predict_fn("endpoints:/chat")
+            mlflow.genai.evaluate(
+                data=data,
+                predict_fn=predict_fn,
+            )
     """
     if not _is_model_deployment_endpoint_uri(endpoint_uri):
         raise ValueError(

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -120,9 +120,7 @@ def evaluate(
         extra_metrics.append(_convert_scorer_to_legacy_metric(_scorer))
 
     if not is_model_traced(predict_fn):
-        logger.info(
-            "Annotating predict_fn with tracing since it is not already traced."
-        )
+        logger.info("Annotating predict_fn with tracing since it is not already traced.")
         predict_fn = mlflow.trace(predict_fn)
 
     mlflow.evaluate(

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 from pyspark import sql as spark
 
@@ -31,7 +31,7 @@ class EvaluationResult:
 
 
 def evaluate(
-    data: pd.DataFrame | spark.DataFrame | list[dict] | EvaluationDataset,
+    data: Union[pd.DataFrame, spark.DataFrame, list[dict], EvaluationDataset],
     predict_fn: Optional[Callable[..., Any]] = None,
     scorers: Optional[list[Scorer]] = None,
     model_id: Optional[str] = None,
@@ -120,7 +120,9 @@ def evaluate(
         extra_metrics.append(_convert_scorer_to_legacy_metric(_scorer))
 
     if not is_model_traced(predict_fn):
-        logger.info("Annotating predict_fn with tracing since it is not already traced.")
+        logger.info(
+            "Annotating predict_fn with tracing since it is not already traced."
+        )
         predict_fn = mlflow.trace(predict_fn)
 
     mlflow.evaluate(
@@ -161,7 +163,8 @@ def to_predict_fn(endpoint_uri: str) -> Callable:
     """
     if not _is_model_deployment_endpoint_uri(endpoint_uri):
         raise ValueError(
-            f"Invalid endpoint URI: {endpoint_uri}. The endpoint URI must be a valid model deployment endpoint URI."
+            f"Invalid endpoint URI: {endpoint_uri}. The endpoint URI must be a valid model "
+            f"deployment endpoint URI."
         )
 
     model = _get_model_from_deployment_endpoint_uri(endpoint_uri)

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -1,4 +1,7 @@
-from databricks.agents.evals import metric
+try:
+    from databricks.agents.evals import metric
+except ImportError:
+    pass
 from pyspark import sql as spark
 
 from mlflow.genai.scorers import Scorer

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -1,3 +1,7 @@
+from typing import Union
+
+from mlflow.data.evaluation_dataset import EvaluationDataset
+
 try:
     from databricks.agents.evals import metric
 except ImportError:
@@ -15,7 +19,7 @@ except ImportError:
 
 # TODO: ML-52299
 def _convert_to_legacy_eval_set(
-    data: pd.DataFrame | spark.DataFrame | list[dict], EvaluationDataset
+    data: Union[pd.DataFrame, spark.DataFrame, list[dict], EvaluationDataset],
 ) -> dict:
     """
     Takes in different types of inputs and converts it into to the current eval-set schema that

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1,0 +1,64 @@
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+import mlflow.genai.evaluation
+
+from tests.evaluate.test_evaluation import _DUMMY_CHAT_RESPONSE
+
+
+@pytest.mark.parametrize(
+    "model_input",
+    [
+        # Case 1: Single chat dictionary.
+        # This is an expected input format from the Databricks RAG Evaluator.
+        {
+            "messages": [{"content": "What is MLflow?", "role": "user"}],
+            "max_tokens": 10,
+        },
+        # Case 2: List of chat dictionaries.
+        # This is not a typical input format from either default or Databricks RAG evaluators,
+        # but we support it for compatibility with the normal Pyfunc models.
+        [
+            {"messages": [{"content": "What is MLflow?", "role": "user"}]},
+            {"messages": [{"content": "What is Spark?", "role": "user"}]},
+        ],
+        # Case 3: DataFrame with a column of dictionaries
+        pd.DataFrame(
+            {
+                "inputs": [
+                    {
+                        "messages": [{"content": "What is MLflow?", "role": "user"}],
+                        "max_tokens": 10,
+                    },
+                    {
+                        "messages": [{"content": "What is Spark?", "role": "user"}],
+                    },
+                ]
+            }
+        ),
+        # Case 4: DataFrame with a column of strings
+        pd.DataFrame(
+            {
+                "inputs": ["What is MLflow?", "What is Spark?"],
+            }
+        ),
+    ],
+)
+@mock.patch("mlflow.deployments.get_deploy_client")
+def test_model_from_deployment_endpoint(mock_deploy_client, model_input):
+    mock_deploy_client.return_value.predict.return_value = _DUMMY_CHAT_RESPONSE
+    mock_deploy_client.return_value.get_endpoint.return_value = {"task": "llm/v1/chat"}
+
+    predict_fn = mlflow.genai.to_predict_fn("endpoints:/chat")
+
+    response = predict_fn(model_input)
+
+    if isinstance(model_input, dict):
+        assert mock_deploy_client.return_value.predict.call_count == 1
+        # Chat response should be unwrapped
+        assert response == "This is a response"
+    else:
+        assert mock_deploy_client.return_value.predict.call_count == 2
+        assert pd.Series(response).equals(pd.Series(["This is a response"] * 2))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/15381?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15381/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15381/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15381
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Provide a simple interface to convert a endpoint URI into a callable predict model function.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
