### PR TITLE
[pyspark] Link metrics to LoggedModels in autologging

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -6,6 +6,7 @@ import traceback
 import weakref
 from collections import OrderedDict, defaultdict, namedtuple
 from itertools import zip_longest
+from typing import Optional
 from urllib.parse import urlparse
 
 import numpy as np
@@ -397,7 +398,14 @@ def _get_instance_param_map(instance, uid_to_indexed_name_map):
     )
 
 
-def _create_child_runs_for_parameter_search(parent_estimator, parent_model, parent_run, child_tags):
+def _create_child_runs_for_parameter_search(
+    parent_estimator,
+    parent_model,
+    parent_run,
+    child_tags,
+    best_model_id=None,
+    best_model_params=None,
+):
     client = MlflowClient()
     # Use the start time of the parent parameter search run as a rough estimate for the
     # start time of child runs, since we cannot precisely determine when each point
@@ -424,6 +432,11 @@ def _create_child_runs_for_parameter_search(parent_estimator, parent_model, pare
         params_to_log = _get_instance_param_map(
             child_estimator, parent_estimator._autologging_metadata.uid_to_indexed_name_map
         )
+        params = {
+            _gen_log_key(p, parent_estimator._autologging_metadata.uid_to_indexed_name_map): value
+            for p, value in est_param.items()
+        }
+        model_id = best_model_id if params == best_model_params else None
         param_batches_to_log = _chunk_dict(params_to_log, chunk_size=MAX_PARAMS_TAGS_PER_BATCH)
         metrics_to_log = {k: v[i] for k, v in metrics_dict.items()}
         for params_batch, metrics_batch in zip_longest(
@@ -443,7 +456,13 @@ def _create_child_runs_for_parameter_search(parent_estimator, parent_model, pare
                     Param(str(key), str(value)) for key, value in truncated_params_batch.items()
                 ],
                 metrics=[
-                    Metric(key=str(key), value=value, timestamp=child_run_end_time, step=0)
+                    Metric(
+                        key=str(key),
+                        value=value,
+                        timestamp=child_run_end_time,
+                        step=0,
+                        model_id=model_id,
+                    )
                     for key, value in truncated_metrics_batch.items()
                 ],
             )
@@ -477,19 +496,22 @@ def _get_warning_msg_for_fit_call_with_a_list_of_params(estimator):
     )
 
 
+def _gen_log_key(param, uid_to_indexed_name_map):
+    if param.parent not in uid_to_indexed_name_map:
+        raise ValueError(
+            "Tuning params should not include params not owned by the tuned estimator, but "
+            f"found a param {param}"
+        )
+    return f"{uid_to_indexed_name_map[param.parent]}.{param.name}"
+
+
 def _get_tuning_param_maps(param_search_estimator, uid_to_indexed_name_map):
     tuning_param_maps = []
 
-    def gen_log_key(param):
-        if param.parent not in uid_to_indexed_name_map:
-            raise ValueError(
-                "Tuning params should not include params not owned by the tuned estimator, but "
-                f"found a param {param}"
-            )
-        return f"{uid_to_indexed_name_map[param.parent]}.{param.name}"
-
     for eps in param_search_estimator.getEstimatorParamMaps():
-        tuning_param_maps.append({gen_log_key(k): v for k, v in eps.items()})
+        tuning_param_maps.append(
+            {_gen_log_key(k, uid_to_indexed_name_map): v for k, v in eps.items()}
+        )
     return tuning_param_maps
 
 
@@ -569,11 +591,12 @@ class _AutologgingMetricsManager:
     """
 
     def __init__(self):
-        self._pred_result_id_to_dataset_name_and_run_id = {}
+        self._pred_result_id_mapping = {}
         self._eval_dataset_info_map = defaultdict(lambda: defaultdict(list))
         self._evaluator_call_info = defaultdict(lambda: defaultdict(list))
         self._log_post_training_metrics_enabled = True
         self._metric_info_artifact_need_update = defaultdict(lambda: False)
+        self._model_id_mapping = {}
 
     def should_log_post_training_metrics(self):
         """
@@ -622,6 +645,16 @@ class _AutologgingMetricsManager:
         """
         model._mlflow_run_id = run_id
 
+    def record_model_id(self, model, model_id):
+        """
+        Record the id(model) -> model_id mapping so that we can log metrics to the
+        model later.
+        """
+        self._model_id_mapping[id(model)] = model_id
+
+    def get_model_id_for_model(self, model) -> Optional[str]:
+        return self._model_id_mapping.get(id(model))
+
     @staticmethod
     def gen_name_with_index(name, index):
         assert index >= 0
@@ -667,35 +700,33 @@ class _AutologgingMetricsManager:
 
         return self.gen_name_with_index(eval_dataset_name, index)
 
-    def register_prediction_result(self, run_id, eval_dataset_name, predict_result):
+    def register_prediction_result(self, run_id, eval_dataset_name, predict_result, model_id):
         """
         Register the relationship
-         id(prediction_result) --> (eval_dataset_name, run_id)
-        into map `_pred_result_id_to_dataset_name_and_run_id`
+         id(prediction_result) --> (eval_dataset_name, run_id, model_id)
+        into map `_pred_result_id_mapping`
         """
-        value = (eval_dataset_name, run_id)
+        value = (eval_dataset_name, run_id, model_id)
         prediction_result_id = id(predict_result)
-        self._pred_result_id_to_dataset_name_and_run_id[prediction_result_id] = value
+        self._pred_result_id_mapping[prediction_result_id] = value
 
         def clean_id(id_):
-            _AUTOLOGGING_METRICS_MANAGER._pred_result_id_to_dataset_name_and_run_id.pop(id_, None)
+            _AUTOLOGGING_METRICS_MANAGER._pred_result_id_mapping.pop(id_, None)
 
         # When the `predict_result` object being GCed, its ID may be reused, so register a finalizer
         # to clear the ID from the dict for preventing wrong ID mapping.
         weakref.finalize(predict_result, clean_id, prediction_result_id)
 
-    def get_run_id_and_dataset_name_for_evaluator_call(self, pred_result_dataset):
+    def get_info_for_metric_api_call(self, pred_result_dataset):
         """
         Given a registered prediction result dataset object,
-        return a tuple of (run_id, eval_dataset_name)
+        return a tuple of (run_id, eval_dataset_name, model_id)
         """
-        if id(pred_result_dataset) in self._pred_result_id_to_dataset_name_and_run_id:
-            dataset_name, run_id = self._pred_result_id_to_dataset_name_and_run_id[
-                id(pred_result_dataset)
-            ]
-            return run_id, dataset_name
+        if id(pred_result_dataset) in self._pred_result_id_mapping:
+            dataset_name, run_id, model_id = self._pred_result_id_mapping[id(pred_result_dataset)]
+            return run_id, dataset_name, model_id
         else:
-            return None, None
+            return None, None, None
 
     def gen_evaluator_info(self, evaluator):
         """
@@ -727,7 +758,7 @@ class _AutologgingMetricsManager:
         self._metric_info_artifact_need_update[run_id] = True
         return metric_key
 
-    def log_post_training_metric(self, run_id, key, value):
+    def log_post_training_metric(self, run_id, key, value, model_id=None):
         """
         Log the metric into the specified mlflow run.
         and it will also update the metric_info artifact if needed.
@@ -735,7 +766,7 @@ class _AutologgingMetricsManager:
         # Note: if the case log the same metric key multiple times,
         #  newer value will overwrite old value
         client = MlflowClient()
-        client.log_metric(run_id=run_id, key=key, value=value)
+        client.log_metric(run_id=run_id, key=key, value=value, model_id=model_id)
         if self._metric_info_artifact_need_update[run_id]:
             evaluator_call_list = []
             for v in self._evaluator_call_info[run_id].values():
@@ -1031,49 +1062,9 @@ def autolog(
                     "Failed to log training dataset information to MLflow Tracking. Reason: %s", e
                 )
 
-    def _log_posttraining_metadata(estimator, spark_model, params, input_df):
-        if _is_parameter_search_estimator(estimator):
-            try:
-                # Fetch environment-specific tags (e.g., user and source) to ensure that lineage
-                # information is consistent with the parent run
-                child_tags = context_registry.resolve_tags()
-                child_tags.update({MLFLOW_AUTOLOGGING: AUTOLOGGING_INTEGRATION_NAME})
-                _create_child_runs_for_parameter_search(
-                    parent_estimator=estimator,
-                    parent_model=spark_model,
-                    parent_run=mlflow.active_run(),
-                    child_tags=child_tags,
-                )
-            except Exception:
-                msg = (
-                    "Encountered exception during creation of child runs for parameter search."
-                    f" Child runs may be missing. Exception: {traceback.format_exc()}"
-                )
-                _logger.warning(msg)
-
-            estimator_param_maps = _get_tuning_param_maps(
-                estimator, estimator._autologging_metadata.uid_to_indexed_name_map
-            )
-
-            metrics_dict, best_index = _get_param_search_metrics_and_best_index(
-                estimator, spark_model
-            )
-            _log_parameter_search_results_as_artifact(
-                estimator_param_maps, metrics_dict, mlflow.active_run().info.run_id
-            )
-
-            # Log best_param_map as JSON artifact
-            best_param_map = estimator_param_maps[best_index]
-            mlflow.log_dict(best_param_map, artifact_file="best_parameters.json")
-
-            # Log best_param_map as autologging parameters as well
-            _log_estimator_params(
-                {
-                    f"best_{param_name}": param_value
-                    for param_name, param_value in best_param_map.items()
-                }
-            )
-
+    def _log_posttraining_metadata(estimator, spark_model, params, input_df) -> Optional[str]:
+        spark_model_id = None
+        best_model_id = None
         if log_models:
             if _should_log_model(spark_model):
                 from mlflow.pyspark.ml._autolog import (
@@ -1120,20 +1111,63 @@ def autolog(
                     ).toPandas()
                 else:
                     input_example = None
-                mlflow.spark.log_model(
+                spark_model_id = mlflow.spark.log_model(
                     spark_model,
                     "model",
                     registered_model_name=registered_model_name,
                     input_example=input_example,
                     signature=signature,
-                )
+                ).model_id
                 if _is_parameter_search_model(spark_model):
-                    mlflow.spark.log_model(
+                    best_model_id = mlflow.spark.log_model(
                         spark_model.bestModel,
                         "best_model",
-                    )
+                    ).model_id
             else:
                 _logger.warning(_get_warning_msg_for_skip_log_model(spark_model))
+        if _is_parameter_search_estimator(estimator):
+            estimator_param_maps = _get_tuning_param_maps(
+                estimator, estimator._autologging_metadata.uid_to_indexed_name_map
+            )
+
+            metrics_dict, best_index = _get_param_search_metrics_and_best_index(
+                estimator, spark_model
+            )
+            _log_parameter_search_results_as_artifact(
+                estimator_param_maps, metrics_dict, mlflow.active_run().info.run_id
+            )
+
+            # Log best_param_map as JSON artifact
+            best_param_map = estimator_param_maps[best_index]
+            mlflow.log_dict(best_param_map, artifact_file="best_parameters.json")
+
+            # Log best_param_map as autologging parameters as well
+            _log_estimator_params(
+                {
+                    f"best_{param_name}": param_value
+                    for param_name, param_value in best_param_map.items()
+                }
+            )
+            try:
+                # Fetch environment-specific tags (e.g., user and source) to ensure that lineage
+                # information is consistent with the parent run
+                child_tags = context_registry.resolve_tags()
+                child_tags.update({MLFLOW_AUTOLOGGING: AUTOLOGGING_INTEGRATION_NAME})
+                _create_child_runs_for_parameter_search(
+                    parent_estimator=estimator,
+                    parent_model=spark_model,
+                    parent_run=mlflow.active_run(),
+                    child_tags=child_tags,
+                    best_model_id=best_model_id,
+                    best_model_params=best_param_map,
+                )
+            except Exception:
+                msg = (
+                    "Encountered exception during creation of child runs for parameter search."
+                    f" Child runs may be missing. Exception: {traceback.format_exc()}"
+                )
+                _logger.warning(msg)
+        return spark_model_id
 
     def fit_mlflow(original, self, *args, **kwargs):
         params = get_method_call_arg_value(1, "params", None, args, kwargs)
@@ -1156,9 +1190,12 @@ def autolog(
             input_training_df = args[0].persist(StorageLevel.MEMORY_AND_DISK)
             _log_pretraining_metadata(estimator, params, input_training_df)
             spark_model = original(self, *args, **kwargs)
-            _log_posttraining_metadata(estimator, spark_model, params, input_training_df)
+            spark_model_id = _log_posttraining_metadata(
+                estimator, spark_model, params, input_training_df
+            )
             input_training_df.unpersist()
 
+            _AUTOLOGGING_METRICS_MANAGER.record_model_id(spark_model, spark_model_id)
             return spark_model
 
     def patched_fit(original, self, *args, **kwargs):
@@ -1188,7 +1225,10 @@ def autolog(
                 self, eval_dataset
             )
             _AUTOLOGGING_METRICS_MANAGER.register_prediction_result(
-                run_id, eval_dataset_name, predict_result
+                run_id,
+                eval_dataset_name,
+                predict_result,
+                model_id=_AUTOLOGGING_METRICS_MANAGER.get_model_id_for_model(self),
             )
             return predict_result
         else:
@@ -1208,18 +1248,15 @@ def autolog(
                 evaluator_info = _AUTOLOGGING_METRICS_MANAGER.gen_evaluator_info(evaluator)
 
                 pred_result_dataset = get_method_call_arg_value(0, "dataset", None, args, kwargs)
-                (
-                    run_id,
-                    dataset_name,
-                ) = _AUTOLOGGING_METRICS_MANAGER.get_run_id_and_dataset_name_for_evaluator_call(
-                    pred_result_dataset
+                (run_id, dataset_name, model_id) = (
+                    _AUTOLOGGING_METRICS_MANAGER.get_info_for_metric_api_call(pred_result_dataset)
                 )
                 if run_id and dataset_name:
                     metric_key = _AUTOLOGGING_METRICS_MANAGER.register_evaluator_call(
                         run_id, metric_name, dataset_name, evaluator_info
                     )
                     _AUTOLOGGING_METRICS_MANAGER.log_post_training_metric(
-                        run_id, metric_key, metric
+                        run_id, metric_key, metric, model_id=model_id
                     )
                     if log_datasets:
                         try:

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -591,12 +591,14 @@ class _AutologgingMetricsManager:
     """
 
     def __init__(self):
-        self._pred_result_id_mapping = {}
+        # record mapping of id(prediction_result) -> (eval_dataset_name, run_id, model_id)
+        self._pred_result_id_mapping: dict[int, tuple[str, str, str]] = {}
+        # record mapping of id(model) -> model_id
+        self._model_id_mapping: dict[int, str] = {}
         self._eval_dataset_info_map = defaultdict(lambda: defaultdict(list))
         self._evaluator_call_info = defaultdict(lambda: defaultdict(list))
         self._log_post_training_metrics_enabled = True
         self._metric_info_artifact_need_update = defaultdict(lambda: False)
-        self._model_id_mapping = {}
 
     def should_log_post_training_metrics(self):
         """
@@ -722,8 +724,8 @@ class _AutologgingMetricsManager:
         Given a registered prediction result dataset object,
         return a tuple of (run_id, eval_dataset_name, model_id)
         """
-        if id(pred_result_dataset) in self._pred_result_id_mapping:
-            dataset_name, run_id, model_id = self._pred_result_id_mapping[id(pred_result_dataset)]
+        if (pred_result_dataset_id := id(pred_result_dataset)) in self._pred_result_id_mapping:
+            dataset_name, run_id, model_id = self._pred_result_id_mapping[pred_result_dataset_id]
             return run_id, dataset_name, model_id
         else:
             return None, None, None

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -825,6 +825,6 @@ def get_logged_model_by_name(name: str) -> Optional[LoggedModel]:
         The logged model.
     """
     logged_models = mlflow.search_logged_models(
-        filter_string=f"name='{name}'", output_format="list"
+        filter_string=f"name='{name}'", output_format="list", max_results=1
     )
     return logged_models[0] if len(logged_models) >= 1 else None

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from contextlib import ExitStack, contextmanager
 from functools import wraps
-from typing import Iterator
+from typing import Iterator, Optional
 from unittest import mock
 
 import pytest
@@ -21,6 +21,7 @@ import requests
 import yaml
 
 import mlflow
+from mlflow.entities.logged_model import LoggedModel
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import (
@@ -810,3 +811,20 @@ def skip_if_hf_hub_unhealthy():
             "See https://status.huggingface.co/ for more information."
         ),
     )
+
+
+def get_logged_model_by_name(name: str) -> Optional[LoggedModel]:
+    """
+    Get a logged model by name. If multiple logged models with
+    the same name exist, get the latest one.
+
+    Args:
+        name: The name of the logged model.
+
+    Returns:
+        The logged model.
+    """
+    logged_models = mlflow.search_logged_models(
+        filter_string=f"name='{name}'", output_format="list"
+    )
+    return logged_models[0] if len(logged_models) >= 1 else None

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -60,6 +60,7 @@ from mlflow.utils.validation import (
     MAX_PARAM_VAL_LENGTH,
 )
 
+from tests.helper_functions import get_logged_model_by_name
 from tests.utils.test_file_utils import spark_session  # noqa: F401
 
 MODEL_DIR = "model"
@@ -589,6 +590,7 @@ def test_param_search_estimator(
     )
     assert len(child_runs) == len(search_results)
 
+    best_model_run_metrics = None
     for row_index, row in search_results.iterrows():
         row_params = json.loads(row.get("params", "{}"))
         for param_name, param_value in row_params.items():
@@ -606,6 +608,8 @@ def test_param_search_estimator(
         child_run = child_runs[0]
         assert child_run.info.status == RunStatus.to_string(RunStatus.FINISHED)
         run_data = get_run_data(child_run.info.run_id)
+        if row_params == best_params:
+            best_model_run_metrics = run_data.metrics
         child_estimator = estimator.getEstimator().copy(
             estimator.getEstimatorParamMaps()[row_index]
         )
@@ -636,6 +640,10 @@ def test_param_search_estimator(
             std_metric_value = model.stdMetrics[row_index]
             assert math.isclose(std_metric_value, run_data.metrics[std_metric_name], rel_tol=1e-6)
             assert math.isclose(std_metric_value, float(row.get(std_metric_name)), rel_tol=1e-6)
+
+    assert best_model_run_metrics is not None
+    best_logged_model = get_logged_model_by_name("best_model")
+    assert best_model_run_metrics == {m.key: m.value for m in best_logged_model.metrics}
 
 
 def test_get_params_to_log(spark_session):
@@ -883,6 +891,10 @@ def test_basic_post_training_metric_autologging(dataset_iris_binomial):
     area_under_roc_original = bce.evaluate(pred_result)
     assert np.isclose(area_under_roc, area_under_roc_original)
 
+    logged_model = get_logged_model_by_name("model")
+    assert logged_model is not None
+    assert run_data.metrics == {m.key: m.value for m in logged_model.metrics}
+
 
 def test_multi_model_interleaved_fit_and_post_train_metric_call(dataset_iris_binomial):
     mlflow.pyspark.ml.autolog()
@@ -905,11 +917,20 @@ def test_multi_model_interleaved_fit_and_post_train_metric_call(dataset_iris_bin
     logloss1 = mce.evaluate(pred1_result)
     logloss2 = mce.evaluate(pred2_result)
 
+    logged_models = mlflow.search_logged_models(filter_string="name='model'", output_format="list")
+    assert len(logged_models) == 2
+    logged_model1 = logged_models[1]
+    logged_model2 = logged_models[0]
+
     metrics1 = get_run_data(run1.info.run_id).metrics
     assert np.isclose(logloss1, metrics1["logLoss_eval_dataset1"])
+    assert logged_model1 is not None
+    assert metrics1 == {m.key: m.value for m in logged_model1.metrics}
 
     metrics2 = get_run_data(run2.info.run_id).metrics
     assert np.isclose(logloss2, metrics2["logLoss_eval_dataset2"])
+    assert logged_model2 is not None
+    assert metrics2 == {m.key: m.value for m in logged_model2.metrics}
 
 
 def test_meta_estimator_disable_post_training_autologging(dataset_regression):

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -919,8 +919,7 @@ def test_multi_model_interleaved_fit_and_post_train_metric_call(dataset_iris_bin
 
     logged_models = mlflow.search_logged_models(filter_string="name='model'", output_format="list")
     assert len(logged_models) == 2
-    logged_model1 = logged_models[1]
-    logged_model2 = logged_models[0]
+    logged_model2, logged_model1 = logged_models
 
     metrics1 = get_run_data(run1.info.run_id).metrics
     assert np.isclose(logloss1, metrics1["logLoss_eval_dataset1"])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15475?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15475/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15475/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15475
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Link metrics during pyspark autologging.
1. patched_fit: link metrics when _log_posttraining_metadata --> we log the best metrics to the best model for parameter search estimators
2. patched_evaluate: log evaluate metrics to the original logged model

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
