### PR TITLE
Fix typo: "instumentation" -> "instrumentation" (#15488)

### DIFF
--- a/docs/docs/tracing/tracing-schema.mdx
+++ b/docs/docs/tracing/tracing-schema.mdx
@@ -384,7 +384,7 @@ The sections below provide a detailed view of the structure of a span.
       <td>
         It is recommended to provide a name for your span that is unique and
         relevant to the functionality that is being executed when using manual
-        instumentation via the client or fluent APIs. Generic names for spans or
+        instrumentation via the client or fluent APIs. Generic names for spans or
         confusing names can make it difficult to diagnose issues when reviewing
         traces.
       </td>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,6 +299,7 @@ gam = "gam"          # generalized additive models
 ser = "ser"          # serialization
 yhat = "yhat"        # ŷ
 iternal = "internal" # typo of "internal"
+instumentation = "instrumentation" # typo of "instrumentation"
 
 # https://github.com/crate-ci/typos/blob/master/docs/reference.md
 [tool.typos.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,13 +292,13 @@ typing-extensions-allowlist = [
 
 # typos
 [tool.typos.default.extend-words]
-als = "als"          # alternating least squares
-mape = "mape"        # mean absolute percentage error
-fpr = "fpr"          # false positive rate
-gam = "gam"          # generalized additive models
-ser = "ser"          # serialization
-yhat = "yhat"        # ŷ
-iternal = "internal" # typo of "internal"
+als = "als"                        # alternating least squares
+mape = "mape"                      # mean absolute percentage error
+fpr = "fpr"                        # false positive rate
+gam = "gam"                        # generalized additive models
+ser = "ser"                        # serialization
+yhat = "yhat"                      # ŷ
+iternal = "internal"               # typo of "internal"
 instumentation = "instrumentation" # typo of "instrumentation"
 
 # https://github.com/crate-ci/typos/blob/master/docs/reference.md


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/vzamboulingame/mlflow/pull/15507?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15507/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15507/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15507
```

</p>
</details>


### Related Issues/PRs

Resolve #15488 

### What changes are proposed in this pull request?

- Corrected the typo "instumentation" to "instrumentation" in "tracing-schema.mdx".
- Added a reference to the typo fix in "pyproject.toml".

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
