### PR TITLE
Add lint rule for empty cell

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -514,11 +514,7 @@ def _lint_cell(path: Path, config: Config, cell: dict[str, Any], index: int) -> 
     if type_ != "code":
         return []
 
-    lines = cell.get("source")
-    if not lines:
-        return []
-
-    src = "\n".join(lines)
+    src = "\n".join(cell.get("source"))
     try:
         tree = ast.parse(src)
     except SyntaxError:
@@ -527,7 +523,13 @@ def _lint_cell(path: Path, config: Config, cell: dict[str, Any], index: int) -> 
 
     linter = Linter(path=path, config=config, ignore=ignore_map(src), cell=index)
     linter.visit(tree)
-    return linter.violations
+    violations = linter.violations
+
+    if not src.strip():
+        violations.append(
+            Violation(rules.EmptyNotebookCell(), path, lineno=1, col_offset=1, cell=index)
+        )
+    return violations
 
 
 def lint_file(path: Path, config: Config) -> list[Violation]:

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -514,7 +514,7 @@ def _lint_cell(path: Path, config: Config, cell: dict[str, Any], index: int) -> 
     if type_ != "code":
         return []
 
-    src = "\n".join(cell.get("source"))
+    src = "\n".join(cell.get("source", []))
     try:
         tree = ast.parse(src)
     except SyntaxError:

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -338,3 +338,11 @@ class LazyModule(Rule):
 
     def _message(self) -> str:
         return "Module loaded by `LazyLoader` must be imported in `TYPE_CHECKING` block."
+
+
+class EmptyNotebookCell(Rule):
+    def _id(self) -> str:
+        return "MLF0020"
+
+    def _message(self) -> str:
+        return "Empty notebook cell. Remove it or add some content."

--- a/docs/docs/llms/llm-evaluate/notebooks/question-answering-evaluation.ipynb
+++ b/docs/docs/llms/llm-evaluate/notebooks/question-answering-evaluation.ipynb
@@ -1377,21 +1377,6 @@
    "source": [
     "results.tables[\"eval_results_table\"]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
-     "inputWidgets": {},
-     "nuid": "e44bbe77-433a-4e03-a44e-d17eb6c06820",
-     "showTitle": false,
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/docs/llms/llm-evaluate/notebooks/rag-evaluation.ipynb
+++ b/docs/docs/llms/llm-evaluate/notebooks/rag-evaluation.ipynb
@@ -777,13 +777,6 @@
    "source": [
     "results.tables[\"eval_results_table\"]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/docs/llms/rag/notebooks/retriever-evaluation-tutorial.ipynb
+++ b/docs/docs/llms/rag/notebooks/retriever-evaluation-tutorial.ipynb
@@ -1893,21 +1893,6 @@
     "# Uncomment the following line to render the interactive widget\n",
     "# pyLDAvis.display(vis_data)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
-     "inputWidgets": {},
-     "nuid": "31945151-7cf9-4f25-af30-d9b9bd526e7b",
-     "showTitle": false,
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/docs/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/parent-child-runs.ipynb
+++ b/docs/docs/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/parent-child-runs.ipynb
@@ -368,14 +368,6 @@
     "    )\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ca894eee",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/evaluation/qa-evaluation.ipynb
+++ b/examples/evaluation/qa-evaluation.ipynb
@@ -1513,21 +1513,6 @@
    "source": [
     "results.tables[\"eval_results_table\"]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
-     "inputWidgets": {},
-     "nuid": "e44bbe77-433a-4e03-a44e-d17eb6c06820",
-     "showTitle": false,
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/evaluation/rag-evaluation.ipynb
+++ b/examples/evaluation/rag-evaluation.ipynb
@@ -557,13 +557,6 @@
    "source": [
     "results.tables[\"eval_results_table\"]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/h2o/random_forest.ipynb
+++ b/examples/h2o/random_forest.ipynb
@@ -174,13 +174,6 @@
    "source": [
     "yaml.safe_dump"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/llms/RAG/retriever-evaluation-tutorial.ipynb
+++ b/examples/llms/RAG/retriever-evaluation-tutorial.ipynb
@@ -1888,21 +1888,6 @@
     "# Uncomment the following line to render the interactive widget\n",
     "# pyLDAvis.display(vis_data)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
-     "inputWidgets": {},
-     "nuid": "31945151-7cf9-4f25-af30-d9b9bd526e7b",
-     "showTitle": false,
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/rapids/mlflow_project/notebooks/rapids_mlflow.ipynb
+++ b/examples/rapids/mlflow_project/notebooks/rapids_mlflow.ipynb
@@ -248,17 +248,6 @@
     "        print(\"Sleeping\")\n",
     "        time.sleep(20)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/sklearn_elasticnet_wine/train.ipynb
+++ b/examples/sklearn_elasticnet_wine/train.ipynb
@@ -166,13 +166,6 @@
    "source": [
     "train(0.1, 0.1)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15404?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15404/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15404/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15404
```

</p>
</details>

### Related Issues/PRs
N/A

### What changes are proposed in this pull request?

This PR adds a new custom lint rule for empty notebook cells.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
