### PR TITLE
Increase `multipart_upload_batch_url_count` for MPU

### DIFF
--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -30,6 +30,7 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
         from databricks.sdk.config import Config
 
         super().__init__(artifact_uri)
+        print(os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT"))  # noqa: T201
         self.wc = WorkspaceClient(
             config=(
                 Config(

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -30,7 +30,7 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
         from databricks.sdk.config import Config
 
         super().__init__(artifact_uri)
-        print(os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT"))  # noqa: T201
+        print("👉👉👉", os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT"))  # noqa: T201
         self.wc = WorkspaceClient(
             config=(
                 Config(

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -30,7 +30,6 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
         from databricks.sdk.config import Config
 
         super().__init__(artifact_uri)
-        print("👉👉👉", os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT"))  # noqa: T201
         wc = WorkspaceClient(
             config=(
                 Config(

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -34,6 +34,7 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
                 Config(
                     enable_experimental_files_api_client=True,
                     multipart_upload_chunk_size=MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
+                    multipart_upload_batch_url_count=16,
                 )
                 if _sdk_supports_large_file_uploads()
                 else None

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -44,10 +44,10 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
                 else None
             )
         )
-        wc._config.multipart_upload_batch_url_count = int(
+        wc.files._config.multipart_upload_batch_url_count = int(
             os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT", "1")
         )
-        wc._config.multipart_upload_chunk_size = MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
+        wc.files._config.multipart_upload_chunk_size = MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
         self.wc = wc
 
     @property

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import os
 import posixpath
 from concurrent.futures import Future
 from pathlib import Path
@@ -34,7 +35,9 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
                 Config(
                     enable_experimental_files_api_client=True,
                     multipart_upload_chunk_size=MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
-                    multipart_upload_batch_url_count=16,
+                    multipart_upload_batch_url_count=os.environ.get(
+                        "DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT"
+                    ),
                 )
                 if _sdk_supports_large_file_uploads()
                 else None

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -31,7 +31,7 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
 
         super().__init__(artifact_uri)
         print("👉👉👉", os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT"))  # noqa: T201
-        self.wc = WorkspaceClient(
+        wc = WorkspaceClient(
             config=(
                 Config(
                     enable_experimental_files_api_client=True,
@@ -44,6 +44,11 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
                 else None
             )
         )
+        wc._config.multipart_upload_batch_url_count = int(
+            os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT", "1")
+        )
+        wc._config.multipart_upload_chunk_size = MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
+        self.wc = wc
 
     @property
     def files_api(self) -> "FilesAPI":

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -35,10 +35,10 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
             config=(
                 Config(
                     enable_experimental_files_api_client=True,
-                    multipart_upload_chunk_size=MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
-                    multipart_upload_batch_url_count=int(
-                        os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT")
-                    ),
+                    # multipart_upload_chunk_size=MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
+                    # multipart_upload_batch_url_count=int(
+                    #     os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT")
+                    # ),
                 )
                 if _sdk_supports_large_file_uploads()
                 else None

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -35,8 +35,8 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
                 Config(
                     enable_experimental_files_api_client=True,
                     multipart_upload_chunk_size=MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
-                    multipart_upload_batch_url_count=os.environ.get(
-                        "DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT"
+                    multipart_upload_batch_url_count=int(
+                        os.environ.get("DATABRICKS_MULTIPART_UPLOAD_BATCH_URL_COUNT")
                     ),
                 )
                 if _sdk_supports_large_file_uploads()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15556?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15556/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15556/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15556
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

When databricks SDK uploads a large file, it first sends a request to generate pre-signed URLs for uploading chunks. `multipart_upload_batch_url_count` determines the number of URLs to generate. It's 1 by default, which is highly inefficient (but safer). This PR updates this value to 16.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
