### PR TITLE
Support tracing ResponsesAgent predict

### DIFF
--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -60,7 +60,8 @@ def _parse_inputs_output(inputs: dict[str, Any], output: Any) -> list[ChatMessag
         from openai.types.chat import ChatCompletion
 
         if isinstance(output, ChatCompletion):
-            return [*messages, output.choices[0].message.to_dict(exclude_unset=True)]
+            messages.append(output.choices[0].message.to_dict(exclude_unset=True))
+            return messages
     except ImportError:
         pass
 

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -36,6 +36,7 @@ from mlflow.tracing.utils import (
     encode_span_id,
     exclude_immutable_tags,
     get_otel_attribute,
+    set_chat_attributes_special_case,
 )
 from mlflow.tracing.utils.search import extract_span_inputs_outputs, traces_to_df
 from mlflow.tracing.utils.warning import request_id_backward_compatible
@@ -188,9 +189,16 @@ def _wrap_function(
                 name=span_name, span_type=span_type, attributes=attributes, model_id=model_id
             ) as span:
                 span.set_attribute(SpanAttributeKey.FUNCTION_NAME, fn.__name__)
-                span.set_inputs(capture_function_input_args(fn, args, kwargs))
+                inputs = capture_function_input_args(fn, args, kwargs)
+                span.set_inputs(inputs)
                 result = yield  # sync/async function output to be sent here
                 span.set_outputs(result)
+
+                try:
+                    set_chat_attributes_special_case(span, inputs=inputs, outputs=result)
+                except Exception:
+                    pass
+
                 try:
                     yield result
                 except GeneratorExit:
@@ -261,14 +269,14 @@ def _wrap_generator(
     even worse, leak span context and pollute subsequent traces.
     """
 
-    def _start_stream_span(fn, args, kwargs):
+    def _start_stream_span(fn, inputs):
         try:
             return start_span_no_context(
                 name=name or fn.__name__,
                 parent_span=get_current_active_span(),
                 span_type=span_type,
                 attributes=attributes,
-                inputs=capture_function_input_args(fn, args, kwargs),
+                inputs=inputs,
             )
         except Exception as e:
             _logger.debug(f"Failed to start stream span: {e}")
@@ -276,6 +284,7 @@ def _wrap_generator(
 
     def _end_stream_span(
         span: LiveSpan,
+        inputs: Optional[dict[str, Any]] = None,
         outputs: Optional[list[Any]] = None,
         output_reducer: Optional[Callable] = None,
         error: Optional[Exception] = None,
@@ -290,6 +299,8 @@ def _wrap_generator(
                 outputs = output_reducer(outputs)
             except Exception as e:
                 _logger.debug(f"Failed to reduce outputs from stream: {e}")
+
+        set_chat_attributes_special_case(span, inputs=inputs, outputs=outputs)
         span.end(outputs=outputs)
 
     def _record_chunk_event(span: LiveSpan, chunk: Any, chunk_index: int):
@@ -306,7 +317,8 @@ def _wrap_generator(
     if inspect.isgeneratorfunction(fn):
 
         def wrapper(*args, **kwargs):
-            span = _start_stream_span(fn, args, kwargs)
+            inputs = capture_function_input_args(fn, args, kwargs)
+            span = _start_stream_span(fn, inputs)
             generator = fn(*args, **kwargs)
 
             i = 0
@@ -326,10 +338,11 @@ def _wrap_generator(
                     _record_chunk_event(span, value, i)
                     yield value
                     i += 1
-            _end_stream_span(span, outputs, output_reducer)
+            _end_stream_span(span, inputs, outputs, output_reducer)
     else:
 
         async def wrapper(*args, **kwargs):
+            inputs = capture_function_input_args(fn, args, kwargs)
             span = _start_stream_span(fn, args, kwargs)
             generator = fn(*args, **kwargs)
 
@@ -349,7 +362,7 @@ def _wrap_generator(
                     _record_chunk_event(span, value, i)
                     yield value
                     i += 1
-            _end_stream_span(span, outputs, output_reducer)
+            _end_stream_span(span, inputs, outputs, output_reducer)
 
     return functools.wraps(fn)(wrapper)
 

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -194,10 +194,7 @@ def _wrap_function(
                 result = yield  # sync/async function output to be sent here
                 span.set_outputs(result)
 
-                try:
-                    set_chat_attributes_special_case(span, inputs=inputs, outputs=result)
-                except Exception:
-                    pass
+                set_chat_attributes_special_case(span, inputs=inputs, outputs=result)
 
                 try:
                     yield result

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -343,7 +343,7 @@ def _wrap_generator(
 
         async def wrapper(*args, **kwargs):
             inputs = capture_function_input_args(fn, args, kwargs)
-            span = _start_stream_span(fn, args, kwargs)
+            span = _start_stream_span(fn, inputs)
             generator = fn(*args, **kwargs)
 
             i = 0

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -423,9 +423,9 @@ def set_chat_attributes_special_case(span: LiveSpan, inputs: Any, outputs: Any):
         from mlflow.openai.utils.chat_schema import set_span_chat_attributes
         from mlflow.types.responses import ResponsesResponse
 
-        if isinstance(outputs, ResponsesResponse):
+        if ResponsesResponse.validate_compat(outputs):
             inputs = inputs["request"].model_dump_compat()
             set_span_chat_attributes(span, inputs, outputs)
 
-    except ImportError:
+    except Exception:
         pass

--- a/tests/pyfunc/test_responses_agent.py
+++ b/tests/pyfunc/test_responses_agent.py
@@ -2,7 +2,11 @@ from typing import Generator
 
 import pytest
 
+from mlflow.entities.span import SpanType
+from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER
+
+from tests.tracing.helper import get_traces
 
 if not IS_PYDANTIC_V2_OR_NEWER:
     pytest.skip(
@@ -230,3 +234,176 @@ def test_responses_agent_throws_with_invalid_output(tmp_path):
         MlflowException, match="Failed to save ResponsesAgent. Ensure your model's predict"
     ):
         mlflow.pyfunc.save_model(python_model=model, path=tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("input", "outputs", "expected_chat_messages", "expected_chat_tools"),
+    [
+        # 1. Normal text input output
+        (
+            RESPONSES_AGENT_INPUT_EXAMPLE,
+            {
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "test",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Dummy output"}],
+                    }
+                ],
+            },
+            [
+                {
+                    "content": "Hello!",
+                    "role": "user",
+                },
+                {
+                    "content": [{"text": "Dummy output", "type": "text"}],
+                    "role": "assistant",
+                },
+            ],
+            None,
+        ),
+        # 2. Image input
+        (
+            {
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "what is in this image?"},
+                            {"type": "input_image", "image_url": "test.jpg"},
+                        ],
+                    }
+                ],
+            },
+            {
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "test",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Dummy output"}],
+                    }
+                ],
+            },
+            [
+                {
+                    "content": [
+                        {
+                            "text": "what is in this image?",
+                            "type": "text",
+                        },
+                        {
+                            "image_url": {
+                                "detail": None,
+                                "url": "test.jpg",
+                            },
+                            "type": "image_url",
+                        },
+                    ],
+                    "role": "user",
+                },
+                {
+                    "content": [{"text": "Dummy output", "type": "text"}],
+                    "role": "assistant",
+                },
+            ],
+            None,
+        ),
+        # 3. Tool calling
+        (
+            {
+                "input": [
+                    {
+                        "role": "user",
+                        "content": "What is the weather like in Boston today?",
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "get_current_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                            "required": ["location", "unit"],
+                        },
+                    }
+                ],
+            },
+            {
+                "output": [
+                    {
+                        "arguments": '{"location":"Boston, MA","unit":"celsius"}',
+                        "call_id": "function_call_1",
+                        "name": "get_current_weather",
+                        "type": "function_call",
+                        "id": "fc_6805c835567481918c27724bbe931dc40b1b7951a48825bb",
+                        "status": "completed",
+                    }
+                ]
+            },
+            [
+                {
+                    "role": "user",
+                    "content": "What is the weather like in Boston today?",
+                },
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "function_call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_current_weather",
+                                "arguments": '{"location":"Boston, MA","unit":"celsius"}',
+                            },
+                        }
+                    ],
+                },
+            ],
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                            "required": ["location", "unit"],
+                        },
+                    },
+                }
+            ],
+        ),
+    ],
+)
+def test_responses_agent_trace(
+    tmp_path, input, outputs, expected_chat_messages, expected_chat_tools
+):
+    class TracedResponsesAgent(ResponsesAgent):
+        @mlflow.trace(span_type=SpanType.AGENT)
+        def predict(self, request: ResponsesRequest) -> ResponsesResponse:
+            return ResponsesResponse(**outputs)
+
+        def predict_stream(self, request: ResponsesRequest):
+            # Dummy
+            pass
+
+    model = TracedResponsesAgent()
+    model.predict(input)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    spans = traces[0].data.spans
+    assert len(spans) == 1
+    assert spans[0].name == "predict"
+    assert spans[0].attributes[SpanAttributeKey.CHAT_MESSAGES] == expected_chat_messages
+
+    if expected_chat_tools is not None:
+        assert spans[0].attributes[SpanAttributeKey.CHAT_TOOLS] == expected_chat_tools
+    else:
+        assert SpanAttributeKey.CHAT_TOOLS not in spans[0].attributes


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15437?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15437/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15437/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15437
```

</p>
</details>

### What changes are proposed in this pull request?

Support tracing ResponsesAgent predict method with `@mlflow.trace` decorator, without requiring users to write complex parsing logic.

```

class TracedResponsesAgent(ResponsesAgent):
    @mlflow.trace(span_type=SpanType.AGENT)
    def predict(self, request: ResponsesRequest) -> ResponsesResponse:
        return ResponsesResponse(**outputs)
```

This PR does **not** include
* Automatically add the trace decorator
* Handling stream

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

![Screenshot 2025-04-23 at 12 32 33](https://github.com/user-attachments/assets/66fe561d-07fc-43e7-b64c-6680e880f47b)
![Screenshot 2025-04-23 at 12 32 42](https://github.com/user-attachments/assets/33494387-ffee-4fb0-bf1d-5fa8dab67fef)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
