### PR TITLE
Pagination for Model Version

### DIFF
--- a/mlflow/server/js/src/model-registry/components/ModelView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelView.tsx
@@ -26,6 +26,7 @@ import { shouldShowModelsNextUI } from '../../common/utils/FeatureUtils';
 import { ModelsNextUIToggleSwitch } from './ModelsNextUIToggleSwitch';
 import { withNextModelsUIContext } from '../hooks/useNextModelsUI';
 import { ErrorWrapper } from '../../common/utils/ErrorWrapper';
+import { CursorPagination } from '@databricks/design-system';
 
 export const StageFilters = {
   ALL: 'ALL',
@@ -49,6 +50,15 @@ type ModelViewImplProps = {
   intl: IntlShape;
   onMetadataUpdated: () => void;
   usingNextModelsUI: boolean;
+  paginationProps: {
+    currentPage: number;
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+    maxResultValue: number;
+    onNext: () => void;
+    onPrev: () => void;
+    onPageSizeChange: (args: { key: number }) => void;
+  };
 };
 
 type ModelViewImplState = any;
@@ -235,7 +245,7 @@ export class ModelViewImpl extends React.Component<ModelViewImplProps, ModelView
   }
 
   renderDetails = () => {
-    const { model, modelVersions, tags } = this.props;
+    const { model, modelVersions, tags, paginationProps } = this.props;
     const {
       stageFilter,
       showDescriptionEditor,
@@ -389,17 +399,6 @@ export class ModelViewImpl extends React.Component<ModelViewImplProps, ModelView
           }
           data-test-id="model-versions-section"
         >
-          {shouldShowModelsNextUI() && (
-            <div
-              css={{
-                marginBottom: 8,
-                display: 'flex',
-                justifyContent: 'flex-end',
-              }}
-            >
-              <ModelsNextUIToggleSwitch />
-            </div>
-          )}
           <ModelVersionTable
             activeStageOnly={stageFilter === StageFilters.ACTIVE && !this.props.usingNextModelsUI}
             modelName={modelName}
@@ -409,7 +408,22 @@ export class ModelViewImpl extends React.Component<ModelViewImplProps, ModelView
             onMetadataUpdated={this.props.onMetadataUpdated}
             usingNextModelsUI={this.props.usingNextModelsUI}
             aliases={model?.aliases}
+            serverPaginated
           />
+          <div css={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
+            <CursorPagination
+              componentId="model_page.cursor_pagination"
+              hasNextPage={paginationProps.hasNextPage}
+              hasPreviousPage={paginationProps.hasPreviousPage}
+              onNextPage={paginationProps.onNext}
+              onPreviousPage={paginationProps.onPrev}
+              pageSizeSelect={{
+                onChange: (num) => paginationProps.onPageSizeChange({ key: num }),
+                default: paginationProps.maxResultValue,
+                options: [10, 25, 50, 100],
+              }}
+            />
+          </div>
         </CollapsibleSection>
 
         {/* Delete Model Dialog */}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/15386?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15386/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15386/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15386
```

</p>
</details>

### Related Issues/PRs

Fix #15384 

### What changes are proposed in this pull request?

Adds cursor‑based pagination to the Model Versions page, improving performance and scalability for models with large version histories. Instead of fetching all versions on every 10‑second poll, the UI now sends max_results and page_token parameters to the searchModelVersions API, so it only loads the number of entries the user selects and fetches subsequent slices on demand via Next/Previous controls. This change reduces network traffic, lowers client/server memory usage, and delivers a faster, smoother browsing experience.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Earlier
Request: 
<img width="441" alt="Screenshot 2025-04-20 at 10 15 27 PM" src="https://github.com/user-attachments/assets/904cc3ea-07c4-4aa0-afb8-de036a2b2ed4" />

API calls every 10 seconds(Getting the complete version details in single api call)
<img width="643" alt="Screenshot 2025-04-20 at 8 59 14 PM" src="https://github.com/user-attachments/assets/c20d0bae-2904-4d9a-80ee-2df3b4bc0295" />

After:
 Pagination added:
<img width="1393" alt="Screenshot 2025-04-20 at 10 17 45 PM" src="https://github.com/user-attachments/assets/c080179c-88fe-485e-aab3-ba01a927775b" />

Request with max_results parameter which retrieves only the needed data
<img width="441" alt="Screenshot 2025-04-20 at 9 07 47 PM" src="https://github.com/user-attachments/assets/c3974977-ac04-4ec1-a1ca-9e96b022b8d8" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The Model Versions page now uses cursor‑based pagination instead of loading all versions on every refresh. Users can select how many versions to display per page (10, 25, 50, 100), and navigate through versions with Next/Previous controls. This update dramatically reduces network traffic, memory usage on both client and server, and eliminates disruptive full‑page reloads, resulting in a faster, smoother experience when browsing large version histories.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations


#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
