### PR TITLE
Add missing docstring to the trace entities

### DIFF
--- a/mlflow/entities/trace_info_v3.py
+++ b/mlflow/entities/trace_info_v3.py
@@ -15,6 +15,31 @@ from mlflow.protos import databricks_trace_server_pb2 as pb
 
 @dataclass
 class TraceInfoV3(_MlflowObject):
+    """Metadata about a trace, such as its ID, location, timestamp, etc.
+
+    Args:
+        trace_id: The primary identifier for the trace.
+        trace_location: The location where the trace is stored, represented as
+            a :py:class:`~mlflow.entities.TraceLocation>` object. MLflow currently
+            support MLflow Experiment or Databricks Inference Table as a trace location.
+        request_time: Start time of the trace, in milliseconds.
+        state: State of the trace, represented as a :py:class:`~mlflow.entities.TraceState>`
+            enum. Can be one of [`OK`, `ERROR`, `IN_PROGRESS`, `STATE_UNSPECIFIED`].
+        request_preview: Request to the model/agent, equivalent to the input of the root,
+            span but JSON-encoded and can be truncated.
+        request_preview: REsponse from the model/agent, equivalent to the output of the
+            root span but JSON-encoded and can be truncated.
+        client_request_id: Client supplied request ID associated with the trace. This
+            could be used to identify the trace/request from an external system that
+            produced the trace, e.g., a session ID in a web application.
+        execution_duration: Duration of the trace, in milliseconds.
+        trace_metadata: Key-value pairs associated with the trace. They are designed
+            for immutable values like run ID associated with the trace.
+        tags: Tags associated with the trace. They are designed for mutable values,
+            that can be updated after the trace is created via MLflow UI or API.
+        assessments: List of assessments associated with the trace.
+    """
+
     trace_id: str
     trace_location: TraceLocation
     request_time: int
@@ -28,6 +53,7 @@ class TraceInfoV3(_MlflowObject):
     assessments: list[Assessment] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
+        """Convert the TraceInfoV3 object to a dictionary."""
         res = MessageToDict(self.to_proto(), preserving_proto_field_name=True)
         if self.execution_duration is not None:
             res.pop("execution_duration", None)
@@ -36,6 +62,7 @@ class TraceInfoV3(_MlflowObject):
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "TraceInfoV3":
+        """Create a TraceInfoV3 object from a dictionary."""
         if "request_id" in d:
             from mlflow.entities.trace_info import TraceInfo as TraceInfoV2
 
@@ -108,10 +135,15 @@ class TraceInfoV3(_MlflowObject):
     # Aliases for backward compatibility with V2 format
     @property
     def request_id(self) -> str:
+        """Deprecated: Use `trace_id` instead."""
         return self.trace_id
 
     @property
     def experiment_id(self) -> Optional[str]:
+        """
+        An MLflow experiment ID associated with the trace, if the trace is stored
+        in MLflow tracking server. Otherwise, None.
+        """
         return (
             self.trace_location.mlflow_experiment
             and self.trace_location.mlflow_experiment.experiment_id
@@ -123,6 +155,7 @@ class TraceInfoV3(_MlflowObject):
 
     @property
     def request_metadata(self) -> dict[str, str]:
+        """Deprecated: Use `trace_metadata` instead."""
         return self.trace_metadata
 
     @property
@@ -143,6 +176,7 @@ class TraceInfoV3(_MlflowObject):
 
     @property
     def status(self) -> TraceStatus:
+        """Deprecated. Use `state` instead."""
         return TraceStatus.from_state(self.state)
 
     @status.setter

--- a/mlflow/entities/trace_info_v3.py
+++ b/mlflow/entities/trace_info_v3.py
@@ -20,14 +20,14 @@ class TraceInfoV3(_MlflowObject):
     Args:
         trace_id: The primary identifier for the trace.
         trace_location: The location where the trace is stored, represented as
-            a :py:class:`~mlflow.entities.TraceLocation>` object. MLflow currently
+            a :py:class:`~mlflow.entities.TraceLocation` object. MLflow currently
             support MLflow Experiment or Databricks Inference Table as a trace location.
         request_time: Start time of the trace, in milliseconds.
-        state: State of the trace, represented as a :py:class:`~mlflow.entities.TraceState>`
+        state: State of the trace, represented as a :py:class:`~mlflow.entities.TraceState`
             enum. Can be one of [`OK`, `ERROR`, `IN_PROGRESS`, `STATE_UNSPECIFIED`].
         request_preview: Request to the model/agent, equivalent to the input of the root,
             span but JSON-encoded and can be truncated.
-        request_preview: REsponse from the model/agent, equivalent to the output of the
+        response_preview: Response from the model/agent, equivalent to the output of the
             root span but JSON-encoded and can be truncated.
         client_request_id: Client supplied request ID associated with the trace. This
             could be used to identify the trace/request from an external system that
@@ -135,7 +135,7 @@ class TraceInfoV3(_MlflowObject):
     # Aliases for backward compatibility with V2 format
     @property
     def request_id(self) -> str:
-        """Deprecated: Use `trace_id` instead."""
+        """Deprecated. Use `trace_id` instead."""
         return self.trace_id
 
     @property
@@ -155,7 +155,7 @@ class TraceInfoV3(_MlflowObject):
 
     @property
     def request_metadata(self) -> dict[str, str]:
-        """Deprecated: Use `trace_metadata` instead."""
+        """Deprecated. Use `trace_metadata` instead."""
         return self.trace_metadata
 
     @property

--- a/mlflow/entities/trace_location.py
+++ b/mlflow/entities/trace_location.py
@@ -85,7 +85,7 @@ class TraceLocation(_MlflowObject):
     Currently, MLflow supports two types of trace locations:
 
         - MLflow experiment: The trace is stored in an MLflow experiment.
-        - Inference table: The trace is stored in an Databricks inference table.
+        - Inference table: The trace is stored in a Databricks inference table.
 
     Args:
         type: The type of the trace location, should be one of the

--- a/mlflow/entities/trace_location.py
+++ b/mlflow/entities/trace_location.py
@@ -9,6 +9,13 @@ from mlflow.protos import databricks_trace_server_pb2 as pb
 
 @dataclass
 class MlflowExperimentLocation(_MlflowObject):
+    """
+    Represents the location of an MLflow experiment.
+
+    Args:
+        experiment_id: The ID of the MLflow experiment where the trace is stored.
+    """
+
     experiment_id: str
 
     def to_proto(self):
@@ -28,6 +35,14 @@ class MlflowExperimentLocation(_MlflowObject):
 
 @dataclass
 class InferenceTableLocation(_MlflowObject):
+    """
+    Represents the location of a Databricks inference table.
+
+    Args:
+        full_table_name: The fully qualified name of the inference table where
+            the trace is stored, in the format of `<catalog>.<schema>.<table>`.
+    """
+
     full_table_name: str
 
     def to_proto(self):
@@ -64,6 +79,23 @@ class TraceLocationType(str, Enum):
 
 @dataclass
 class TraceLocation(_MlflowObject):
+    """
+    Represents the location where the trace is stored.
+
+    Currently, MLflow supports two types of trace locations:
+
+        - MLflow experiment: The trace is stored in an MLflow experiment.
+        - Inference table: The trace is stored in an Databricks inference table.
+
+    Args:
+        type: The type of the trace location, should be one of the
+            :py:class:`TraceLocationType` enum values.
+        mlflow_experiment: The MLflow experiment location. Set this when the
+            location type is MLflow experiment.
+        inference_table: The inference table location. Set this when the
+            location type is Databricks Inference table.
+    """
+
     type: TraceLocationType
     mlflow_experiment: Optional[MlflowExperimentLocation] = None
     inference_table: Optional[InferenceTableLocation] = None

--- a/mlflow/entities/trace_state.py
+++ b/mlflow/entities/trace_state.py
@@ -6,6 +6,14 @@ from mlflow.protos import databricks_trace_server_pb2 as pb
 
 
 class TraceState(str, Enum):
+    """Enum representing the state of a trace.
+
+    - ``STATE_UNSPECIFIED``: Unspecified trace state.
+    - ``OK``: Trace successfully completed.
+    - ``ERROR``: Trace encountered an error.
+    - ``IN_PROGRESS``: Trace is currently in progress.
+    """
+
     STATE_UNSPECIFIED = "STATE_UNSPECIFIED"
     OK = "OK"
     ERROR = "ERROR"
@@ -20,17 +28,8 @@ class TraceState(str, Enum):
 
     @staticmethod
     def from_otel_status(otel_status: trace_api.Status):
+        """Convert OpenTelemetry status code to MLflow TraceState."""
         return _OTEL_STATUS_CODE_TO_MLFLOW[otel_status.status_code]
-
-    @classmethod
-    def pending_states(cls):
-        """Traces in pending statuses can be updated to any statuses."""
-        return {cls.IN_PROGRESS}
-
-    @classmethod
-    def end_states(cls):
-        """Traces in end statuses cannot be updated to any statuses."""
-        return {cls.UNSPECIFIED, cls.OK, cls.ERROR}
 
 
 _OTEL_STATUS_CODE_TO_MLFLOW = {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15462?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15462/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15462/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15462
```

</p>
</details>

### What changes are proposed in this pull request?

Add missing docstring for trace entities to make API documentation useful.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
