### PR TITLE
Deprecate mlflow.evaluations module

### DIFF
--- a/mlflow/evaluation/assessment.py
+++ b/mlflow/evaluation/assessment.py
@@ -11,10 +11,10 @@ from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import deprecated
 
 
-@experimental
+@deprecated(since="3.0.0", alternative="mlflow.entities.Assessment")
 class AssessmentEntity(_MlflowObject):
     """
     Assessment data associated with an evaluation.
@@ -195,7 +195,7 @@ class AssessmentEntity(_MlflowObject):
         )
 
 
-@experimental
+@deprecated(since="3.0.0", alternative="mlflow.entities.Assessment")
 class Assessment(_MlflowObject):
     """
     Assessment data associated with an evaluation result.

--- a/mlflow/evaluation/evaluation.py
+++ b/mlflow/evaluation/evaluation.py
@@ -1,6 +1,8 @@
 """
-THE 'mlflow.evaluation` MODULE IS LEGACY AND WILL BE REMOVED SOON. PLEASE DO NOT USE THESE CLASSES
-IN NEW CODE. INSTEAD, USE `mlflow/entities/assessment.py` FOR ASSESSMENT CLASSES.
+THE 'mlflow.evaluation` MODULE IS LEGACY AND WILL BE REMOVED IN MLFLOW 3.0.
+For assessment functionality, use `mlflow.entities.assessment` for assessment classes and
+`mlflow.tracing.assessments` for assessment APIs. There are no alternatives for Evaluation and
+EvaluationEntity objects and related APIs.
 """
 
 import hashlib
@@ -14,10 +16,10 @@ from mlflow.evaluation.evaluation_tag import (
     EvaluationTag,  # Assuming EvaluationTag is in this module
 )
 from mlflow.tracing.utils import TraceJSONEncoder
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import deprecated
 
 
-@experimental
+@deprecated(since="3.0.0")
 class EvaluationEntity(_MlflowObject):
     """
     Evaluation result data, including inputs, outputs, targets, assessments, and more.
@@ -201,7 +203,7 @@ class EvaluationEntity(_MlflowObject):
         )
 
 
-@experimental
+@deprecated(since="3.0.0")
 class Evaluation(_MlflowObject):
     """
     Evaluation result data.

--- a/mlflow/evaluation/evaluation_tag.py
+++ b/mlflow/evaluation/evaluation_tag.py
@@ -4,8 +4,10 @@ IN NEW CODE. INSTEAD, USE `mlflow/entities/assessment.py` FOR ASSESSMENT CLASSES
 """
 
 from mlflow.entities._mlflow_object import _MlflowObject
+from mlflow.utils.annotations import deprecated
 
 
+@deprecated(since="3.0.0")
 class EvaluationTag(_MlflowObject):
     """Key-value tag associated with an evaluation."""
 

--- a/mlflow/evaluation/fluent.py
+++ b/mlflow/evaluation/fluent.py
@@ -10,10 +10,10 @@ from mlflow.evaluation.evaluation import Evaluation, EvaluationEntity
 from mlflow.evaluation.utils import evaluations_to_dataframes
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import _get_or_start_run
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import deprecated
 
 
-@experimental
+@deprecated(since="3.0.0")
 def log_evaluations(
     *, evaluations: list[Evaluation], run_id: Optional[str] = None
 ) -> list[EvaluationEntity]:

--- a/mlflow/evaluation/utils.py
+++ b/mlflow/evaluation/utils.py
@@ -6,10 +6,10 @@ IN NEW CODE. INSTEAD, USE `mlflow/entities/assessment.py` FOR ASSESSMENT CLASSES
 import pandas as pd
 
 from mlflow.evaluation.evaluation import EvaluationEntity as EvaluationEntity
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import deprecated
 
 
-@experimental
+@deprecated(since="3.0.0")
 def evaluations_to_dataframes(
     evaluations: list[EvaluationEntity],
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15590?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15590/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15590/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15590
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.evaluations` modules are deprecated. Adding `@deprecated` marker. It will be completed removed from DBX as well soon.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
