### PR TITLE
Make TraceInfo/Data V3 backward compatible for agent eval

### DIFF
--- a/mlflow/entities/trace_data.py
+++ b/mlflow/entities/trace_data.py
@@ -22,10 +22,10 @@ class TraceData:
     _response: Optional[str] = field(default=None)
 
     def __init__(self,
-                 spans: list[Span],
+                 spans: Optional[list[Span]] = None,
                  request: Optional[str] = None,
                  response: Optional[str] = None):
-        self.spans = spans
+        self.spans = spans or []
         self._request = request
         self._response = response
 

--- a/mlflow/entities/trace_data.py
+++ b/mlflow/entities/trace_data.py
@@ -12,13 +12,14 @@ class TraceData:
 
     Args:
         spans: List of spans that are part of the trace.
-        request: Input data for the entire trace. Equivalent to the input of the root span
-            but added for ease of access. Stored as a JSON string.
-        response: Output data for the entire trace. Equivalent to the output of the root span.
-            Stored as a JSON string.
     """
 
     spans: list[Span] = field(default_factory=list)
+
+    # NB: Custom constructor to allow passing additional kwargs for backward compatibility for
+    # DBX agent evaluator. Once they migrates to trace V3 schema, we can remove this.
+    def __init__(self, spans: Optional[list[Span]] = None, **kwargs):
+        self.spans = spans
 
     @classmethod
     def from_dict(cls, d):

--- a/mlflow/entities/trace_data.py
+++ b/mlflow/entities/trace_data.py
@@ -70,7 +70,7 @@ class TraceData:
     # `request` and `response` are preserved for backward compatibility with v2
     @property
     def request(self) -> Optional[str]:
-        if self._request:
+        if self._request is not None:
             return self._request
 
         if span := self._get_root_span():
@@ -80,7 +80,7 @@ class TraceData:
 
     @property
     def response(self) -> Optional[str]:
-        if self._response:
+        if self._response is not None:
             return self._response
 
         if span := self._get_root_span():

--- a/mlflow/entities/trace_info_v3.py
+++ b/mlflow/entities/trace_info_v3.py
@@ -120,6 +120,10 @@ class TraceInfoV3(_MlflowObject):
     def request_id(self) -> str:
         return self.trace_id
 
+    @request_id.setter
+    def request_id(self, value: str) -> None:
+        self.trace_id = value
+
     @property
     def experiment_id(self) -> Optional[str]:
         return (


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15407?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15407/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15407/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15407
```

</p>
</details>

### What changes are proposed in this pull request?

I've tested the mlflow-3 branch and found two issues:

* The `request` and `response` field in the `TraceData` constructor is used by one place in DBX evaluator. This PR make the constructor permissive to those extra inputs as a temporary workaround. We can simply discard them as they are equivalent to the one derived from the root span.
* The trace info `request_id` setter is used in one place in agent evaluator....

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
