### PR TITLE
Connect `model_id` to the traces created by `mlflow.genai.evaluate`

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -129,6 +129,7 @@ def evaluate(
         evaluator_config=evaluation_config,
         extra_metrics=extra_metrics,
         model_type=GENAI_CONFIG_NAME,
+        model_id=model_id,
     )
 
     return EvaluationResult(

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import mlflow.genai.evaluation
+from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME
 
 from tests.evaluate.test_evaluation import _DUMMY_CHAT_RESPONSE
 
@@ -88,7 +89,7 @@ def test_evaluate_passes_model_id_to_mlflow_evaluate():
         mock_evaluate.assert_called_once_with(
             model=model,
             data=data,
-            evaluator_config={"databricks-agent": {"metrics": []}},
+            evaluator_config={GENAI_CONFIG_NAME: {"metrics": []}},
             model_type="databricks-agent",
             extra_metrics=[],
             model_id="test_model_id",

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -65,14 +65,16 @@ def test_model_from_deployment_endpoint(mock_deploy_client, model_input):
 
 
 def test_evaluate_passes_model_id_to_mlflow_evaluate():
+    # Tracking URI = databricks is required to use mlflow.genai.evaluate()
+    mlflow.set_tracking_uri("databricks")
     data = []
     with (
-        mock.patch("mlflow.get_tracking_uri", return_value="databricks"),
         mock.patch("mlflow.genai.evaluation.base.is_model_traced", return_value=True),
         mock.patch("mlflow.genai.evaluation.base._convert_to_legacy_eval_set", return_value=data),
         mock.patch("mlflow.evaluate") as mock_evaluate,
     ):
 
+        @mlflow.trace
         def model(x):
             return x
 

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 
 import mlflow.genai.evaluation
-from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME
 
 from tests.evaluate.test_evaluation import _DUMMY_CHAT_RESPONSE
 
@@ -89,7 +88,7 @@ def test_evaluate_passes_model_id_to_mlflow_evaluate():
         mock_evaluate.assert_called_once_with(
             model=model,
             data=data,
-            evaluator_config={GENAI_CONFIG_NAME: {"metrics": []}},
+            evaluator_config={},
             model_type="databricks-agent",
             extra_metrics=[],
             model_id="test_model_id",

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -62,3 +62,32 @@ def test_model_from_deployment_endpoint(mock_deploy_client, model_input):
     else:
         assert mock_deploy_client.return_value.predict.call_count == 2
         assert pd.Series(response).equals(pd.Series(["This is a response"] * 2))
+
+
+def test_evaluate_passes_model_id_to_mlflow_evaluate():
+    data = []
+    with (
+        mock.patch("mlflow.get_tracking_uri", return_value="databricks"),
+        mock.patch("mlflow.genai.evaluation.base.is_model_traced", return_value=True),
+        mock.patch("mlflow.genai.evaluation.base._convert_to_legacy_eval_set", return_value=data),
+        mock.patch("mlflow.evaluate") as mock_evaluate,
+    ):
+
+        def model(x):
+            return x
+
+        mlflow.genai.evaluate(
+            data=data,
+            predict_fn=model,
+            model_id="test_model_id",
+        )
+
+        # Verify the call was made with the right parameters
+        mock_evaluate.assert_called_once_with(
+            model=model,
+            data=data,
+            evaluator_config={"databricks-agent": {"metrics": []}},
+            model_type="databricks-agent",
+            extra_metrics=[],
+            model_id="test_model_id",
+        )

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -90,6 +90,7 @@ def test_evaluate_parameters():
             evaluator_config=expected,
             extra_metrics=[],
             model_type=GENAI_CONFIG_NAME,
+            model_id=None,
         )
 
 

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -81,7 +81,6 @@ def test_evaluate_parameters():
         mlflow.genai.evaluate(
             data=data,
             scorers=ALL_SCORERS,
-            model_id="test_model_id",
         )
 
         # Verify the call was made with the right parameters
@@ -91,7 +90,6 @@ def test_evaluate_parameters():
             evaluator_config=expected,
             extra_metrics=[],
             model_type=GENAI_CONFIG_NAME,
-            model_id="test_model_id",
         )
 
 

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -81,6 +81,7 @@ def test_evaluate_parameters():
         mlflow.genai.evaluate(
             data=data,
             scorers=ALL_SCORERS,
+            model_id="test_model_id",
         )
 
         # Verify the call was made with the right parameters
@@ -90,6 +91,7 @@ def test_evaluate_parameters():
             evaluator_config=expected,
             extra_metrics=[],
             model_type=GENAI_CONFIG_NAME,
+            model_id="test_model_id",
         )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ShaylanDias/mlflow/pull/15606?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15606/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15606/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15606
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #15248

### What changes are proposed in this pull request?

Passes the `model_id` that `mlflow.genai.evaluate` takes in to the internal `mlflow.evaluate` call. This will cause it to link the `model_id` to the traces as a metadata entry if a `model_id` is provided. We already add a model_id if it is in the context.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

1. Ran the following to generate simple eval runs:
```
## Add model_id explicitly
import mlflow
import mlflow.genai
import pandas as pd
@mlflow.trace
def model(inputs):
    return inputs
eval_data = pd.DataFrame(
    {
        "inputs": [
            "What is MLflow?",
            "What is Spark?",
        ]
    }
)
model_id = mlflow.create_external_model(name="shaylan-test-model").model_id
mlflow.genai.evaluate(data = eval_data, predict_fn = model, model_id=model_id)
```

```
# Add model_id via context
import mlflow
import mlflow.genai
import pandas as pd
@mlflow.trace
def model(inputs):
    return inputs
eval_data = pd.DataFrame(
    {
        "inputs": [
            "What is MLflow?",
            "What is Spark?",
        ]
    }
)
model_id = mlflow.create_external_model(name="shaylan-test-model").model_id
with mlflow.set_active_model(model_id=model_id):
  mlflow.genai.evaluate(data = eval_data, predict_fn = model, model_id=None)
```

2. Retrieved the created traces and confirmed that the model ID was placed in their metadata:
```
{
  "trace": {
    "trace_info": {
      "trace_id": "tr-9c777f83d3c84f92a53b9d91d50c0eb3",
      "trace_location": {
        "type": "MLFLOW_EXPERIMENT",
        "mlflow_experiment": {
          "experiment_id": "1978327378659290"
        }
      },
      "request_time": "2025-05-06T04:21:08.828Z",
      "execution_duration": "0.163s",
      "state": "OK",
      "trace_metadata": {
        "mlflow.modelId": "m-d66b977a71fa4343b052df80561e592e",
        "mlflow.sourceRun": "0b7728d83f1d4fa697c9eced980cf736",
        "mlflow.trace_schema.version": "3",
        "mlflow.traceOutputs": "{\"messages\": [{\"role\": \"user\", \"content\": \"What is Spark?\"}]}",
        "mlflow.traceInputs": "{\"inputs\": {\"messages\": [{\"role\": \"user\", \"content\": \"What is Spark?\"}]}}"
      },
      "tags": {
        "eval.requestId": "a13633c0-0de8-4513-9ba9-f2309ff0d36b",
        "mlflow.traceName": "model",
        "mlflow.databricks.notebook.commandID": "1746503721280_8719310256788601290_603d8b09da934bc8ab3a32fb45b5f803",
        "mlflow.databricks.notebookPath": "/Users/shaylan.dias@databricks.com/Test model_id link",
        "mlflow.artifactLocation": "dbfs:/databricks/mlflow-tracking/1978327378659290/tr-9c777f83d3c84f92a53b9d91d50c0eb3/artifacts",
        "mlflow.databricks.notebookID": "1978327378659290",
        "mlflow.source.type": "NOTEBOOK",
        "mlflow.source.name": "/Users/shaylan.dias@databricks.com/Test model_id link",
        "mlflow.user": "8097961923562830",
        "mlflow.databricks.workspaceURL": "https://e2-dogfood.staging.cloud.databricks.com",
        "mlflow.databricks.workspaceID": "6051921418418893",
        "mlflow.databricks.webappURL": "https://e2-dogfood.staging.cloud.databricks.com"
      }
    }
  }
}
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The `model_id` parameter for `mlflow.genai.evaluate` will be used to add a `mlflow.modelId` parameter on the created traces.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
