### PR TITLE
[FR] API support to list all registered prompts in mlflow by alias #1…

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -203,6 +203,7 @@ from mlflow.tracking._model_registry.fluent import (
     search_model_versions,
     search_registered_models,
     set_prompt_alias,
+    list_prompts,
 )
 from mlflow.tracking.fluent import (
     ActiveRun,
@@ -334,6 +335,7 @@ __all__ = [
     "register_prompt",
     "set_prompt_alias",
     "delete_prompt_alias",
+    "list_prompts",
 ]
 
 

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, List
 
 from mlflow.entities.model_registry import ModelVersion, Prompt, RegisteredModel
 from mlflow.exceptions import MlflowException
@@ -471,6 +471,57 @@ def load_prompt(
 
     return prompt
 
+@experimental
+@require_prompt_registry
+def list_prompts(alias: Optional[str] = None, max_results: Optional[int] = 1000) -> List[Prompt]:
+    """
+    List prompts in the MLflow Prompt Registry.
+    
+    This function retrieves prompts from the MLflow Prompt Registry. By default, it returns
+    the latest version of each registered prompt. If an alias is specified, it returns only
+    prompts that have the given alias.
+    
+    Args:
+        alias: If provided, returns only prompts with this alias. If None, returns the
+              latest version of each prompt.
+        max_results: Maximum number of prompts to return. Must be a positive integer.
+                    Default is 1000.
+        
+    Returns:
+        A list of :py:class:`Prompt <mlflow.entities.Prompt>` objects.
+        
+    Raises:
+        MlflowException: If max_results is not a positive integer.
+        
+    .. note::
+        This API is experimental and may change in future versions.
+        
+    Example:
+    
+    .. code-block:: python
+    
+        import mlflow
+        
+        # List all prompts (latest versions)
+        prompts = mlflow.list_prompts()
+        
+        # List prompts with specific alias
+        production_prompts = mlflow.list_prompts(alias="production")
+        
+        # List with limited results
+        limited_prompts = mlflow.list_prompts(max_results=10)
+        
+        # Iterate through prompts
+        for prompt in prompts:
+            print(f"Name: {prompt.name}")
+            print(f"Version: {prompt.version}")
+            print(f"Template: {prompt.template}")
+            print("-----")
+            
+        # Sort prompts by name
+        sorted_prompts = sorted(prompts, key=lambda p: p.name)
+    """
+    return MlflowClient().list_prompts(alias=alias, max_results=max_results)
 
 @experimental
 @require_prompt_registry
@@ -483,7 +534,6 @@ def delete_prompt(name: str, version: int) -> Prompt:
         version: The version of the prompt to delete.
     """
     return MlflowClient().delete_prompt(name=name, version=version)
-
 
 @experimental
 @require_prompt_registry


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/iRahulPandey/mlflow/pull/15478?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15478/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15478/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15478
```

</p>
</details>

…5439

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Implemented a new function called **list_prompts** that allows users to list prompts from the MLflow Prompt Registry. The implementation:

1. **Client API:** Added a list_prompts method to tracking/client.py
2. Fluent API: Added a corresponding list_prompts function in the fluent API  that delegates to the client implementation, making it easier to use.
3. Filter Capabilities: By default, returns the latest version of each registered prompt. User can filter prompts by alias (e.g., "production", "staging") and limit the number of results with max_results. Note: Edge Case Handling: Properly validates inputs like max_results, requiring it to be a positive integer.

Unit test overview: test_list_prompts  that tests the following:

1. Basic listing of latest prompt versions
2. Filtering by different aliases (production, staging, dev)
3. Handling of nonexistent aliases
4. Pagination with different max_results values
5. Fluent API consistency with client API
6. Behavior after deleting prompt versions
7. Alias behavior after deleting a version it pointed to


### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

Verified local behavior using the Python client also. Attached is the test result of unit test

<img width="1461" alt="Screenshot 2025-04-24 at 10 00 09" src="https://github.com/user-attachments/assets/551680d0-0a35-45fc-8f0b-de5187f9ddd7" />

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduces a new list prompt API (list_prompts) that allows users to list all prompts and the possibility to list all prompts by alias from the MLflow Prompt Registry. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. 

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
