### PR TITLE
Increase traceinfo tag value limit

### DIFF
--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -12,24 +12,22 @@ from mlflow.protos.service_pb2 import TraceTag as ProtoTraceTag
 
 
 def _truncate_request_metadata(d: dict[str, Any]) -> dict[str, str]:
-    from mlflow.tracing.constant import MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+    from mlflow.tracing.constant import MAX_CHARS_IN_TRACE_INFO_METADATA
 
     return {
-        k[:MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS]: str(v)[
-            :MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
-        ]
+        k[:MAX_CHARS_IN_TRACE_INFO_METADATA]: str(v)[:MAX_CHARS_IN_TRACE_INFO_METADATA]
         for k, v in d.items()
     }
 
 
 def _truncate_tags(d: dict[str, Any]) -> dict[str, str]:
     from mlflow.tracing.constant import (
-        MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
+        MAX_CHARS_IN_TRACE_INFO_TAGS_KEY,
         MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE,
     )
 
     return {
-        k[:MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS]: str(v)[:MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE]
+        k[:MAX_CHARS_IN_TRACE_INFO_TAGS_KEY]: str(v)[:MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE]
         for k, v in d.items()
     }
 

--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -11,13 +11,25 @@ from mlflow.protos.service_pb2 import TraceRequestMetadata as ProtoTraceRequestM
 from mlflow.protos.service_pb2 import TraceTag as ProtoTraceTag
 
 
-def _truncate_dict_keys_and_values(d: dict[str, Any]) -> dict[str, str]:
+def _truncate_request_metadata(d: dict[str, Any]) -> dict[str, str]:
     from mlflow.tracing.constant import MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
 
     return {
         k[:MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS]: str(v)[
             :MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
         ]
+        for k, v in d.items()
+    }
+
+
+def _truncate_tags(d: dict[str, Any]) -> dict[str, str]:
+    from mlflow.tracing.constant import (
+        MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
+        MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE,
+    )
+
+    return {
+        k[:MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS]: str(v)[:MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE]
         for k, v in d.items()
     }
 
@@ -64,7 +76,7 @@ class TraceInfo(_MlflowObject):
         proto.status = self.status.to_proto()
 
         request_metadata = []
-        for key, value in _truncate_dict_keys_and_values(self.request_metadata).items():
+        for key, value in _truncate_request_metadata(self.request_metadata).items():
             attr = ProtoTraceRequestMetadata()
             attr.key = key
             attr.value = value
@@ -72,7 +84,7 @@ class TraceInfo(_MlflowObject):
         proto.request_metadata.extend(request_metadata)
 
         tags = []
-        for key, value in _truncate_dict_keys_and_values(self.tags).items():
+        for key, value in _truncate_tags(self.tags).items():
             tag = ProtoTraceTag()
             tag.key = key
             tag.value = str(value)
@@ -130,9 +142,9 @@ class TraceInfo(_MlflowObject):
             proto.execution_duration.FromMilliseconds(self.execution_time_ms)
 
         if self.request_metadata:
-            proto.trace_metadata.update(_truncate_dict_keys_and_values(self.request_metadata))
+            proto.trace_metadata.update(_truncate_request_metadata(self.request_metadata))
 
         if self.tags:
-            proto.tags.update(_truncate_dict_keys_and_values(self.tags))
+            proto.tags.update(_truncate_tags(self.tags))
 
         return proto

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -32,10 +32,11 @@ class SpanAttributeKey:
     INTERMEDIATE_OUTPUTS = "mlflow.trace.intermediate_outputs"
 
 
-# All storage backends are guaranteed to support request_metadata key/value and tag key
-# length up to 250 characters
-MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS = 250
-# All storage backends are guaranteed to support tag values up to 4096 characters
+# All storage backends are guaranteed to support request_metadata key/value up to 250 characters
+MAX_CHARS_IN_TRACE_INFO_METADATA = 250
+# All storage backends are guaranteed to support tag keys up to 250 characters,
+# values up to 4096 characters
+MAX_CHARS_IN_TRACE_INFO_TAGS_KEY = 259
 MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE = 4096
 TRUNCATION_SUFFIX = "..."
 

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -32,8 +32,8 @@ class SpanAttributeKey:
     INTERMEDIATE_OUTPUTS = "mlflow.trace.intermediate_outputs"
 
 
-# All storage backends are guaranteed to support key values up to 250 characters
-MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS = 250
+# All storage backends are guaranteed to support key values up to 4096 characters
+MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS = 4096
 TRUNCATION_SUFFIX = "..."
 
 # Trace request ID must have the prefix "tr-" appended to the OpenTelemetry trace ID

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -36,7 +36,7 @@ class SpanAttributeKey:
 MAX_CHARS_IN_TRACE_INFO_METADATA = 250
 # All storage backends are guaranteed to support tag keys up to 250 characters,
 # values up to 4096 characters
-MAX_CHARS_IN_TRACE_INFO_TAGS_KEY = 259
+MAX_CHARS_IN_TRACE_INFO_TAGS_KEY = 250
 MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE = 4096
 TRUNCATION_SUFFIX = "..."
 

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -32,8 +32,11 @@ class SpanAttributeKey:
     INTERMEDIATE_OUTPUTS = "mlflow.trace.intermediate_outputs"
 
 
-# All storage backends are guaranteed to support key values up to 4096 characters
-MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS = 4096
+# All storage backends are guaranteed to support request_metadata key/value and tag key
+# length up to 250 characters
+MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS = 250
+# All storage backends are guaranteed to support tag values up to 4096 characters
+MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE = 4096
 TRUNCATION_SUFFIX = "..."
 
 # Trace request ID must have the prefix "tr-" appended to the OpenTelemetry trace ID

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -11,7 +11,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.tracing.constant import (
-    MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
+    MAX_CHARS_IN_TRACE_INFO_METADATA,
     TRACE_SCHEMA_VERSION,
     TRACE_SCHEMA_VERSION_KEY,
     TRUNCATION_SUFFIX,
@@ -224,7 +224,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         if not value:
             return ""
 
-        if len(value) > MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS:
-            trunc_length = MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS - len(TRUNCATION_SUFFIX)
+        if len(value) > MAX_CHARS_IN_TRACE_INFO_METADATA:
+            trunc_length = MAX_CHARS_IN_TRACE_INFO_METADATA - len(TRUNCATION_SUFFIX)
             value = value[:trunc_length] + TRUNCATION_SUFFIX
         return value

--- a/tests/entities/test_trace_info.py
+++ b/tests/entities/test_trace_info.py
@@ -8,7 +8,8 @@ from mlflow.protos.service_pb2 import TraceInfo as ProtoTraceInfo
 from mlflow.protos.service_pb2 import TraceRequestMetadata as ProtoTraceRequestMetadata
 from mlflow.protos.service_pb2 import TraceTag as ProtoTraceTag
 from mlflow.tracing.constant import (
-    MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
+    MAX_CHARS_IN_TRACE_INFO_METADATA,
+    MAX_CHARS_IN_TRACE_INFO_TAGS_KEY,
     MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE,
 )
 
@@ -69,15 +70,15 @@ def test_to_proto(trace_info):
     assert request_metadata_1.value == "bar"
     request_metadata_2 = proto.request_metadata[1]
     assert isinstance(request_metadata_2, ProtoTraceRequestMetadata)
-    assert request_metadata_2.key == "k" * MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
-    assert request_metadata_2.value == "v" * MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+    assert request_metadata_2.key == "k" * MAX_CHARS_IN_TRACE_INFO_METADATA
+    assert request_metadata_2.value == "v" * MAX_CHARS_IN_TRACE_INFO_METADATA
     tag_1 = proto.tags[0]
     assert isinstance(tag_1, ProtoTraceTag)
     assert tag_1.key == "baz"
     assert tag_1.value == "qux"
     tag_2 = proto.tags[1]
     assert isinstance(tag_2, ProtoTraceTag)
-    assert tag_2.key == "k" * MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+    assert tag_2.key == "k" * MAX_CHARS_IN_TRACE_INFO_TAGS_KEY
     assert tag_2.value == "v" * MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE
 
 
@@ -152,6 +153,12 @@ def test_trace_info_v3(trace_info):
     assert v3_proto.execution_duration.ToMilliseconds() == 1
     assert v3_proto.state == 1
     assert v3_proto.trace_metadata["foo"] == "bar"
-    assert v3_proto.trace_metadata["k" * 250] == "v" * MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+    assert (
+        v3_proto.trace_metadata["k" * MAX_CHARS_IN_TRACE_INFO_METADATA]
+        == "v" * MAX_CHARS_IN_TRACE_INFO_METADATA
+    )
     assert v3_proto.tags["baz"] == "qux"
-    assert v3_proto.tags["k" * 250] == "v" * MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE
+    assert (
+        v3_proto.tags["k" * MAX_CHARS_IN_TRACE_INFO_TAGS_KEY]
+        == "v" * MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE
+    )

--- a/tests/entities/test_trace_info.py
+++ b/tests/entities/test_trace_info.py
@@ -7,6 +7,10 @@ from mlflow.entities.trace_status import TraceStatus
 from mlflow.protos.service_pb2 import TraceInfo as ProtoTraceInfo
 from mlflow.protos.service_pb2 import TraceRequestMetadata as ProtoTraceRequestMetadata
 from mlflow.protos.service_pb2 import TraceTag as ProtoTraceTag
+from mlflow.tracing.constant import (
+    MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
+    MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE,
+)
 
 
 @pytest.fixture
@@ -23,7 +27,7 @@ def trace_info():
         },
         tags={
             "baz": "qux",
-            "k" * 2000: "v" * 2000,
+            "k" * 2000: "v" * 8000,
         },
         assessments=[],
     )
@@ -65,16 +69,16 @@ def test_to_proto(trace_info):
     assert request_metadata_1.value == "bar"
     request_metadata_2 = proto.request_metadata[1]
     assert isinstance(request_metadata_2, ProtoTraceRequestMetadata)
-    assert request_metadata_2.key == "k" * 250
-    assert request_metadata_2.value == "v" * 250
+    assert request_metadata_2.key == "k" * MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+    assert request_metadata_2.value == "v" * MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
     tag_1 = proto.tags[0]
     assert isinstance(tag_1, ProtoTraceTag)
     assert tag_1.key == "baz"
     assert tag_1.value == "qux"
     tag_2 = proto.tags[1]
     assert isinstance(tag_2, ProtoTraceTag)
-    assert tag_2.key == "k" * 250
-    assert tag_2.value == "v" * 250
+    assert tag_2.key == "k" * MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+    assert tag_2.value == "v" * MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE
 
 
 def test_to_dict(trace_info):
@@ -91,7 +95,7 @@ def test_to_dict(trace_info):
         },
         "tags": {
             "baz": "qux",
-            "k" * 2000: "v" * 2000,
+            "k" * 2000: "v" * 8000,
         },
         "assessments": [],
     }
@@ -148,6 +152,6 @@ def test_trace_info_v3(trace_info):
     assert v3_proto.execution_duration.ToMilliseconds() == 1
     assert v3_proto.state == 1
     assert v3_proto.trace_metadata["foo"] == "bar"
-    assert v3_proto.trace_metadata["k" * 250] == "v" * 250
+    assert v3_proto.trace_metadata["k" * 250] == "v" * MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
     assert v3_proto.tags["baz"] == "qux"
-    assert v3_proto.tags["k" * 250] == "v" * 250
+    assert v3_proto.tags["k" * 250] == "v" * MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -42,7 +42,11 @@ from mlflow.protos.databricks_pb2 import (
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.file_store import FileStore
-from mlflow.tracing.constant import TraceMetadataKey, TraceTagKey
+from mlflow.tracing.constant import (
+    MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE,
+    TraceMetadataKey,
+    TraceTagKey,
+)
 from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 from mlflow.utils.file_utils import (
     TempDir,
@@ -2953,9 +2957,9 @@ def test_set_trace_tag(store_and_trace_info):
     assert trace_info.tags["int_key"] == "1234"
 
     # test value length
-    store.set_trace_tag(trace.request_id, "key", "v" * 4096)
+    store.set_trace_tag(trace.request_id, "key", "v" * MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE)
     trace_info = store.get_trace_info(trace.request_id)
-    assert trace_info.tags["key"] == "v" * 4096
+    assert trace_info.tags["key"] == "v" * MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE
 
     with pytest.raises(MlflowException, match=r"Missing value for required parameter \'key\'"):
         store.set_trace_tag(trace.request_id, None, "test")

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2952,6 +2952,11 @@ def test_set_trace_tag(store_and_trace_info):
     trace_info = store.get_trace_info(trace.request_id)
     assert trace_info.tags["int_key"] == "1234"
 
+    # test value length
+    store.set_trace_tag(trace.request_id, "key", "v" * 4096)
+    trace_info = store.get_trace_info(trace.request_id)
+    assert trace_info.tags["key"] == "v" * 4096
+
     with pytest.raises(MlflowException, match=r"Missing value for required parameter \'key\'"):
         store.set_trace_tag(trace.request_id, None, "test")
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -72,7 +72,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlTraceTag,
 )
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore, _get_orderby_clauses
-from mlflow.tracing.constant import TraceMetadataKey
+from mlflow.tracing.constant import MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE, TraceMetadataKey
 from mlflow.utils import mlflow_tags
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import (
@@ -4463,8 +4463,8 @@ def test_set_and_delete_tags(store: SqlAlchemyStore):
     assert store.get_trace_info(request_id).tags == {"tag2": "orange"}
 
     # test value length
-    store.set_trace_tag(request_id, "key", "v" * 4096)
-    assert store.get_trace_info(request_id).tags["key"] == "v" * 4096
+    store.set_trace_tag(request_id, "key", "v" * MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE)
+    assert store.get_trace_info(request_id).tags["key"] == "v" * MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE
 
     with pytest.raises(MlflowException, match="No trace tag with key 'tag1'"):
         store.delete_trace_tag(request_id, "tag1")

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4462,6 +4462,10 @@ def test_set_and_delete_tags(store: SqlAlchemyStore):
     store.delete_trace_tag(request_id, "tag1")
     assert store.get_trace_info(request_id).tags == {"tag2": "orange"}
 
+    # test value length
+    store.set_trace_tag(request_id, "key", "v" * 4096)
+    assert store.get_trace_info(request_id).tags["key"] == "v" * 4096
+
     with pytest.raises(MlflowException, match="No trace tag with key 'tag1'"):
         store.delete_trace_tag(request_id, "tag1")
 

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -10,6 +10,7 @@ from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
 from mlflow.pyfunc.context import Context, set_prediction_context
 from mlflow.tracing.constant import (
+    MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
     TRACE_SCHEMA_VERSION,
     TRACE_SCHEMA_VERSION_KEY,
     SpanAttributeKey,
@@ -248,10 +249,10 @@ def test_on_end():
     assert trace_info.status == TraceStatus.OK
     assert trace_info.execution_time_ms == 4
     trace_input = trace_info.request_metadata.get(TraceMetadataKey.INPUTS)
-    assert len(trace_input) == 250
+    assert len(trace_input) == MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
     assert trace_input.startswith('{"input1": "very long input')
     trace_output = trace_info.request_metadata.get(TraceMetadataKey.OUTPUTS)
-    assert len(trace_output) == 250
+    assert len(trace_output) == MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
     assert trace_output.startswith('{"output": "very long output')
     assert trace_info.tags == {}
 

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -10,7 +10,7 @@ from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
 from mlflow.pyfunc.context import Context, set_prediction_context
 from mlflow.tracing.constant import (
-    MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
+    MAX_CHARS_IN_TRACE_INFO_METADATA,
     TRACE_SCHEMA_VERSION,
     TRACE_SCHEMA_VERSION_KEY,
     SpanAttributeKey,
@@ -249,10 +249,10 @@ def test_on_end():
     assert trace_info.status == TraceStatus.OK
     assert trace_info.execution_time_ms == 4
     trace_input = trace_info.request_metadata.get(TraceMetadataKey.INPUTS)
-    assert len(trace_input) == MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+    assert len(trace_input) == MAX_CHARS_IN_TRACE_INFO_METADATA
     assert trace_input.startswith('{"input1": "very long input')
     trace_output = trace_info.request_metadata.get(TraceMetadataKey.OUTPUTS)
-    assert len(trace_output) == MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
+    assert len(trace_output) == MAX_CHARS_IN_TRACE_INFO_METADATA
     assert trace_output.startswith('{"output": "very long output')
     assert trace_info.tags == {}
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15396?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15396/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15396/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15396
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #15277

### What changes are proposed in this pull request?
Increase traceInfo tag value limit to 4096.
Keep 250 as the limit for request_metadata key/value length, and traceInfo tag key length.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Verified with this code snippet
```
import mlflow
from mlflow.client import MlflowClient

mlflow.set_tracking_uri("http://127.0.0.1:5000")

client = MlflowClient()

span = client.start_trace(
    name="test",
    tags={"custom_tag": "tag_value", "k": "v" * 4096},
)
client.end_trace(span.request_id, status="OK")
trace = client.search_traces(experiment_ids=["0"])[0]
assert len(trace.info.tags["k"]) == 4096, len(trace.info.tags["k"])
```
<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
