### PR TITLE
Remove `verbose` argument of `ReduceLROnPlateau`

### DIFF
--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -354,7 +354,6 @@ class BertNewsClassifier(L.LightningModule):
                 factor=0.2,
                 patience=2,
                 min_lr=1e-6,
-                verbose=True,
             ),
             "monitor": "val_loss",
         }

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -222,7 +222,6 @@ class LightningMNISTClassifier(L.LightningModule):
                 factor=0.2,
                 patience=2,
                 min_lr=1e-6,
-                verbose=True,
             ),
             "monitor": "val_loss",
         }

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -228,7 +228,6 @@ class LightningMNISTClassifier(L.LightningModule):
                 factor=0.2,
                 patience=2,
                 min_lr=1e-6,
-                verbose=True,
             ),
             "monitor": "val_loss",
         }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15499?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15499/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15499/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15499
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

In pytorch 2.7.0, `ReduceLROnPlateau` no longer has a `verbose` argument. It's removed. I'm fixing this issue as a prep for mlflow-3 branch merge.

https://github.com/mlflow/mlflow/actions/runs/14657424259/job/41134860061?pr=13211

```
  File "/home/runner/.mlflow/envs/mlflow-168faf96ed9c0908b24153e2478323a4fbb37b9c/lib/python3.9/site-packages/lightning/pytorch/strategies/strategy.py", line 148, in setup
    self.setup_optimizers(trainer)
  File "/home/runner/.mlflow/envs/mlflow-168faf96ed9c0908b24153e2478323a4fbb37b9c/lib/python3.9/site-packages/lightning/pytorch/strategies/strategy.py", line 138, in setup_optimizers
    self.optimizers, self.lr_scheduler_configs = _init_optimizers_and_lr_schedulers(self.lightning_module)
  File "/home/runner/.mlflow/envs/mlflow-168faf96ed9c0908b24153e2478323a4fbb37b9c/lib/python3.9/site-packages/lightning/pytorch/core/optimizer.py", line 171, in _init_optimizers_and_lr_schedulers
    optim_conf = call._call_lightning_module_hook(model.trainer, "configure_optimizers", pl_module=model)
  File "/home/runner/.mlflow/envs/mlflow-168faf96ed9c0908b24153e2478323a4fbb37b9c/lib/python3.9/site-packages/lightning/pytorch/trainer/call.py", line 142, in _call_lightning_module_hook
    output = fn(*args, **kwargs)
  File "/tmp/pytest-of-runner/pytest-0/test_mlflow_run_example_pytorc0/544e1de8-8b9d-4ac3-b3e9-8375c197c5cb/examples/pytorch/MNIST/mnist_autolog_example.py", line 225, in configure_optimizers
    "scheduler": torch.optim.lr_scheduler.ReduceLROnPlateau(
TypeError: __init__() got an unexpected keyword argument 'verbose'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
