### PR TITLE
Fix trace table styles

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/HomePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/HomePage.tsx
@@ -73,7 +73,7 @@ const HomePage = () => {
         {shouldRenderTabbedView && <ExperimentPageTabs />}
         {!shouldRenderTabbedView && (
           // Main content with the experiment view
-          <div css={{ height: '100%', flex: 1, padding: theme.spacing.md, paddingTop: theme.spacing.lg }}>
+          <div css={{ height: '100%', flex: 1, padding: theme.spacing.md, paddingTop: theme.spacing.lg, minWidth: 0 }}>
             <GetExperimentsContextProvider actions={getExperimentActions}>
               {hasExperiments ? <ExperimentView /> : <NoExperimentView />}
             </GetExperimentsContextProvider>

--- a/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
@@ -117,7 +117,7 @@ const ExpandedParamCell = ({ value }: { value: string }) => {
       }}
     >
       <CodeSnippet
-        language={structuredJSONValue ? "json" : "text"}
+        language={structuredJSONValue ? 'json' : 'text'}
         wrapLongLines
         style={{
           padding: theme.spacing.sm,

--- a/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
@@ -34,10 +34,9 @@ const TracesViewTablePreviewCell = ({
   const fetchFullData = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await MlflowService.getExperimentTraceData<{
-        request?: any;
-        response?: any;
-      }>(traceId);
+      const response = await MlflowService.getExperimentTraceInfo(traceId);
+
+      console.log('@@@ response', response);
 
       if (previewFieldName in response) {
         const previewValue = response[previewFieldName];
@@ -117,7 +116,7 @@ const ExpandedParamCell = ({ value }: { value: string }) => {
       }}
     >
       <CodeSnippet
-        language={structuredJSONValue ? "json" : "text"}
+        language={structuredJSONValue ? 'json' : 'text'}
         wrapLongLines
         style={{
           padding: theme.spacing.sm,

--- a/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
@@ -117,7 +117,7 @@ const ExpandedParamCell = ({ value }: { value: string }) => {
       }}
     >
       <CodeSnippet
-        language="json"
+        language={structuredJSONValue ? "json" : "text"}
         wrapLongLines
         style={{
           padding: theme.spacing.sm,

--- a/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
@@ -34,9 +34,10 @@ const TracesViewTablePreviewCell = ({
   const fetchFullData = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await MlflowService.getExperimentTraceInfo(traceId);
-
-      console.log('@@@ response', response);
+      const response = await MlflowService.getExperimentTraceData<{
+        request?: any;
+        response?: any;
+      }>(traceId);
 
       if (previewFieldName in response) {
         const previewValue = response[previewFieldName];
@@ -116,7 +117,7 @@ const ExpandedParamCell = ({ value }: { value: string }) => {
       }}
     >
       <CodeSnippet
-        language={structuredJSONValue ? 'json' : 'text'}
+        language={structuredJSONValue ? "json" : "text"}
         wrapLongLines
         style={{
           padding: theme.spacing.sm,

--- a/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
@@ -107,6 +107,7 @@ const ExpandedParamCell = ({ value }: { value: string }) => {
       return null;
     }
   }, [value]);
+
   return (
     <div
       css={{
@@ -120,6 +121,7 @@ const ExpandedParamCell = ({ value }: { value: string }) => {
         wrapLongLines
         style={{
           padding: theme.spacing.sm,
+          whiteSpace: 'pre-wrap',
         }}
         theme={theme.isDarkMode ? 'duotoneDark' : 'light'}
       >


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/15492?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15492/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15492/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15492
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix:

1. table overflowing max width
2. expanded request/response not wrapping

https://github.com/user-attachments/assets/66462e4c-d462-4e25-b000-d613a6174b90


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/user-attachments/assets/c6e33e8f-2cf2-4bcd-a8b4-7a9d464bd4a0


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
