### PR TITLE
[pytorch] Link metrics to LoggedModels in autologging

### DIFF
--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -420,7 +420,7 @@ def _log_early_stop_params(early_stop_callback, client, run_id):
     )
 
 
-def _log_early_stop_metrics(early_stop_callback, client, run_id):
+def _log_early_stop_metrics(early_stop_callback, client, run_id, model_id=None):
     """
     Logs early stopping behavior results (e.g. stopped epoch) as metrics to MLflow.
 
@@ -428,6 +428,7 @@ def _log_early_stop_metrics(early_stop_callback, client, run_id):
         early_stop_callback: The early stopping callback instance used during training.
         client: An `MlflowAutologgingQueueingClient` instance used for MLflow logging.
         run_id: The ID of the MLflow Run to which to log configuration parameters.
+        model_id: The ID of the LoggedModel to which the metrics are associated.
     """
     if early_stop_callback.stopped_epoch == 0:
         return
@@ -443,7 +444,7 @@ def _log_early_stop_metrics(early_stop_callback, client, run_id):
     if hasattr(early_stop_callback, "wait_count"):
         metrics["wait_count"] = early_stop_callback.wait_count
 
-    client.log_metrics(run_id, metrics)
+    client.log_metrics(run_id, metrics, model_id=model_id)
 
 
 def patched_fit(original, self, *args, **kwargs):
@@ -472,9 +473,13 @@ def patched_fit(original, self, *args, **kwargs):
         run_id = mlflow.active_run().info.run_id
         tracking_uri = mlflow.get_tracking_uri()
         client = MlflowAutologgingQueueingClient(tracking_uri)
-        metrics_logger = BatchMetricsLogger(run_id, tracking_uri)
 
         log_models = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_models", True)
+        model_id = None
+        if log_models:
+            model_id = mlflow.initialize_logged_model(name="model").model_id
+        metrics_logger = BatchMetricsLogger(run_id, tracking_uri, model_id=model_id)
+
         log_every_n_epoch = get_autologging_config(
             mlflow.pytorch.FLAVOR_NAME, "log_every_n_epoch", 1
         )
@@ -539,7 +544,7 @@ def patched_fit(original, self, *args, **kwargs):
         result = original(self, *args, **kwargs)
 
         if early_stop_callback is not None:
-            _log_early_stop_metrics(early_stop_callback, client, run_id)
+            _log_early_stop_metrics(early_stop_callback, client, run_id, model_id=model_id)
 
         if Version(pl.__version__) < Version("1.4.0"):
             summary = str(ModelSummary(self.model, mode="full"))
@@ -561,6 +566,7 @@ def patched_fit(original, self, *args, **kwargs):
                 self.model,
                 "model",
                 registered_model_name=registered_model_name,
+                model_id=model_id,
             )
 
             if early_stop_callback is not None and self.checkpoint_callback.best_model_path:

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -254,8 +254,9 @@ class BatchMetricsLogger:
     `record_metrics()` or `flush()`.
     """
 
-    def __init__(self, run_id=None, tracking_uri=None):
+    def __init__(self, run_id=None, tracking_uri=None, model_id=None):
         self.run_id = run_id
+        self.model_id = model_id
         self.client = MlflowClient(tracking_uri)
 
         # data is an array of Metric objects
@@ -318,7 +319,9 @@ class BatchMetricsLogger:
             step = 0
 
         for key, value in metrics.items():
-            self.data.append(Metric(key, value, int(current_timestamp * 1000), step))
+            self.data.append(
+                Metric(key, value, int(current_timestamp * 1000), step, model_id=self.model_id)
+            )
 
         if self._should_flush():
             self.flush()
@@ -327,7 +330,7 @@ class BatchMetricsLogger:
 
 
 @contextlib.contextmanager
-def batch_metrics_logger(run_id):
+def batch_metrics_logger(run_id, model_id: Optional[str] = None):
     """
     Context manager that yields a BatchMetricsLogger object, which metrics can be logged against.
     The BatchMetricsLogger keeps metrics in a list until it decides they should be logged, at
@@ -342,9 +345,10 @@ def batch_metrics_logger(run_id):
 
     Args:
         run_id: ID of the run that the metrics will be logged to.
+        model_id: ID of the model that the metrics will be associated with.
     """
 
-    batch_metrics_logger = BatchMetricsLogger(run_id)
+    batch_metrics_logger = BatchMetricsLogger(run_id, model_id=model_id)
     yield batch_metrics_logger
     batch_metrics_logger.flush()
 

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -330,7 +330,7 @@ class BatchMetricsLogger:
 
 
 @contextlib.contextmanager
-def batch_metrics_logger(run_id, model_id: Optional[str] = None):
+def batch_metrics_logger(run_id: Optional[str] = None, model_id: Optional[str] = None):
     """
     Context manager that yields a BatchMetricsLogger object, which metrics can be logged against.
     The BatchMetricsLogger keeps metrics in a list until it decides they should be logged, at

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -323,6 +323,10 @@ def test_pytorch_with_early_stopping_autolog_log_models_configuration_with(log_m
     client = MlflowClient()
     artifacts = [f.path for f in client.list_artifacts(run_id)]
     assert ("restored_model_checkpoint" in artifacts) == log_models
+    if log_models:
+        logged_model = mlflow.last_logged_model()
+        assert logged_model is not None
+        assert {metric.key: metric.value for metric in logged_model.metrics} == run.data.metrics
 
 
 @pytest.mark.parametrize("patience", [0, 1, 5])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15423?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15423/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15423/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15423
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Link metrics to the LoggedModel in autologging
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
