### PR TITLE
Fix mlflow.genai.evaluate runtime errors

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -31,7 +31,7 @@ def evaluate(
     predict_fn: Optional[Callable[..., Any]] = None,
     scorers: Optional[list[Scorer]] = None,
     model_id: Optional[str] = None,
-) -> mlflow.genai.EvaluationResult:
+) -> EvaluationResult:
     """
     TODO: updating docstring with real examples and API links
     Args:

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -13,7 +13,7 @@ except ImportError:
 
 # TODO: ML-52299
 def _convert_to_legacy_eval_set(
-    data: pd.DataFrame | spark.DataFrame | list[dict] | EvaluationDataset
+    data: pd.DataFrame | spark.DataFrame | list[dict] | EvaluationDataset,
 ) -> dict:
     """
     Takes in different types of inputs and converts it into to the current eval-set schema that

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -1,6 +1,7 @@
 from databricks.agents.evals import metric
 from pyspark import sql as spark
 
+from mlflow.data.evaluation_dataset import EvaluationDataset
 from mlflow.genai.scorers import Scorer
 
 try:
@@ -12,7 +13,7 @@ except ImportError:
 
 # TODO: ML-52299
 def _convert_to_legacy_eval_set(
-    data: pd.DataFrame | spark.DataFrame | list[dict], EvaluationDataset
+    data: pd.DataFrame | spark.DataFrame | list[dict] | EvaluationDataset
 ) -> dict:
     """
     Takes in different types of inputs and converts it into to the current eval-set schema that

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -11,10 +11,7 @@ from mlflow.genai.scorers import BuiltInScorer
 @mock.patch("mlflow.get_tracking_uri", return_value="databricks")
 def test_evaluate_calls_mlflow_evaluate(tracking_mock, trace_mock, mock_mlflow_evaluate):
     # Setup test data
-    test_data = pd.DataFrame({
-        "inputs": ["test input"],
-        "expectations": ["expected output"]
-    })
+    test_data = pd.DataFrame({"inputs": ["test input"], "expectations": ["expected output"]})
 
     # Create a mock predict function
     def predict_fn(text):
@@ -23,18 +20,18 @@ def test_evaluate_calls_mlflow_evaluate(tracking_mock, trace_mock, mock_mlflow_e
     # Create a mock scorer
     mock_scorer = mock.Mock(spec=BuiltInScorer)
     mock_scorer.update_evaluation_config.return_value = {
-        "databricks-agents": {
-            "metrics": ["metric1"]
-        }
+        "databricks-agents": {"metrics": ["metric1"]}
     }
 
     # Call the evaluate function
-    with mock.patch("mlflow.genai.evaluation.base._convert_to_legacy_eval_set", return_value=test_data):
+    with mock.patch(
+        "mlflow.genai.evaluation.base._convert_to_legacy_eval_set", return_value=test_data
+    ):
         evaluate(
             data=test_data,
             predict_fn=predict_fn,
             scorers=[mock_scorer],
-            model_id="models:/my-model/1"
+            model_id="models:/my-model/1",
         )
 
     # Assert mlflow.evaluate was called with the right parameters
@@ -44,4 +41,3 @@ def test_evaluate_calls_mlflow_evaluate(tracking_mock, trace_mock, mock_mlflow_e
     assert call_args["model"] == predict_fn
     assert call_args["model_type"] == "databricks-agent"
     assert call_args["evaluator_config"] == {"databricks-agents": {"metrics": ["metric1"]}}
-

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1,0 +1,47 @@
+from unittest import mock
+
+import pandas as pd
+
+from mlflow.genai.evaluation.base import evaluate
+from mlflow.genai.scorers import BuiltInScorer
+
+
+@mock.patch("mlflow.evaluate")
+@mock.patch("mlflow.genai.evaluation.base.is_model_traced", return_value=True)
+@mock.patch("mlflow.get_tracking_uri", return_value="databricks")
+def test_evaluate_calls_mlflow_evaluate(tracking_mock, trace_mock, mock_mlflow_evaluate):
+    # Setup test data
+    test_data = pd.DataFrame({
+        "inputs": ["test input"],
+        "expectations": ["expected output"]
+    })
+
+    # Create a mock predict function
+    def predict_fn(text):
+        return f"{text} predicted output"
+
+    # Create a mock scorer
+    mock_scorer = mock.Mock(spec=BuiltInScorer)
+    mock_scorer.update_evaluation_config.return_value = {
+        "databricks-agents": {
+            "metrics": ["metric1"]
+        }
+    }
+
+    # Call the evaluate function
+    with mock.patch("mlflow.genai.evaluation.base._convert_to_legacy_eval_set", return_value=test_data):
+        evaluate(
+            data=test_data,
+            predict_fn=predict_fn,
+            scorers=[mock_scorer],
+            model_id="models:/my-model/1"
+        )
+
+    # Assert mlflow.evaluate was called with the right parameters
+    mock_mlflow_evaluate.assert_called_once()
+    call_args = mock_mlflow_evaluate.call_args[1]
+
+    assert call_args["model"] == predict_fn
+    assert call_args["model_type"] == "databricks-agent"
+    assert call_args["evaluator_config"] == {"databricks-agents": {"metrics": ["metric1"]}}
+


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/15382?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15382/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15382/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15382
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Followup to https://github.com/mlflow/mlflow/pull/15282
In my other PRs https://github.com/mlflow/mlflow/pull/15381 and https://github.com/mlflow/mlflow/pull/15376 I noticed some runtime errors when trying to write tests around `mlflow.genai.evaluate`. 
The problem still remains that the `databricks-agents` dependency is not available by default (see failing Python tests). How can we remedy that? 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
