### PR TITLE
Fix GenAI logging

### DIFF
--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -9,7 +9,6 @@ from mlflow.models.model import _update_active_model_id_based_on_mlflow_model
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import disable_autologging_globally
 from mlflow.utils.model_utils import (
     _add_code_from_conf_to_system_path,
     _get_flavor_configuration,
@@ -51,7 +50,6 @@ def _load_model(model_uri, dst_path=None):
 
 @experimental
 @trace_disabled  # Suppress traces for internal calls while loading model
-@disable_autologging_globally  # Avoid side-effect of autologging while loading model
 def load_model(model_uri, dst_path=None):
     """
     Load a Dspy model from a run.

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -28,7 +28,6 @@ from mlflow.models.utils import _save_example
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import disable_autologging_globally
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -255,7 +254,6 @@ def save_model(
 @experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces for internal predict calls while logging model
-@disable_autologging_globally  # Avoid side-effect of autologging while logging model
 def log_model(
     dspy_model,
     artifact_path: Optional[str] = None,

--- a/mlflow/langchain/model.py
+++ b/mlflow/langchain/model.py
@@ -66,9 +66,6 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import ColSpec, DataType, Schema
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import (
-    disable_autologging_globally,
-)
 from mlflow.utils.databricks_utils import (
     _get_databricks_serverless_env_vars,
     is_in_databricks_model_serving_environment,
@@ -420,7 +417,6 @@ def save_model(
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces for internal predict calls while logging model
-@disable_autologging_globally  # Avoid side-effect of autologging while logging model
 def log_model(
     lc_model,
     artifact_path: Optional[str] = None,
@@ -892,7 +888,6 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
 @experimental
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces while loading model
-@disable_autologging_globally  # Avoid side-effect of autologging while loading model
 def load_model(model_uri, dst_path=None):
     """
     Load a LangChain model from a local file or a run.

--- a/mlflow/llama_index/model.py
+++ b/mlflow/llama_index/model.py
@@ -28,9 +28,6 @@ from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import (
-    disable_autologging_globally,
-)
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -318,7 +315,6 @@ def save_model(
 @experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces while loading model
-@disable_autologging_globally  # Avoid side-effect of autologging while logging model
 def log_model(
     llama_index_model,
     artifact_path: Optional[str] = None,
@@ -534,7 +530,6 @@ def _load_llama_model(path, flavor_conf):
 
 @experimental
 @trace_disabled  # Suppress traces while loading model
-@disable_autologging_globally  # Avoid side-effect of autologging while loading model
 def load_model(model_uri, dst_path=None):
     """
     Load a LlamaIndex index/engine/workflow from a local file or a run.

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -25,7 +25,6 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import ColSpec, Schema, TensorSpec
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import disable_autologging_globally
 from mlflow.utils.databricks_utils import (
     check_databricks_secret_scope_access,
     is_in_databricks_runtime,
@@ -413,7 +412,6 @@ def save_model(
 
 @experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
-@disable_autologging_globally
 def log_model(
     model,
     task,

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -1,5 +1,4 @@
 import contextlib
-import functools
 import importlib
 import inspect
 import logging
@@ -565,24 +564,6 @@ def disable_autologging():
         yield
     finally:
         _AUTOLOGGING_GLOBALLY_DISABLED = False
-
-
-def disable_autologging_globally(fn):
-    """
-    Decorator that temporarily disables autologging globally for all integrations
-    while the decorated function is executed.
-    """
-
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        global _AUTOLOGGING_GLOBALLY_DISABLED
-        _AUTOLOGGING_GLOBALLY_DISABLED = True
-        try:
-            return fn(*args, **kwargs)
-        finally:
-            _AUTOLOGGING_GLOBALLY_DISABLED = False
-
-    return wrapper
 
 
 @contextlib.contextmanager

--- a/tests/langgraph/sample_code/langgraph_with_autolog.py
+++ b/tests/langgraph/sample_code/langgraph_with_autolog.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+from langchain.tools import tool
+from langgraph.graph import END, StateGraph
+
+import mlflow
+
+mlflow.langchain.autolog()
+
+
+@dataclass
+class OverallState:
+    name: str = "LangChain"  # add whatever fields you need
+
+
+@tool
+def my_tool():
+    """
+    Called as the very first node.
+    Side‑effect: add an MLflow tag to the *current* trace.
+    Must return a dict of state‑field updates.
+    """
+    mlflow.update_current_trace(tags={"order_total": "hello"})
+    return {"status": "done"}
+
+
+builder = StateGraph(dict)
+builder.add_node("test_tool", my_tool)  # ← calls your tool
+builder.set_entry_point("test_tool")  # start here
+builder.add_edge("test_tool", END)  # nothing else to do
+
+graph = builder.compile()
+mlflow.models.set_model(graph)

--- a/tests/langgraph/test_langgraph_autolog.py
+++ b/tests/langgraph/test_langgraph_autolog.py
@@ -212,3 +212,5 @@ def test_langgraph_autolog_with_update_current_span():
         input_example={"status": "done"},
     )
     assert model_info.signature is not None
+    assert model_info.signature.inputs is not None
+    assert model_info.signature.outputs is not None

--- a/tests/langgraph/test_langgraph_autolog.py
+++ b/tests/langgraph/test_langgraph_autolog.py
@@ -204,3 +204,11 @@ def test_langgraph_chat_agent_trace():
     assert traces[0].info.request_metadata[SpanAttributeKey.MODEL_ID] == model_info.model_id
     assert traces[0].data.spans[0].name == "LangGraph"
     assert traces[0].data.spans[0].inputs == input_example
+
+
+def test_langgraph_autolog_with_update_current_span():
+    model_info = mlflow.langchain.log_model(
+        lc_model="tests/langgraph/sample_code/langgraph_with_autolog.py",
+        input_example={"status": "done"},
+    )
+    assert model_info.signature is not None


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Remove the disable_autologging_global decorator, since we only need to disable tracing in model logging&loading, and there's already a decorator doing that

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
