### PR TITLE
Remove `every_n_iter` param in tensorflow autologging in MLflow 3

### DIFF
--- a/docs/docs/deep-learning/tensorflow/guide/index.mdx
+++ b/docs/docs/deep-learning/tensorflow/guide/index.mdx
@@ -70,8 +70,9 @@ documentation <APILink fn="mlflow.tensorflow.autolog" /> for full customization 
 The way we autolog Tensorflow is by registering a custom callback to the Keras model via monkey patch.
 Briefly we attach a MLflow callback to the Keras model that works similarly to normal Keras callbacks.
 At training start, training parameters including epochs, batch_size, learning_rate and model information
-such as model summary will be logged. In addition, the callback will be triggered per `every_n_iter`
-epochs to log the training metrics, and after the training finishes, the trained model will be saved to MLflow.
+such as model summary will be logged. In addition, the callback will be triggered per epoch or per
+`log_every_n_steps` steps to log the training metrics, and after the training finishes,
+the trained model will be saved to MLflow.
 
 ## Logging to MLflow with Keras Callback
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -1012,7 +1012,6 @@ def _setup_callbacks(callbacks, log_every_epoch, log_every_n_steps):
 
 @autologging_integration(FLAVOR_NAME)
 def autolog(
-    every_n_iter=1,
     log_models=True,
     log_datasets=True,
     disable=False,
@@ -1074,8 +1073,6 @@ def autolog(
     autologging by calling `mlflow.tensorflow.autolog(disable=True)`.
 
     Args:
-        every_n_iter: deprecated, please use ``log_every_epoch`` instead. Per ``every_n_iter``
-            steps, metrics will be logged.
         log_models: If ``True``, trained models are logged as MLflow model artifacts.
             If ``False``, trained models are not logged.
         log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
@@ -1134,14 +1131,6 @@ def autolog(
             every epoch). Defaults to `"epoch"`.
     """
     import tensorflow as tf
-
-    if every_n_iter != 1:
-        _logger.warning(
-            "The `every_n_iter` parameter is deprecated, please use `log_every_epoch` and "
-            "`log_every_n_steps` instead. Automatically set `log_every_n_steps` to `every_n_iter`."
-        )
-        log_every_epoch = False
-        log_every_n_steps = every_n_iter
 
     if Version(tf.__version__) < Version("2.3"):
         _logger.error(

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -731,7 +731,7 @@ def get_tf_keras_random_data_run_with_callback(
     initial_epoch,
     log_models,
 ):
-    mlflow.tensorflow.autolog(every_n_iter=1, log_models=log_models)
+    mlflow.tensorflow.autolog(log_models=log_models)
 
     data = random_train_data
     labels = random_one_hot_labels


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/15412?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15412/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15412/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15412
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Remove `every_n_iter` param in tensorflow autologging in MLflow 3
### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Remove `every_n_iter` param in tensorflow autologging in MLflow 3
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
