### PR TITLE
Migrate `UCVolumesArtifactRepository` to use `DatabricksSdkArtifactRepository`

### DIFF
--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -82,7 +82,7 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
                 if artifact_path:
                     paths.append(artifact_path)
                 if f.parent != local_dir:
-                    paths.append(f.parent.relative_to(local_dir))
+                    paths.append(str(f.parent.relative_to(local_dir)))
 
                 fut = executor.submit(
                     self.log_artifact,

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -21,7 +21,6 @@ def _sdk_supports_large_file_uploads() -> bool:
 
 
 # TODO: The following artifact repositories should use this class. Migrate them.
-#   - uc_volume_artifact_repo.py
 #   - databricks_sdk_models_artifact_repo.py
 class DatabricksSdkArtifactRepository(ArtifactRepository):
     def __init__(self, artifact_uri: str) -> None:

--- a/mlflow/store/artifact/uc_volume_artifact_repo.py
+++ b/mlflow/store/artifact/uc_volume_artifact_repo.py
@@ -1,19 +1,9 @@
-import os
-import posixpath
-from pathlib import Path
-from typing import Optional
-
 import mlflow.utils.databricks_utils
-from mlflow.entities import FileInfo
 from mlflow.environment_variables import MLFLOW_ENABLE_UC_VOLUME_FUSE_ARTIFACT_REPO
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.store.artifact.artifact_repo import ArtifactRepository
+from mlflow.store.artifact.databricks_sdk_artifact_repo import DatabricksSdkArtifactRepository
 from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
-from mlflow.utils.databricks_utils import get_databricks_host_creds
-from mlflow.utils.file_utils import relative_path_to_artifact_path
-from mlflow.utils.request_utils import augmented_raise_for_status
-from mlflow.utils.rest_utils import http_request
 from mlflow.utils.uri import (
     get_databricks_profile_uri_from_artifact_uri,
     is_databricks_model_registry_artifacts_uri,
@@ -22,18 +12,13 @@ from mlflow.utils.uri import (
     strip_scheme,
 )
 
-# https://docs.databricks.com/api/workspace/files
-DIRECTORIES_API_ENDPOINT = "/api/2.0/fs/directories"
-FILES_API_ENDPOINT = "/api/2.0/fs/files"
-DOWNLOAD_CHUNK_SIZE = 1024
 
-
-class UCVolumesArtifactRepository(ArtifactRepository):
+class UCVolumesArtifactRepository(DatabricksSdkArtifactRepository):
     """
     Stores artifacts on UC Volumes using the Files REST API.
     """
 
-    def __init__(self, artifact_uri):
+    def __init__(self, artifact_uri: str) -> None:
         if not is_valid_uc_volumes_uri(artifact_uri):
             raise MlflowException(
                 message=(
@@ -42,156 +27,7 @@ class UCVolumesArtifactRepository(ArtifactRepository):
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             )
-
-        # The dbfs:/ path ultimately used for artifact operations should not contain the
-        # Databricks profile info, so strip it before setting `artifact_uri`.
-        super().__init__(remove_databricks_profile_info_from_artifact_uri(artifact_uri))
-
-        # Absolute path to the root of the volume. For example, '/Volumes/my-volume' for
-        # 'dbfs:/Volumes/my-volume'.
-        self.root_path = "/" + strip_scheme(self.artifact_uri).strip("/")
-        self.databricks_profile_uri = (
-            get_databricks_profile_uri_from_artifact_uri(artifact_uri)
-            or mlflow.tracking.get_tracking_uri()
-        )
-
-    def _relative_to_root(self, path):
-        return posixpath.relpath(path, self.root_path)
-
-    def _api_request(self, endpoint, method, **kwargs):
-        creds = get_databricks_host_creds(self.databricks_profile_uri)
-        return http_request(host_creds=creds, endpoint=endpoint, method=method, **kwargs)
-
-    def _list_directory_contents(self, directory_path: str, page_token: Optional[str] = None):  # noqa: D417
-        """
-        Lists the contents of a directory.
-
-        Args:
-            directory_path: The absolute path of a directory.
-
-        Returns:
-            The response from the API.
-
-        See also:
-            https://docs.databricks.com/api/workspace/files/listdirectorycontents
-        """
-        endpoint = f"{DIRECTORIES_API_ENDPOINT}{directory_path}"
-        return self._api_request(
-            endpoint=endpoint,
-            method="GET",
-            params={"page_token": page_token} if page_token else None,
-        )
-
-    def _paginated_list_directory_contents(
-        self, directory_path: str, page_token: Optional[str] = None
-    ):
-        response = self._list_directory_contents(directory_path, page_token)
-        if response.status_code == 404:
-            return []
-
-        augmented_raise_for_status(response)
-
-        response_json = response.json()
-        contents = response_json.get("contents", [])
-        if next_page_token := response_json.get("next_page_token"):
-            next_contents = self._paginated_list_directory_contents(directory_path, next_page_token)
-            return contents + next_contents
-        return contents
-
-    def _download(self, output_path: str, file_path: str):
-        """
-        Downloads a file.
-
-        Args:
-            output_path: The local path to save the downloaded file.
-            file_path: The absolute path of the file to download.
-
-        Returns:
-            The response from the API.
-
-        See also:
-            https://docs.databricks.com/api/workspace/files/download
-        """
-        endpoint = f"{FILES_API_ENDPOINT}{file_path}"
-        with open(output_path, "wb") as f:
-            with self._api_request(endpoint=endpoint, method="GET", stream=True) as resp:
-                for content in resp.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
-                    f.write(content)
-                return resp
-
-    def _upload(self, local_file, file_path):
-        """
-        Uploads a file.
-
-        Args:
-            local_file: The local path of the file to upload.
-            file_path: The absolute path of the file to upload.
-
-        Returns:
-            The response from the API.
-
-        See also:
-            https://docs.databricks.com/api/workspace/files/upload
-        """
-        endpoint = f"{FILES_API_ENDPOINT}{file_path}"
-        with open(local_file, "rb") as f:
-            return self._api_request(endpoint=endpoint, method="PUT", data=f, allow_redirects=False)
-
-    def _get_path(self, artifact_path=None):
-        return (
-            posixpath.join(self.root_path, artifact_path.strip("/"))
-            if artifact_path
-            else self.root_path
-        )
-
-    def log_artifact(self, local_file, artifact_path=None):
-        basename = os.path.basename(local_file)
-        artifact_path = posixpath.join(artifact_path, basename) if artifact_path else basename
-        resp = self._upload(local_file, self._get_path(artifact_path))
-        augmented_raise_for_status(resp)
-
-    def log_artifacts(self, local_dir, artifact_path=None):
-        local_dir = Path(local_dir).resolve()
-        for local_path in local_dir.rglob("*"):
-            if local_path.is_file():
-                if local_path.parent == local_dir:
-                    artifact_subdir = artifact_path
-                else:
-                    rel_path = local_path.parent.relative_to(local_dir)
-                    posix_rel_path = relative_path_to_artifact_path(str(rel_path))
-                    artifact_subdir = (
-                        posixpath.join(artifact_path, posix_rel_path)
-                        if artifact_path
-                        else posix_rel_path
-                    )
-                self.log_artifact(local_path, artifact_subdir)
-
-    def list_artifacts(self, path=None):
-        # Response sample (https://docs.databricks.com/api/workspace/files/listdirectorycontents):
-        # {
-        #    "contents": [
-        #        {
-        #            "path": "string",
-        #            "is_directory": True,
-        #            "file_size": 0,
-        #            "last_modified": 0,
-        #            "name": "string",
-        #        }
-        #    ],
-        #    "next_page_token": "string",
-        # }
-        infos = []
-        for content in self._paginated_list_directory_contents(self._get_path(path)):
-            rel_path = self._relative_to_root(content["path"])
-            infos.append(FileInfo(rel_path, content["is_directory"], content.get("file_size")))
-        return sorted(infos, key=lambda f: f.path)
-
-    def _download_file(self, remote_file_path, local_path):
-        resp = self._download(output_path=local_path, file_path=self._get_path(remote_file_path))
-        augmented_raise_for_status(resp)
-
-    def delete_artifacts(self, artifact_path=None):
-        raise NotImplementedError("Not implemented yet")
+        super().__init__("/" + strip_scheme(artifact_uri).strip("/"))
 
 
 def uc_volume_artifact_repo_factory(artifact_uri):

--- a/mlflow/store/artifact/uc_volume_artifact_repo.py
+++ b/mlflow/store/artifact/uc_volume_artifact_repo.py
@@ -27,7 +27,8 @@ class UCVolumesArtifactRepository(DatabricksSdkArtifactRepository):
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        super().__init__("/" + strip_scheme(artifact_uri).strip("/"))
+        uri = remove_databricks_profile_info_from_artifact_uri(artifact_uri)
+        super().__init__("/" + strip_scheme(uri).strip("/"))
 
 
 def uc_volume_artifact_repo_factory(artifact_uri):

--- a/tests/store/artifact/test_uc_volumes_artifact_repo.py
+++ b/tests/store/artifact/test_uc_volumes_artifact_repo.py
@@ -2,6 +2,7 @@ import posixpath
 from unittest import mock
 
 import pytest
+from databricks.sdk.service.files import DirectoryEntry
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.exceptions import MlflowException
@@ -64,28 +65,26 @@ def test_get_artifact_repository_invalid_uri(artifact_uri: str):
 
 @pytest.mark.parametrize("artifact_path", [None, "dir"])
 def test_log_artifact(artifact_repo, artifact_path, tmp_path):
-    mock_response = mock.MagicMock()
-    mock_response.status_code = 204
-
-    with mock.patch("mlflow.store.artifact.uc_volume_artifact_repo.http_request") as mock_request:
+    with mock.patch(
+        "mlflow.store.artifact.databricks_sdk_artifact_repo.DatabricksSdkArtifactRepository.files_api"
+    ) as mock_files_api:
         tmp_file = tmp_path.joinpath("local_file")
         tmp_file.touch()
         artifact_repo.log_artifact(tmp_file, artifact_path)
-        mock_request.assert_called_once()
-        rel_path = join_non_empty(artifact_path, tmp_file.name)
-        endpoint = mock_request.call_args.kwargs["endpoint"]
-        file_path = join_non_empty(artifact_repo.root_path, rel_path)
-        assert endpoint == f"/api/2.0/fs/files{file_path}"
+        mock_files_api.upload.assert_called_once_with(
+            join_non_empty(
+                "/Volumes/catalog/schema/volume/run_id/artifacts", artifact_path, tmp_file.name
+            ),
+            mock.ANY,
+            overwrite=True,
+        )
 
 
 @pytest.mark.parametrize("artifact_path", [None, "dir"])
 def test_log_artifacts(artifact_repo, artifact_path, tmp_path):
-    mock_response = mock.MagicMock()
-    mock_response.status_code = 204
-
     with mock.patch(
-        "mlflow.store.artifact.uc_volume_artifact_repo.http_request", return_value=mock_response
-    ) as mock_request:
+        "mlflow.store.artifact.databricks_sdk_artifact_repo.DatabricksSdkArtifactRepository.files_api"
+    ) as mock_files_api:
         file1 = tmp_path.joinpath("local_file1")
         file1.touch()
         subdir = tmp_path.joinpath("dir")
@@ -93,130 +92,56 @@ def test_log_artifacts(artifact_repo, artifact_path, tmp_path):
         file2 = subdir.joinpath("local_file2")
         file2.touch()
         artifact_repo.log_artifacts(tmp_path, artifact_path)
-        assert mock_request.call_count == 2
-
-        rel_path_1 = join_non_empty(artifact_path, file1.name)
-        rel_path_2 = join_non_empty(artifact_path, subdir.name, file2.name)
-
-        endpoints = [c.kwargs["endpoint"] for c in mock_request.call_args_list]
-        file_path1 = join_non_empty(artifact_repo.root_path, rel_path_1)
-        file_path2 = join_non_empty(artifact_repo.root_path, rel_path_2)
-        assert endpoints == [f"/api/2.0/fs/files{file_path1}", f"/api/2.0/fs/files{file_path2}"]
+        assert mock_files_api.upload.call_count == 2
+        mock_files_api.upload.assert_any_call(
+            join_non_empty(
+                "/Volumes/catalog/schema/volume/run_id/artifacts", artifact_path, file1.name
+            ),
+            mock.ANY,
+            overwrite=True,
+        )
+        mock_files_api.upload.assert_any_call(
+            join_non_empty(
+                "/Volumes/catalog/schema/volume/run_id/artifacts", artifact_path, "dir", file2.name
+            ),
+            mock.ANY,
+            overwrite=True,
+        )
 
 
 @pytest.mark.parametrize("artifact_path", [None, "dir"])
 def test_list_artifacts(artifact_repo, artifact_path):
-    mock_response = mock.MagicMock()
-    mock_response.status_code = 200
-
-    mock_response.json.return_value = {
-        "contents": [
-            {
-                "path": join_non_empty(artifact_repo.root_path, artifact_path, "directory"),
-                "is_directory": True,
-                "last_modified": 0,
-                "name": "directory",
-            },
-            {
-                "path": join_non_empty(artifact_repo.root_path, artifact_path, "file"),
-                "is_directory": False,
-                "file_size": 1,
-                "last_modified": 0,
-                "name": "file",
-            },
-        ],
-    }
     with mock.patch(
-        "mlflow.store.artifact.uc_volume_artifact_repo.http_request", return_value=mock_response
-    ) as mock_request:
+        "mlflow.store.artifact.databricks_sdk_artifact_repo.DatabricksSdkArtifactRepository.files_api"
+    ) as mock_files_api:
+        mock_files_api.list_directory_contents.return_value = [
+            DirectoryEntry(
+                path=join_non_empty(
+                    "/Volumes/catalog/schema/volume/run_id/artifacts", artifact_path, "file"
+                ),
+                is_directory=False,
+                file_size=123,
+            ),
+            DirectoryEntry(
+                path=join_non_empty(
+                    "/Volumes/catalog/schema/volume/run_id/artifacts", artifact_path, "dir"
+                ),
+                is_directory=True,
+            ),
+        ]
         artifacts = artifact_repo.list_artifacts(artifact_path)
         assert artifacts == [
-            FileInfo(join_non_empty(artifact_path, "directory"), True, None),
-            FileInfo(join_non_empty(artifact_path, "file"), False, 1),
-        ]
-        mock_request.assert_called_once()
-        endpoint = mock_request.call_args.kwargs["endpoint"]
-        directory_path = join_non_empty(artifact_repo.root_path, artifact_path)
-        assert endpoint == f"/api/2.0/fs/directories{directory_path}"
-
-
-@pytest.mark.parametrize("artifact_path", [None, "dir"])
-def test_list_artifacts_pagination(artifact_repo, artifact_path):
-    first_mock_response = mock.MagicMock()
-    first_mock_response.status_code = 200
-    first_mock_response.json.return_value = {
-        "contents": [
-            {
-                "path": join_non_empty(artifact_repo.root_path, artifact_path, "directory"),
-                "is_directory": True,
-                "last_modified": 0,
-                "name": "directory",
-            },
-            {
-                "path": join_non_empty(artifact_repo.root_path, artifact_path, "file"),
-                "is_directory": False,
-                "file_size": 1,
-                "last_modified": 0,
-                "name": "file",
-            },
-        ],
-        "next_page_token": "token",
-    }
-
-    second_mock_response = mock.MagicMock()
-    second_mock_response.status_code = 200
-    second_mock_response.json.return_value = {
-        "contents": [
-            {
-                "path": join_non_empty(artifact_repo.root_path, artifact_path, "another_directory"),
-                "is_directory": True,
-                "last_modified": 0,
-                "name": "another_directory",
-            },
-            {
-                "path": join_non_empty(artifact_repo.root_path, artifact_path, "another_file"),
-                "is_directory": False,
-                "file_size": 1,
-                "last_modified": 0,
-                "name": "another_file",
-            },
-        ]
-    }
-
-    with mock.patch(
-        "mlflow.store.artifact.uc_volume_artifact_repo.http_request",
-        side_effect=[first_mock_response, second_mock_response],
-    ) as mock_request:
-        artifacts = artifact_repo.list_artifacts(artifact_path)
-        assert artifacts == [
-            FileInfo(join_non_empty(artifact_path, "another_directory"), True, None),
-            FileInfo(join_non_empty(artifact_path, "another_file"), False, 1),
-            FileInfo(join_non_empty(artifact_path, "directory"), True, None),
-            FileInfo(join_non_empty(artifact_path, "file"), False, 1),
-        ]
-        assert mock_request.call_count == 2
-
-        endpoints = [c.kwargs["endpoint"] for c in mock_request.call_args_list]
-        directory_path = join_non_empty(artifact_repo.root_path, artifact_path)
-        assert endpoints == [
-            f"/api/2.0/fs/directories{directory_path}",
-            f"/api/2.0/fs/directories{directory_path}",
+            FileInfo(join_non_empty(artifact_path, "dir"), True, None),
+            FileInfo(join_non_empty(artifact_path, "file"), False, 123),
         ]
 
 
 @pytest.mark.parametrize("remote_file_path", ["file", "dir/file"])
 def test_download_file(artifact_repo, remote_file_path, tmp_path):
-    mock_response = mock.MagicMock()
-    mock_response.status_code = 200
-    mock_response.__enter__.return_value.iter_content.return_value = iter([b"content"])
     with mock.patch(
-        "mlflow.store.artifact.uc_volume_artifact_repo.http_request", return_value=mock_response
-    ) as mock_request:
+        "mlflow.store.artifact.databricks_sdk_artifact_repo.DatabricksSdkArtifactRepository.files_api"
+    ) as mock_files_api:
         output_path = tmp_path.joinpath("output_path")
+        mock_files_api.download.return_value.contents.read.side_effect = [b"test", b""]
         artifact_repo._download_file(remote_file_path, output_path)
-        mock_request.assert_called_once()
-        assert output_path.read_bytes() == b"content"
-
-        endpoint = mock_request.call_args.kwargs["endpoint"]
-        file_path = join_non_empty(artifact_repo.root_path, remote_file_path)
-        assert endpoint == f"/api/2.0/fs/files{file_path}"
+        assert mock_files_api.download.call_count == 1


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15559?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15559/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15559/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15559
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Migrate `UCVolumesArtifactRepository` to use the databricks SDK files API for uploading/downloading files to/from a UC volume. This updates allows users to upload files larger than >5GB.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
from __future__ import annotations

import contextlib
from unittest import mock

import requests
from databricks.sdk import WorkspaceClient
from databricks.sdk.errors import ResourceAlreadyExists
from databricks.sdk.service import catalog

import mlflow


@contextlib.contextmanager
def log_request() -> None:
    original = requests.Session.request

    def patched_request(self, *args, **kwargs):
        res = original(self, *args, **kwargs)
        print(args, kwargs, res)
        return res

    with mock.patch("requests.Session.request", patched_request):
        yield


w = WorkspaceClient()

try:
    w.volumes.create(
        catalog_name="ml",
        schema_name="haru",
        name="uc-volume-test",
        volume_type=catalog.VolumeType.MANAGED,
    )
except ResourceAlreadyExists:
    pas


name = "/Users/harutaka.kawamura@databricks.com/uc-volume-test-2"

mlflow.set_tracking_uri("databricks")
if exp := mlflow.get_experiment_by_name(name):
    mlflow.set_experiment(experiment_id=exp.experiment_id)
else:
    exp_id = mlflow.create_experiment(
        "/Users/harutaka.kawamura@databricks.com/uc-volume-test-2",
        artifact_location="dbfs:/Volumes/ml/haru/uc-volume-test/artifacts",
    )
    mlflow.set_experiment(experiment_id=exp_id)


with mlflow.start_run() as run:
    with log_request():
        info = mlflow.sklearn.log_model({"fake_model": "a" * (1024**2)}, "model")
        model = mlflow.sklearn.load_model(info.model_uri)

```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
