### PR TITLE
Fix cross version test for crewai 0.117

### DIFF
--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -423,15 +423,28 @@ def test_kickoff_tool_calling(tool_agent_1, task_1_with_tool, autolog):
     assert span_4.inputs["messages"] is not None
     assert span_4.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
     chat_attributes = span_4.get_attribute("mlflow.chat.messages")
-    assert len(chat_attributes) == 4
+
+    if Version(crewai.__version__) < Version("0.117.0"):
+        assert len(chat_attributes) == 4
+    else:
+        assert len(chat_attributes) == 5
     assert chat_attributes[0]["role"] == "system"
     assert _AGENT_1_GOAL in chat_attributes[0]["content"]
     assert chat_attributes[1]["role"] == "user"
     assert _TASK_1_DESCRIPTION in chat_attributes[1]["content"]
     assert chat_attributes[2]["role"] == "assistant"
     assert "Tool Answer" in chat_attributes[2]["content"]
-    assert chat_attributes[3]["role"] == "assistant"
-    assert _LLM_ANSWER in chat_attributes[3]["content"]
+
+    if Version(crewai.__version__) < Version("0.117.0"):
+        assert chat_attributes[3]["role"] == "assistant"
+        assert _LLM_ANSWER in chat_attributes[3]["content"]
+    else:
+        # Since 0.114.0 CrewAI includes Tool call observation in the LLM calls
+        # https://github.com/crewAIInc/crewAI/commit/efe27bd570d91f00af59f1d605d87e7b82c2bc88
+        assert chat_attributes[3]["role"] == "assistant"
+        assert '{"argument": "a"}' in chat_attributes[3]["content"]
+        assert chat_attributes[4]["role"] == "assistant"
+        assert _LLM_ANSWER in chat_attributes[4]["content"]
 
     # Create Long Term Memory
     span_5 = traces[0].data.spans[5]

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -424,7 +424,7 @@ def test_kickoff_tool_calling(tool_agent_1, task_1_with_tool, autolog):
     assert span_4.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
     chat_attributes = span_4.get_attribute("mlflow.chat.messages")
 
-    if Version(crewai.__version__) < Version("0.117.0"):
+    if Version(crewai.__version__) < Version("0.114.0"):
         assert len(chat_attributes) == 4
     else:
         assert len(chat_attributes) == 5
@@ -435,7 +435,7 @@ def test_kickoff_tool_calling(tool_agent_1, task_1_with_tool, autolog):
     assert chat_attributes[2]["role"] == "assistant"
     assert "Tool Answer" in chat_attributes[2]["content"]
 
-    if Version(crewai.__version__) < Version("0.117.0"):
+    if Version(crewai.__version__) < Version("0.114.0"):
         assert chat_attributes[3]["role"] == "assistant"
         assert _LLM_ANSWER in chat_attributes[3]["content"]
     else:

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -12,6 +12,8 @@ from mlflow.entities.span import SpanType
 
 from tests.tracing.helper import get_traces
 
+IS_OLDER_THAN_0_114 = Version(crewai.__version__) < Version("0.114.0")
+
 # This is a special word for CrewAI to complete the agent execution: https://github.com/crewAIInc/crewAI/blob/c6a6c918e0eba167be1fb82831c73dd664c641e3/src/crewai/agents/parser.py#L7
 _FINAL_ANSWER_KEYWORD = "Final Answer:"
 
@@ -424,7 +426,7 @@ def test_kickoff_tool_calling(tool_agent_1, task_1_with_tool, autolog):
     assert span_4.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
     chat_attributes = span_4.get_attribute("mlflow.chat.messages")
 
-    if Version(crewai.__version__) < Version("0.114.0"):
+    if IS_OLDER_THAN_0_114:
         assert len(chat_attributes) == 4
     else:
         assert len(chat_attributes) == 5
@@ -435,7 +437,7 @@ def test_kickoff_tool_calling(tool_agent_1, task_1_with_tool, autolog):
     assert chat_attributes[2]["role"] == "assistant"
     assert "Tool Answer" in chat_attributes[2]["content"]
 
-    if Version(crewai.__version__) < Version("0.114.0"):
+    if IS_OLDER_THAN_0_114:
         assert chat_attributes[3]["role"] == "assistant"
         assert _LLM_ANSWER in chat_attributes[3]["content"]
     else:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15566?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15566/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15566/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15566
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Fix for https://github.com/mlflow-automation/mlflow/actions/runs/14732566891/job/41373470451

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
