### PR TITLE
Fix predict premission issue

### DIFF
--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -8,7 +8,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.utils import env_manager as _EnvManager
 from mlflow.utils.annotations import experimental
-from mlflow.utils.databricks_utils import is_databricks_connect, is_in_databricks_runtime
+from mlflow.utils.databricks_utils import is_databricks_connect
 from mlflow.utils.file_utils import TempDir
 
 _logger = logging.getLogger(__name__)
@@ -260,28 +260,19 @@ def predict(
         pyfunc_backend_env_root_config = {"create_env_root_dir": True}
 
     def _predict(_input_path: str):
-        try:
-            return get_flavor_backend(
-                model_uri,
-                env_manager=env_manager,
-                install_mlflow=install_mlflow,
-                **pyfunc_backend_env_root_config,
-            ).predict(
-                model_uri=model_uri,
-                input_path=_input_path,
-                output_path=output_path,
-                content_type=content_type,
-                pip_requirements_override=pip_requirements_override,
-                extra_envs=extra_envs,
-            )
-        except Exception as e:
-            if is_in_databricks_runtime() and "Permission denied" in str(e):
-                raise MlflowException(
-                    "The virtual environment cannot be retrieved. To resolve this issue, either "
-                    "detach your notebook from your running environment and reattach, or restart "
-                    "your compute resource to build a new environment."
-                ) from e
-            raise
+        return get_flavor_backend(
+            model_uri,
+            env_manager=env_manager,
+            install_mlflow=install_mlflow,
+            **pyfunc_backend_env_root_config,
+        ).predict(
+            model_uri=model_uri,
+            input_path=_input_path,
+            output_path=output_path,
+            content_type=content_type,
+            pip_requirements_override=pip_requirements_override,
+            extra_envs=extra_envs,
+        )
 
     if input_data is not None and input_path is not None:
         raise MlflowException.invalid_parameter_value(

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -16,6 +16,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models.model import MLMODEL_FILE_NAME, Model
 from mlflow.utils import env_manager as em
 from mlflow.utils.conda import _PIP_CACHE_DIR
+from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
     _PYTHON_ENV_FILE_NAME,
@@ -239,6 +240,22 @@ def _get_virtualenv_activate_cmd(env_dir: Path) -> str:
     return f"source {activate_cmd}" if not is_windows() else str(activate_cmd)
 
 
+class PermissionError(Exception):
+    """
+    Custom exception to handle permission errors when checking for the existence of a directory.
+    """
+
+
+def _check_dir_exists(dir: Path):
+    try:
+        return dir.exists()
+    except Exception as e:
+        if is_in_databricks_runtime() and "Permission denied" in str(e):
+            raise PermissionError(e)
+        _logger.warning(f"Failed to check directory existence. Error: {e}")
+        return False
+
+
 def _create_virtualenv(
     local_model_path: Path,
     python_env: _PythonEnv,
@@ -420,12 +437,18 @@ def _get_or_create_virtualenv(  # noqa: D417
             pyenv_root_path.mkdir(parents=True, exist_ok=True)
             pyenv_root_dir = str(pyenv_root_path)
 
-    virtual_envs_root_path = (
-        Path(env_root_dir) / _VIRTUALENV_ENVS_DIR
-        if env_root_dir is not None
-        else Path(_get_mlflow_virtualenv_root())
-    )
     virtual_envs_root_path.mkdir(parents=True, exist_ok=True)
+    try:
+        _check_dir_exists(virtual_envs_root_path)
+    except PermissionError:
+        virtual_envs_root_path = Path(env_root_dir) / _VIRTUALENV_ENVS_DIR + uuid.uuid4().hex[:4]
+        virtual_envs_root_path.mkdir(parents=True, exist_ok=True)
+        _logger.debug(
+            f"Existing virtual environment directory {virtual_envs_root_path} cannot be accessed "
+            "due to permission error. Creating a new directory for virtual "
+            f"environments: {virtual_envs_root_path}"
+        )
+
     env_name = _get_virtualenv_name(python_env, local_model_path, env_id)
     env_dir = virtual_envs_root_path / env_name
     extra_env = _get_virtualenv_extra_env_vars(env_root_dir)

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -441,6 +441,7 @@ def _get_or_create_virtualenv(  # noqa: D417
                 "due to permission error. Check the permissions of the directory and "
                 "try again. If the issue persists, consider cleaning up the directory manually."
             )
+            raise
 
     extra_env = _get_virtualenv_extra_env_vars(env_root_dir)
 

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -431,7 +431,7 @@ def _get_or_create_virtualenv(  # noqa: D417
             # Updating env_name only doesn't work because the cluster may not have
             # permission to access the original virtual_envs_root_path
             virtual_envs_root_path = (
-                Path(env_root_dir) / f"{_VIRTUALENV_ENVS_DIR}_{uuid.uuid4().hex[:4]}"
+                Path(env_root_dir) / f"{_VIRTUALENV_ENVS_DIR}_{uuid.uuid4().hex[:8]}"
             )
             virtual_envs_root_path.mkdir(parents=True, exist_ok=True)
             env_dir = virtual_envs_root_path / env_name


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15612?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15612/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15612/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15612
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
In Databricks serverless runtime, when a cluster is detached & reattached, there could be a permission issue if the virtual_env directory already exists.
This PR fixes the issue by creating a new virtual_envs directory using a random suffix.
Verified this works:
Before
<img width="992" alt="image" src="https://github.com/user-attachments/assets/2d333887-d458-4ef9-994b-c6e672a6720d" />
After
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/e2e6f3b2-6c2e-443e-af45-f9f2ae1167e9" />


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
