### PR TITLE
Enable ruff n804

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -222,7 +222,7 @@ class Feedback(_MlflowObject):
         )
 
     @classmethod
-    def from_proto(self, proto) -> "Feedback":
+    def from_proto(cls, proto) -> "Feedback":
         return Feedback(
             value=MessageToDict(proto.value),
             error=AssessmentError.from_proto(proto.error) if proto.HasField("error") else None,

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -135,7 +135,7 @@ class OpenAIAdapter(ProviderAdapter):
         )
 
     @classmethod
-    def model_to_completions(self, resp, config):
+    def model_to_completions(cls, resp, config):
         # Response example (https://platform.openai.com/docs/api-reference/completions/create)
         # ```
         # {

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -179,9 +179,9 @@ class InMemoryTraceManager:
                     self._traces = get_trace_cache_with_timeout()
 
     @classmethod
-    def reset(self):
+    def reset(cls):
         """Clear all the aggregated trace data. This should only be used for testing."""
-        if self._instance:
-            with self._instance._lock:
-                self._instance._traces.clear()
-            self._instance = None
+        if cls._instance:
+            with cls._instance._lock:
+                cls._instance._traces.clear()
+            cls._instance = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ select = [
   "C4",      # flake8-comprehensions
   "I",       # isort
   "ISC001",  # single-line-implicit-string-concatenation
+  "N804",    # invalid-first-argument-name-for-class-method
   "PIE790",  # unnecessary-placeholder
   "PLR0402", # manual-from-import
   "PLE1205", # logging-too-many-args


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/UnMelow/mlflow/pull/15459?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15459/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15459/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15459
```

</p>
</details>


### Related Issues/PRs

Resolve #15427

### What changes are proposed in this pull request?

This pull request enables the `N804` rule in Ruff to enforce the correct naming of the first argument in `@classmethod` definitions (should be `cls`, not `self`). It also updates all current violations to comply with this rule.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
