### PR TITLE
Client + Server Communication Issue: Handle New Response Proto (GetTraceInfoV3)

### DIFF
--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -405,7 +405,7 @@ class RestStore(AbstractStore):
                 trace_v3_response_proto = self._call_endpoint(
                     GetTraceInfoV3, trace_v3_req_body, endpoint=trace_v3_endpoint
                 )
-                return TraceInfoV3.from_proto(trace_v3_response_proto)
+                return TraceInfoV3.from_proto(trace_v3_response_proto.trace.trace_info)
             except Exception:
                 # TraceV3 endpoint is not globally enabled yet; graceful fallback path.
                 _logger.debug(

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import time
 from unittest import mock
@@ -21,6 +22,9 @@ from mlflow.entities import (
 from mlflow.entities.assessment import Assessment, Expectation, Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.entities.trace_info import TraceInfo
+from mlflow.entities.trace_info_v3 import TraceInfoV3
+from mlflow.entities.trace_location import TraceLocation
+from mlflow.entities.trace_state import TraceState
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
@@ -369,35 +373,65 @@ def test_requestor():
 
     with mock_http_request() as mock_http:
         request_id = "tr-123"
+        # Regular call, which will use V2 API
         store.get_trace_info(request_id)
-        expected_message = GetTraceInfo(request_id=request_id)
+        v2_expected_message = GetTraceInfo(request_id=request_id)
         _verify_requests(
             mock_http,
             creds,
             "traces/tr-123/info",
             "GET",
-            message_to_json(expected_message),
+            message_to_json(v2_expected_message),
         )
 
+    # For V3 call, we need to ensure the mock's behavior matches expectations
     with mock_http_request() as mock_http:
         request_id = "tr-123"
+        # Successful V3 API call (no fallback)
         store.get_trace_info(request_id, should_query_v3=True)
-        expected_message = GetTraceInfo(request_id=request_id)
-        _verify_requests(
-            mock_http,
-            creds,
-            "traces/tr-123/info",
-            "GET",
-            message_to_json(expected_message),
-        )
-        expected_message = GetTraceInfoV3(trace_id=request_id)
+
+        # Verify the V3 API was called
+        v3_expected_message = GetTraceInfoV3(trace_id=request_id)
         _verify_requests(
             mock_http,
             creds,
             "traces/tr-123",
             "GET",
-            message_to_json(expected_message),
+            message_to_json(v3_expected_message),
         )
+
+    # Now test the fallback path by raising an exception from the V3 call
+    with mock_http_request() as mock_http:
+        request_id = "tr-123"
+        # Make the first call raise an exception
+        calls = []
+        def side_effect(*args, **kwargs):
+            calls.append((args, kwargs))
+            if len(calls) == 1:  # First call (V3 API)
+                raise MlflowException("V3 API not available")
+            # Second call (fallback to V2 API) returns a normal response
+            response = mock.MagicMock()
+            response.status_code = 200
+            response.text = "{}"
+            return response
+
+        mock_http.side_effect = side_effect
+
+        # Now when we call get_trace_info, it should try V3 first, fail, then fall back to V2
+        store.get_trace_info(request_id, should_query_v3=True)
+
+        # Check call arguments to verify V2 fallback was used
+        assert len(mock_http.call_args_list) == 2
+
+        # First call should be to V3 API
+        v3_call = mock_http.call_args_list[0]
+        assert v3_call[1]["endpoint"] == "/api/2.0/mlflow/traces/tr-123"
+        assert v3_call[1]["params"] == {"trace_id": "tr-123"}
+
+        # Second call should be to V2 API
+        v2_call = mock_http.call_args_list[1]
+        assert v2_call[1]["endpoint"] == "/api/2.0/mlflow/traces/tr-123/info"
+        assert v2_call[1]["params"] == {"request_id": "tr-123"}
 
 
 def test_get_experiment_by_name():
@@ -923,3 +957,46 @@ def test_delete_assessment():
         "DELETE",
         json.dumps(expected_request_json),
     )
+
+
+def test_get_trace_info_v3_api():
+    """
+    Test that get_trace_info with should_query_v3=True correctly extracts the trace_info
+    from the nested structure in the V3 API response.
+    """
+    trace_id = "tr-123"
+    trace_location = TraceLocation.from_experiment_id("exp-123")
+    trace_info_v3 = TraceInfoV3(
+        trace_id=trace_id,
+        trace_location=trace_location,
+        request_time=int(datetime.datetime(2023, 5, 1, 12, 0, 0).timestamp() * 1000),
+        state=TraceState.OK,
+        trace_metadata={"key1": "value1"},
+        tags={"tag1": "value1"}
+    )
+
+    with mock.patch("mlflow.entities.trace_info_v3.TraceInfoV3.from_proto",
+                   return_value=trace_info_v3) as mock_from_proto:
+
+        store = RestStore(lambda: MlflowHostCreds("https://hello"))
+
+        with mock.patch.object(store, "_call_endpoint") as mock_call_endpoint:
+            # Set up the mock to return a dummy response with a trace field
+            mock_response = mock.MagicMock()
+            mock_response.trace.trace_info = mock.MagicMock()
+            mock_call_endpoint.return_value = mock_response
+
+            # Call the method we're testing
+            result = store.get_trace_info(trace_id, should_query_v3=True)
+
+            # Verify mock_from_proto was called with the trace_info from the response
+            mock_from_proto.assert_called_once_with(mock_response.trace.trace_info)
+
+            # Verify we get the expected object back
+            assert result is trace_info_v3
+            assert isinstance(result, TraceInfoV3)
+            assert result.trace_id == trace_id
+            assert result.experiment_id == "exp-123"
+            assert result.trace_metadata == {"key1": "value1"}
+            assert result.tags == {"tag1": "value1"}
+            assert result.state == TraceState.OK

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -405,6 +405,7 @@ def test_requestor():
         request_id = "tr-123"
         # Make the first call raise an exception
         calls = []
+
         def side_effect(*args, **kwargs):
             calls.append((args, kwargs))
             if len(calls) == 1:  # First call (V3 API)
@@ -972,12 +973,12 @@ def test_get_trace_info_v3_api():
         request_time=int(datetime.datetime(2023, 5, 1, 12, 0, 0).timestamp() * 1000),
         state=TraceState.OK,
         trace_metadata={"key1": "value1"},
-        tags={"tag1": "value1"}
+        tags={"tag1": "value1"},
     )
 
-    with mock.patch("mlflow.entities.trace_info_v3.TraceInfoV3.from_proto",
-                   return_value=trace_info_v3) as mock_from_proto:
-
+    with mock.patch(
+        "mlflow.entities.trace_info_v3.TraceInfoV3.from_proto", return_value=trace_info_v3
+    ) as mock_from_proto:
         store = RestStore(lambda: MlflowHostCreds("https://hello"))
 
         with mock.patch.object(store, "_call_endpoint") as mock_call_endpoint:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rohitarun-db/mlflow/pull/15581?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15581/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15581/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15581
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

GetTraceInfoV3 returns a Trace proto instead of a TraceInfoV3 proto directly. Therefore, in order to properly interpret assessments, we must send in the TraceInfoV3 proto from within the nested Trace proto.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
