### PR TITLE
Fix Search Logged Models Fluent to use Max Results

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2447,7 +2447,14 @@ def search_logged_models(
     elif output_format == "pandas":
         import pandas as pd
 
-        return pd.DataFrame([model.to_dictionary() for model in models])
+        model_dicts = []
+        for model in models:
+            model_dict = model.to_dictionary()
+            # Convert the status back from int to the enum string
+            model_dict["status"] = LoggedModelStatus.from_int(model_dict["status"])
+            model_dicts.append(model_dict)
+
+        return pd.DataFrame(model_dicts)
 
     else:
         raise MlflowException(

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2432,9 +2432,15 @@ def search_logged_models(
             page_token=page_token,
         )
         models.extend(logged_models_page.to_list())
+        if max_results is not None and len(models) >= max_results:
+            break
         if not logged_models_page.token:
             break
         page_token = logged_models_page.token
+
+    # Only return at most max_results logged models if specified
+    if max_results is not None:
+        models = models[:max_results]
 
     if output_format == "list":
         return models

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1903,25 +1903,27 @@ def test_search_logged_models():
         )
 
 
-def test_search_logged_models_pagination():
-    def make_search_logged_model_page(models, token):
-        page = mock.Mock()
-        page.to_list.return_value = models
-        page.token = token
-        return page
+def make_mock_search_logged_model_page(models, token):
+    page = mock.Mock()
+    page.to_list.return_value = models
+    page.token = token
+    return page
 
+
+def test_search_logged_models_pagination():
     with mock.patch("mlflow.tracking.fluent.MlflowClient") as MockClient:
         mock_client = MockClient.return_value
-        page_1 = make_search_logged_model_page(["model_1", "model_2"], "token_1")
-        page_2 = make_search_logged_model_page(["model_3"], None)
+        page_1 = make_mock_search_logged_model_page(["model_1", "model_2"], "token_1")
+        page_2 = make_mock_search_logged_model_page(["model_3"], None)
         mock_client.search_logged_models.side_effect = [page_1, page_2]
 
-        result = mlflow.search_logged_models(experiment_ids=["123"], output_format="list")
+        experiment_ids = ["123"]
+        result = mlflow.search_logged_models(experiment_ids=experiment_ids, output_format="list")
         assert result == [f"model_{i + 1}" for i in range(3)]
 
         expected_calls = [
             mock.call(
-                experiment_ids=["123"],
+                experiment_ids=experiment_ids,
                 filter_string=None,
                 datasets=None,
                 max_results=None,
@@ -1929,7 +1931,7 @@ def test_search_logged_models_pagination():
                 page_token=None,
             ),
             mock.call(
-                experiment_ids=["123"],
+                experiment_ids=experiment_ids,
                 filter_string=None,
                 datasets=None,
                 max_results=None,
@@ -1938,6 +1940,29 @@ def test_search_logged_models_pagination():
             ),
         ]
         mock_client.search_logged_models.assert_has_calls(expected_calls)
+
+
+def test_search_logged_models_max_results():
+    with mock.patch("mlflow.tracking.fluent.MlflowClient") as MockClient:
+        mock_client = MockClient.return_value
+        page = make_mock_search_logged_model_page(["model_1", "model_2"], "token_1")
+        mock_client.search_logged_models.side_effect = [page]
+
+        experiment_ids = ["123"]
+        max_results = 1
+        result = mlflow.search_logged_models(
+            experiment_ids=experiment_ids, max_results=max_results, output_format="list"
+        )
+        assert result == ["model_1"]
+
+        mock_client.search_logged_models.assert_called_once_with(
+            experiment_ids=experiment_ids,
+            filter_string=None,
+            datasets=None,
+            max_results=max_results,
+            order_by=None,
+            page_token=None,
+        )
 
 
 def test_set_active_model():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/raymondzhou-db/mlflow/pull/15616?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15616/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15616/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15616
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #15285


### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The fluent API for search logged models currently calls the client API with the given `max_results` until no more models are returned. This fixes the API to stop and only return the first `max_results`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Manually tested that `max_results` is respected now. User error at `max_results=100` comes from backend and is same as when client API is called directly

<img width="1354" alt="image" src="https://github.com/user-attachments/assets/11aa563f-bf12-4c44-adb7-42b48b519d8d" />
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/58545dd4-17cc-440e-9dce-c064a4e0f3bf" />


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
