### PR TITLE
Update `TraceInfoV3.to_dict` to serialize `execution_duration` as int for JSON representation for inference tables

### DIFF
--- a/mlflow/entities/trace_info_v3.py
+++ b/mlflow/entities/trace_info_v3.py
@@ -29,8 +29,8 @@ class TraceInfoV3(_MlflowObject):
 
     def to_dict(self) -> dict[str, Any]:
         res = MessageToDict(self.to_proto(), preserving_proto_field_name=True)
-        res.pop("execution_duration", None)
         if self.execution_duration is not None:
+            res.pop("execution_duration", None)
             res["execution_duration_ms"] = self.execution_duration
         return res
 
@@ -56,7 +56,7 @@ class TraceInfoV3(_MlflowObject):
             timestamp.FromJsonString(request_time)
             d["request_time"] = timestamp.ToMilliseconds()
 
-        if (execution_duration := d.pop("execution_duration_ms")) is not None:
+        if (execution_duration := d.pop("execution_duration_ms", None)) is not None:
             d["execution_duration"] = execution_duration
 
         return cls(**d)

--- a/mlflow/entities/trace_info_v3.py
+++ b/mlflow/entities/trace_info_v3.py
@@ -28,7 +28,11 @@ class TraceInfoV3(_MlflowObject):
     assessments: list[Assessment] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
-        return MessageToDict(self.to_proto(), preserving_proto_field_name=True)
+        res = MessageToDict(self.to_proto(), preserving_proto_field_name=True)
+        res.pop("execution_duration", None)
+        if self.execution_duration is not None:
+            res["execution_duration_ms"] = self.execution_duration
+        return res
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "TraceInfoV3":
@@ -52,10 +56,8 @@ class TraceInfoV3(_MlflowObject):
             timestamp.FromJsonString(request_time)
             d["request_time"] = timestamp.ToMilliseconds()
 
-        if execution_duration := d.get("execution_duration"):
-            duration = Duration()
-            duration.FromJsonString(execution_duration)
-            d["execution_duration"] = duration.ToMilliseconds()
+        if (execution_duration := d.pop("execution_duration_ms")) is not None:
+            d["execution_duration"] = execution_duration
 
         return cls(**d)
 

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -15,7 +15,6 @@ from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_K
 from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.utils.mlflow_tags import MLFLOW_ARTIFACT_LOCATION
 from mlflow.utils.proto_json_utils import (
-    milliseconds_to_proto_duration,
     milliseconds_to_proto_timestamp,
 )
 
@@ -68,7 +67,7 @@ def test_json_deserialization(monkeypatch):
                 "type": "MLFLOW_EXPERIMENT",
             },
             "request_time": milliseconds_to_proto_timestamp(trace.info.timestamp_ms),
-            "execution_duration": milliseconds_to_proto_duration(trace.info.execution_time_ms),
+            "execution_duration_ms": trace.info.execution_time_ms,
             "state": "OK",
             "request_preview": '{"x": 2, "y": 5}',
             "response_preview": "8",

--- a/tests/entities/test_trace_info_v3.py
+++ b/tests/entities/test_trace_info_v3.py
@@ -67,7 +67,7 @@ def test_trace_info_v3():
         "request_preview": "request",
         "response_preview": "response",
         "request_time": "1970-01-15T06:56:07.890Z",
-        "execution_duration": "0.100s",
+        "execution_duration_ms": 100,
         "state": "OK",
         "trace_metadata": {"foo": "bar"},
         "assessments": [

--- a/tests/tracing/export/test_inference_table_exporter.py
+++ b/tests/tracing/export/test_inference_table_exporter.py
@@ -53,7 +53,7 @@ def test_export():
     trace_dict = pop_trace(_REQUEST_ID)
     trace_info = trace_dict["info"]
     assert trace_info["request_time"] == "1970-01-01T00:00:00Z"
-    assert trace_info["execution_duration"] == "0.001s"
+    assert trace_info["execution_duration_ms"] == 1
 
     spans = trace_dict["data"]["spans"]
     assert len(spans) == 2


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15403?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15403/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15403/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15403
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix `TraceInfoV3.to_dict` to serialize execution_duration as int for JSON representation for inference tables.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
