### PR TITLE
Avoid using `NULLS LAST` when sorting logged models for MySQL

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -152,7 +152,7 @@ jobs:
           set +e
           err=0
           trap 'err=1' ERR
-
+          RESULTS=""
           for service in $(./tests/db/compose.sh config --services | grep '^mlflow-' | sort)
           do
             # Set `--no-TTY` to show container logs on GitHub Actions:
@@ -161,8 +161,10 @@ jobs:
               tests/store/tracking/test_sqlalchemy_store.py \
               tests/store/model_registry/test_sqlalchemy_store.py \
               tests/db
+              RESULTS="$RESULTS\n$service: $(if [ $? -eq 0 ]; then echo "✅"; else echo "❌"; fi)"
           done
 
+          echo -e "$RESULTS"
           test $err = 0
 
       - name: Run migration check

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2473,7 +2473,7 @@ def _get_orderby_clauses(order_by_list, session):
                 ordering_joins.append(subquery)
                 order_value = subquery.c.value
 
-            # sqlite does not support NULLS LAST expression, so we sort first by
+            # MySQL does not support NULLS LAST expression, so we sort first by
             # presence of the field (and is_nan for metrics), then by actual value
             # As the subqueries are created independently and used later in the
             # same main query, the CASE WHEN columns need to have unique names to

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1897,7 +1897,8 @@ class SqlAlchemyStore(AbstractStore):
                 # Why not use `nulls_last`? Because it's not supported by all dialects (e.g., MySQL)
                 order_by_clauses.extend(
                     [
-                        col.is_(None).asc(),  # Sort nulls last
+                        # Sort nulls last
+                        sqlalchemy.case((col.is_(None), 1), else_=0).asc(),
                         col.asc() if ascending else col.desc(),
                     ]
                 )
@@ -1946,7 +1947,8 @@ class SqlAlchemyStore(AbstractStore):
             # Why not use `nulls_last`? Because it's not supported by all dialects (e.g., MySQL)
             order_by_clauses.extend(
                 [
-                    subquery.c.metric_value.is_(None).asc(),  # Sort nulls last
+                    # Sort nulls last
+                    sqlalchemy.case((subquery.c.metric_value.is_(None), 1), else_=0).asc(),
                     subquery.c.metric_value.asc() if ascending else subquery.c.metric_value.desc(),
                 ]
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,8 +115,12 @@ def reset_active_experiment_id():
 @pytest.fixture(autouse=True)
 def reset_mlflow_uri():
     yield
-    os.environ.pop("MLFLOW_TRACKING_URI", None)
-    os.environ.pop("MLFLOW_REGISTRY_URI", None)
+
+    # Resetting those environment variables cause sqlalchemy store tests to run with a sqlite
+    # database instead of mysql/postgresql/mssql.
+    if "DISABLE_RESET_MLFLOW_URI_FIXTURE" not in os.environ:
+        os.environ.pop("MLFLOW_TRACKING_URI", None)
+        os.environ.pop("MLFLOW_REGISTRY_URI", None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,7 @@ def reset_active_experiment_id():
 def reset_mlflow_uri():
     yield
 
-    # Resetting those environment variables cause sqlalchemy store tests to run with a sqlite
+    # Resetting these environment variables cause sqlalchemy store tests to run with a sqlite
     # database instead of mysql/postgresql/mssql.
     if "DISABLE_RESET_MLFLOW_URI_FIXTURE" not in os.environ:
         os.environ.pop("MLFLOW_TRACKING_URI", None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,6 @@ def reset_active_experiment_id():
 @pytest.fixture(autouse=True)
 def reset_mlflow_uri():
     yield
-
     # Resetting these environment variables cause sqlalchemy store tests to run with a sqlite
     # database instead of mysql/postgresql/mssql.
     if "DISABLE_RESET_MLFLOW_URI_FIXTURE" not in os.environ:

--- a/tests/db/compose.yml
+++ b/tests/db/compose.yml
@@ -53,7 +53,6 @@ services:
       - mysql
     environment:
       MLFLOW_TRACKING_URI: mysql://mlflowuser:mlflowpassword@mysql:3306/mlflowdb?charset=utf8mb4
-      DO_NOT_RESET_URI: "true"
       INSTALL_MLFLOW_FROM_REPO: true
 
   migration-mysql:

--- a/tests/db/compose.yml
+++ b/tests/db/compose.yml
@@ -8,6 +8,8 @@ services:
     working_dir: /mlflow/home
     entrypoint: /mlflow/home/tests/db/entrypoint.sh
     command: pytest tests/db
+    environment:
+      DISABLE_RESET_MLFLOW_URI_FIXTURE: "true"
 
   postgresql:
     image: postgres
@@ -51,6 +53,7 @@ services:
       - mysql
     environment:
       MLFLOW_TRACKING_URI: mysql://mlflowuser:mlflowpassword@mysql:3306/mlflowdb?charset=utf8mb4
+      DO_NOT_RESET_URI: "true"
       INSTALL_MLFLOW_FROM_REPO: true
 
   migration-mysql:

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -5407,7 +5407,9 @@ def test_log_batch_logged_model(store: SqlAlchemyStore):
     )
     store.log_batch(run.info.run_id, metrics=[another_metric], params=[], tags=[])
     model = store.get_logged_model(model.model_id)
-    assert model.metrics == [metric, another_metric]
+    actual_metrics = sorted(model.metrics, key=lambda m: m.key)
+    expected_metrics = sorted([metric, another_metric], key=lambda m: m.key)
+    assert actual_metrics == expected_metrics
 
     # Log multiple metrics
     metrics = [
@@ -5426,4 +5428,6 @@ def test_log_batch_logged_model(store: SqlAlchemyStore):
 
     store.log_batch(run.info.run_id, metrics=metrics, params=[], tags=[])
     model = store.get_logged_model(model.model_id)
-    assert model.metrics == [metric, another_metric] + metrics
+    actual_metrics = sorted(model.metrics, key=lambda m: m.key)
+    expected_metrics = sorted([metric, another_metric, *metrics], key=lambda m: m.key)
+    assert actual_metrics == expected_metrics

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -5414,7 +5414,7 @@ def test_log_batch_logged_model(store: SqlAlchemyStore):
     # Log multiple metrics
     metrics = [
         Metric(
-            key=f"metric_{i}",
+            key=f"metric{i + 3}",
             value=3,
             timestamp=int(time.time() * 1000),
             step=5,

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -68,6 +68,10 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlInput,
     SqlInputTag,
     SqlLatestMetric,
+    SqlLoggedModel,
+    SqlLoggedModelMetric,
+    SqlLoggedModelParam,
+    SqlLoggedModelTag,
     SqlMetric,
     SqlParam,
     SqlRun,
@@ -209,6 +213,10 @@ def _cleanup_database(store: SqlAlchemyStore):
     with store.ManagedSessionMaker() as session:
         # Delete all rows in all tables
         for model in (
+            SqlLoggedModel,
+            SqlLoggedModelMetric,
+            SqlLoggedModelParam,
+            SqlLoggedModelTag,
             SqlParam,
             SqlMetric,
             SqlLatestMetric,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15577?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15577/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15577/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15577
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Fix #15549

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Avoid using `NULLS LAST` when sorting logged models for MySQL.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
