### PR TITLE
Avoid llama-index-core 0.12.34

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -3,3 +3,5 @@
 transformers!=4.51.0
 # https://github.com/BerriAI/litellm/issues/10373
 litellm!=1.67.4
+# https://github.com/run-llama/llama_index/issues/18587
+llama-index-core!=0.12.34


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15576?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15576/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15576/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15576
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The latest version of `llama-index-core` (0.12.34) has an issue:

https://github.com/run-llama/llama_index/issues/18587

One of our CI jobs failed due to this issue:

https://github.com/mlflow/mlflow/actions/runs/14768371335/job/41464031615?pr=15559.

```
________ ERROR collecting tests/tracking/fluent/test_fluent_autolog.py _________
ImportError while importing test module '/home/runner/work/mlflow/mlflow/tests/tracking/fluent/test_fluent_autolog.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.9.18/x[64](https://github.com/mlflow/mlflow/actions/runs/14768371335/job/41464031615?pr=15559#step:11:65)/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/tracking/fluent/test_fluent_autolog.py:19: in <module>
    import llama_index.core
.venv/lib/python3.9/site-packages/llama_index/core/__init__.py:25: in <module>
    from llama_index.core.indices import (
.venv/lib/python3.9/site-packages/llama_index/core/indices/__init__.py:4: in <module>
    from llama_index.core.indices.composability.graph import ComposableGraph
.venv/lib/python3.9/site-packages/llama_index/core/indices/composability/__init__.py:4: in <module>
    from llama_index.core.indices.composability.graph import ComposableGraph
.venv/lib/python3.9/site-packages/llama_index/core/indices/composability/graph.py:7: in <module>
    from llama_index.core.indices.base import BaseIndex
.venv/lib/python3.9/site-packages/llama_index/core/indices/base.py:10: in <module>
    from llama_index.core.chat_engine.types import BaseChatEngine, ChatMode
.venv/lib/python3.9/site-packages/llama_index/core/chat_engine/__init__.py:1: in <module>
    from llama_index.core.chat_engine.condense_plus_context import (
.venv/lib/python3.9/site-packages/llama_index/core/chat_engine/condense_plus_context.py:16: in <module>
    from llama_index.core.chat_engine.types import (
.venv/lib/python3.9/site-packages/llama_index/core/chat_engine/types.py:19: in <module>
    from llama_index.core.memory import BaseMemory
.venv/lib/python3.9/site-packages/llama_index/core/memory/__init__.py:1: in <module>
    from llama_index.core.memory.chat_memory_buffer import ChatMemoryBuffer
.venv/lib/python3.9/site-packages/llama_index/core/memory/chat_memory_buffer.py:7: in <module>
    from llama_index.core.memory.types import (
.venv/lib/python3.9/site-packages/llama_index/core/memory/types.py:8: in <module>
    from llama_index.core.storage.chat_store import BaseChatStore, SimpleChatStore
E   ModuleNotFoundError: No module named 'llama_index.core.storage
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
