### PR TITLE
Fix global_guideline_adherence

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -55,24 +55,6 @@ def document_recall():
     return _DocumentRecall()
 
 
-class _GlobalGuidelineAdherence(_BaseBuiltInScorer):
-    name: str = "global_guideline_adherence"
-    global_guideline: str
-
-    def update_evaluation_config(self, evaluation_config) -> dict:
-        config = super().update_evaluation_config(evaluation_config)
-        config[GENAI_CONFIG_NAME]["global_guideline"] = self.global_guideline
-        return config
-
-
-def global_guideline_adherence(guideline: str):
-    """
-    Guideline adherence evaluates whether the agent’s response follows specific constraints or
-    instructions provided in the guidelines.
-    """
-    return _GlobalGuidelineAdherence(global_guideline=guideline)
-
-
 class _Groundedness(_BaseBuiltInScorer):
     name: str = "groundedness"
 
@@ -95,6 +77,23 @@ def guideline_adherence():
     or instructions provided in the guidelines.
     """
     return _GuidelineAdherence()
+
+
+class _GlobalGuidelineAdherence(_GuidelineAdherence):
+    global_guidelines: list[str]
+
+    def update_evaluation_config(self, evaluation_config) -> dict:
+        config = super().update_evaluation_config(evaluation_config)
+        config[GENAI_CONFIG_NAME]["global_guidelines"] = self.global_guidelines
+        return config
+
+
+def global_guideline_adherence(global_guidelines: list[str]):
+    """
+    Guideline adherence evaluates whether the agent’s response follows specific constraints or
+    instructions provided in the guidelines.
+    """
+    return _GlobalGuidelineAdherence(global_guidelines=global_guidelines)
 
 
 class _RelevanceToQuery(_BaseBuiltInScorer):

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -28,9 +28,9 @@ ALL_SCORERS = [
     chunk_relevance(),
     context_sufficiency(),
     document_recall(),
-    global_guideline_adherence("Be polite"),
     groundedness(),
     guideline_adherence(),
+    global_guideline_adherence(["Be polite", "Be kind"]),
     relevance_to_query(),
     safety(),
 ]
@@ -41,13 +41,12 @@ expected = {
             "chunk_relevance",
             "context_sufficiency",
             "document_recall",
-            "global_guideline_adherence",
             "groundedness",
             "guideline_adherence",
             "relevance_to_query",
             "safety",
         ],
-        "global_guideline": "Be polite",
+        "global_guidelines": ["Be polite", "Be kind"],
     }
 }
 
@@ -57,9 +56,10 @@ expected = {
     [
         ALL_SCORERS,
         [*ALL_SCORERS] + [*ALL_SCORERS],  # duplicate scorers
-        rag_scorers() + [global_guideline_adherence("Be polite"), guideline_adherence(), safety()],
+        rag_scorers()
+        + [global_guideline_adherence(["Be polite", "Be kind"]), guideline_adherence(), safety()],
         [*rag_scorers()]
-        + [global_guideline_adherence("Be polite"), guideline_adherence(), safety()],
+        + [global_guideline_adherence(["Be polite", "Be kind"]), guideline_adherence(), safety()],
     ],
 )
 def test_scorers_and_rag_scorers_config(scorers):
@@ -91,3 +91,67 @@ def test_evaluate_parameters():
             extra_metrics=[],
             model_type=GENAI_CONFIG_NAME,
         )
+
+
+@pytest.mark.parametrize(
+    ("scorer", "expected_metric"),
+    [
+        (chunk_relevance(), "chunk_relevance"),
+        (context_sufficiency(), "context_sufficiency"),
+        (document_recall(), "document_recall"),
+        (groundedness(), "groundedness"),
+        (guideline_adherence(), "guideline_adherence"),
+        (relevance_to_query(), "relevance_to_query"),
+        (safety(), "safety"),
+    ],
+)
+def test_individual_scorers(scorer, expected_metric):
+    """Test that each individual scorer correctly updates the evaluation config."""
+    evaluation_config = {}
+    evaluation_config = scorer.update_evaluation_config(evaluation_config)
+
+    expected_conf = {
+        GENAI_CONFIG_NAME: {
+            "metrics": [expected_metric],
+        }
+    }
+
+    assert normalize_config(evaluation_config) == normalize_config(expected_conf)
+
+
+def test_global_guideline_adherence():
+    """Test that the global guideline adherence scorer correctly updates the evaluation config."""
+    evaluation_config = {}
+    scorer = global_guideline_adherence(["Be polite", "Be kind"])
+    evaluation_config = scorer.update_evaluation_config(evaluation_config)
+
+    expected_conf = {
+        GENAI_CONFIG_NAME: {
+            "metrics": ["guideline_adherence"],
+            "global_guidelines": ["Be polite", "Be kind"],
+        }
+    }
+
+    assert normalize_config(evaluation_config) == normalize_config(expected_conf)
+
+
+@pytest.mark.parametrize(
+    "scorers",
+    [
+        [global_guideline_adherence(["Be polite", "Be kind"]), guideline_adherence()],
+        [guideline_adherence(), global_guideline_adherence(["Be polite", "Be kind"])],
+    ],
+)
+def test_guideline_adherence_scorers(scorers):
+    evaluation_config = {}
+    for scorer in scorers:
+        evaluation_config = scorer.update_evaluation_config(evaluation_config)
+
+    expected_conf = {
+        GENAI_CONFIG_NAME: {
+            "metrics": ["guideline_adherence"],
+            "global_guidelines": ["Be polite", "Be kind"],
+        }
+    }
+
+    assert normalize_config(evaluation_config) == normalize_config(expected_conf)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/15572?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15572/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15572/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15572
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Looking at the [docs](https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/llm-judge-reference#examples), some elements of `global_guideline_adherence` need fixing:
- `global_guideline_adherence`'s metric name is `guideline_adherence` NOT `global_guideline_adherence`.
- `global_guidelines` should be plural and should be `list[str]` NOT 'str`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
