### PR TITLE
Add test to load trace from v2 dict

### DIFF
--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -305,3 +305,81 @@ def test_search_spans_raise_for_invalid_param_type():
 
     with pytest.raises(MlflowException, match="Invalid type for 'name'"):
         trace.search_spans(name=123)
+
+
+def test_from_v2_dict():
+    v2_dict = {
+        "info": {
+            "request_id": "58f4e27101304034b15c512b603bf1b2",
+            "experiment_id": "0",
+            "timestamp_ms": 100,
+            "execution_time_ms": 200,
+            "status": "OK",
+            "request_metadata": {
+                "mlflow.trace_schema.version": "2",
+                "mlflow.traceInputs": '{"x": 2, "y": 5}',
+                "mlflow.traceOutputs": "8",
+            },
+            "tags": {
+                "mlflow.source.name": "test",
+                "mlflow.source.type": "LOCAL",
+                "mlflow.traceName": "predict",
+                "mlflow.artifactLocation": "/path/to/artifact",
+            },
+            "assessments": [],
+        },
+        "data": {
+            "spans": [
+                {
+                    "name": "predict",
+                    "context": {
+                        "span_id": "0d48a6670588966b",
+                        "trace_id": "63076d0c1b90f1df0970f897dc428bd6",
+                    },
+                    "parent_id": None,
+                    "start_time": 100,
+                    "end_time": 200,
+                    "status_code": "OK",
+                    "status_message": "",
+                    "attributes": {
+                        "mlflow.traceRequestId": '"58f4e27101304034b15c512b603bf1b2"',
+                        "mlflow.spanType": '"UNKNOWN"',
+                        "mlflow.spanFunctionName": '"predict"',
+                        "mlflow.spanInputs": '{"x": 2, "y": 5}',
+                        "mlflow.spanOutputs": "8",
+                    },
+                    "events": [],
+                },
+                {
+                    "name": "add_one_with_custom_name",
+                    "context": {
+                        "span_id": "6fc32f36ef591f60",
+                        "trace_id": "63076d0c1b90f1df0970f897dc428bd6",
+                    },
+                    "parent_id": "0d48a6670588966b",
+                    "start_time": 300,
+                    "end_time": 400,
+                    "status_code": "OK",
+                    "status_message": "",
+                    "attributes": {
+                        "mlflow.traceRequestId": '"58f4e27101304034b15c512b603bf1b2"',
+                        "mlflow.spanType": '"LLM"',
+                        "delta": "1",
+                        "metadata": '{"foo": "bar"}',
+                        "datetime": '"2025-04-29 08:37:06.772253"',
+                        "mlflow.spanFunctionName": '"add_one"',
+                        "mlflow.spanInputs": '{"z": 7}',
+                        "mlflow.spanOutputs": "8",
+                    },
+                    "events": [],
+                },
+            ],
+            "request": '{"x": 2, "y": 5}',
+            "response": "8",
+        },
+    }
+    trace = Trace.from_dict(v2_dict)
+    assert trace.info.request_id == "58f4e27101304034b15c512b603bf1b2"
+    assert trace.info.request_time == 100
+    assert trace.info.execution_duration == 200
+    assert len(trace.data.spans) == 2


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15542?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15542/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15542/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15542
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Title

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
