### PR TITLE
Handle request error in hugging hub health check

### DIFF
--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -773,7 +773,14 @@ def _iter_pr_files() -> Iterator[str]:
             params={"per_page": per_page, "page": page},
             headers=headers,
         )
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            _logger.warning(
+                f"Failed to fetch PR files: {e}. Skipping the check for Hugging Face Hub health."
+            )
+            return
+
         files = [f["filename"] for f in resp.json()]
         yield from files
         if len(files) < per_page:


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

In the hugging hub health check, we fetch changed files in a PR using the GitHub REST API. As we don't use a token, this request can fail with rate limit. This PR makes a change to handle the error.

https://github.com/mlflow/mlflow/actions/runs/14567549915/job/40859122351?pr=15299

```
tests\helper_functions.py:800: in skip_if_hf_hub_unhealthy
    _should_skip_hf_test(),
tests\helper_functions.py:790: in _should_skip_hf_test
    if any(("huggingface" in f or "transformers" in f) for f in _iter_pr_files()):
tests\helper_functions.py:790: in <genexpr>
    if any(("huggingface" in f or "transformers" in f) for f in _iter_pr_files()):
        .0         = <generator object _iter_pr_files at 0x000001462683F740>
tests\helper_functions.py:776: in _iter_pr_files
    resp.raise_for_status()
        f          = <_io.TextIOWrapper name='D:\\a\\_temp\\_github_workflow\\event.json' mode='r' encoding='UTF-8'>
        headers    = None
        page       = 1
        per_page   = [100](https://github.com/mlflow/mlflow/actions/runs/14567549915/job/40859122351?pr=15299#step:13:101)
        pr_data    = {'action': 'synchronize', 'after': 'd32987e525bc004eab706600067293d66090d691', 'before': 'a0a297e5708da0795b8ac579bdde...eated_at': '2023-09-15T14:11:52Z', 'description': None, 'html_url': 'https://github.com/enterprises/mlflow', ...}, ...}
        pull_number = 15299
        repo       = 'mlflow/mlflow'
        resp       = <Response [403]>
        token      = None
.venv\lib\site-packages\requests\models.py:[102](https://github.com/mlflow/mlflow/actions/runs/14567549915/job/40859122351?pr=15299#step:13:103)4: in raise_for_status
    raise HTTPError(http_error_msg, response=self)
E   requests.exceptions.HTTPError: 403 Client Error: rate limit exceeded for url: https://api.github.com/repos/mlflow/mlflow/pulls/15299/files?per_page=100&page=1
        http_error_msg = '403 Client Error: rate limit exceeded for url: https://api.github.com/repos/mlflow/mlflow/pulls/15299/files?per_page=100&page=1'
        reason     = 'rate limit exceeded'
        self       = <Response [403]>
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
