### PR TITLE
Fix bedrock provider, configured inference profile compatibility

### DIFF
--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -155,7 +155,7 @@ class AmazonBedrockModelProvider(Enum):
         name = name.lower()
 
         for opt in cls:
-            if opt.name.lower() == name or opt.value.lower() == name:
+            if opt.name.lower() in name or opt.value.lower() in name:
                 return opt
 
 
@@ -249,8 +249,7 @@ class AmazonBedrockProvider(BaseProvider):
     def _underlying_provider(self):
         if (not self.config.model.name) or "." not in self.config.model.name:
             return None
-        provider = self.config.model.name.split(".")[0]
-        return AmazonBedrockModelProvider.of_str(provider)
+        return AmazonBedrockModelProvider.of_str(self.config.model.name)
 
     @property
     def adapter_class(self) -> type[ProviderAdapter]:

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -401,3 +401,19 @@ async def test_bedrock_request_response(
 
         mock_request.assert_called_once()
         mock_request.assert_called_once_with(model_request)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("us.anthropic.claude-3-sonnet", AmazonBedrockModelProvider.ANTHROPIC),
+        ("apac.anthropic.claude-3-haiku", AmazonBedrockModelProvider.ANTHROPIC),
+        ("anthropic.claude-3-5-sonnet", AmazonBedrockModelProvider.ANTHROPIC),
+        ("ai21.jamba-1-5-large-v1:0", AmazonBedrockModelProvider.AI21),
+        ("cohere.embed-multilingual-v3", AmazonBedrockModelProvider.COHERE),
+        ("us.amazon.nova-premier-v1:0", AmazonBedrockModelProvider.AMAZON),
+    ],
+)
+def test_amazon_bedrock_model_provider(model_name, expected):
+    provider = AmazonBedrockModelProvider.of_str(model_name)
+    assert provider == expected


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/lloydhamilton/mlflow/pull/15604?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15604/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15604/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15604
```

</p>
</details>

### Related Issues/PRs

#15603

### What changes are proposed in this pull request?

I have updated the `AmazonBedrockModelProvider` to be compatible with models using inference profile ids. Inference profile ids follow the syntax `us.anthropic.claude-3-sonnet` while standard model names follow `anthropic.claude-3-sonnet`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
