### PR TITLE
Support DSPy tracing in lightweight SDK

### DIFF
--- a/mlflow/dspy/__init__.py
+++ b/mlflow/dspy/__init__.py
@@ -1,18 +1,24 @@
 from mlflow.dspy.autolog import autolog
-from mlflow.dspy.load import _load_pyfunc, load_model
-from mlflow.dspy.save import (
-    get_default_conda_env,
-    get_default_pip_requirements,
-    log_model,
-    save_model,
-)
+from mlflow.version import IS_TRACING_SDK_ONLY
 
-__all__ = [
-    "autolog",
-    "get_default_conda_env",
-    "get_default_pip_requirements",
-    "save_model",
-    "log_model",
-    "load_model",
-    "_load_pyfunc",
-]
+__all__ = ["autolog"]
+
+# Import model logging APIs only if mlflow-skinny is installed,
+# i.e., skip if only mlflow-trace package is installed.
+if not IS_TRACING_SDK_ONLY:
+    from mlflow.dspy.load import _load_pyfunc, load_model
+    from mlflow.dspy.save import (
+        get_default_conda_env,
+        get_default_pip_requirements,
+        log_model,
+        save_model,
+    )
+
+    __all__ += [
+        "get_default_conda_env",
+        "get_default_pip_requirements",
+        "save_model",
+        "log_model",
+        "load_model",
+        "_load_pyfunc",
+    ]

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -3,7 +3,7 @@ import importlib
 from packaging.version import Version
 
 import mlflow
-from mlflow.dspy.save import FLAVOR_NAME
+from mlflow.dspy.constant import FLAVOR_NAME
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracing.utils import construct_full_inputs
 from mlflow.utils.annotations import experimental

--- a/mlflow/dspy/constant.py
+++ b/mlflow/dspy/constant.py
@@ -1,0 +1,1 @@
+FLAVOR_NAME = "dspy"

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -9,6 +9,7 @@ import yaml
 
 import mlflow
 from mlflow import pyfunc
+from mlflow.dspy.constant import FLAVOR_NAME
 from mlflow.dspy.wrapper import DspyChatModelWrapper, DspyModelWrapper
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.exceptions import INVALID_PARAMETER_VALUE, MlflowException
@@ -45,8 +46,6 @@ from mlflow.utils.model_utils import (
     _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
-
-FLAVOR_NAME = "dspy"
 
 _MODEL_SAVE_PATH = "model"
 _MODEL_DATA_PATH = "data"

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -16,19 +16,35 @@ from dspy.utils.dummies import DummyLM
 from packaging.version import Version
 
 import mlflow
-from mlflow import set_active_model
 from mlflow.entities import SpanType
 from mlflow.entities.trace import Trace
-from mlflow.models.dependencies_schemas import DependenciesSchemasType, _clear_retriever_schema
 from mlflow.tracing.constant import SpanAttributeKey
-from mlflow.tracking import MlflowClient
+from mlflow.version import IS_TRACING_SDK_ONLY
 
-from tests.dspy.test_save import CoT
-from tests.tracing.helper import get_traces, score_in_model_serving
+from tests.tracing.helper import get_traces, score_in_model_serving, skip_when_testing_trace_sdk
+
+if not IS_TRACING_SDK_ONLY:
+    from mlflow.tracking import MlflowClient
+
 
 _DSPY_VERSION = Version(importlib.metadata.version("dspy"))
 
 _DSPY_UNDER_2_6 = _DSPY_VERSION < Version("2.6.0rc1")
+
+
+# Test module
+class CoT(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.prog = dspy.ChainOfThought("question -> answer")
+        mlflow.models.set_retriever_schema(
+            primary_key="id",
+            text_column="text",
+            doc_uri="source",
+        )
+
+    def forward(self, question):
+        return self.prog(question=question)
 
 
 def test_autolog_lm():
@@ -451,24 +467,14 @@ def test_disable_autolog():
     assert len(get_traces()) == 1
 
 
+@skip_when_testing_trace_sdk
 def test_autolog_set_retriever_schema():
+    from mlflow.models.dependencies_schemas import DependenciesSchemasType, _clear_retriever_schema
+
     mlflow.dspy.autolog()
     dspy.settings.configure(
         lm=DummyLM([{"answer": answer, "reasoning": "reason"} for answer in ["4", "6", "8", "10"]])
     )
-
-    class CoT(dspy.Module):
-        def __init__(self):
-            super().__init__()
-            self.prog = dspy.ChainOfThought("question -> answer")
-            mlflow.models.set_retriever_schema(
-                primary_key="id",
-                text_column="text",
-                doc_uri="source",
-            )
-
-        def forward(self, question):
-            return self.prog(question=question)
 
     with mlflow.start_run():
         model_info = mlflow.dspy.log_model(CoT(), "model")
@@ -493,8 +499,11 @@ def test_autolog_set_retriever_schema():
     ]
 
 
+@skip_when_testing_trace_sdk
 @pytest.mark.parametrize("with_dependencies_schema", [True, False])
 def test_dspy_auto_tracing_in_databricks_model_serving(with_dependencies_schema):
+    from mlflow.models.dependencies_schemas import DependenciesSchemasType
+
     mlflow.dspy.autolog()
 
     dspy.settings.configure(
@@ -555,6 +564,7 @@ def test_dspy_auto_tracing_in_databricks_model_serving(with_dependencies_schema)
         ]
 
 
+@skip_when_testing_trace_sdk
 @pytest.mark.parametrize("log_compiles", [True, False])
 def test_autolog_log_compile(log_compiles):
     class DummyOptimizer(dspy.teleprompt.Teleprompter):
@@ -583,6 +593,7 @@ def test_autolog_log_compile(log_compiles):
         assert mlflow.last_active_run() is None
 
 
+@skip_when_testing_trace_sdk
 def test_autolog_log_compile_disable():
     class DummyOptimizer(dspy.teleprompt.Teleprompter):
         def compile(self, program):
@@ -607,6 +618,7 @@ def test_autolog_log_compile_disable():
     assert len(runs) == 1
 
 
+@skip_when_testing_trace_sdk
 def test_autolog_log_nested_compile():
     class NestedOptimizer(dspy.teleprompt.Teleprompter):
         def compile(self, program):
@@ -651,6 +663,7 @@ skip_if_evaluate_callback_unavailable = pytest.mark.skipif(
 is_2_7_or_newer = Version(importlib.metadata.version("dspy")) >= Version("2.7.0")
 
 
+@skip_when_testing_trace_sdk
 @skip_if_evaluate_callback_unavailable
 @pytest.mark.parametrize("log_evals", [True, False])
 @pytest.mark.parametrize("return_outputs", [True, False])
@@ -746,6 +759,7 @@ def test_autolog_log_evals(
         assert run is None
 
 
+@skip_when_testing_trace_sdk
 @skip_if_evaluate_callback_unavailable
 def test_autolog_nested_evals():
     lm = DummyLM(
@@ -791,6 +805,7 @@ def test_autolog_nested_evals():
         assert "model.json" in artifacts
 
 
+@skip_when_testing_trace_sdk
 @skip_if_evaluate_callback_unavailable
 def test_autolog_log_compile_with_evals():
     class EvalOptimizer(dspy.teleprompt.Teleprompter):
@@ -863,6 +878,7 @@ def test_autolog_log_compile_with_evals():
         }
 
 
+@skip_when_testing_trace_sdk
 def test_autolog_link_traces_loaded_model_custom_module():
     mlflow.dspy.autolog()
     dspy.settings.configure(
@@ -886,6 +902,7 @@ def test_autolog_link_traces_loaded_model_custom_module():
         assert model_id == trace.info.request_metadata[SpanAttributeKey.MODEL_ID]
 
 
+@skip_when_testing_trace_sdk
 def test_autolog_link_traces_loaded_model_custom_module_pyfunc():
     mlflow.dspy.autolog()
     dspy.settings.configure(
@@ -909,9 +926,10 @@ def test_autolog_link_traces_loaded_model_custom_module_pyfunc():
         assert model_id == trace.info.request_metadata[SpanAttributeKey.MODEL_ID]
 
 
+@skip_when_testing_trace_sdk
 def test_autolog_link_traces_active_model():
     model = mlflow.create_external_model(name="test_model")
-    set_active_model(model_id=model.model_id)
+    mlflow.set_active_model(model_id=model.model_id)
     mlflow.dspy.autolog()
     dspy.settings.configure(
         lm=DummyLM([{"answer": "test output", "reasoning": "No more responses"}] * 5)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15530?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15530/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15530/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15530
```

</p>
</details>

### What changes are proposed in this pull request?

Make DSPy auto-tracing logic works with the lightweight tracing SDK, by adjusting the import logic.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
