### PR TITLE
Mandate source ID for assessments

### DIFF
--- a/mlflow/entities/assessment_source.py
+++ b/mlflow/entities/assessment_source.py
@@ -1,6 +1,6 @@
 import warnings
 from dataclasses import asdict, dataclass
-from typing import Any, Optional
+from typing import Any
 
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.exceptions import MlflowException
@@ -15,14 +15,58 @@ class AssessmentSource(_MlflowObject):
     """
     Source of an assessment (human, LLM as a judge with GPT-4, etc).
 
+    When recording an assessment, it is highly recommended to provide a sufficient
+    source information to help keep track of how the assessment is conducted.
+
     Args:
         source_type: The type of the assessment source. Must be one of the values in
             the AssessmentSourceType enum.
         source_id: An identifier for the source, e.g. user ID or LLM judge ID.
+
+    Example:
+
+    Human annotation can be represented with a source type of "HUMAN":
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
+
+        source = AssessmentSource(
+            source_type=AssessmentSourceType.HUMAN,
+            source_id="bob@example.com",
+        )
+
+    LLM-as-a-judge can be represented with a source type of "LLM_JUDGE":
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
+
+        source = AssessmentSource(
+            source_type=AssessmentSourceType.LLM_JUDGE,
+            source_id="gpt-4o-mini",
+        )
+
+    Heuristic evaluation can be represented with a source type of "CODE":
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
+
+        source = AssessmentSource(
+            source_type=AssessmentSourceType.CODE,
+            source_id="repo/evaluation_script.py",
+        )
+
+    To record more context about the assessment, you can use the `metadata` field of
+    the assessment logging APIs as well.
     """
 
     source_type: str
-    source_id: Optional[str] = None
+    source_id: str
 
     def __post_init__(self):
         # Perform the standardization on source_type after initialization

--- a/mlflow/entities/assessment_source.py
+++ b/mlflow/entities/assessment_source.py
@@ -15,8 +15,8 @@ class AssessmentSource(_MlflowObject):
     """
     Source of an assessment (human, LLM as a judge with GPT-4, etc).
 
-    When recording an assessment, it is highly recommended to provide a sufficient
-    source information to help keep track of how the assessment is conducted.
+    When recording an assessment, MLflow mandates providing a source information
+    to keep track of how the assessment is conducted.
 
     Args:
         source_type: The type of the assessment source. Must be one of the values in

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -131,11 +131,7 @@ def update_expectation(
 
         # Update the expectation with a new value 43.
         mlflow.update_expectation(
-            trace_id="1234",
-            assessment_id=assessment.assessment_id,
-            value=43,
-            # Record additional metadata for the update
-            metadata={"override_reason": "Correction by alice@example.com"},
+            trace_id="1234", assessment_id=assessment.assessment_id, value=43
         )
     """
     return TracingClient().update_assessment(

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -67,8 +67,10 @@ def log_expectation(
     if value is None:
         raise MlflowException.invalid_parameter_value("Expectation value cannot be None.")
 
-    if source is None:
-        raise MlflowException.invalid_parameter_value("`source` must be provided.")
+    if not isinstance(source, AssessmentSource):
+        raise MlflowException.invalid_parameter_value(
+            f"`source` must be an instance of `AssessmentSource`. Got {type(source)} instead."
+        )
 
     return TracingClient().log_assessment(
         trace_id=trace_id,
@@ -249,8 +251,10 @@ def log_feedback(
     if value is None and error is None:
         raise MlflowException.invalid_parameter_value("Either `value` or `error` must be provided.")
 
-    if source is None:
-        raise MlflowException.invalid_parameter_value("`source` must be provided.")
+    if not isinstance(source, AssessmentSource):
+        raise MlflowException.invalid_parameter_value(
+            f"`source` must be an instance of `AssessmentSource`. Got {type(source)} instead."
+        )
 
     return TracingClient().log_assessment(
         trace_id=trace_id,

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from mlflow.entities.assessment import (
     Assessment,
@@ -17,7 +17,7 @@ from mlflow.tracing.client import TracingClient
 def log_expectation(
     trace_id: str,
     name: str,
-    source: Union[str, AssessmentSource],
+    source: AssessmentSource,
     value: AssessmentValueType,
     metadata: Optional[dict[str, Any]] = None,
     span_id: Optional[str] = None,
@@ -32,10 +32,8 @@ def log_expectation(
     Args:
         trace_id: The ID of the trace.
         name: The name of the expectation assessment e.g., "expected_answer
-        source: The source of the expectation assessment. Must be either an instance of
-                :py:class:`~mlflow.entities.AssessmentSource` or a string that
-                is a valid value in the
-                :py:class:`~mlflow.entities.AssessmentSourceType` enum.
+        source: The source of the expectation assessment. Must be an instance of
+                :py:class:`~mlflow.entities.AssessmentSource`.
         value: The value of the expectation. It can be any JSON-serializable value.
         metadata: Additional metadata for the expectation.
         span_id: The ID of the span associated with the expectation, if it needs be
@@ -51,23 +49,31 @@ def log_expectation(
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment import AssessmentSourceType
+        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
+
+        # Specify the annotator information as a source.
+        source = AssessmentSource(
+            source_type=AssessmentSourceType.HUMAN,
+            source_id="john@example.com",
+        )
 
         mlflow.log_expectation(
             trace_id="1234",
             name="expected_answer",
             value=42,
-            source=AssessmentSourceType.HUMAN,
+            source=source,
         )
-
     """
     if value is None:
         raise MlflowException.invalid_parameter_value("Expectation value cannot be None.")
 
+    if source is None:
+        raise MlflowException.invalid_parameter_value("`source` must be provided.")
+
     return TracingClient().log_assessment(
         trace_id=trace_id,
         name=name,
-        source=_parse_source(source),
+        source=source,
         expectation=Expectation(value) if value is not None else None,
         metadata=metadata,
         span_id=span_id,
@@ -107,14 +113,18 @@ def update_expectation(
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment import AssessmentSourceType
+        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
 
         # Create an expectation with value 42.
         assessment = mlflow.log_expectation(
             trace_id="1234",
             name="expected_answer",
             value=42,
-            source=AssessmentSourceType.HUMAN,
+            # Original annotator
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN,
+                source_id="bob@example.com",
+            ),
         )
 
         # Update the expectation with a new value 43.
@@ -122,6 +132,8 @@ def update_expectation(
             trace_id="1234",
             assessment_id=assessment.assessment_id,
             value=43,
+            # Record additional metadata for the update
+            metadata={"override_reason": "Correction by alice@example.com"},
         )
     """
     return TracingClient().update_assessment(
@@ -153,7 +165,7 @@ def delete_expectation(trace_id: str, assessment_id: str):
 def log_feedback(
     trace_id: str,
     name: str,
-    source: Union[str, AssessmentSource],
+    source: AssessmentSource,
     value: Optional[AssessmentValueType] = None,
     error: Optional[AssessmentError] = None,
     rationale: Optional[str] = None,
@@ -170,10 +182,8 @@ def log_feedback(
     Args:
         trace_id: The ID of the trace.
         name: The name of the feedback assessment e.g., "faithfulness"
-        source: The source of the feedback assessment. Must be either an instance of
-                :py:class:`~mlflow.entities.AssessmentSource` or a string that
-                is a valid value in the
-                :py:class:`~mlflow.entities.AssessmentSourceType` enum.
+        source: The source of the feedback assessment. Must be an instance of
+                :py:class:`~mlflow.entities.AssessmentSource`.
         value: The value of the feedback.
         error: An error object representing any issues encountered while computing the
             feedback, e.g., a timeout error from an LLM judge. Either this or `value`
@@ -193,7 +203,7 @@ def log_feedback(
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment import AssessmentSourceType
+        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
 
         source = AssessmentSource(
             source_type=Type.LLM_JUDGE,
@@ -238,10 +248,14 @@ def log_feedback(
     """
     if value is None and error is None:
         raise MlflowException.invalid_parameter_value("Either `value` or `error` must be provided.")
+
+    if source is None:
+        raise MlflowException.invalid_parameter_value("`source` must be provided.")
+
     return TracingClient().log_assessment(
         trace_id=trace_id,
         name=name,
-        source=_parse_source(source),
+        source=source,
         feedback=Feedback(value, error),
         rationale=rationale,
         metadata=metadata,
@@ -285,14 +299,17 @@ def update_feedback(
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment import AssessmentSourceType
+        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
 
         # Create a feedback with value 0.9.
         assessment = mlflow.log_feedback(
             trace_id="1234",
             name="faithfulness",
             value=0.9,
-            source=AssessmentSourceType.LLM_JUDGE,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE,
+                source_id="gpt-4o-mini",
+            ),
         )
 
         # Update the feedback with a new value 0.95.
@@ -326,17 +343,3 @@ def delete_feedback(trace_id: str, assessment_id: str):
         assessment_id: The ID of the feedback assessment to delete.
     """
     return TracingClient().delete_assessment(trace_id=trace_id, assessment_id=assessment_id)
-
-
-def _parse_source(source: Union[str, AssessmentSource]) -> AssessmentSource:
-    if source is None:
-        raise MlflowException.invalid_parameter_value("`source` must be provided.")
-
-    if isinstance(source, str):
-        return AssessmentSource(source_type=source)
-    elif isinstance(source, AssessmentSource):
-        return source
-
-    raise MlflowException.invalid_parameter_value(
-        "Invalid source type. Must be one of str, AssessmentSource, or AssessmentSourceType."
-    )

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -186,7 +186,7 @@ def test_assessment_value_validation():
     "source",
     [
         AssessmentSource(source_type="HUMAN", source_id="user_1"),
-        AssessmentSource(source_type="CODE"),
+        AssessmentSource(source_type="CODE", source_id="code.py"),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -74,7 +74,7 @@ def test_log_expectation_invalid_parameters(tracking_uri):
             source=_HUMAN_ASSESSMENT_SOURCE,
         )
 
-    with pytest.raises(MlflowException, match=r"`source` must be provided."):
+    with pytest.raises(MlflowException, match=r"`source` must be an instance of"):
         mlflow.log_feedback(
             trace_id="1234",
             name="faithfulness",
@@ -187,7 +187,7 @@ def test_log_feedback_invalid_parameters(tracking_uri):
             source=_LLM_ASSESSMENT_SOURCE,
         )
 
-    with pytest.raises(MlflowException, match=r"`source` must be provided."):
+    with pytest.raises(MlflowException, match=r"`source` must be an instance of"):
         mlflow.log_feedback(
             trace_id="1234",
             name="faithfulness",

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -31,12 +31,23 @@ def tracking_uri():
     mlflow.set_tracking_uri(original_tracking_uri)
 
 
+_HUMAN_ASSESSMENT_SOURCE = AssessmentSource(
+    source_type=AssessmentSourceType.HUMAN,
+    source_id="bob@example.com",
+)
+
+_LLM_ASSESSMENT_SOURCE = AssessmentSource(
+    source_type=AssessmentSourceType.LLM_JUDGE,
+    source_id="gpt-4o-mini",
+)
+
+
 def test_log_expectation(store, tracking_uri):
     mlflow.log_expectation(
         trace_id="1234",
         name="expected_answer",
         value="MLflow",
-        source=AssessmentSourceType.HUMAN,
+        source=_HUMAN_ASSESSMENT_SOURCE,
         metadata={"key": "value"},
     )
 
@@ -45,8 +56,7 @@ def test_log_expectation(store, tracking_uri):
     assert assessment.name == "expected_answer"
     assert assessment.trace_id == "1234"
     assert assessment.span_id is None
-    assert assessment.source.source_type == "HUMAN"
-    assert assessment.source.source_id is None
+    assert assessment.source == _HUMAN_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
     assert assessment.last_update_time_ms is not None
     assert assessment.expectation.value == "MLflow"
@@ -61,7 +71,7 @@ def test_log_expectation_invalid_parameters(tracking_uri):
             trace_id="1234",
             name="expected_answer",
             value=None,
-            source=AssessmentSourceType.HUMAN,
+            source=_HUMAN_ASSESSMENT_SOURCE,
         )
 
     with pytest.raises(MlflowException, match=r"`source` must be provided."):
@@ -70,14 +80,6 @@ def test_log_expectation_invalid_parameters(tracking_uri):
             name="faithfulness",
             value=1.0,
             source=None,
-        )
-
-    with pytest.raises(MlflowException, match=r"Invalid assessment source type"):
-        mlflow.log_feedback(
-            trace_id="1234",
-            name="faithfulness",
-            value=1.0,
-            source="INVALID_SOURCE_TYPE",
         )
 
 
@@ -104,10 +106,7 @@ def test_log_feedback(store, tracking_uri):
         trace_id="1234",
         name="faithfulness",
         value=1.0,
-        source=AssessmentSource(
-            source_type=AssessmentSourceType.LLM_JUDGE,
-            source_id="faithfulness-judge",
-        ),
+        source=_LLM_ASSESSMENT_SOURCE,
         rationale="This answer is very faithful.",
         metadata={"model": "gpt-4o-mini"},
     )
@@ -117,8 +116,7 @@ def test_log_feedback(store, tracking_uri):
     assert assessment.name == "faithfulness"
     assert assessment.trace_id == "1234"
     assert assessment.span_id is None
-    assert assessment.source.source_type == "LLM_JUDGE"
-    assert assessment.source.source_id == "faithfulness-judge"
+    assert assessment.source == _LLM_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
     assert assessment.last_update_time_ms is not None
     assert assessment.feedback.value == 1.0
@@ -132,7 +130,7 @@ def test_log_feedback_with_error(store, tracking_uri):
     mlflow.log_feedback(
         trace_id="1234",
         name="faithfulness",
-        source=AssessmentSourceType.LLM_JUDGE,
+        source=_LLM_ASSESSMENT_SOURCE,
         error=AssessmentError(
             error_code="RATE_LIMIT_EXCEEDED",
             error_message="Rate limit for the judge exceeded.",
@@ -144,8 +142,7 @@ def test_log_feedback_with_error(store, tracking_uri):
     assert assessment.name == "faithfulness"
     assert assessment.trace_id == "1234"
     assert assessment.span_id is None
-    assert assessment.source.source_type == "LLM_JUDGE"
-    assert assessment.source.source_id is None
+    assert assessment.source == _LLM_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
     assert assessment.last_update_time_ms is not None
     assert assessment.expectation is None
@@ -159,7 +156,7 @@ def test_log_feedback_with_value_and_error(store, tracking_uri):
     mlflow.log_feedback(
         trace_id="1234",
         name="faithfulness",
-        source=AssessmentSourceType.LLM_JUDGE,
+        source=_LLM_ASSESSMENT_SOURCE,
         value=0.5,
         error=AssessmentError(
             error_code="RATE_LIMIT_EXCEEDED",
@@ -172,8 +169,7 @@ def test_log_feedback_with_value_and_error(store, tracking_uri):
     assert assessment.name == "faithfulness"
     assert assessment.trace_id == "1234"
     assert assessment.span_id is None
-    assert assessment.source.source_type == "LLM_JUDGE"
-    assert assessment.source.source_id is None
+    assert assessment.source == _LLM_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
     assert assessment.last_update_time_ms is not None
     assert assessment.expectation is None
@@ -188,7 +184,7 @@ def test_log_feedback_invalid_parameters(tracking_uri):
         mlflow.log_feedback(
             trace_id="1234",
             name="faithfulness",
-            source=AssessmentSourceType.LLM_JUDGE,
+            source=_LLM_ASSESSMENT_SOURCE,
         )
 
     with pytest.raises(MlflowException, match=r"`source` must be provided."):
@@ -241,18 +237,12 @@ def test_delete_feedback(store, tracking_uri):
 def test_assessment_apis_only_available_in_databricks():
     with pytest.raises(MlflowException, match=r"This API is currently only available"):
         mlflow.log_expectation(
-            trace_id="1234",
-            name="expected_answer",
-            value="MLflow",
-            source=AssessmentSourceType.HUMAN,
+            trace_id="1234", name="expected_answer", value="MLflow", source=_HUMAN_ASSESSMENT_SOURCE
         )
 
     with pytest.raises(MlflowException, match=r"This API is currently only available"):
         mlflow.log_feedback(
-            trace_id="1234",
-            name="faithfulness",
-            value=1.0,
-            source=AssessmentSourceType.LLM_JUDGE,
+            trace_id="1234", name="faithfulness", value=1.0, source=_LLM_ASSESSMENT_SOURCE
         )
 
     with pytest.raises(MlflowException, match=r"This API is currently only available"):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15593?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15593/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15593/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15593
```

</p>
</details>

### What changes are proposed in this pull request?

The `source` field and its `source_id` field is mandated by DBX MLflow backend now. Updating the API signature and examples accordingly.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
