### PR TITLE
upgrade ag-grid-community version to avoid sourcemap warnings

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -23,9 +23,9 @@
     "graphql-codegen:clean": "find . -path '**/__generated__/*.ts' | xargs rm"
   },
   "dependencies": {
-    "@ag-grid-community/client-side-row-model": "^27.2.1",
-    "@ag-grid-community/core": "^27.2.1",
-    "@ag-grid-community/react": "^27.2.1",
+    "@ag-grid-community/client-side-row-model": "^28.0.2",
+    "@ag-grid-community/core": "^28.0.2",
+    "@ag-grid-community/react": "^28.0.2",
     "@apollo/client": "^3.6.9",
     "@apollo/client-3-12": "npm:@apollo/client@^3.12.7",
     "@craco/craco": "7.0.0-alpha.0",

--- a/mlflow/server/js/yarn.lock
+++ b/mlflow/server/js/yarn.lock
@@ -30,32 +30,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ag-grid-community/client-side-row-model@npm:^27.2.1":
-  version: 27.3.0
-  resolution: "@ag-grid-community/client-side-row-model@npm:27.3.0"
+"@ag-grid-community/client-side-row-model@npm:^28.0.2":
+  version: 28.2.1
+  resolution: "@ag-grid-community/client-side-row-model@npm:28.2.1"
   dependencies:
-    "@ag-grid-community/core": "npm:~27.3.0"
-  checksum: 10c0/996e2e8b28dc66228fe835983cf5d2c1c728ddac92c4e006db4ef25af1cd1f1d486d67a149d3c38f66e5e6baf523017b8cb6fb117acadd1a2893406592fd0fc4
+    "@ag-grid-community/core": "npm:~28.2.1"
+  checksum: 10c0/1135c024beb5d89c9036b2adcd2b36a083ec7ca2203bb3445c79dd44a1b8a95e001b2f5fa5319445bcbf2226d3440ec31415d882498e996c7c26cb5a6adb5e85
   languageName: node
   linkType: hard
 
-"@ag-grid-community/core@npm:^27.2.1, @ag-grid-community/core@npm:~27.3.0":
-  version: 27.3.0
-  resolution: "@ag-grid-community/core@npm:27.3.0"
-  checksum: 10c0/b3b071cf4e2fa459dfaf6548d0f630f4f1a3d16c907f12f7b769b51d3dded476f3e53b1ec7696abb003dcbf53095da46234aebcc94f1bc82f7b73638b1615420
+"@ag-grid-community/core@npm:^28.0.2, @ag-grid-community/core@npm:~28.2.1":
+  version: 28.2.1
+  resolution: "@ag-grid-community/core@npm:28.2.1"
+  checksum: 10c0/6fa7540cd5b3391f879959b297d98cd3b3b43b7ad3216d499c5da3ce048c6bbfe5a73b2928dfaa9024559f63d14e5bbb7282c90fc06fef81cf2b88c1adb0d89f
   languageName: node
   linkType: hard
 
-"@ag-grid-community/react@npm:^27.2.1":
-  version: 27.3.0
-  resolution: "@ag-grid-community/react@npm:27.3.0"
+"@ag-grid-community/react@npm:^28.0.2":
+  version: 28.2.1
+  resolution: "@ag-grid-community/react@npm:28.2.1"
   dependencies:
     prop-types: "npm:^15.8.1"
   peerDependencies:
-    "@ag-grid-community/core": ~27.3.0
+    "@ag-grid-community/core": ~28.2.1
     react: ^16.3.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.3.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/116f135cc961e6d907cc15373ba0c3106e5f110be559e915826d57dd96309a06449147a1ab19b7dfa50c20a23fdc4d3ee250f2ea308b115addeb018f8b3e3119
+  checksum: 10c0/91ddb9d313d0e152dd235952ec067f02d4c6bdf8b6d69c386babdf64114377c5ef096f92681498385aeb0236bafd314f2d7dc62fb46245e10560a14f3cd099d2
   languageName: node
   linkType: hard
 
@@ -4338,9 +4338,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mlflow/mlflow@workspace:."
   dependencies:
-    "@ag-grid-community/client-side-row-model": "npm:^27.2.1"
-    "@ag-grid-community/core": "npm:^27.2.1"
-    "@ag-grid-community/react": "npm:^27.2.1"
+    "@ag-grid-community/client-side-row-model": "npm:^28.0.2"
+    "@ag-grid-community/core": "npm:^28.0.2"
+    "@ag-grid-community/react": "npm:^28.0.2"
     "@apollo/client": "npm:^3.6.9"
     "@apollo/client-3-12": "npm:@apollo/client@^3.12.7"
     "@babel/core": "npm:^7.26.0"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/y-okt/mlflow/pull/15583?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15583/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15583/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15583
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #15579

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Upgrading the version of ag-grid-community related packages. The reason is to avoid the following warnings. This is because of the setting of sourcemap generation on this package ([issue](https://github.com/ag-grid/ag-grid/issues/5039#issuecomment-1150825882))

```
WARNING in ./node_modules/@ag-grid-community/client-side-row-model/dist/esm/es5/main.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/y-okt/ghq/github.com/y-okt/mlflow/mlflow/server/js/node_modules/@ag-grid-community/client-side-row-model/src/main.ts' file: Error: ENOENT: no such file or directory, open '/Users/y-okt/ghq/github.com/y-okt/mlflow/mlflow/server/js/node_modules/@ag-grid-community/client-side-row-model/src/main.ts'
 @ ./src/common/components/ag-grid/AgGrid.tsx 4:0-84 17:14-38
 @ ./src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListPageTable.tsx 8:0-69 133:22-34
 @ ./src/experiment-tracking/pages/experiment-logged-models/ExperimentLoggedModelListPage.tsx 14:0-130 99:12-46
 @ ./src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.tsx 19:73-140
 @ ./src/experiment-tracking/components/HomePage.tsx 24:0-82 109:41-59
 @ ./src/MlflowRouter.tsx 24:40-91
 @ ./src/app.tsx 20:0-46 49:27-39
 @ ./src/index.tsx 5:0-35 10:17-27
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
