### PR TITLE
Rename `request_id` to `trace_id`

### DIFF
--- a/docs/docs/mlflow-3/genai-agent.mdx
+++ b/docs/docs/mlflow-3/genai-agent.mdx
@@ -88,10 +88,10 @@ logged_model = mlflow.last_logged_model()
 traces = mlflow.search_traces(model_id=logged_model.model_id)
 print(traces)
 
-#                          request_id                                              trace  ...                                               tags assessments
-# 0  56be163823ff457db4b30a97e704c709  Trace(request_id=56be163823ff457db4b30a97e704c...  ...  {'mlflow.artifactLocation': 'file:///Users/ser...          []
-# 1  71b7dc5eafd7486b989712e428a96522  Trace(request_id=71b7dc5eafd7486b989712e428a96...  ...  {'mlflow.artifactLocation': 'file:///Users/ser...          []
-# 2  68fa9c943dbc44df96da0b89611ed643  Trace(request_id=68fa9c943dbc44df96da0b89611ed...  ...  {'mlflow.artifactLocation': 'file:///Users/ser...          []
+#                          trace_id                                              trace  ...                                               tags assessments
+# 0  56be163823ff457db4b30a97e704c709  Trace(trace_id=56be163823ff457db4b30a97e704c...  ...  {'mlflow.artifactLocation': 'file:///Users/ser...          []
+# 1  71b7dc5eafd7486b989712e428a96522  Trace(trace_id=71b7dc5eafd7486b989712e428a96...  ...  {'mlflow.artifactLocation': 'file:///Users/ser...          []
+# 2  68fa9c943dbc44df96da0b89611ed643  Trace(trace_id=68fa9c943dbc44df96da0b89611ed...  ...  {'mlflow.artifactLocation': 'file:///Users/ser...          []
 ```
 
 Check out the **Models** tab in the experiment to view the newly logged model.

--- a/docs/docs/mlflow-3/index.mdx
+++ b/docs/docs/mlflow-3/index.mdx
@@ -138,8 +138,8 @@ print(f"LoggedModel model id: {logged_model.model_id}")
 
 traces = mlflow.search_traces(model_id=logged_model.model_id)
 print(traces)
-#                          request_id                                              trace  ...                                               tags assessments
-# 0  5882df1240cf4dbf845fdc9fa26c4168  Trace(request_id=5882df1240cf4dbf845fdc9fa26c4...  ...  {'mlflow.artifactLocation': 'file:///Users/ser...          []
+#                          trace_id                                              trace  ...                                               tags assessments
+# 0  5882df1240cf4dbf845fdc9fa26c4168  Trace(trace_id=5882df1240cf4dbf845fdc9fa26c4...  ...  {'mlflow.artifactLocation': 'file:///Users/ser...          []
 # [1 rows x 11 columns]
 ```
 

--- a/docs/docs/tracing/api/client.mdx
+++ b/docs/docs/tracing/api/client.mdx
@@ -20,7 +20,7 @@ We recommend using the client APIs ONLY when the high-level APIs like `@mlflow.t
 ### Starting a Trace
 
 Unlike with the high-level APIs, the MLflow Trace Client API requires that you explicitly start a trace before adding child spans. This initial API call
-starts the root span for the trace, providing a context request_id that is used for associating subsequent spans to the root span.
+starts the root span for the trace, providing a context trace_id that is used for associating subsequent spans to the root span.
 
 To start a new trace, use the <APILink fn="mlflow.client.MlflowClient.start_trace" /> method. This method creates a new trace and returns the root span object.
 
@@ -32,8 +32,8 @@ client = MlflowClient()
 # Start a new trace
 root_span = client.start_trace("my_trace")
 
-# The request_id is used for creating additional spans that have a hierarchical association to this root span
-request_id = root_span.request_id
+# The trace_id is used for creating additional spans that have a hierarchical association to this root span
+trace_id = root_span.trace_id
 ```
 
 ### Adding a Child Span
@@ -45,7 +45,7 @@ each representing a specific operation or step within the overall process.
 # Create a child span
 child_span = client.start_span(
     name="child_span",
-    request_id=request_id,
+    trace_id=trace_id,
     parent_id=root_span.span_id,
     inputs={"input_key": "input_value"},
     attributes={"attribute_key": "attribute_value"},
@@ -57,12 +57,12 @@ child_span = client.start_span(
 After performing the operations associated with a span, you must end the span explicitly using the <APILink fn="mlflow.client.MlflowClient.end_span" /> method. Make note of the two required fields
 that are in the API signature:
 
-- **request_id**: The identifier associated with the root span
+- **trace_id**: The identifier associated with the root span
 - **span_id**: The identifier associated with the span that is being ended
 
 In order to effectively end a particular span, both the root span (returned from calling `start_trace`) and the targeted span (returned from calling `start_span`)
 need to be identified when calling the `end_span` API.
-The initiating `request_id` can be accessed from any parent span object's properties.
+The initiating `trace_id` can be accessed from any parent span object's properties.
 
 :::note
 Spans created via the Client API will need to be terminated manually. Ensure that all spans that have been started with the `start_span` API
@@ -72,7 +72,7 @@ have been ended with the `end_span` API.
 ```python
 # End the child span
 client.end_span(
-    request_id=child_span.request_id,
+    trace_id=child_span.trace_id,
     span_id=child_span.span_id,
     outputs={"output_key": "output_value"},
     attributes={"custom_attribute": "value"},
@@ -87,7 +87,7 @@ spans are properly ended.
 ```python
 # End the root span (trace)
 client.end_trace(
-    request_id=request_id,
+    trace_id=trace_id,
     outputs={"final_output_key": "final_output_value"},
     attributes={"token_usage": "1174"},
 )

--- a/docs/docs/tracing/api/how-to.mdx
+++ b/docs/docs/tracing/api/how-to.mdx
@@ -99,10 +99,10 @@ and the <APILink fn="mlflow.client.MlflowClient.delete_trace_tag">`MlflowClient.
 
 ```python
 # Set a tag on a trace
-client.set_trace_tag(request_id=request_id, key="tag_key", value="tag_value")
+client.set_trace_tag(trace_id=trace_id, key="tag_key", value="tag_value")
 
 # Delete a tag from a trace
-client.delete_trace_tag(request_id=request_id, key="tag_key")
+client.delete_trace_tag(trace_id=trace_id, key="tag_key")
 ```
 
 ### Setting Tags via the MLflow UI
@@ -114,7 +114,7 @@ Alternatively, you can update or delete tags on a trace from the MLflow UI. To d
 ## Delete Traces
 
 You can delete traces based on specific criteria using the <APILink fn="mlflow.client.MlflowClient.delete_traces">`MlflowClient.delete_traces`</APILink> method. This method allows you to delete traces by **experiment ID**,
-**maximum timestamp**, or **request IDs**.
+**maximum timestamp**, or **trace IDs**.
 
 :::tip
 Deleting a trace is an irreversible process. Ensure that the setting provided within the `delete_traces` API meet the intended range for deletion.

--- a/docs/docs/tracing/api/search.mdx
+++ b/docs/docs/tracing/api/search.mdx
@@ -191,7 +191,7 @@ API will always return a Pandas DataFrame. To get a list of Trace objects, you c
 
 When using `return_type="pandas"` (default), the returned DataFrame includes these columns:
 
-- **request_id**: A primary identifier of a trace
+- **trace_id**: A primary identifier of a trace
 - **trace**: A trace object
 - **timestamp_ms**: The start time of the trace in milliseconds
 - **status**: The status of the trace
@@ -241,7 +241,7 @@ print(traces)
 The output Pandas DataFrame will contain additional columns for the extracted span fields:
 
 ```text
-    request_id                              ...     morning_greeting.inputs.name   morning_greeting.outputs
+    trace_id                              ...     morning_greeting.inputs.name   morning_greeting.outputs
 0   053adf2f5f5e4ad68d432e06e254c8a4        ...     'Tom'                          'Good morning Tom.'
 ```
 
@@ -288,7 +288,7 @@ while True:
     # Process the current page of results
     for trace in results:
         # Do something with each trace
-        print(trace.request_id)
+        print(trace.trace_id)
 
     # Check if there are more pages
     if not results.token:

--- a/docs/docs/tracing/tracing-schema.mdx
+++ b/docs/docs/tracing/tracing-schema.mdx
@@ -13,6 +13,12 @@ import TabItem from "@theme/TabItem";
 This document provides a detailed view of the schema for traces and its ingredients. MLflow traces are **compatible to OpenTelemetry specs**,
 but we also define a few additional layers of structure upon the OpenTelemetry Spans to provide additional metadata about the trace.
 
+:::note
+
+    The `request_id` field was renamed to `trace_id` in MLflow 3.
+
+:::
+
 ## Structure of Traces
 
 **TL;DR**: `Trace = TraceInfo + TraceData` where `TraceData = List[Span]`
@@ -111,7 +117,7 @@ The primary components of MLflow <APILink fn="mlflow.entities.TraceInfo">`TraceI
   </thead>
   <tbody>
     <tr>
-      <td>**request_id**</td>
+      <td>**trace_id**</td>
       <td>
         A unique identifier for the trace. The identifier is used within MLflow
         and integrated system to resolve the event being captured and to provide
@@ -364,12 +370,12 @@ The sections below provide a detailed view of the structure of a span.
       <td>A `span_id` is set when a span is created and is immutable.</td>
     </tr>
     <tr>
-      <td>**request_id**</td>
+      <td>**trace_id**</td>
       <td>
-        The `request_id` property is a unique identifier that is generated for
+        The `trace_id` property is a unique identifier that is generated for
         each **trace** and is propagated to each span that is a member of that trace.
       </td>
-      <td>The `request_id` is a system-generated property and is immutable.</td>
+      <td>The `trace_id` is a system-generated property and is immutable.</td>
     </tr>
     <tr>
       <td>**name**</td>

--- a/docs/docs/tracing/ui.mdx
+++ b/docs/docs/tracing/ui.mdx
@@ -32,7 +32,7 @@ This table includes high-level information about the traces, such as the trace I
 
 ## Browsing span data
 
-In order to browse the span data of an individual trace, simply click on the link in the "Request ID" or "Trace name" columns to open the trace viewer:
+In order to browse the span data of an individual trace, simply click on the link in the "Trace ID" or "Trace name" columns to open the trace viewer:
 
 ![Trace Browser](/images/llms/tracing/tracing-top.gif)
 

--- a/examples/tracing/client.py
+++ b/examples/tracing/client.py
@@ -26,15 +26,15 @@ def run(x: int, y: int) -> int:
 
     z = x + y
 
-    # Request ID is a unique identifier for the trace. You will need this ID
+    # Trace ID is a unique identifier for the trace. You will need this ID
     # to interact with the trace later using the MLflow client.
-    request_id = root_span.request_id
+    trace_id = root_span.trace_id
 
     # Create a child span of the root span.
     child_span = client.start_span(
         name="child_span",
-        # Specify the request ID to which the child span belongs.
-        request_id=request_id,
+        # Specify the trace ID to which the child span belongs.
+        trace_id=trace_id,
         # Also specify the ID of the parent span to build the span hierarchy.
         # You can access the span ID via `span_id` property of the span object.
         parent_id=root_span.span_id,
@@ -51,7 +51,7 @@ def run(x: int, y: int) -> int:
 
     # End the child span. Please make sure to end the child span before ending the root span.
     client.end_span(
-        request_id=request_id,
+        trace_id=trace_id,
         span_id=child_span.span_id,
         # Set the output(s) of the span.
         outputs=z,
@@ -63,7 +63,7 @@ def run(x: int, y: int) -> int:
 
     # End the root span.
     client.end_trace(
-        request_id=request_id,
+        trace_id=trace_id,
         # Set the output(s) of the span.
         outputs=z,
     )
@@ -84,10 +84,10 @@ assert trace.info.tags["fruit"] == "apple"
 assert trace.info.tags["vegetable"] == "carrot"
 
 # Update the tags using set_trace_tag() and delete_trace_tag() APIs.
-client.set_trace_tag(trace.info.request_id, "fruit", "orange")
-client.delete_trace_tag(trace.info.request_id, "vegetable")
+client.set_trace_tag(trace.info.trace_id, "fruit", "orange")
+client.delete_trace_tag(trace.info.trace_id, "vegetable")
 
-trace = client.get_trace(trace.info.request_id)
+trace = client.get_trace(trace.info.trace_id)
 assert trace.info.tags["fruit"] == "orange"
 assert "vegetable" not in trace.info.tags
 

--- a/mlflow/autogen/autogen_logger.py
+++ b/mlflow/autogen/autogen_logger.py
@@ -136,7 +136,7 @@ class MlflowAutogenLogger(BaseLogger):
                     raise e
                 finally:
                     self._client.end_trace(
-                        request_id=span.request_id, outputs=result, status=span.status
+                        trace_id=span.trace_id, outputs=result, status=span.status
                     )
                     # Clear the state to start a new chat session
                     self._chat_state.clear()
@@ -154,7 +154,7 @@ class MlflowAutogenLogger(BaseLogger):
                     raise e
                 finally:
                     self._client.end_span(
-                        request_id=span.request_id,
+                        trace_id=span.trace_id,
                         span_id=span.span_id,
                         outputs=result,
                         status=span.status,
@@ -191,7 +191,7 @@ class MlflowAutogenLogger(BaseLogger):
             return NoOpSpan()
 
         return self._client.start_span(
-            request_id=self._chat_state.session_span.request_id,
+            trace_id=self._chat_state.session_span.trace_id,
             # Tentatively set the parent ID to the session root span, because we
             # cannot create a span without a parent span (otherwise it will start
             # a new trace). The actual parent will be determined once the chat
@@ -219,7 +219,7 @@ class MlflowAutogenLogger(BaseLogger):
                     start_time_ns=self._chat_state.last_message_timestamp,
                 )
                 self._client.end_span(
-                    request_id=span.request_id,
+                    trace_id=span.trace_id,
                     span_id=span.span_id,
                     outputs=kwargs,
                     end_time_ns=event_end_time,
@@ -265,7 +265,7 @@ class MlflowAutogenLogger(BaseLogger):
             start_time_ns=start_time_ns,
         )
         self._client.end_span(
-            request_id=span.request_id,
+            trace_id=span.trace_id,
             span_id=span.span_id,
             outputs=response,
             end_time_ns=time.time_ns(),

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -546,7 +546,7 @@ class LiveSpan(Span):
         return clone_span
 
 
-NO_OP_SPAN_REQUEST_ID = "MLFLOW_NO_OP_SPAN_TRACE_ID"
+NO_OP_SPAN_TRACE_ID = "MLFLOW_NO_OP_SPAN_TRACE_ID"
 
 
 class NoOpSpan(Span):
@@ -577,7 +577,7 @@ class NoOpSpan(Span):
         """
         No-op span returns a special trace ID to distinguish it from the real spans.
         """
-        return NO_OP_SPAN_REQUEST_ID
+        return NO_OP_SPAN_TRACE_ID
 
     @property
     def span_id(self):

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -101,7 +101,6 @@ class Span:
         """The trace ID of the span, a unique identifier for the trace it belongs to."""
         return self.get_attribute(SpanAttributeKey.REQUEST_ID)
 
-
     @property
     def request_id(self) -> str:
         """Deprecated. Use `trace_id` instead."""

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -48,7 +48,7 @@ class SpanType:
 
 
 def create_mlflow_span(
-    otel_span: Any, request_id: str, span_type: Optional[str] = None
+    otel_span: Any, trace_id: str, span_type: Optional[str] = None
 ) -> Union["Span", "LiveSpan", "NoOpSpan"]:
     """
     Factory function to create a span object.
@@ -60,7 +60,7 @@ def create_mlflow_span(
         return NoOpSpan()
 
     if isinstance(otel_span, OTelSpan):
-        return LiveSpan(otel_span, request_id, span_type)
+        return LiveSpan(otel_span, trace_id, span_type)
 
     if isinstance(otel_span, OTelReadableSpan):
         return Span(otel_span)
@@ -97,13 +97,15 @@ class Span:
 
     @property
     @lru_cache(maxsize=1)
-    def request_id(self) -> str:
-        """
-        The request ID of the span, a unique identifier for the trace it belongs to.
-        Request ID is equivalent to the trace ID in OpenTelemetry, but generated
-        differently by the tracing backend.
-        """
+    def trace_id(self) -> str:
+        """The trace ID of the span, a unique identifier for the trace it belongs to."""
         return self.get_attribute(SpanAttributeKey.REQUEST_ID)
+
+
+    @property
+    def request_id(self) -> str:
+        """Deprecated. Use `trace_id` instead."""
+        return self.trace_id
 
     @property
     def span_id(self) -> str:
@@ -156,7 +158,7 @@ class Span:
     def _trace_id(self) -> str:
         """
         The OpenTelemetry trace ID of the span. Note that this should not be exposed to
-        the user, instead, use request_id as an unique identifier for a trace.
+        the user, instead, use trace_id property as an unique identifier for a trace.
         """
         return encode_trace_id(self._span.context.trace_id)
 
@@ -191,7 +193,7 @@ class Span:
 
     def __repr__(self):
         return (
-            f"{type(self).__name__}(name={self.name!r}, request_id={self.request_id!r}, "
+            f"{type(self).__name__}(name={self.name!r}, trace_id={self.trace_id!r}, "
             f"span_id={self.span_id!r}, parent_id={self.parent_id!r})"
         )
 
@@ -353,7 +355,7 @@ class LiveSpan(Span):
     def __init__(
         self,
         otel_span: OTelSpan,
-        request_id: str,
+        trace_id: str,
         span_type: str = SpanType.UNKNOWN,
     ):
         """
@@ -373,7 +375,7 @@ class LiveSpan(Span):
 
         self._span = otel_span
         self._attributes = _SpanAttributesRegistry(otel_span)
-        self._attributes.set(SpanAttributeKey.REQUEST_ID, request_id)
+        self._attributes.set(SpanAttributeKey.REQUEST_ID, trace_id)
         self._attributes.set(SpanAttributeKey.SPAN_TYPE, span_type)
 
     def set_span_type(self, span_type: str):
@@ -477,8 +479,8 @@ class LiveSpan(Span):
         cls,
         span: Span,
         parent_span_id: Optional[str] = None,
-        request_id: Optional[str] = None,
         trace_id: Optional[str] = None,
+        otel_trace_id: Optional[str] = None,
     ) -> "LiveSpan":
         """
         Create a new LiveSpan object from the given immutable span by
@@ -486,17 +488,18 @@ class LiveSpan(Span):
 
         This is particularly useful when we merging a remote trace into the current trace.
         We cannot merge the remote trace directly, because it is already stored as an immutable
-        span, meaning that we cannot update metadata like request ID, trace ID, parent span ID,
+        span, meaning that we cannot update metadata like trace ID, parent span ID,
         which are necessary for merging the trace.
 
         Args:
             span: The immutable span object to clone.
             parent_span_id: The parent span ID of the new span.
                 If it is None, the span will be created as a root span.
-            request_id: The request ID to be set on the new span. Specify this if you want to
-                create the new span with a different request ID from the original span.
-            trace_id: The trace ID of the new span in hex encoded format. Specify this if you
-                want to create the new span with a different trace ID from the original span
+            trace_id: The trace ID to be set on the new span. Specify this if you want to
+                create the new span with a different trace ID from the original span.
+            otel_trace_id: The OpenTelemetry trace ID of the new span in hex encoded format.
+                Specify this if you want to create the new span with a different trace ID
+                from the original span
 
         Returns:
             The new LiveSpan object with the same state as the original span.
@@ -506,8 +509,8 @@ class LiveSpan(Span):
         from mlflow.tracing.trace_manager import InMemoryTraceManager
 
         trace_manager = InMemoryTraceManager.get_instance()
-        request_id = request_id or span.request_id
-        parent_span = trace_manager.get_span_from_id(request_id, parent_span_id)
+        trace_id = trace_id or span.trace_id
+        parent_span = trace_manager.get_span_from_id(trace_id, parent_span_id)
 
         # Create a new span with the same name, parent, and start time
         otel_span = mlflow.tracing.provider.start_detached_span(
@@ -516,7 +519,7 @@ class LiveSpan(Span):
             start_time_ns=span.start_time_ns,
         )
         # otel_span._span_processor = span._span._span_processor
-        clone_span = LiveSpan(otel_span, request_id, span.span_type)
+        clone_span = LiveSpan(otel_span, trace_id, span.span_type)
 
         # Copy all the attributes, inputs, outputs, and events from the original span
         clone_span.set_status(span.status)
@@ -531,8 +534,8 @@ class LiveSpan(Span):
         # Update trace ID and span ID
         context = span._span.get_span_context()
         clone_span._span._context = SpanContext(
-            # Override trace_id if provided, otherwise use the original trace ID
-            trace_id=decode_id(trace_id) or context.trace_id,
+            # Override otel_trace_id if provided, otherwise use the original trace ID
+            trace_id=decode_id(otel_trace_id) or context.trace_id,
             span_id=context.span_id,
             is_remote=context.is_remote,
             # Override trace flag as if it is sampled within current context.
@@ -544,7 +547,7 @@ class LiveSpan(Span):
         return clone_span
 
 
-NO_OP_SPAN_REQUEST_ID = "MLFLOW_NO_OP_SPAN_REQUEST_ID"
+NO_OP_SPAN_REQUEST_ID = "MLFLOW_NO_OP_SPAN_TRACE_ID"
 
 
 class NoOpSpan(Span):
@@ -571,9 +574,9 @@ class NoOpSpan(Span):
         self._attributes = {}
 
     @property
-    def request_id(self):
+    def trace_id(self):
         """
-        No-op span returns a special request ID to distinguish it from the real spans.
+        No-op span returns a special trace ID to distinguish it from the real spans.
         """
         return NO_OP_SPAN_REQUEST_ID
 

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -35,7 +35,7 @@ class Trace(_MlflowObject):
             self.info = self.info.to_v3(request=self.data.request, response=self.data.response)
 
     def __repr__(self) -> str:
-        return f"Trace(request_id={self.info.request_id})"
+        return f"Trace(trace_id={self.info.trace_id})"
 
     def to_dict(self) -> dict[str, Any]:
         return {"info": self.info.to_dict(), "data": self.data.to_dict()}
@@ -107,7 +107,7 @@ class Trace(_MlflowObject):
 
     def to_pandas_dataframe_row(self) -> dict[str, Any]:
         return {
-            "request_id": self.info.request_id,
+            "trace_id": self.info.trace_id,
             "trace": self,
             "timestamp_ms": self.info.timestamp_ms,
             "status": self.info.status,
@@ -118,6 +118,9 @@ class Trace(_MlflowObject):
             "spans": [span.to_dict() for span in self.data.spans],
             "tags": self.info.tags,
             "assessments": self.info.assessments,
+            # For backward compatibility, we need to keep the old "request_id" field
+            # Ref: https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/evaluation-schema
+            "request_id": self.info.request_id,
         }
 
     def _deserialize_json_attr(self, value: str):
@@ -228,7 +231,7 @@ class Trace(_MlflowObject):
     @staticmethod
     def pandas_dataframe_columns() -> list[str]:
         return [
-            "request_id",
+            "trace_id",
             "trace",
             "timestamp_ms",
             "status",
@@ -239,6 +242,7 @@ class Trace(_MlflowObject):
             "spans",
             "tags",
             "assessments",
+            "request_id",
         ]
 
     def to_proto(self):

--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -62,6 +62,11 @@ class TraceInfo(_MlflowObject):
             return self.__dict__ == other.__dict__
         return False
 
+    @property
+    def trace_id(self) -> str:
+        """Returns the trace ID of the trace info."""
+        return self.request_id
+
     def to_proto(self):
         proto = ProtoTraceInfo()
         proto.request_id = self.request_id

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -21,7 +21,7 @@ import mlflow
 from mlflow import MlflowClient
 from mlflow.entities import Document as MlflowDocument
 from mlflow.entities import LiveSpan, SpanEvent, SpanStatus, SpanStatusCode, SpanType
-from mlflow.entities.span import NO_OP_SPAN_REQUEST_ID
+from mlflow.entities.span import NO_OP_SPAN_TRACE_ID
 from mlflow.exceptions import MlflowException
 from mlflow.langchain.utils.chat import (
     convert_lc_generation_to_chat_message,
@@ -188,7 +188,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
             if parent:
                 span = self._mlflow_client.start_span(
                     name=span_name,
-                    request_id=parent.request_id,
+                    trace_id=parent.trace_id,
                     parent_id=parent.span_id,
                     span_type=span_type,
                     inputs=inputs,
@@ -208,7 +208,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
                     attributes=serialized_attributes,
                     tags=dependencies_schemas,
                 )
-                if span.request_id == NO_OP_SPAN_REQUEST_ID:
+                if span.trace_id == NO_OP_SPAN_TRACE_ID:
                     _logger.debug("No Op span was created, the trace will not be recorded.")
 
             # Attach the span to the current context to mark it "active"
@@ -241,7 +241,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         try:
             with maybe_set_prediction_context(self._prediction_context):
                 self._mlflow_client.end_span(
-                    request_id=span.request_id,
+                    trace_id=span.trace_id,
                     span_id=span.span_id,
                     outputs=outputs,
                     attributes=attributes,

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -125,9 +125,9 @@ def _end_span(span: LiveSpan, status=SpanStatusCode.OK, outputs=None, token=None
     try:
         if span.parent_id is None:
             # NB: Initiate the new client every time to handle tracking URI updates.
-            MlflowClient().end_trace(span.request_id, status=status, outputs=outputs)
+            MlflowClient().end_trace(span.trace_id, status=status, outputs=outputs)
         else:
-            MlflowClient().end_span(span.request_id, span.span_id, status=status, outputs=outputs)
+            MlflowClient().end_span(span.trace_id, span.span_id, status=status, outputs=outputs)
     finally:
         # We should detach span even when end_span / end_trace API call fails
         if token:
@@ -169,7 +169,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
             if parent_span:
                 # NB: Initiate the new client every time to handle tracking URI updates.
                 span = MlflowClient().start_span(
-                    request_id=parent_span.request_id,
+                    trace_id=parent_span.trace_id,
                     parent_id=parent_span.span_id,
                     name=id_.partition("-")[0],
                     span_type=span_type,

--- a/mlflow/openai/_openai_autolog.py
+++ b/mlflow/openai/_openai_autolog.py
@@ -162,7 +162,7 @@ def _start_span(
     # associated with the trace.
     if run_id is not None:
         tm = InMemoryTraceManager().get_instance()
-        tm.set_request_metadata(span.request_id, TraceMetadataKey.SOURCE_RUN, run_id)
+        tm.set_request_metadata(span.trace_id, TraceMetadataKey.SOURCE_RUN, run_id)
 
     return span
 
@@ -217,7 +217,7 @@ def _is_responses_final_event(chunk: Any) -> bool:
 def _end_span_on_exception(mlflow_client: MlflowClient, span: LiveSpan, e: Exception):
     try:
         span.add_event(SpanEvent.from_exception(e))
-        mlflow_client.end_span(span.request_id, span.span_id, status=SpanStatusCode.ERROR)
+        mlflow_client.end_span(span.trace_id, span.span_id, status=SpanStatusCode.ERROR)
     except Exception as inner_e:
         _logger.warning(f"Encountered unexpected error when ending trace: {inner_e}")
 

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -15,12 +15,12 @@ from mlflow.tracing.trace_manager import InMemoryTraceManager
 _logger = logging.getLogger(__name__)
 
 
-def pop_trace(trace_id: str) -> Optional[dict[str, Any]]:
+def pop_trace(request_id: str) -> Optional[dict[str, Any]]:
     """
     Pop the completed trace data from the buffer. This method is used in
     the Databricks model serving so please be careful when modifying it.
     """
-    return _TRACE_BUFFER.pop(trace_id, None)
+    return _TRACE_BUFFER.pop(request_id, None)
 
 
 # For Inference Table, we use special TTLCache to store the finished traces

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -15,12 +15,12 @@ from mlflow.tracing.trace_manager import InMemoryTraceManager
 _logger = logging.getLogger(__name__)
 
 
-def pop_trace(request_id: str) -> Optional[dict[str, Any]]:
+def pop_trace(trace_id: str) -> Optional[dict[str, Any]]:
     """
     Pop the completed trace data from the buffer. This method is used in
     the Databricks model serving so please be careful when modifying it.
     """
-    return _TRACE_BUFFER.pop(request_id, None)
+    return _TRACE_BUFFER.pop(trace_id, None)
 
 
 # For Inference Table, we use special TTLCache to store the finished traces

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -44,7 +44,7 @@ from mlflow.tracing.utils import (
 from mlflow.tracing.utils.search import extract_span_inputs_outputs, traces_to_df
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils import get_results_from_paginated_fn
-from mlflow.utils.annotations import deprecated, experimental
+from mlflow.utils.annotations import experimental
 
 _logger = logging.getLogger(__name__)
 
@@ -718,65 +718,6 @@ def get_current_active_span() -> Optional[LiveSpan]:
     return trace_manager.get_span_from_id(request_id, encode_span_id(otel_span.context.span_id))
 
 
-@deprecated(
-    impact=(
-        "Use `mlflow.get_last_active_trace_id()` API instead to get the last active trace ID. "
-        "You can then use the `mlflow.get_trace()` API to get the trace object as well."
-    )
-)
-def get_last_active_trace() -> Optional[Trace]:
-    """
-    Get the last active trace in the same process if exists.
-
-    .. warning::
-
-        This function DOES NOT work in the model deployed in Databricks model serving.
-
-    .. note::
-
-        This function returns an immutable copy of the original trace that is logged
-        in the tracking store. Any changes made to the returned object will not be reflected
-        in the original trace. To modify the already ended trace (while most of the data is
-        immutable after the trace is ended, you can still edit some fields such as `tags`),
-        please use the respective MlflowClient APIs with the request ID of the trace, as
-        shown in the example below.
-
-    .. code-block:: python
-        :test:
-
-        import mlflow
-
-
-        @mlflow.trace
-        def f():
-            pass
-
-
-        f()
-
-        trace = mlflow.get_last_active_trace()
-
-
-        # Use MlflowClient APIs to mutate the ended trace
-        mlflow.MlflowClient().set_trace_tag(trace.info.trace_id, "key", "value")
-
-    Returns:
-        The last active trace if exists, otherwise None.
-    """
-    if _LAST_ACTIVE_TRACE_ID_GLOBAL is not None:
-        try:
-            return MlflowClient().get_trace(_LAST_ACTIVE_TRACE_ID_GLOBAL, display=False)
-        except:
-            _logger.debug(
-                "Failed to get the last active trace with "
-                f"request ID {_LAST_ACTIVE_TRACE_ID_GLOBAL}.",
-                exc_info=True,
-            )
-            raise
-    else:
-        return None
-
-
 def get_last_active_trace_id(thread_local: bool = False) -> Optional[str]:
     """
     Get the last active trace in the same process if exists.
@@ -1104,9 +1045,7 @@ def _merge_trace(
     # The merged trace should have the same trace ID as the parent trace.
     with trace_manager.get_trace(target_trace_id) as parent_trace:
         if not parent_trace:
-            _logger.warning(
-                f"Parent trace with ID {target_trace_id} not found. Skipping merge."
-            )
+            _logger.warning(f"Parent trace with ID {target_trace_id} not found. Skipping merge.")
             return
 
         new_trace_id = parent_trace.span_dict[target_parent_span_id]._trace_id

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -42,6 +42,7 @@ from mlflow.tracing.utils import (
     start_client_span_or_trace,
 )
 from mlflow.tracing.utils.search import extract_span_inputs_outputs, traces_to_df
+from mlflow.tracing.utils.warning import request_id_backward_compatible
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.annotations import deprecated, experimental
@@ -456,6 +457,7 @@ def start_span(
             _logger.debug(f"Failed to end span {mlflow_span.span_id}.", exc_info=True)
 
 
+@request_id_backward_compatible
 def get_trace(trace_id: str) -> Optional[Trace]:
     """
     Get a trace by the given request ID if it exists.

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -410,7 +410,7 @@ def start_client_span_or_trace(
     if parent_span := parent_span or mlflow.get_current_active_span():
         return client.start_span(
             name=name,
-            request_id=parent_span.request_id,
+            trace_id=parent_span.trace_id,
             parent_id=parent_span.span_id,
             span_type=span_type,
             inputs=inputs,
@@ -440,7 +440,7 @@ def end_client_span_or_trace(
     """
     if span.parent_id is not None:
         return client.end_span(
-            request_id=span.request_id,
+            trace_id=span.trace_id,
             span_id=span.span_id,
             outputs=outputs,
             attributes=attributes,
@@ -451,7 +451,7 @@ def end_client_span_or_trace(
         span.set_status(status)
         span.set_outputs(outputs)
         return client.end_trace(
-            request_id=span.request_id,
+            trace_id=span.trace_id,
             outputs=outputs,
             attributes=attributes,
             status=status,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -87,6 +87,7 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import exclude_immutable_tags, get_otel_attribute
+from mlflow.tracing.utils.warning import request_id_backward_compatible
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking._model_registry import utils as registry_utils
 from mlflow.tracking._model_registry.client import ModelRegistryClient
@@ -851,6 +852,7 @@ class MlflowClient:
             request_ids=trace_ids,
         )
 
+    @request_id_backward_compatible
     def get_trace(self, trace_id: str, display=True) -> Trace:
         """
         Get the trace matching the specified ``trace_id``.
@@ -1067,6 +1069,7 @@ class MlflowClient:
             )
             return NoOpSpan()
 
+    @request_id_backward_compatible
     def end_trace(
         self,
         trace_id: str,
@@ -1161,6 +1164,7 @@ class MlflowClient:
         self._upload_trace_data(new_info, trace.data)
         return new_info.trace_id
 
+    @request_id_backward_compatible
     def start_span(
         self,
         name: str,
@@ -1326,6 +1330,7 @@ class MlflowClient:
             )
             return NoOpSpan()
 
+    @request_id_backward_compatible
     def end_span(
         self,
         trace_id: str,
@@ -1426,6 +1431,7 @@ class MlflowClient:
             tags=trace_info.tags or {},
         )
 
+    @request_id_backward_compatible
     def set_trace_tag(self, trace_id: str, key: str, value: str):
         """
         Set a tag on the trace with the given trace ID.
@@ -1474,6 +1480,7 @@ class MlflowClient:
         # If the trace is not active, try to set the tag on the trace in the backend
         self._tracking_client.set_trace_tag(trace_id, key, value)
 
+    @request_id_backward_compatible
     def delete_trace_tag(self, trace_id: str, key: str) -> None:
         """
         Delete a tag on the trace with the given trace ID.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -799,13 +799,13 @@ class MlflowClient:
         experiment_id: str,
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
-        request_ids: Optional[list[str]] = None,
+        trace_ids: Optional[list[str]] = None,
     ) -> int:
         """
         Delete traces based on the specified criteria.
 
-        - Either `max_timestamp_millis` or `request_ids` must be specified, but not both.
-        - `max_traces` can't be specified if `request_ids` is specified.
+        - Either `max_timestamp_millis` or `trace_ids` must be specified, but not both.
+        - `max_traces` can't be specified if `trace_ids` is specified.
 
         Args:
             experiment_id: ID of the associated experiment.
@@ -814,7 +814,7 @@ class MlflowClient:
             max_traces: The maximum number of traces to delete. If max_traces is specified, and
                 it is less than the number of traces that would be deleted based on the
                 max_timestamp_millis, the oldest traces will be deleted first.
-            request_ids: A set of request IDs to delete.
+            trace_ids: A set of trace IDs to delete.
 
         Returns:
             The number of traces deleted.
@@ -841,22 +841,22 @@ class MlflowClient:
                 experiment_id="0", max_timestamp_millis=some_timestamp, max_traces=2
             )
 
-            # Delete traces based on request_ids
-            client.delete_traces(experiment_id="0", request_ids=["id_1", "id_2"])
+            # Delete traces based on trace_ids
+            client.delete_traces(experiment_id="0", trace_ids=["id_1", "id_2"])
         """
         return self._tracking_client.delete_traces(
             experiment_id=experiment_id,
             max_timestamp_millis=max_timestamp_millis,
             max_traces=max_traces,
-            request_ids=request_ids,
+            request_ids=trace_ids,
         )
 
-    def get_trace(self, request_id: str, display=True) -> Trace:
+    def get_trace(self, trace_id: str, display=True) -> Trace:
         """
-        Get the trace matching the specified ``request_id``.
+        Get the trace matching the specified ``trace_id``.
 
         Args:
-            request_id: String ID of the trace to fetch.
+            trace_id: String ID of the trace to fetch.
             display: If ``True``, display the trace on the notebook.
 
         Returns:
@@ -868,16 +868,16 @@ class MlflowClient:
             from mlflow import MlflowClient
 
             client = MlflowClient()
-            request_id = "12345678"
-            trace = client.get_trace(request_id)
+            trace_id = "12345678"
+            trace = client.get_trace(trace_id)
         """
-        if is_databricks_uri(str(self.tracking_uri)) and is_uuid(request_id):
+        if is_databricks_uri(str(self.tracking_uri)) and is_uuid(trace_id):
             raise MlflowException.invalid_parameter_value(
                 "Traces from inference tables can only be loaded using SQL or "
                 "the search_traces() API."
             )
 
-        trace = self._tracking_client.get_trace(request_id)
+        trace = self._tracking_client.get_trace(trace_id)
         if display:
             get_display_handler().display_traces([trace])
         return trace
@@ -974,7 +974,7 @@ class MlflowClient:
         .. attention::
 
             A trace started with this method must be ended by calling
-            ``MlflowClient().end_trace(request_id)``. Otherwise the trace will be not recorded.
+            ``MlflowClient().end_trace(trace_id)``. Otherwise the trace will be not recorded.
 
         Args:
             name: The name of the trace (and the root span).
@@ -1003,23 +1003,23 @@ class MlflowClient:
             client = MlflowClient()
 
             root_span = client.start_trace("my_trace")
-            request_id = root_span.request_id
+            trace_id = root_span.trace_id
 
             # Create a child span
             child_span = client.start_span(
-                "child_span", request_id=request_id, parent_id=root_span.span_id
+                "child_span", trace_id=trace_id, parent_id=root_span.span_id
             )
             # Do something...
-            client.end_span(request_id=request_id, span_id=child_span.span_id)
+            client.end_span(trace_id=trace_id, span_id=child_span.span_id)
 
-            client.end_trace(request_id)
+            client.end_trace(trace_id)
         """
         # Validate no active trace is set in the global context. If there is an active trace,
         # the span created by this method will be a child span under the active trace rather than
         # a root span of a new trace, which is not desired behavior.
         if span := mlflow.get_current_active_span():
             raise MlflowException(
-                f"Another trace is already set in the global context with ID {span.request_id}. "
+                f"Another trace is already set in the global context with ID {span.trace_id}. "
                 "It appears that you have already started a trace using fluent APIs like "
                 "`@mlflow.trace()` or `with mlflow.start_span()`. However, it is not allowed "
                 "to call MlflowClient.start_trace() under an active trace created by fluent APIs "
@@ -1039,8 +1039,8 @@ class MlflowClient:
             otel_span = mlflow.tracing.provider.start_detached_span(
                 name, experiment_id=experiment_id, start_time_ns=start_time_ns
             )
-            request_id = get_otel_attribute(otel_span, SpanAttributeKey.REQUEST_ID)
-            mlflow_span = create_mlflow_span(otel_span, request_id, span_type)
+            trace_id = get_otel_attribute(otel_span, SpanAttributeKey.REQUEST_ID)
+            mlflow_span = create_mlflow_span(otel_span, trace_id, span_type)
 
             # # If the span is a no-op span i.e. tracing is disabled, do nothing
             if isinstance(mlflow_span, NoOpSpan):
@@ -1053,7 +1053,7 @@ class MlflowClient:
             trace_manager = InMemoryTraceManager.get_instance()
             tags = exclude_immutable_tags(tags or {})
             # Update trace tags for trace in in-memory trace manager
-            with trace_manager.get_trace(request_id) as trace:
+            with trace_manager.get_trace(trace_id) as trace:
                 trace.info.tags.update(tags)
             # Register new span in the in-memory trace manager
             trace_manager.register_span(mlflow_span)
@@ -1069,7 +1069,7 @@ class MlflowClient:
 
     def end_trace(
         self,
-        request_id: str,
+        trace_id: str,
         outputs: Optional[Any] = None,
         attributes: Optional[dict[str, Any]] = None,
         status: Union[SpanStatus, str] = "OK",
@@ -1084,7 +1084,7 @@ class MlflowClient:
         no effect.
 
         Args:
-            request_id: The ID of the trace to end.
+            trace_id: The ID of the trace to end.
             outputs: Outputs to set on the trace.
             attributes: A dictionary of attributes to set on the trace. If the trace already
                 has attributes, the new attributes will be merged with the existing ones.
@@ -1099,33 +1099,33 @@ class MlflowClient:
         # NB: If the specified request ID is of no-op span, this means something went wrong in
         #     the span start logic. We should simply ignore it as the upstream should already
         #     have logged the error.
-        if request_id == NO_OP_SPAN_REQUEST_ID:
+        if trace_id == NO_OP_SPAN_REQUEST_ID:
             return
 
         trace_manager = InMemoryTraceManager.get_instance()
-        root_span_id = trace_manager.get_root_span_id(request_id)
+        root_span_id = trace_manager.get_root_span_id(trace_id)
 
         if root_span_id is None:
-            trace = self.get_trace(request_id=request_id)
+            trace = self.get_trace(trace_id=trace_id)
             if trace is None:
                 raise MlflowException(
-                    f"Trace with ID {request_id} not found.",
+                    f"Trace with ID {trace_id} not found.",
                     error_code=RESOURCE_DOES_NOT_EXIST,
                 )
             elif trace.info.status in TraceStatus.end_statuses():
                 raise MlflowException(
-                    f"Trace with ID {request_id} already finished.",
+                    f"Trace with ID {trace_id} already finished.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
 
-        self.end_span(request_id, root_span_id, outputs, attributes, status, end_time_ns)
+        self.end_span(trace_id, root_span_id, outputs, attributes, status, end_time_ns)
 
     @experimental
     def _log_trace(self, trace: Trace) -> str:
         """
         Log the complete Trace object to the backend store.
 
-        # NB: Since the backend API is used directly here, customization of request ID's
+        # NB: Since the backend API is used directly here, customization of trace ID's
         # are not possible with this internal API. A backend-generated ID will be generated
         # directly with this invocation, instead of the one from the given trace object.
 
@@ -1133,7 +1133,7 @@ class MlflowClient:
             trace: The trace object to log.
 
         Returns:
-            The request ID of the logged trace.
+            The trace ID of the logged trace.
         """
         from mlflow.tracking.fluent import _get_experiment_id
 
@@ -1151,7 +1151,7 @@ class MlflowClient:
             tags={},
         )
         self._tracking_client.end_trace(
-            request_id=new_info.request_id,
+            request_id=new_info.trace_id,
             # Compute the end time of the original trace
             timestamp_ms=trace.info.timestamp_ms + trace.info.execution_time_ms,
             status=trace.info.status,
@@ -1159,12 +1159,12 @@ class MlflowClient:
             tags=trace.info.tags,
         )
         self._upload_trace_data(new_info, trace.data)
-        return new_info.request_id
+        return new_info.trace_id
 
     def start_span(
         self,
         name: str,
-        request_id: str,
+        trace_id: str,
         parent_id: str,
         span_type: str = SpanType.UNKNOWN,
         inputs: Optional[Any] = None,
@@ -1215,14 +1215,14 @@ class MlflowClient:
                 with mlflow.start_span("parent_span") as parent_span:
                     child_span = client.start_span(
                         name="child_span",
-                        request_id=parent_span.request_id,
+                        trace_id=parent_span.trace_id,
                         parent_id=parent_span.span_id,
                     )
 
                     # Do something...
 
                     client.end_span(
-                        request_id=parent_span.request_id,
+                        trace_id=parent_span.trace_id,
                         span_id=child_span.span_id,
                     )
 
@@ -1235,7 +1235,7 @@ class MlflowClient:
 
         Args:
             name: The name of the span.
-            request_id: The ID of the trace to attach the span to. This is synonym to
+            trace_id: The ID of the trace to attach the span to. This is synonym to
                 trace_id` in OpenTelemetry.
             parent_id: The ID of the parent span. The parent span can be a span created by
                 both fluent APIs like `with mlflow.start_span()`, and imperative APIs like this.
@@ -1265,7 +1265,7 @@ class MlflowClient:
             # Create a child span
             child_span = client.start_span(
                 "child_span",
-                request_id=span.request_id,
+                trace_id=span.trace_id,
                 parent_id=span.span_id,
                 inputs={"x": x},
             )
@@ -1273,16 +1273,16 @@ class MlflowClient:
             y = x**2
 
             client.end_span(
-                request_id=child_span.request_id,
+                trace_id=child_span.trace_id,
                 span_id=child_span.span_id,
                 attributes={"factor": 2},
                 outputs={"y": y},
             )
 
-            client.end_trace(span.request_id)
+            client.end_trace(span.trace_id)
         """
         # If parent span is no-op span, the child should also be no-op too
-        if request_id == NO_OP_SPAN_REQUEST_ID:
+        if trace_id == NO_OP_SPAN_REQUEST_ID:
             return NoOpSpan()
 
         if not parent_id:
@@ -1292,14 +1292,14 @@ class MlflowClient:
                 "to start a new trace and root span.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        if not request_id:
+        if not trace_id:
             raise MlflowException(
-                "Request ID must be provided to start a span.",
+                "Trace ID must be provided to start a span.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
         trace_manager = InMemoryTraceManager.get_instance()
-        if not (parent_span := trace_manager.get_span_from_id(request_id, parent_id)):
+        if not (parent_span := trace_manager.get_span_from_id(trace_id, parent_id)):
             raise MlflowException(
                 f"Parent span with ID '{parent_id}' not found.",
                 error_code=RESOURCE_DOES_NOT_EXIST,
@@ -1312,7 +1312,7 @@ class MlflowClient:
                 start_time_ns=start_time_ns,
             )
 
-            span = create_mlflow_span(otel_span, request_id, span_type)
+            span = create_mlflow_span(otel_span, trace_id, span_type)
             span.set_attributes(attributes or {})
             if inputs is not None:
                 span.set_inputs(inputs)
@@ -1328,7 +1328,7 @@ class MlflowClient:
 
     def end_span(
         self,
-        request_id: str,
+        trace_id: str,
         span_id: str,
         outputs: Optional[Any] = None,
         attributes: Optional[dict[str, Any]] = None,
@@ -1339,7 +1339,7 @@ class MlflowClient:
         End the span with the given trace ID and span ID.
 
         Args:
-            request_id: The ID of the trace to end.
+            trace_id: The ID of the trace to end.
             span_id: The ID of the span to end.
             outputs: Outputs to set on the span.
             attributes: A dictionary of attributes to set on the span. If the span already has
@@ -1353,11 +1353,11 @@ class MlflowClient:
             end_time_ns: The end time of the span in nano seconds since the UNIX epoch.
                 If not provided, the current time will be used.
         """
-        if request_id == NO_OP_SPAN_REQUEST_ID:
+        if trace_id == NO_OP_SPAN_REQUEST_ID:
             return
 
         trace_manager = InMemoryTraceManager.get_instance()
-        span = trace_manager.get_span_from_id(request_id, span_id)
+        span = trace_manager.get_span_from_id(trace_id, span_id)
 
         if span is None:
             raise MlflowException(
@@ -1419,20 +1419,20 @@ class MlflowClient:
             The updated TraceInfo object.
         """
         return self._tracking_client.end_trace(
-            request_id=trace_info.request_id,
+            request_id=trace_info.trace_id,
             timestamp_ms=trace_info.timestamp_ms + trace_info.execution_time_ms,
             status=trace_info.status,
             request_metadata=trace_info.request_metadata,
             tags=trace_info.tags or {},
         )
 
-    def set_trace_tag(self, request_id: str, key: str, value: str):
+    def set_trace_tag(self, trace_id: str, key: str, value: str):
         """
         Set a tag on the trace with the given trace ID.
 
         The trace can be an active one or the one that has already ended and recorded in the
         backend. Below is an example of setting a tag on an active trace. You can replace the
-        ``request_id`` parameter to set a tag on an already ended trace.
+        ``trace_id`` parameter to set a tag on an already ended trace.
 
         .. code-block:: python
             :test:
@@ -1442,11 +1442,11 @@ class MlflowClient:
             client = MlflowClient()
 
             root_span = client.start_trace("my_trace")
-            client.set_trace_tag(root_span.request_id, "key", "value")
-            client.end_trace(root_span.request_id)
+            client.set_trace_tag(root_span.trace_id, "key", "value")
+            client.end_trace(root_span.trace_id)
 
         Args:
-            request_id: The ID of the trace to set the tag on.
+            trace_id: The ID of the trace to set the tag on.
             key: The string key of the tag. Must be at most 250 characters long, otherwise
                 it will be truncated when stored.
             value: The string value of the tag. Must be at most 250 characters long, otherwise
@@ -1455,7 +1455,7 @@ class MlflowClient:
         if key.startswith("mlflow."):
             raise MlflowException(
                 f"Tags starting with 'mlflow.' are reserved and cannot be set. "
-                f"Attempted to set tag with key '{key}' on trace with ID '{request_id}'.",
+                f"Attempted to set tag with key '{key}' on trace with ID '{trace_id}'.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
@@ -1466,21 +1466,21 @@ class MlflowClient:
             )
 
         # Trying to set the tag on the active trace first
-        with InMemoryTraceManager.get_instance().get_trace(request_id) as trace:
+        with InMemoryTraceManager.get_instance().get_trace(trace_id) as trace:
             if trace:
                 trace.info.tags[key] = str(value)
                 return
 
         # If the trace is not active, try to set the tag on the trace in the backend
-        self._tracking_client.set_trace_tag(request_id, key, value)
+        self._tracking_client.set_trace_tag(trace_id, key, value)
 
-    def delete_trace_tag(self, request_id: str, key: str) -> None:
+    def delete_trace_tag(self, trace_id: str, key: str) -> None:
         """
         Delete a tag on the trace with the given trace ID.
 
         The trace can be an active one or the one that has already ended and recorded in the
         backend. Below is an example of deleting a tag on an active trace. You can replace the
-        ``request_id`` parameter to delete a tag on an already ended trace.
+        ``trace_id`` parameter to delete a tag on an already ended trace.
 
         .. code-block:: python
             :test:
@@ -1490,28 +1490,28 @@ class MlflowClient:
             client = MlflowClient()
 
             root_span = client.start_trace("my_trace", tags={"key": "value"})
-            client.delete_trace_tag(root_span.request_id, "key")
-            client.end_trace(root_span.request_id)
+            client.delete_trace_tag(root_span.trace_id, "key")
+            client.end_trace(root_span.trace_id)
 
         Args:
-            request_id: The ID of the trace to delete the tag from.
+            trace_id: The ID of the trace to delete the tag from.
             key: The string key of the tag. Must be at most 250 characters long, otherwise
                 it will be truncated when stored.
         """
         # Trying to delete the tag on the active trace first
-        with InMemoryTraceManager.get_instance().get_trace(request_id) as trace:
+        with InMemoryTraceManager.get_instance().get_trace(trace_id) as trace:
             if trace:
                 if key in trace.info.tags:
                     trace.info.tags.pop(key)
                     return
                 else:
                     raise MlflowException(
-                        f"Tag with key {key} not found in trace with ID {request_id}.",
+                        f"Tag with key {key} not found in trace with ID {trace_id}.",
                         error_code=RESOURCE_DOES_NOT_EXIST,
                     )
 
         # If the trace is not active, try to delete the tag on the trace in the backend
-        self._tracking_client.delete_trace_tag(request_id, key)
+        self._tracking_client.delete_trace_tag(trace_id, key)
 
     def log_assessment(
         self,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -50,7 +50,7 @@ from mlflow.entities.assessment import (
 from mlflow.entities.assessment_source import AssessmentSource
 from mlflow.entities.model_registry import ModelVersion, Prompt, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
-from mlflow.entities.span import NO_OP_SPAN_REQUEST_ID, NoOpSpan, create_mlflow_span
+from mlflow.entities.span import NO_OP_SPAN_TRACE_ID, NoOpSpan, create_mlflow_span
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_LOGGING
 from mlflow.exceptions import MlflowException
@@ -1102,7 +1102,7 @@ class MlflowClient:
         # NB: If the specified request ID is of no-op span, this means something went wrong in
         #     the span start logic. We should simply ignore it as the upstream should already
         #     have logged the error.
-        if trace_id == NO_OP_SPAN_REQUEST_ID:
+        if trace_id == NO_OP_SPAN_TRACE_ID:
             return
 
         trace_manager = InMemoryTraceManager.get_instance()
@@ -1286,7 +1286,7 @@ class MlflowClient:
             client.end_trace(span.trace_id)
         """
         # If parent span is no-op span, the child should also be no-op too
-        if trace_id == NO_OP_SPAN_REQUEST_ID:
+        if trace_id == NO_OP_SPAN_TRACE_ID:
             return NoOpSpan()
 
         if not parent_id:
@@ -1358,7 +1358,7 @@ class MlflowClient:
             end_time_ns: The end time of the span in nano seconds since the UNIX epoch.
                 If not provided, the current time will be used.
         """
-        if trace_id == NO_OP_SPAN_REQUEST_ID:
+        if trace_id == NO_OP_SPAN_TRACE_ID:
             return
 
         trace_manager = InMemoryTraceManager.get_instance()

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -52,7 +52,7 @@ def test_json_deserialization():
                 },
                 "trace_state": "",
                 "attributes": {
-                    "mlflow.traceRequestId": json.dumps(trace.info.request_id),
+                    "mlflow.traceRequestId": json.dumps(trace.info.trace_id),
                     "mlflow.spanType": '"UNKNOWN"',
                     "mlflow.spanFunctionName": '"predict"',
                     "mlflow.spanInputs": '{"x": 2, "y": 5}',
@@ -83,7 +83,7 @@ def test_json_deserialization():
                 },
                 "trace_state": "",
                 "attributes": {
-                    "mlflow.traceRequestId": json.dumps(trace.info.request_id),
+                    "mlflow.traceRequestId": json.dumps(trace.info.trace_id),
                     "mlflow.spanType": '"UNKNOWN"',
                 },
                 "events": [
@@ -108,7 +108,7 @@ def test_json_deserialization():
                 "trace_state": "",
                 "attributes": {
                     "delta": "1",
-                    "mlflow.traceRequestId": json.dumps(trace.info.request_id),
+                    "mlflow.traceRequestId": json.dumps(trace.info.trace_id),
                     "mlflow.spanType": '"LLM"',
                     "mlflow.spanFunctionName": '"always_fail"',
                     "mlflow.spanInputs": "{}",

--- a/tests/pyfunc/test_logged_models.py
+++ b/tests/pyfunc/test_logged_models.py
@@ -26,7 +26,7 @@ class TraceModel(mlflow.pyfunc.PythonModel):
 def test_model_id_tracking():
     model = TraceModel()
     model.predict([1, 2, 3])
-    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    trace = mlflow.get_last_active_trace()
     assert TraceMetadataKey.MODEL_ID not in trace.info.request_metadata
 
     with mlflow.start_run():
@@ -37,7 +37,7 @@ def test_model_id_tracking():
     model = mlflow.pyfunc.load_model(info.model_uri)
     model.predict([4, 5, 6])
 
-    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    trace = mlflow.get_last_active_trace()
     assert trace is not None
     assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == info.model_id
 
@@ -47,7 +47,7 @@ def test_model_id_tracking_evaluate():
         info = mlflow.pyfunc.log_model("my_model", python_model=TraceModel())
 
     mlflow.evaluate(model=info.model_uri, data=[[1, 2, 3]], model_type="regressor", targets=[1])
-    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    trace = mlflow.get_last_active_trace()
     assert trace is not None
     assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == info.model_id
 

--- a/tests/pyfunc/test_logged_models.py
+++ b/tests/pyfunc/test_logged_models.py
@@ -26,7 +26,7 @@ class TraceModel(mlflow.pyfunc.PythonModel):
 def test_model_id_tracking():
     model = TraceModel()
     model.predict([1, 2, 3])
-    trace = mlflow.get_last_active_trace()
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert TraceMetadataKey.MODEL_ID not in trace.info.request_metadata
 
     with mlflow.start_run():
@@ -37,7 +37,7 @@ def test_model_id_tracking():
     model = mlflow.pyfunc.load_model(info.model_uri)
     model.predict([4, 5, 6])
 
-    trace = mlflow.get_last_active_trace()
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert trace is not None
     assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == info.model_id
 
@@ -47,7 +47,7 @@ def test_model_id_tracking_evaluate():
         info = mlflow.pyfunc.log_model("my_model", python_model=TraceModel())
 
     mlflow.evaluate(model=info.model_uri, data=[[1, 2, 3]], model_type="regressor", targets=[1])
-    trace = mlflow.get_last_active_trace()
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert trace is not None
     assert trace.info.request_metadata[TraceMetadataKey.MODEL_ID] == info.model_id
 

--- a/tests/tracing/export/test_inference_table_exporter.py
+++ b/tests/tracing/export/test_inference_table_exporter.py
@@ -26,7 +26,7 @@ def test_export():
         start_time=0,
         end_time=1_000_000,  # 1 millisecond
     )
-    span = LiveSpan(otel_span, request_id=_REQUEST_ID)
+    span = LiveSpan(otel_span, _REQUEST_ID)
     span.set_inputs({"input1": "very long input" * 100})
     span.set_outputs("very long output" * 100)
     _register_span_and_trace(span)
@@ -34,7 +34,7 @@ def test_export():
     child_otel_span = create_mock_otel_span(
         name="child", trace_id=_TRACE_ID, span_id=2, parent_id=1
     )
-    child_span = LiveSpan(child_otel_span, request_id=_REQUEST_ID)
+    child_span = LiveSpan(child_otel_span, _REQUEST_ID)
     _register_span_and_trace(child_span)
 
     # Invalid span should be also ignored
@@ -65,7 +65,7 @@ def test_export():
 
 def test_export_warn_invalid_attributes():
     otel_span = create_mock_otel_span(trace_id=_TRACE_ID, span_id=1)
-    span = LiveSpan(otel_span, request_id=_REQUEST_ID)
+    span = LiveSpan(otel_span, _REQUEST_ID)
     span.set_attribute("valid", "value")
     # # Users may set attribute directly to the OpenTelemetry span
     # otel_span.set_attribute("int", 1)
@@ -104,14 +104,14 @@ def test_export_trace_buffer_not_exceeds_max_size(monkeypatch):
     exporter = InferenceTableSpanExporter()
 
     otel_span_1 = create_mock_otel_span(name="1", trace_id=_TRACE_ID, span_id=1)
-    _register_span_and_trace(LiveSpan(otel_span_1, request_id=_REQUEST_ID))
+    _register_span_and_trace(LiveSpan(otel_span_1, _REQUEST_ID))
 
     exporter.export([otel_span_1])
 
     assert pop_trace(_REQUEST_ID) is not None
 
     otel_span_2 = create_mock_otel_span(name="2", trace_id=_TRACE_ID + 1, span_id=1)
-    _register_span_and_trace(LiveSpan(otel_span_2, request_id=_REQUEST_ID_2))
+    _register_span_and_trace(LiveSpan(otel_span_2, _REQUEST_ID_2))
 
     exporter.export([otel_span_2])
 

--- a/tests/tracing/processor/test_inference_table_processor.py
+++ b/tests/tracing/processor/test_inference_table_processor.py
@@ -78,7 +78,7 @@ def test_on_end():
         start_time=5_000_000,
         end_time=9_000_000,
     )
-    span = LiveSpan(otel_span, request_id=_REQUEST_ID)
+    span = LiveSpan(otel_span, _REQUEST_ID)
     span.set_status("OK")
     span.set_inputs({"input1": "very long input" * 100})
     span.set_outputs({"output": "very long output" * 100})

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -232,7 +232,7 @@ def test_on_end():
         start_time=5_000_000,
         end_time=9_000_000,
     )
-    span = LiveSpan(otel_span, request_id=_REQUEST_ID)
+    span = LiveSpan(otel_span, _REQUEST_ID)
     span.set_status("OK")
     span.set_inputs({"input1": "very long input" * 100})
     span.set_outputs({"output": "very long output" * 100})

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -187,7 +187,7 @@ def test_trace(wrap_sync_func, with_active_run, async_logging_enabled):
     traces = get_traces()
     assert len(traces) == 1
     trace = traces[0]
-    assert trace.info.request_id is not None
+    assert trace.info.trace_id is not None
     assert trace.info.experiment_id == "0"  # default experiment
     assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace.info.status == SpanStatusCode.OK
@@ -206,7 +206,7 @@ def test_trace(wrap_sync_func, with_active_run, async_logging_enabled):
     # assert root_span.start_time_ns // 1e6 == trace.info.timestamp_ms
     assert root_span.parent_id is None
     assert root_span.attributes == {
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanFunctionName": "predict",
         "mlflow.spanType": "UNKNOWN",
         "mlflow.spanInputs": {"x": 2, "y": 5},
@@ -217,7 +217,7 @@ def test_trace(wrap_sync_func, with_active_run, async_logging_enabled):
     assert child_span_1.parent_id == root_span.span_id
     assert child_span_1.attributes == {
         "delta": 1,
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanFunctionName": "add_one",
         "mlflow.spanType": "LLM",
         "mlflow.spanInputs": {"z": 7},
@@ -228,7 +228,7 @@ def test_trace(wrap_sync_func, with_active_run, async_logging_enabled):
     assert child_span_2.parent_id == root_span.span_id
     assert child_span_2.start_time_ns <= child_span_2.end_time_ns - 0.1 * 1e6
     assert child_span_2.attributes == {
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanFunctionName": "square",
         "mlflow.spanType": "UNKNOWN",
         "mlflow.spanInputs": {"t": 8},
@@ -266,7 +266,7 @@ def test_trace_stream(wrap_sync_func):
     traces = get_traces()
     assert len(traces) == 1
     trace = traces[0]
-    assert trace.info.request_id is not None
+    assert trace.info.trace_id is not None
     assert trace.info.experiment_id == "0"  # default experiment
     assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace.info.status == SpanStatusCode.OK
@@ -385,7 +385,7 @@ def test_trace_in_databricks_model_serving(
 
     trace_dict = response.json["trace"]
     trace = Trace.from_dict(trace_dict)
-    assert trace.info.request_id == databricks_request_id
+    assert trace.info.trace_id == databricks_request_id
     assert trace.info.request_metadata[TRACE_SCHEMA_VERSION_KEY] == "3"
     assert len(trace.data.spans) == 3
 
@@ -484,7 +484,7 @@ def test_trace_handle_exception_during_prediction(sync):
 
     # Trace should be logged even if the function fails, with status code ERROR
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
-    assert trace.info.request_id is not None
+    assert trace.info.trace_id is not None
     assert trace.info.status == TraceStatus.ERROR
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
     assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == ""
@@ -639,7 +639,7 @@ def test_start_span_context_manager(async_logging_enabled):
     traces = get_traces()
     assert len(traces) == 1
     trace = traces[0]
-    assert trace.info.request_id is not None
+    assert trace.info.trace_id is not None
     assert trace.info.experiment_id == "0"  # default experiment
     assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace.info.status == TraceStatus.OK
@@ -654,7 +654,7 @@ def test_start_span_context_manager(async_logging_enabled):
     root_span = span_name_to_span["root_span"]
     assert root_span.parent_id is None
     assert root_span.attributes == {
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanType": "UNKNOWN",
         "mlflow.spanInputs": {"x": 1, "y": 2},
         "mlflow.spanOutputs": 25,
@@ -666,7 +666,7 @@ def test_start_span_context_manager(async_logging_enabled):
     assert child_span_1.attributes == {
         "delta": 2,
         "time": str(datetime_now),
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanType": "LLM",
         "mlflow.spanInputs": 3,
         "mlflow.spanOutputs": 5,
@@ -675,7 +675,7 @@ def test_start_span_context_manager(async_logging_enabled):
     child_span_2 = span_name_to_span["child_span_2"]
     assert child_span_2.parent_id == root_span.span_id
     assert child_span_2.attributes == {
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanType": "UNKNOWN",
         "mlflow.spanInputs": {"t": 5},
         "mlflow.spanOutputs": 25,
@@ -700,7 +700,7 @@ def test_start_span_context_manager_with_imperative_apis(async_logging_enabled):
                 child_span = self._mlflow_client.start_span(
                     name="child_span_1",
                     span_type=SpanType.LLM,
-                    request_id=root_span.request_id,
+                    trace_id=root_span.trace_id,
                     parent_id=root_span.span_id,
                 )
                 child_span.set_inputs(z)
@@ -724,7 +724,7 @@ def test_start_span_context_manager_with_imperative_apis(async_logging_enabled):
     traces = get_traces()
     assert len(traces) == 1
     trace = traces[0]
-    assert trace.info.request_id is not None
+    assert trace.info.trace_id is not None
     assert trace.info.experiment_id == "0"  # default experiment
     assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace.info.status == TraceStatus.OK
@@ -739,7 +739,7 @@ def test_start_span_context_manager_with_imperative_apis(async_logging_enabled):
     root_span = span_name_to_span["root_span"]
     assert root_span.parent_id is None
     assert root_span.attributes == {
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanType": "UNKNOWN",
         "mlflow.spanInputs": {"x": 1, "y": 2},
         "mlflow.spanOutputs": 5,
@@ -749,7 +749,7 @@ def test_start_span_context_manager_with_imperative_apis(async_logging_enabled):
     assert child_span_1.parent_id == root_span.span_id
     assert child_span_1.attributes == {
         "delta": 2,
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanType": "LLM",
         "mlflow.spanInputs": 3,
         "mlflow.spanOutputs": 5,
@@ -798,17 +798,17 @@ def test_get_trace(mock_get_display_handler):
     model.predict(2, 5)
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
-    request_id = trace.info.request_id
+    trace_id = trace.info.trace_id
     mock_get_display_handler.reset_mock()
 
     # Fetch trace from in-memory buffer
-    trace_in_memory = mlflow.get_trace(request_id)
-    assert trace.info.request_id == trace_in_memory.info.request_id
+    trace_in_memory = mlflow.get_trace(trace_id)
+    assert trace.info.trace_id == trace_in_memory.info.trace_id
     mock_get_display_handler.assert_not_called()
 
     # Fetch trace from backend
-    trace_from_backend = mlflow.get_trace(request_id)
-    assert trace.info.request_id == trace_from_backend.info.request_id
+    trace_from_backend = mlflow.get_trace(trace_id)
+    assert trace.info.trace_id == trace_from_backend.info.trace_id
     mock_get_display_handler.assert_not_called()
 
     # If not found, return None with warning
@@ -944,7 +944,7 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
 
     df = mlflow.search_traces(max_results=10, order_by=["timestamp ASC"])
     assert df.columns.tolist() == [
-        "request_id",
+        "trace_id",
         "trace",
         "timestamp_ms",
         "status",
@@ -955,10 +955,11 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
         "spans",
         "tags",
         "assessments",
+        "request_id",
     ]
     for idx, trace in enumerate(expected_traces):
-        assert df.iloc[idx].request_id == trace.info.request_id
-        assert df.iloc[idx].trace.info.request_id == trace.info.request_id
+        assert df.iloc[idx].trace_id == trace.info.trace_id
+        assert df.iloc[idx].trace.info.trace_id == trace.info.trace_id
         assert df.iloc[idx].timestamp_ms == trace.info.timestamp_ms
         assert df.iloc[idx].status == trace.info.status
         assert df.iloc[idx].execution_time_ms == trace.info.execution_time_ms
@@ -967,6 +968,8 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
         assert df.iloc[idx].request_metadata == trace.info.request_metadata
         assert df.iloc[idx].spans == [s.to_dict() for s in trace.data.spans]
         assert df.iloc[idx].tags == trace.info.tags
+        assert df.iloc[idx].assessments == trace.info.assessments
+        assert df.iloc[idx].request_id == trace.info.request_id
 
 
 def test_search_traces_handles_missing_response_tags_and_metadata(monkeypatch):
@@ -1225,8 +1228,8 @@ def test_search_traces_with_run_id():
     def _create_trace(name, tags=None):
         with mlflow.start_span(name=name) as span:
             for k, v in (tags or {}).items():
-                mlflow.MlflowClient().set_trace_tag(request_id=span.request_id, key=k, value=v)
-        return span.request_id
+                mlflow.MlflowClient().set_trace_tag(trace_id=span.trace_id, key=k, value=v)
+        return span.trace_id
 
     def _get_names(traces):
         tags = traces["tags"].tolist()
@@ -1286,12 +1289,12 @@ def test_get_last_active_trace_id():
 
     trace_id = mlflow.get_last_active_trace_id()
     trace = mlflow.get_trace(trace_id)
-    assert trace.info.request_id is not None
+    assert trace.info.trace_id is not None
     assert trace.data.request == '{"x": 3, "y": 6}'
 
     # Mutation of the copy should not affect the original trace logged in the backend
     trace.info.status = TraceStatus.ERROR
-    original_trace = mlflow.MlflowClient().get_trace(trace.info.request_id)
+    original_trace = mlflow.MlflowClient().get_trace(trace.info.trace_id)
     assert original_trace.info.status == TraceStatus.OK
 
 
@@ -1356,7 +1359,7 @@ def test_non_ascii_characters_not_encoded_as_unicode():
     with mlflow.start_span() as span:
         span.set_inputs({"japanese": "あ", "emoji": "👍"})
 
-    trace = mlflow.MlflowClient().get_trace(span.request_id)
+    trace = mlflow.MlflowClient().get_trace(span.trace_id)
     span = trace.data.spans[0]
     assert span.inputs == {"japanese": "あ", "emoji": "👍"}
 
@@ -1486,13 +1489,13 @@ def test_add_trace():
     # If we call add_trace, the trace from the remote service should be merged
     predict(add_trace=True)
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
-    request_id = trace.info.request_id
-    assert request_id is not None
+    trace_id = trace.info.trace_id
+    assert trace_id is not None
     assert trace.data.request == '{"add_trace": true}'
     assert trace.data.response == "1"
     # Remote spans should be merged
     assert len(trace.data.spans) == 3
-    assert all(span.request_id == request_id for span in trace.data.spans)
+    assert all(span.trace_id == trace_id for span in trace.data.spans)
     parent_span, child_span, grandchild_span = trace.data.spans
     assert child_span.parent_id == parent_span.span_id
     assert child_span._trace_id == parent_span._trace_id
@@ -1541,7 +1544,7 @@ def test_add_trace_specific_target_span():
     client = mlflow.MlflowClient()
     span = client.start_trace(name="parent")
     mlflow.add_trace(_SAMPLE_REMOTE_TRACE, target=span)
-    client.end_trace(span.request_id)
+    client.end_trace(span.trace_id)
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert len(trace.data.spans) == 3
@@ -1558,8 +1561,8 @@ def test_add_trace_merge_tags():
 
     # Start the parent trace and merge the above trace as a child
     with mlflow.start_span(name="parent") as span:
-        client.set_trace_tag(span.request_id, "vegetable", "carrot")
-        client.set_trace_tag(span.request_id, "food", "sushi")
+        client.set_trace_tag(span.trace_id, "vegetable", "carrot")
+        client.set_trace_tag(span.trace_id, "food", "sushi")
 
         mlflow.add_trace(Trace.from_dict(_SAMPLE_REMOTE_TRACE))
 
@@ -1620,9 +1623,9 @@ def test_add_trace_in_databricks_model_serving(mock_databricks_serving_with_trac
     # Pop the trace to be written to the inference table
     trace = Trace.from_dict(pop_trace(request_id=db_request_id))
 
-    assert trace.info.request_id == db_request_id
+    assert trace.info.trace_id == db_request_id
     assert len(trace.data.spans) == 3
-    assert all(span.request_id == db_request_id for span in trace.data.spans)
+    assert all(span.trace_id == db_request_id for span in trace.data.spans)
     parent_span, child_span, grandchild_span = trace.data.spans
     assert child_span.parent_id == parent_span.span_id
     assert child_span._trace_id == parent_span._trace_id

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -807,7 +807,7 @@ def test_get_trace(mock_get_display_handler):
     mock_get_display_handler.assert_not_called()
 
     # Fetch trace from backend
-    trace_from_backend = mlflow.get_trace(trace_id)
+    trace_from_backend = mlflow.get_trace(trace.info.trace_id)
     assert trace.info.trace_id == trace_from_backend.info.trace_id
     mock_get_display_handler.assert_not_called()
 

--- a/tests/tracing/test_trace_manager.py
+++ b/tests/tracing/test_trace_manager.py
@@ -230,6 +230,6 @@ def _create_test_span(
         end_time=end_time,
     )
 
-    span = LiveSpan(mock_otel_span, request_id=request_id)
+    span = LiveSpan(mock_otel_span, request_id)
     span.set_status("OK")
     return span

--- a/tests/tracing/utils/test_timeout.py
+++ b/tests/tracing/utils/test_timeout.py
@@ -114,11 +114,11 @@ def test_trace_halted_after_timeout_in_model_serving(
     assert len(_TRACE_BUFFER) == 3
 
     # Long operation should be halted
-    assert pop_trace(request_id="request-id-1")["info"]["state"] == SpanStatusCode.ERROR
-    assert pop_trace(request_id="request-id-2")["info"]["state"] == SpanStatusCode.ERROR
+    assert pop_trace(trace_id="request-id-1")["info"]["state"] == SpanStatusCode.ERROR
+    assert pop_trace(trace_id="request-id-2")["info"]["state"] == SpanStatusCode.ERROR
 
     # Short operation should complete successfully
-    assert pop_trace(request_id="request-id-3")["info"]["state"] == SpanStatusCode.OK
+    assert pop_trace(trace_id="request-id-3")["info"]["state"] == SpanStatusCode.OK
 
 
 def test_handle_timeout_update(monkeypatch):

--- a/tests/tracing/utils/test_timeout.py
+++ b/tests/tracing/utils/test_timeout.py
@@ -114,11 +114,11 @@ def test_trace_halted_after_timeout_in_model_serving(
     assert len(_TRACE_BUFFER) == 3
 
     # Long operation should be halted
-    assert pop_trace(trace_id="request-id-1")["info"]["state"] == SpanStatusCode.ERROR
-    assert pop_trace(trace_id="request-id-2")["info"]["state"] == SpanStatusCode.ERROR
+    assert pop_trace(request_id="request-id-1")["info"]["state"] == SpanStatusCode.ERROR
+    assert pop_trace(request_id="request-id-2")["info"]["state"] == SpanStatusCode.ERROR
 
     # Short operation should complete successfully
-    assert pop_trace(trace_id="request-id-3")["info"]["state"] == SpanStatusCode.OK
+    assert pop_trace(request_id="request-id-3")["info"]["state"] == SpanStatusCode.OK
 
 
 def test_handle_timeout_update(monkeypatch):

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -26,7 +26,7 @@ def test_deduplicate_span_names():
     span_names = ["red", "red", "blue", "red", "green", "blue"]
 
     spans = [
-        LiveSpan(create_mock_otel_span("trace_id", span_id=i, name=span_name), request_id="tr-123")
+        LiveSpan(create_mock_otel_span("trace_id", span_id=i, name=span_name), trace_id="tr-123")
         for i, span_name in enumerate(span_names)
     ]
     deduplicate_span_names_in_place(spans)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -510,9 +510,7 @@ def test_start_and_end_trace_capture_falsy_input_and_output(tracking_uri):
     experiment_id = client.create_experiment("test_experiment")
 
     root = client.start_trace(name="root", experiment_id=experiment_id, inputs=[])
-    span = client.start_span(
-        name="child", trace_id=root.trace_id, parent_id=root.span_id, inputs=0
-    )
+    span = client.start_span(name="child", trace_id=root.trace_id, parent_id=root.span_id, inputs=0)
     client.end_span(trace_id=root.trace_id, span_id=span.span_id, outputs=False)
     client.end_trace(trace_id=root.trace_id, outputs="")
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -207,7 +207,7 @@ def test_client_get_trace(mock_store, mock_artifact_repo):
     mock_store.get_trace_info.assert_called_once_with("1234567", should_query_v3=False)
     mock_artifact_repo.download_trace_data.assert_called_once()
 
-    assert trace.info.request_id == "tr-1234567"
+    assert trace.info.trace_id == "tr-1234567"
     assert trace.info.experiment_id == "0"
     assert trace.info.timestamp_ms == 123
     assert trace.info.execution_time_ms == 456
@@ -217,7 +217,7 @@ def test_client_get_trace(mock_store, mock_artifact_repo):
     assert trace.data.response == '{"answer": 42}'
     assert len(trace.data.spans) == 1
     assert trace.data.spans[0].name == "predict"
-    assert trace.data.spans[0].request_id == "tr-1234567"
+    assert trace.data.spans[0].trace_id == "tr-1234567"
     assert trace.data.spans[0].inputs == {"prompt": "What is the meaning of life?"}
     assert trace.data.spans[0].outputs == {"answer": 42}
     assert trace.data.spans[0].start_time_ns == 123000000
@@ -333,7 +333,7 @@ def test_client_search_traces_trace_data_download_error(mock_store, include_span
             mock_get_artifact_repository.assert_called()
         else:
             assert len(traces) == 1
-            assert traces[0].info.request_id == "1234567"
+            assert traces[0].info.trace_id == "1234567"
             mock_get_artifact_repository.assert_not_called()
 
 
@@ -342,7 +342,7 @@ def test_client_delete_traces(mock_store):
         experiment_id="0",
         max_timestamp_millis=1,
         max_traces=2,
-        request_ids=["tr-1234"],
+        trace_ids=["tr-1234"],
     )
     mock_store.delete_traces.assert_called_once_with(
         experiment_id="0",
@@ -394,14 +394,14 @@ def test_start_and_end_trace(tracking_uri, with_active_run, async_logging_enable
                 tags={"tag": "tag_value"},
                 experiment_id=experiment_id,
             )
-            request_id = root_span.request_id
+            trace_id = root_span.trace_id
 
             z = x + y
 
             child_span = client.start_span(
                 "child_span_1",
                 span_type=SpanType.LLM,
-                request_id=request_id,
+                trace_id=trace_id,
                 parent_id=root_span.span_id,
                 inputs={"z": z},
             )
@@ -409,20 +409,20 @@ def test_start_and_end_trace(tracking_uri, with_active_run, async_logging_enable
             z = z + 2
 
             client.end_span(
-                request_id=request_id,
+                trace_id=trace_id,
                 span_id=child_span.span_id,
                 outputs={"output": z},
                 attributes={"delta": 2},
             )
 
-            res = self.square(z, request_id, root_span.span_id)
-            client.end_trace(request_id, outputs={"output": res}, status="OK")
+            res = self.square(z, trace_id, root_span.span_id)
+            client.end_trace(trace_id, outputs={"output": res}, status="OK")
             return res
 
-        def square(self, t, request_id, parent_id):
+        def square(self, t, trace_id, parent_id):
             span = client.start_span(
                 "child_span_2",
-                request_id=request_id,
+                trace_id=trace_id,
                 parent_id=parent_id,
                 inputs={"t": t},
             )
@@ -431,7 +431,7 @@ def test_start_and_end_trace(tracking_uri, with_active_run, async_logging_enable
             time.sleep(0.1)
 
             client.end_span(
-                request_id=request_id,
+                trace_id=trace_id,
                 span_id=span.span_id,
                 outputs={"output": res},
             )
@@ -448,13 +448,13 @@ def test_start_and_end_trace(tracking_uri, with_active_run, async_logging_enable
     if async_logging_enabled:
         mlflow.flush_trace_async_logging(terminate=True)
 
-    request_id = mlflow.get_trace(mlflow.get_last_active_trace_id()).info.request_id
+    trace_id = mlflow.get_trace(mlflow.get_last_active_trace_id()).info.trace_id
 
     # Validate that trace is logged to the backend
-    trace = client.get_trace(request_id)
+    trace = client.get_trace(trace_id)
     assert trace is not None
 
-    assert trace.info.request_id is not None
+    assert trace.info.trace_id is not None
     assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace.info.status == TraceStatus.OK
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
@@ -477,7 +477,7 @@ def test_start_and_end_trace(tracking_uri, with_active_run, async_logging_enable
     assert root_span.parent_id is None
     assert root_span.attributes == {
         "mlflow.experimentId": experiment_id,
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanType": "UNKNOWN",
         "mlflow.spanInputs": {"x": 1, "y": 2},
         "mlflow.spanOutputs": {"output": 25},
@@ -486,7 +486,7 @@ def test_start_and_end_trace(tracking_uri, with_active_run, async_logging_enable
     child_span_1 = span_name_to_span["child_span_1"]
     assert child_span_1.parent_id == root_span.span_id
     assert child_span_1.attributes == {
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanType": "LLM",
         "mlflow.spanInputs": {"z": 3},
         "mlflow.spanOutputs": {"output": 5},
@@ -496,7 +496,7 @@ def test_start_and_end_trace(tracking_uri, with_active_run, async_logging_enable
     child_span_2 = span_name_to_span["child_span_2"]
     assert child_span_2.parent_id == root_span.span_id
     assert child_span_2.attributes == {
-        "mlflow.traceRequestId": trace.info.request_id,
+        "mlflow.traceRequestId": trace.info.trace_id,
         "mlflow.spanType": "UNKNOWN",
         "mlflow.spanInputs": {"t": 5},
         "mlflow.spanOutputs": {"output": 25},
@@ -511,12 +511,12 @@ def test_start_and_end_trace_capture_falsy_input_and_output(tracking_uri):
 
     root = client.start_trace(name="root", experiment_id=experiment_id, inputs=[])
     span = client.start_span(
-        name="child", request_id=root.request_id, parent_id=root.span_id, inputs=0
+        name="child", trace_id=root.trace_id, parent_id=root.span_id, inputs=0
     )
-    client.end_span(request_id=root.request_id, span_id=span.span_id, outputs=False)
-    client.end_trace(request_id=root.request_id, outputs="")
+    client.end_span(trace_id=root.trace_id, span_id=span.span_id, outputs=False)
+    client.end_trace(trace_id=root.trace_id, outputs="")
 
-    trace = client.get_trace(root.request_id)
+    trace = client.get_trace(root.trace_id)
     assert trace.data.spans[0].inputs == []
     assert trace.data.spans[0].outputs == ""
     assert trace.data.spans[1].inputs == 0
@@ -534,21 +534,21 @@ def test_start_and_end_trace_before_all_span_end(async_logging_enabled):
 
         def predict(self, x):
             root_span = self._client.start_trace(name="predict")
-            request_id = root_span.request_id
+            trace_id = root_span.trace_id
             child_span = self._client.start_span(
                 "ended-span",
-                request_id=request_id,
+                trace_id=trace_id,
                 parent_id=root_span.span_id,
             )
             time.sleep(0.1)
-            self._client.end_span(request_id, child_span.span_id)
+            self._client.end_span(trace_id, child_span.span_id)
 
-            res = self.square(x, request_id, root_span.span_id)
-            self._client.end_trace(request_id)
+            res = self.square(x, trace_id, root_span.span_id)
+            self._client.end_trace(trace_id)
             return res
 
-        def square(self, t, request_id, parent_id):
-            self._client.start_span("non-ended-span", request_id=request_id, parent_id=parent_id)
+        def square(self, t, trace_id, parent_id):
+            self._client.start_span("non-ended-span", trace_id=trace_id, parent_id=parent_id)
             time.sleep(0.1)
             # The span created above is not ended
             return t**2
@@ -563,7 +563,7 @@ def test_start_and_end_trace_before_all_span_end(async_logging_enabled):
     assert len(traces) == 1
 
     trace_info = traces[0].info
-    assert trace_info.request_id is not None
+    assert trace_info.trace_id is not None
     assert trace_info.experiment_id == exp_id
     assert trace_info.timestamp_ms is not None
     assert trace_info.execution_time_ms is not None
@@ -619,14 +619,14 @@ def test_log_trace_with_databricks_tracking_uri(
                 # Trying to override mlflow.user tag, which will be ignored
                 tags={"tag": "tag_value", "mlflow.user": "unknown"},
             )
-            request_id = root_span.request_id
+            trace_id = root_span.trace_id
 
             z = x + y
 
             child_span = self._client.start_span(
                 "child_span_1",
                 span_type=SpanType.LLM,
-                request_id=request_id,
+                trace_id=trace_id,
                 parent_id=root_span.span_id,
                 inputs={"z": z},
             )
@@ -634,12 +634,12 @@ def test_log_trace_with_databricks_tracking_uri(
             z = z + 2
 
             self._client.end_span(
-                request_id=request_id,
+                trace_id=trace_id,
                 span_id=child_span.span_id,
                 outputs={"output": z},
                 attributes={"delta": 2},
             )
-            self._client.end_trace(request_id, outputs=z, status="OK")
+            self._client.end_trace(trace_id, outputs=z, status="OK")
             return z
 
     model = TestModel()
@@ -694,15 +694,15 @@ def test_start_and_end_trace_does_not_log_trace_when_disabled(
         )
         child_span = client.start_span(
             "child_span_1",
-            request_id=span.request_id,
+            trace_id=span.trace_id,
             parent_id=span.span_id,
         )
         client.end_span(
-            request_id=span.request_id,
+            trace_id=span.trace_id,
             span_id=child_span.span_id,
             outputs={"output": 5},
         )
-        client.end_trace(span.request_id, outputs=5, status="OK")
+        client.end_trace(span.trace_id, outputs=5, status="OK")
         return "done"
 
     mock_logger = mock.MagicMock()
@@ -725,7 +725,7 @@ def test_start_trace_within_active_run(async_logging_enabled):
             name="test",
             experiment_id=exp_id,
         )
-        client.end_trace(root_span.request_id)
+        client.end_trace(root_span.trace_id)
 
     if async_logging_enabled:
         mlflow.flush_trace_async_logging(terminate=True)
@@ -789,7 +789,7 @@ def test_trace_status_either_pending_or_end():
 
 def test_start_span_raise_error_when_parent_id_is_not_provided():
     with pytest.raises(MlflowException, match=r"start_span\(\) must be called with"):
-        mlflow.tracking.MlflowClient().start_span("span_name", request_id="test", parent_id=None)
+        mlflow.tracking.MlflowClient().start_span("span_name", trace_id="test", parent_id=None)
 
 
 def test_log_trace(tracking_uri):
@@ -802,21 +802,21 @@ def test_log_trace(tracking_uri):
         experiment_id=experiment_id,
         tags={"custom_tag": "tag_value"},
     )
-    client.end_trace(span.request_id, status="OK")
+    client.end_trace(span.trace_id, status="OK")
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
 
     # Purge all traces in the backend once
-    client.delete_traces(experiment_id=experiment_id, request_ids=[trace.info.request_id])
+    client.delete_traces(experiment_id=experiment_id, trace_ids=[trace.info.trace_id])
     assert client.search_traces(experiment_ids=[experiment_id]) == []
 
     # Log the trace manually
-    new_request_id = client._log_trace(trace)
+    new_trace_id = client._log_trace(trace)
 
     # Validate the trace is added to the backend
     backend_traces = client.search_traces(experiment_ids=[experiment_id])
     assert len(backend_traces) == 1
-    assert backend_traces[0].info.request_id == new_request_id  # new request ID is assigned
+    assert backend_traces[0].info.trace_id == new_trace_id  # new request ID is assigned
     assert backend_traces[0].info.experiment_id == experiment_id
     assert backend_traces[0].info.status == trace.info.status
     assert backend_traces[0].info.tags["custom_tag"] == "tag_value"
@@ -827,7 +827,7 @@ def test_log_trace(tracking_uri):
 
     # If the experiment ID is None in the given trace, it should be set to the default experiment
     trace.info.experiment_id = None
-    new_request_id = client._log_trace(trace)
+    new_trace_id = client._log_trace(trace)
     backend_traces = client.search_traces(experiment_ids=[DEFAULT_EXPERIMENT_ID])
     assert len(backend_traces) == 1
 
@@ -839,12 +839,12 @@ def test_ignore_exception_from_tracing_logic(monkeypatch, async_logging_enabled)
     class TestModel:
         def predict(self, x):
             root_span = client.start_trace(experiment_id=exp_id, name="predict")
-            request_id = root_span.request_id
+            trace_id = root_span.trace_id
             child_span = client.start_span(
-                name="child", request_id=request_id, parent_id=root_span.span_id
+                name="child", trace_id=trace_id, parent_id=root_span.span_id
             )
-            client.end_span(request_id, child_span.span_id)
-            client.end_trace(request_id)
+            client.end_span(trace_id, child_span.span_id)
+            client.end_trace(trace_id)
             return x
 
     model = TestModel()
@@ -875,9 +875,9 @@ def test_set_and_delete_trace_tag_on_active_trace(monkeypatch):
     client = mlflow.tracking.MlflowClient()
 
     root_span = client.start_trace(name="test")
-    request_id = root_span.request_id
-    client.set_trace_tag(request_id, "foo", "bar")
-    client.end_trace(request_id)
+    trace_id = root_span.trace_id
+    client.set_trace_tag(trace_id, "foo", "bar")
+    client.end_trace(trace_id)
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert trace.info.tags["foo"] == "bar"
@@ -894,9 +894,9 @@ def test_delete_trace_tag_on_active_trace(monkeypatch):
 
     client = mlflow.tracking.MlflowClient()
     root_span = client.start_trace(name="test", tags={"foo": "bar", "baz": "qux"})
-    request_id = root_span.request_id
-    client.delete_trace_tag(request_id, "foo")
-    client.end_trace(request_id)
+    trace_id = root_span.trace_id
+    client.delete_trace_tag(trace_id, "foo")
+    client.end_trace(trace_id)
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert "baz" in trace.info.tags
@@ -1670,22 +1670,22 @@ def test_file_store_download_upload_trace_data(tmp_path):
     with _use_tracking_uri(tmp_path.joinpath("mlruns").as_uri()):
         client = MlflowClient()
         span = client.start_trace("test", inputs={"test": 1})
-        client.end_trace(span.request_id, outputs={"result": 2})
-        trace = mlflow.get_trace(span.request_id)
-        trace_data = client.get_trace(span.request_id).data
+        client.end_trace(span.trace_id, outputs={"result": 2})
+        trace = mlflow.get_trace(span.trace_id)
+        trace_data = client.get_trace(span.trace_id).data
         assert trace_data.request == trace.data.request
         assert trace_data.response == trace.data.response
 
 
-def test_get_trace_throw_if_request_id_is_online_trace_id():
+def test_get_trace_throw_if_trace_id_is_online_trace_id():
     client = MlflowClient("databricks")
-    request_id = "3a3c3b56-910a-4721-8d02-0333eda5f37e"
+    trace_id = "3a3c3b56-910a-4721-8d02-0333eda5f37e"
     with pytest.raises(MlflowException, match="Traces from inference tables can only be loaded"):
-        client.get_trace(request_id)
+        client.get_trace(trace_id)
 
     another_client = MlflowClient("mlruns")
     with pytest.raises(MlflowException, match=r"Trace with request ID '[\w-]+' not found"):
-        another_client.get_trace(request_id)
+        another_client.get_trace(trace_id)
 
 
 @pytest.fixture(params=["file", "sqlalchemy"])

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2240,7 +2240,7 @@ def test_delete_traces(mlflow_client):
     request_id_1 = _create_trace(name="trace1", status=TraceStatus.OK)
     request_id_2 = _create_trace(name="trace2", status=TraceStatus.OK)
 
-    deleted_count = mlflow_client.delete_traces(experiment_id, request_ids=[request_id_1])
+    deleted_count = mlflow_client.delete_traces(experiment_id, trace_ids=[request_id_1])
     assert deleted_count == 1
     assert not _is_trace_exists(request_id_1)
     assert _is_trace_exists(request_id_2)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15387?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15387/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15387/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15387
```

</p>
</details>

### What changes are proposed in this pull request?

In MLflow 3 trace schema, we will use "trace ID" as a unique identifier of a trace, instead of "request ID". This PR apply the renaming on the public APIs.

The `request_id` field will still be usable in public APIs, but users will see a deprecation warning and prompt to use `trace_id` instead.

Also, not all internal usage is updated in this PR to avoid too big change size and merge conflict with ongoing PRs. Will file another one after RC release.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The `request_id` field in trace schema is renamed to `trace_id` for simplification.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
