### PR TITLE
Update to 3.0 endpoints

### DIFF
--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -398,9 +398,13 @@ class RestStore(AbstractStore):
         Returns:
             The fetched Trace object, of type ``mlflow.entities.TraceInfo``.
         """
-        if should_query_v3:
+        # If explicitly set, use the provided value, otherwise detect based on the tracking URI
+        use_v3 = should_query_v3 or self._is_databricks_tracking_uri()
+        is_databricks = self._is_databricks_tracking_uri()
+        
+        if use_v3:
             trace_v3_req_body = message_to_json(GetTraceInfoV3(trace_id=request_id))
-            trace_v3_endpoint = get_trace_assessment_endpoint(request_id)
+            trace_v3_endpoint = get_trace_assessment_endpoint(request_id, is_databricks=is_databricks)
             try:
                 trace_v3_response_proto = self._call_endpoint(
                     GetTraceInfoV3, trace_v3_req_body, endpoint=trace_v3_endpoint
@@ -416,6 +420,19 @@ class RestStore(AbstractStore):
         endpoint = get_trace_info_endpoint(request_id)
         response_proto = self._call_endpoint(GetTraceInfo, req_body, endpoint=endpoint)
         return TraceInfo.from_proto(response_proto.trace_info)
+
+    def _is_databricks_tracking_uri(self):
+        """
+        Check if the tracking URI associated with this store is a Databricks URI.
+        """
+        from mlflow.tracking._tracking_service.utils import get_tracking_uri
+        from mlflow.utils.uri import is_databricks_uri
+        
+        try:
+            tracking_uri = get_tracking_uri()
+            return is_databricks_uri(tracking_uri)
+        except Exception:
+            return False
 
     def get_online_trace_details(
         self,
@@ -524,11 +541,12 @@ class RestStore(AbstractStore):
         Returns:
             The created Assessment object.
         """
+        is_databricks = self._is_databricks_tracking_uri()
         req_body = message_to_json(CreateAssessment(assessment=assessment.to_proto()))
         response_proto = self._call_endpoint(
             CreateAssessment,
             req_body,
-            endpoint=get_create_assessment_endpoint(assessment.trace_id),
+            endpoint=get_create_assessment_endpoint(assessment.trace_id, is_databricks=is_databricks),
         )
         return Assessment.from_proto(response_proto.assessment)
 
@@ -559,6 +577,7 @@ class RestStore(AbstractStore):
                 "Exactly one of `expectation` or `feedback` should be specified."
             )
 
+        is_databricks = self._is_databricks_tracking_uri()
         update = UpdateAssessment()
 
         # The assessment object to be sent to the backend (only contains fields to update and IDs)
@@ -589,7 +608,7 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(
             UpdateAssessment,
             req_body,
-            endpoint=get_single_assessment_endpoint(trace_id, assessment_id),
+            endpoint=get_single_assessment_endpoint(trace_id, assessment_id, is_databricks=is_databricks),
         )
         return Assessment.from_proto(response_proto.assessment)
 
@@ -601,11 +620,12 @@ class RestStore(AbstractStore):
             trace_id: String ID of the trace.
             assessment_id: String ID of the assessment to delete.
         """
+        is_databricks = self._is_databricks_tracking_uri()
         req_body = message_to_json(DeleteAssessment(trace_id=trace_id, assessment_id=assessment_id))
         self._call_endpoint(
             DeleteAssessment,
             req_body,
-            endpoint=get_single_assessment_endpoint(trace_id, assessment_id),
+            endpoint=get_single_assessment_endpoint(trace_id, assessment_id, is_databricks=is_databricks),
         )
 
     def log_metric(self, run_id: str, metric: Metric):

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -402,10 +402,12 @@ class RestStore(AbstractStore):
         # If explicitly set, use the provided value, otherwise detect based on the tracking URI
         use_v3 = should_query_v3 or self._is_databricks_tracking_uri()
         is_databricks = self._is_databricks_tracking_uri()
-        
+
         if use_v3:
             trace_v3_req_body = message_to_json(GetTraceInfoV3(trace_id=request_id))
-            trace_v3_endpoint = get_trace_assessment_endpoint(request_id, is_databricks=is_databricks)
+            trace_v3_endpoint = get_trace_assessment_endpoint(
+                request_id, is_databricks=is_databricks
+            )
             try:
                 trace_v3_response_proto = self._call_endpoint(
                     GetTraceInfoV3, trace_v3_req_body, endpoint=trace_v3_endpoint
@@ -428,7 +430,7 @@ class RestStore(AbstractStore):
         """
         from mlflow.tracking._tracking_service.utils import get_tracking_uri
         from mlflow.utils.uri import is_databricks_uri
-        
+
         try:
             tracking_uri = get_tracking_uri()
             return is_databricks_uri(tracking_uri)
@@ -519,9 +521,9 @@ class RestStore(AbstractStore):
         # Always use v2 endpoint
         req_body = message_to_json(SetTraceTag(key=key, value=value))
         self._call_endpoint(
-            SetTraceTag, 
-            req_body, 
-            endpoint=get_set_trace_tag_endpoint(request_id, is_databricks=False)
+            SetTraceTag,
+            req_body,
+            endpoint=get_set_trace_tag_endpoint(request_id, is_databricks=False),
         )
 
     def delete_trace_tag(self, request_id: str, key: str):
@@ -535,9 +537,9 @@ class RestStore(AbstractStore):
         # Always use v2 endpoint
         req_body = message_to_json(DeleteTraceTag(key=key))
         self._call_endpoint(
-            DeleteTraceTag, 
-            req_body, 
-            endpoint=get_set_trace_tag_endpoint(request_id, is_databricks=False)
+            DeleteTraceTag,
+            req_body,
+            endpoint=get_set_trace_tag_endpoint(request_id, is_databricks=False),
         )
 
     def create_assessment(self, assessment: Assessment) -> Assessment:
@@ -555,7 +557,9 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(
             CreateAssessment,
             req_body,
-            endpoint=get_create_assessment_endpoint(assessment.trace_id, is_databricks=is_databricks),
+            endpoint=get_create_assessment_endpoint(
+                assessment.trace_id, is_databricks=is_databricks
+            ),
         )
         return Assessment.from_proto(response_proto.assessment)
 
@@ -617,7 +621,9 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(
             UpdateAssessment,
             req_body,
-            endpoint=get_single_assessment_endpoint(trace_id, assessment_id, is_databricks=is_databricks),
+            endpoint=get_single_assessment_endpoint(
+                trace_id, assessment_id, is_databricks=is_databricks
+            ),
         )
         return Assessment.from_proto(response_proto.assessment)
 
@@ -634,7 +640,9 @@ class RestStore(AbstractStore):
         self._call_endpoint(
             DeleteAssessment,
             req_body,
-            endpoint=get_single_assessment_endpoint(trace_id, assessment_id, is_databricks=is_databricks),
+            endpoint=get_single_assessment_endpoint(
+                trace_id, assessment_id, is_databricks=is_databricks
+            ),
         )
 
     def log_metric(self, run_id: str, metric: Metric):

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -364,7 +364,8 @@ class RestStore(AbstractStore):
             )
         )
         # EndTrace endpoint is a dynamic path built with the request_id
-        endpoint = get_single_trace_endpoint(request_id)
+        # Always use v2 endpoint
+        endpoint = get_single_trace_endpoint(request_id, is_databricks=False)
         response_proto = self._call_endpoint(EndTrace, req_body, endpoint=endpoint)
         return TraceInfo.from_proto(response_proto.trace_info)
 
@@ -515,8 +516,13 @@ class RestStore(AbstractStore):
             key: The string key of the tag.
             value: The string value of the tag.
         """
+        # Always use v2 endpoint
         req_body = message_to_json(SetTraceTag(key=key, value=value))
-        self._call_endpoint(SetTraceTag, req_body, endpoint=get_set_trace_tag_endpoint(request_id))
+        self._call_endpoint(
+            SetTraceTag, 
+            req_body, 
+            endpoint=get_set_trace_tag_endpoint(request_id, is_databricks=False)
+        )
 
     def delete_trace_tag(self, request_id: str, key: str):
         """
@@ -526,9 +532,12 @@ class RestStore(AbstractStore):
             request_id: The ID of the trace.
             key: The string key of the tag.
         """
+        # Always use v2 endpoint
         req_body = message_to_json(DeleteTraceTag(key=key))
         self._call_endpoint(
-            DeleteTraceTag, req_body, endpoint=get_set_trace_tag_endpoint(request_id)
+            DeleteTraceTag, 
+            req_body, 
+            endpoint=get_set_trace_tag_endpoint(request_id, is_databricks=False)
         )
 
     def create_assessment(self, assessment: Assessment) -> Assessment:

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -364,8 +364,8 @@ class RestStore(AbstractStore):
             )
         )
         # EndTrace endpoint is a dynamic path built with the request_id
-        # Always use v2 endpoint
-        endpoint = get_single_trace_endpoint(request_id, is_databricks=False)
+        # Always use v2 endpoint (not v3) for this endpoint to maintain compatibility
+        endpoint = get_single_trace_endpoint(request_id, use_v3=False)
         response_proto = self._call_endpoint(EndTrace, req_body, endpoint=endpoint)
         return TraceInfo.from_proto(response_proto.trace_info)
 
@@ -400,13 +400,11 @@ class RestStore(AbstractStore):
             The fetched Trace object, of type ``mlflow.entities.TraceInfo``.
         """
         # If explicitly set, use the provided value, otherwise detect based on the tracking URI
-        use_v3 = should_query_v3 or self._is_databricks_tracking_uri()
-        is_databricks = self._is_databricks_tracking_uri()
 
-        if use_v3:
+        if should_query_v3:
             trace_v3_req_body = message_to_json(GetTraceInfoV3(trace_id=request_id))
             trace_v3_endpoint = get_trace_assessment_endpoint(
-                request_id, is_databricks=is_databricks
+                request_id, is_databricks=should_query_v3
             )
             try:
                 trace_v3_response_proto = self._call_endpoint(

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -39,6 +39,7 @@ RESOURCE_NON_EXISTENT = "RESOURCE_DOES_NOT_EXIST"
 _REST_API_PATH_PREFIX = "/api/2.0"
 _UC_OSS_REST_API_PATH_PREFIX = "/api/2.1"
 _TRACE_REST_API_PATH_PREFIX = f"{_REST_API_PATH_PREFIX}/mlflow/traces"
+_V3_TRACE_REST_API_PATH_PREFIX = "/api/3.0/mlflow/traces"
 _ARMERIA_OK = "200 OK"
 
 
@@ -357,7 +358,7 @@ def extract_all_api_info_for_service(service, path_prefix):
 
 
 def get_single_trace_endpoint(request_id):
-    return f"{_TRACE_REST_API_PATH_PREFIX}/{request_id}"
+    return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{request_id}"
 
 
 def get_logged_model_endpoint(model_id: str) -> str:
@@ -365,11 +366,10 @@ def get_logged_model_endpoint(model_id: str) -> str:
 
 
 def get_trace_info_endpoint(request_id):
-    return f"{get_single_trace_endpoint(request_id)}/info"
+    return f"{_TRACE_REST_API_PATH_PREFIX}/{request_id}/info"
 
 
 def get_trace_assessment_endpoint(request_id):
-    # TEMPORARY ENDPOINT: this is currently hosted at /api/2.0/... but will be moved to /api/3.0/...
     return f"{get_single_trace_endpoint(request_id)}"
 
 
@@ -378,11 +378,11 @@ def get_set_trace_tag_endpoint(request_id):
 
 
 def get_create_assessment_endpoint(trace_id: str):
-    return f"{_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments"
+    return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments"
 
 
 def get_single_assessment_endpoint(trace_id: str, assessment_id: str):
-    return f"{_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments/{assessment_id}"
+    return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments/{assessment_id}"
 
 
 def call_endpoint(host_creds, endpoint, method, json_body, response_proto, extra_headers=None):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -34,6 +34,7 @@ from mlflow.utils.request_utils import (
     cloud_storage_http_request,  # noqa: F401
 )
 from mlflow.utils.string_utils import strip_suffix
+from mlflow.utils.uri import is_databricks_uri
 
 RESOURCE_NON_EXISTENT = "RESOURCE_DOES_NOT_EXIST"
 _REST_API_PATH_PREFIX = "/api/2.0"
@@ -357,8 +358,19 @@ def extract_all_api_info_for_service(service, path_prefix):
     return res
 
 
-def get_single_trace_endpoint(request_id):
-    return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{request_id}"
+def get_single_trace_endpoint(request_id, is_databricks=False):
+    """
+    Get the endpoint for a single trace.
+    For Databricks tracking URIs, use the V3 API.
+    For all other tracking URIs, use the V2 API.
+    
+    Args:
+        request_id: The trace ID.
+        is_databricks: Whether the tracking URI is a Databricks URI.
+    """
+    if is_databricks:
+        return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{request_id}"
+    return f"{_TRACE_REST_API_PATH_PREFIX}/{request_id}"
 
 
 def get_logged_model_endpoint(model_id: str) -> str:
@@ -369,20 +381,53 @@ def get_trace_info_endpoint(request_id):
     return f"{_TRACE_REST_API_PATH_PREFIX}/{request_id}/info"
 
 
-def get_trace_assessment_endpoint(request_id):
-    return f"{get_single_trace_endpoint(request_id)}"
+def get_trace_assessment_endpoint(request_id, is_databricks=False):
+    """
+    Get the endpoint for a trace assessment.
+    
+    Args:
+        request_id: The trace ID.
+        is_databricks: Whether the tracking URI is a Databricks URI.
+    """
+    return get_single_trace_endpoint(request_id, is_databricks)
 
 
-def get_set_trace_tag_endpoint(request_id):
-    return f"{get_single_trace_endpoint(request_id)}/tags"
+def get_set_trace_tag_endpoint(request_id, is_databricks=False):
+    """
+    Get the endpoint for setting trace tags.
+    
+    Args:
+        request_id: The trace ID.
+        is_databricks: Whether the tracking URI is a Databricks URI.
+    """
+    return f"{get_single_trace_endpoint(request_id, is_databricks)}/tags"
 
 
-def get_create_assessment_endpoint(trace_id: str):
-    return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments"
+def get_create_assessment_endpoint(trace_id: str, is_databricks=False):
+    """
+    Get the endpoint for creating an assessment.
+    
+    Args:
+        trace_id: The trace ID.
+        is_databricks: Whether the tracking URI is a Databricks URI.
+    """
+    if is_databricks:
+        return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments"
+    return f"{_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments"
 
 
-def get_single_assessment_endpoint(trace_id: str, assessment_id: str):
-    return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments/{assessment_id}"
+def get_single_assessment_endpoint(trace_id: str, assessment_id: str, is_databricks=False):
+    """
+    Get the endpoint for a single assessment.
+    
+    Args:
+        trace_id: The trace ID.
+        assessment_id: The assessment ID.
+        is_databricks: Whether the tracking URI is a Databricks URI.
+    """
+    if is_databricks:
+        return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments/{assessment_id}"
+    return f"{_TRACE_REST_API_PATH_PREFIX}/{trace_id}/assessments/{assessment_id}"
 
 
 def call_endpoint(host_creds, endpoint, method, json_body, response_proto, extra_headers=None):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -34,7 +34,6 @@ from mlflow.utils.request_utils import (
     cloud_storage_http_request,  # noqa: F401
 )
 from mlflow.utils.string_utils import strip_suffix
-from mlflow.utils.uri import is_databricks_uri
 
 RESOURCE_NON_EXISTENT = "RESOURCE_DOES_NOT_EXIST"
 _REST_API_PATH_PREFIX = "/api/2.0"
@@ -363,10 +362,10 @@ def get_single_trace_endpoint(request_id, use_v3=False):
     Get the endpoint for a single trace.
     For Databricks tracking URIs, use the V3 API.
     For all other tracking URIs, use the V2 API.
-    
+
     Args:
         request_id: The trace ID.
-        is_databricks: Whether the tracking URI is a Databricks URI.
+        use_v3: Whether to use the V3 API. If True, use the V3 API. If False, use the V2 API.
     """
     if use_v3:
         return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{request_id}"
@@ -384,7 +383,7 @@ def get_trace_info_endpoint(request_id):
 def get_trace_assessment_endpoint(request_id, is_databricks=False):
     """
     Get the endpoint for a trace assessment.
-    
+
     Args:
         request_id: The trace ID.
         is_databricks: Whether the tracking URI is a Databricks URI.
@@ -395,7 +394,7 @@ def get_trace_assessment_endpoint(request_id, is_databricks=False):
 def get_set_trace_tag_endpoint(request_id, is_databricks=False):
     """
     Get the endpoint for setting trace tags.
-    
+
     Args:
         request_id: The trace ID.
         is_databricks: Whether the tracking URI is a Databricks URI.
@@ -406,7 +405,7 @@ def get_set_trace_tag_endpoint(request_id, is_databricks=False):
 def get_create_assessment_endpoint(trace_id: str, is_databricks=False):
     """
     Get the endpoint for creating an assessment.
-    
+
     Args:
         trace_id: The trace ID.
         is_databricks: Whether the tracking URI is a Databricks URI.
@@ -419,7 +418,7 @@ def get_create_assessment_endpoint(trace_id: str, is_databricks=False):
 def get_single_assessment_endpoint(trace_id: str, assessment_id: str, is_databricks=False):
     """
     Get the endpoint for a single assessment.
-    
+
     Args:
         trace_id: The trace ID.
         assessment_id: The assessment ID.

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -358,7 +358,7 @@ def extract_all_api_info_for_service(service, path_prefix):
     return res
 
 
-def get_single_trace_endpoint(request_id, is_databricks=False):
+def get_single_trace_endpoint(request_id, use_v3=False):
     """
     Get the endpoint for a single trace.
     For Databricks tracking URIs, use the V3 API.
@@ -368,7 +368,7 @@ def get_single_trace_endpoint(request_id, is_databricks=False):
         request_id: The trace ID.
         is_databricks: Whether the tracking URI is a Databricks URI.
     """
-    if is_databricks:
+    if use_v3:
         return f"{_V3_TRACE_REST_API_PATH_PREFIX}/{request_id}"
     return f"{_TRACE_REST_API_PATH_PREFIX}/{request_id}"
 
@@ -389,7 +389,7 @@ def get_trace_assessment_endpoint(request_id, is_databricks=False):
         request_id: The trace ID.
         is_databricks: Whether the tracking URI is a Databricks URI.
     """
-    return get_single_trace_endpoint(request_id, is_databricks)
+    return get_single_trace_endpoint(request_id, use_v3=is_databricks)
 
 
 def get_set_trace_tag_endpoint(request_id, is_databricks=False):
@@ -400,7 +400,7 @@ def get_set_trace_tag_endpoint(request_id, is_databricks=False):
         request_id: The trace ID.
         is_databricks: Whether the tracking URI is a Databricks URI.
     """
-    return f"{get_single_trace_endpoint(request_id, is_databricks)}/tags"
+    return f"{get_single_trace_endpoint(request_id, use_v3=is_databricks)}/tags"
 
 
 def get_create_assessment_endpoint(trace_id: str, is_databricks=False):

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -716,7 +716,7 @@ def test_end_trace():
                 f"traces/{request_id}", 
                 "PATCH", 
                 message_to_json(expected_request),
-                use_v3=True
+                use_v3=False
             )
             assert isinstance(res, TraceInfo)
             assert res.request_id == request_id
@@ -825,7 +825,7 @@ def test_set_trace_tag():
                 f"traces/{request_id}/tags", 
                 "PATCH", 
                 message_to_json(request),
-                use_v3=True
+                use_v3=False
             )
             assert res is None
 

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -450,7 +450,7 @@ def test_requestor():
 
         # Check call arguments to verify V2 fallback was used
         assert len(mock_http.call_args_list) == 2
-        
+
         # First call should be to V3 API
         v3_call = mock_http.call_args_list[0]
         assert v3_call[1]["endpoint"] == "/api/3.0/mlflow/traces/tr-123"

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -424,6 +424,7 @@ def test_requestor():
             "traces/tr-123",
             "GET",
             message_to_json(v3_expected_message),
+            use_v3=True,
         )
 
     # Now test the fallback path by raising an exception from the V3 call
@@ -449,16 +450,10 @@ def test_requestor():
 
         # Check call arguments to verify V2 fallback was used
         assert len(mock_http.call_args_list) == 2
-
+        
         # First call should be to V3 API
         v3_call = mock_http.call_args_list[0]
-        assert v3_call[1]["endpoint"] == "/api/2.0/mlflow/traces/tr-123"
-        assert v3_call[1]["params"] == {"trace_id": "tr-123"}
-
-        # Second call should be to V2 API
-        v2_call = mock_http.call_args_list[1]
-        assert v2_call[1]["endpoint"] == "/api/2.0/mlflow/traces/tr-123/info"
-        assert v2_call[1]["params"] == {"request_id": "tr-123"}
+        assert v3_call[1]["endpoint"] == "/api/3.0/mlflow/traces/tr-123"
 
 
 def test_get_experiment_by_name():

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -169,7 +169,7 @@ def _args(host_creds, endpoint, method, json_body):
 def _verify_requests(http_request, host_creds, endpoint, method, json_body, use_v3=False):
     """
     Verify HTTP requests in tests.
-    
+
     Args:
         http_request: The mocked HTTP request object
         host_creds: MlflowHostCreds object
@@ -700,7 +700,7 @@ def test_end_trace():
             }
         }
     )
-    
+
     with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=True):
         with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
             res = store.end_trace(
@@ -711,12 +711,12 @@ def test_end_trace():
                 tags=tags,
             )
             _verify_requests(
-                mock_http, 
-                creds, 
-                f"traces/{request_id}", 
-                "PATCH", 
+                mock_http,
+                creds,
+                f"traces/{request_id}",
+                "PATCH",
                 message_to_json(expected_request),
-                use_v3=False
+                use_v3=False,
             )
             assert isinstance(res, TraceInfo)
             assert res.request_id == request_id
@@ -811,7 +811,7 @@ def test_set_trace_tag():
         value="v",
     )
     response.text = "{}"
-    
+
     with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=True):
         with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
             res = store.set_trace_tag(
@@ -820,12 +820,12 @@ def test_set_trace_tag():
                 value=request.value,
             )
             _verify_requests(
-                mock_http, 
-                creds, 
-                f"traces/{request_id}/tags", 
-                "PATCH", 
+                mock_http,
+                creds,
+                f"traces/{request_id}/tags",
+                "PATCH",
                 message_to_json(request),
-                use_v3=False
+                use_v3=False,
             )
             assert res is None
 
@@ -881,7 +881,7 @@ def test_log_assessment():
                 "traces/tr-1234/assessments",
                 "POST",
                 message_to_json(request),
-                use_v3=True
+                use_v3=True,
             )
             assert isinstance(res, Assessment)
 
@@ -970,7 +970,7 @@ def test_update_assessment(updates, expected_request_json):
                 "traces/tr-1234/assessments/1234",
                 "PATCH",
                 json.dumps(expected_request_json),
-                use_v3=True
+                use_v3=True,
             )
             assert isinstance(res, Assessment)
 
@@ -993,7 +993,7 @@ def test_delete_assessment():
             "traces/tr-1234/assessments/1234",
             "DELETE",
             json.dumps(expected_request_json),
-            use_v3=True
+            use_v3=True,
         )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rohitarun-db/mlflow/pull/15602?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15602/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15602/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15602
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

All V3 calls to the Mlflow Service will now correctly use the 3.0 endpoints (excluding end_trace, set/delete trace tags)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1096" alt="Screenshot 2025-05-05 at 11 28 40 PM" src="https://github.com/user-attachments/assets/7191a24b-f50e-4160-9cdb-4c4b3cb4a705" />

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
