### PR TITLE
Deflake `test_rest_get_artifact_api_log_image`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -441,13 +441,14 @@ jobs:
           MLFLOW_SQLALCHEMYSTORE_POOLCLASS: "NullPool"
         run: |
           source .venv/Scripts/activate
-          # Set Hadoop environment variables required for testing Spark integrations on Windows
-          export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
-          export PATH=$PATH:$HADOOP_HOME/bin
-          # Run Windows tests
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
-            --ignore-flavors --ignore=tests/projects --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate --ignore tests/deployments/server --ignore=tests/optuna \
-            tests
-          # MLeap is incompatible on Windows with PySpark3.4 release.
-          # Reinstate tests when MLeap has released a fix. [ML-30491]
-          # pytest tests/mleap
+          pytest tests/tracking/test_mlflow_artifacts.py::test_rest_get_artifact_api_log_image
+          # # Set Hadoop environment variables required for testing Spark integrations on Windows
+          # export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
+          # export PATH=$PATH:$HADOOP_HOME/bin
+          # # Run Windows tests
+          # pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
+          #   --ignore-flavors --ignore=tests/projects --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate --ignore tests/deployments/server --ignore=tests/optuna \
+          #   tests
+          # # MLeap is incompatible on Windows with PySpark3.4 release.
+          # # Reinstate tests when MLeap has released a fix. [ML-30491]
+          # # pytest tests/mleap

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2818,11 +2818,11 @@ class MlflowClient:
 
             # Sanitize key to use in filename (replace / with # to avoid subdirectories)
             sanitized_key = re.sub(r"/", "#", key)
-            filename_uuid = uuid.uuid4()
+            filename_uuid = str(uuid.uuid4())
             # TODO: reconsider the separator used here since % has special meaning in URL encoding.
             # See https://github.com/mlflow/mlflow/issues/14136 for more details.
             uncompressed_filename = (
-                f"images/{sanitized_key}%step%{step}%timestamp%{timestamp}%{filename_uuid}"
+                f"images/{sanitized_key}%step%{step}%timestamp%{timestamp}%7c{filename_uuid[2:]}"
             )
             compressed_filename = f"{uncompressed_filename}%compressed"
 

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import subprocess
 import tempfile
+import urllib
 from collections import namedtuple
 from io import BytesIO
 
@@ -388,7 +389,7 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
     artifact_list_response.raise_for_status()
 
     for file in artifact_list_response.json()["files"]:
-        path = file["path"]
+        path = urllib.parse.quote(file["path"])
         get_artifact_response = requests.get(
             url=f"{url}/get-artifact", params={"run_id": run.info.run_id, "path": path}
         )

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -370,7 +370,14 @@ def test_mime_type_for_download_artifacts_api(
     assert artifact_response.headers["X-Content-Type-Options"] == "nosniff"
 
 
-def test_rest_get_artifact_api_log_image(artifacts_server):
+@pytest.mark.parametrize(
+    "func",
+    [
+        lambda x: x,
+        urllib.parse.quote,
+    ],
+)
+def test_rest_get_artifact_api_log_image(artifacts_server, func):
     url = artifacts_server.url
     mlflow.set_tracking_uri(url)
 
@@ -389,7 +396,7 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
     artifact_list_response.raise_for_status()
 
     for file in artifact_list_response.json()["files"]:
-        path = urllib.parse.quote(file["path"])
+        path = func(file["path"])
         get_artifact_response = requests.get(
             url=f"{url}/get-artifact", params={"run_id": run.info.run_id, "path": path}
         )


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`tests/tracking/test_mlflow_artifacts.py::test_rest_get_artifact_api_log_image` is flaky on windows.

https://github.com/mlflow/mlflow/actions/runs/14570247372/job/40866083311?pr=15395

```
Traceback (most recent call last):

  File "D:\a\mlflow\mlflow\.venv\lib\site-packages\flask\app.py", line 1511, in wsgi_app

    response = self.full_dispatch_request()

  File "D:\a\mlflow\mlflow\.venv\lib\site-packages\flask\app.py", line 919, in full_dispatch_request

    rv = self.handle_user_exception(e)

  File "D:\a\mlflow\mlflow\.venv\lib\site-packages\flask\app.py", line 917, in full_dispatch_request

    rv = self.dispatch_request()

  File "D:\a\mlflow\mlflow\.venv\lib\site-packages\flask\app.py", line 902, in dispatch_request

    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]

  File "D:\a\mlflow\mlflow\mlflow\server\handlers.py", line 574, in wrapper

    return func(*args, **kwargs)

  File "D:\a\mlflow\mlflow\mlflow\server\handlers.py", line 596, in wrapper

    return func(*args, **kwargs)

  File "D:\a\mlflow\mlflow\mlflow\server\handlers.py", line 2184, in _upload_artifact

    with open(tmp_path, "wb") as f:

OSError: [Errno 22] Invalid argument: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpqgdwxhym\\dog%step%100%timestamp%100|0dc34e-687a-4f10-acb5-2985849ea501.png'
```

What's happening?

1. `log_image` generates a random UUID for the image name suffix.
1. The suffix starts with `7c`.
2. `%7c` is percent-decoded as `|` (vertical line), which is an invalid character for a file name on Windows.
3. `open` throws.

https://github.com/mlflow/mlflow/pull/15395

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
