### PR TITLE
Avoid pip 25.1

### DIFF
--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -44,7 +44,7 @@ sudo apt clean
 df -h
 
 python --version
-pip install --upgrade pip setuptools wheel
+pip install --upgrade pip!=25.1 setuptools wheel
 pip --version
 
 if [[ "$SKINNY" == "true" ]]; then


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15521?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15521/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15521/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15521
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

For some reason, the latest version of pip installs a very old `datasets` version.

https://github.com/mlflow/mlflow/actions/runs/14698031973/job/41242611435?pr=15519

```
Collecting datasets (from -r requirements/extra-ml-requirements.txt (line 47))
  Downloading datasets-3.4.1-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.4.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.3.2-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.3.1-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.3.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.2.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-3.1.0-py3-none-any.whl.metadata (20 kB)
INFO: pip is still looking at multiple versions of datasets to determine which version is compatible with other requirements. This could take a while.
  Downloading datasets-3.0.2-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-3.0.1-py3-none-any.whl.metadata (20 kB)
Collecting multiprocess (from datasets->-r requirements/extra-ml-requirements.txt (line 47))
  Downloading multiprocess-0.70.18-py39-none-any.whl.metadata (7.5 kB)
Collecting datasets (from -r requirements/extra-ml-requirements.txt (line 47))
  Downloading datasets-3.0.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.21.0-py3-none-any.whl.metadata (21 kB)
  Downloading datasets-2.20.0-py3-none-any.whl.metadata (19 kB)
Collecting pyarrow-hotfix (from datasets->-r requirements/extra-ml-requirements.txt (line 47))
  Downloading pyarrow_hotfix-0.7-py3-none-any.whl.metadata (3.6 kB)
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
Collecting datasets (from -r requirements/extra-ml-requirements.txt (line 47))
  Downloading datasets-2.19.2-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.19.1-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.19.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.18.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.17.1-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.17.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.16.1-py3-none-any.whl.metadata (20 kB)
Collecting dill<0.3.8,>=0.3.0 (from datasets->-r requirements/extra-ml-requirements.txt (line 47))
  Downloading dill-0.3.7-py3-none-any.whl.metadata (9.9 kB)
Collecting datasets (from -r requirements/extra-ml-requirements.txt (line 47))
  Downloading datasets-2.16.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.15.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.14.7-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.14.6-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.14.5-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.14.4-py3-none-any.whl.metadata (19 kB)
```

Changelog: https://pip.pypa.io/en/stable/news/#v25-1

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
