### PR TITLE
Remove erroneous 's' from 'databricks-agents'

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -7,6 +7,7 @@ from mlflow.genai.evaluation.utils import (
     _convert_to_legacy_eval_set,
 )
 from mlflow.genai.scorers import BuiltInScorer, Scorer
+from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME
 from mlflow.genai.utils.trace_utils import is_model_traced
 from mlflow.models.evaluation.base import (
     _get_model_from_deployment_endpoint_uri,
@@ -102,7 +103,7 @@ def evaluate(
             )
 
     evaluation_config = {
-        "databricks-agents": {
+        GENAI_CONFIG_NAME: {
             "metrics": [],
         }
     }
@@ -123,7 +124,7 @@ def evaluate(
         data=_convert_to_legacy_eval_set(data),
         evaluator_config=evaluation_config,
         extra_metrics=extra_metrics,
-        model_type="databricks-agent",
+        model_type=GENAI_CONFIG_NAME,
     )
 
 

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -2,6 +2,8 @@ from copy import deepcopy
 
 from mlflow.genai.scorers import BuiltInScorer
 
+GENAI_CONFIG_NAME = "databricks-agent"
+
 
 class _BaseBuiltInScorer(BuiltInScorer):
     """
@@ -11,7 +13,7 @@ class _BaseBuiltInScorer(BuiltInScorer):
 
     def update_evaluation_config(self, evaluation_config) -> dict:
         config = deepcopy(evaluation_config)
-        metrics = config.setdefault("databricks-agents", {}).setdefault("metrics", [])
+        metrics = config.setdefault(GENAI_CONFIG_NAME, {}).setdefault("metrics", [])
         if self.name not in metrics:
             metrics.append(self.name)
         return config
@@ -59,7 +61,7 @@ class _GlobalGuidelineAdherence(_BaseBuiltInScorer):
 
     def update_evaluation_config(self, evaluation_config) -> dict:
         config = super().update_evaluation_config(evaluation_config)
-        config["databricks-agents"]["global_guideline"] = self.global_guideline
+        config[GENAI_CONFIG_NAME]["global_guideline"] = self.global_guideline
         return config
 
 

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 import pytest
 
+import mlflow.genai
 from mlflow.genai.scorers import (
     chunk_relevance,
     context_sufficiency,
@@ -32,6 +35,22 @@ ALL_SCORERS = [
     safety(),
 ]
 
+expected = {
+    GENAI_CONFIG_NAME: {
+        "metrics": [
+            "chunk_relevance",
+            "context_sufficiency",
+            "document_recall",
+            "global_guideline_adherence",
+            "groundedness",
+            "guideline_adherence",
+            "relevance_to_query",
+            "safety",
+        ],
+        "global_guideline": "Be polite",
+    }
+}
+
 
 @pytest.mark.parametrize(
     "scorers",
@@ -48,20 +67,27 @@ def test_scorers_and_rag_scorers_config(scorers):
     for scorer in scorers:
         evaluation_config = scorer.update_evaluation_config(evaluation_config)
 
-    expected = {
-        GENAI_CONFIG_NAME: {
-            "metrics": [
-                "chunk_relevance",
-                "context_sufficiency",
-                "document_recall",
-                "global_guideline_adherence",
-                "groundedness",
-                "guideline_adherence",
-                "relevance_to_query",
-                "safety",
-            ],
-            "global_guideline": "Be polite",
-        }
-    }
-
     assert normalize_config(evaluation_config) == normalize_config(expected)
+
+
+def test_evaluate_parameters():
+    data = []
+    with (
+        patch("mlflow.get_tracking_uri", return_value="databricks"),
+        patch("mlflow.genai.evaluation.base.is_model_traced", return_value=True),
+        patch("mlflow.genai.evaluation.base._convert_to_legacy_eval_set", return_value=data),
+        patch("mlflow.evaluate") as mock_evaluate,
+    ):
+        mlflow.genai.evaluate(
+            data=data,
+            scorers=ALL_SCORERS,
+        )
+
+        # Verify the call was made with the right parameters
+        mock_evaluate.assert_called_once_with(
+            model=None,
+            data=data,
+            evaluator_config=expected,
+            extra_metrics=[],
+            model_type=GENAI_CONFIG_NAME,
+        )

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -11,12 +11,13 @@ from mlflow.genai.scorers import (
     relevance_to_query,
     safety,
 )
+from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME
 
 
 def normalize_config(config):
     config = config.copy()
-    metrics = config.get("databricks-agents", {}).get("metrics", [])
-    config.setdefault("databricks-agents", {})["metrics"] = sorted(metrics)
+    metrics = config.get(GENAI_CONFIG_NAME, {}).get("metrics", [])
+    config.setdefault(GENAI_CONFIG_NAME, {})["metrics"] = sorted(metrics)
     return config
 
 
@@ -48,7 +49,7 @@ def test_scorers_and_rag_scorers_config(scorers):
         evaluation_config = scorer.update_evaluation_config(evaluation_config)
 
     expected = {
-        "databricks-agents": {
+        GENAI_CONFIG_NAME: {
             "metrics": [
                 "chunk_relevance",
                 "context_sufficiency",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/15540?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15540/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15540/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15540
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
