### PR TITLE
Fix global_guideline_adherence to handle multiple guidelines with different names

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from typing import Any, Union
 
 from mlflow.genai.scorers import BuiltInScorer
 

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -74,27 +74,111 @@ class _GuidelineAdherence(_BaseBuiltInScorer):
 
 def guideline_adherence():
     """
-    Guideline adherence evaluates whether the agent’s response follows specific constraints
+    Guideline adherence evaluates whether the agent's response follows specific constraints
     or instructions provided in the guidelines.
+
+    This judge should be used when each example has a different set of guidelines. The guidelines
+    must be specified in the `guidelines` column of the input dataset.
+
+    If you want to apply the same set of guidelines to all examples, use the
+    :py:func:`global_guideline_adherence` scorer instead.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import guideline_adherence
+
+        eval_set = [
+            {
+                "inputs": "Translate the following text to English: 'Hello, world!'",
+                "guidelines": ["The response must be in English"],
+            },
+            {
+                "inputs": "Translate the following text to German: 'Hello, world!'",
+                "guidelines": ["The response must be in German"],
+            },
+        ]
+
+        # Run evaluation
+        mlflow.genai.evaluate(
+            data=data,
+            scorers=[guideline_adherence()],
+        )
     """
     return _GuidelineAdherence()
 
 
 class _GlobalGuidelineAdherence(_GuidelineAdherence):
-    global_guidelines: Union[list[str], dict[str, Any]]
+    guidelines: list[str]
 
     def update_evaluation_config(self, evaluation_config) -> dict:
-        config = super().update_evaluation_config(evaluation_config)
-        config[GENAI_CONFIG_NAME]["global_guidelines"] = self.global_guidelines
+        config = deepcopy(evaluation_config)
+        metrics = config.setdefault(GENAI_CONFIG_NAME, {}).setdefault("metrics", [])
+        if "guideline_adherence" not in metrics:
+            metrics.append("guideline_adherence")
+
+        # NB: The agent eval harness will take multiple global guidelines in a dictionary format
+        #   where the key is the name of the global guideline judge. Therefore, when multiple
+        #   judges are specified, we merge them into a single dictionary.
+        #   https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/llm-judge-reference#examples
+        global_guidelines = config[GENAI_CONFIG_NAME].get("global_guidelines", {})
+        global_guidelines[self.name] = self.guidelines
+        config[GENAI_CONFIG_NAME]["global_guidelines"] = global_guidelines
         return config
 
 
-def global_guideline_adherence(global_guidelines: list[str]):
+def global_guideline_adherence(
+    guidelines: list[str],
+    name: str = "guideline_adherence",
+):
     """
-    Guideline adherence evaluates whether the agent’s response follows specific constraints or
+    Guideline adherence evaluates whether the agent's response follows specific constraints or
     instructions provided in the guidelines.
+
+    Args:
+        guidelines: A list of global guidelines to evaluate the agent's response against.
+        name: The name of the judge. Defaults to "guideline_adherence".
+
+    Example:
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import global_guideline_adherence
+
+        # A single judge with multiple guidelines
+        guideline = global_guideline_adherence(["Be polite", "Be kind"])
+
+        # Create a judge with different names
+        english = global_guideline_adherence(
+            name="english_guidelines",
+            guidelines=["The response must be in English"],
+        )
+
+        clarify = global_guideline_adherence(
+            name="clarify_guidelines",
+            guidelines=["The response must be clear, coherent, and concise"],
+        )
+
+        # Dataset
+        eval_set = [
+            {
+                "inputs": "What is the capital of France?",
+                "outputs": "The capital of France is Paris.",
+            },
+            {
+                "inputs": "What is the capital of Germany?",
+                "outputs": "The capital of Germany is Berlin.",
+            },
+        ]
+
+        # Run evaluation
+        mlflow.genai.evaluate(
+            data=data,
+            scorers=[guideline, english, clarify],
+        )
     """
-    return _GlobalGuidelineAdherence(global_guidelines=global_guidelines)
+    return _GlobalGuidelineAdherence(guidelines=guidelines, name=name)
 
 
 class _RelevanceToQuery(_BaseBuiltInScorer):

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -46,7 +46,9 @@ expected = {
             "relevance_to_query",
             "safety",
         ],
-        "global_guidelines": ["Be polite", "Be kind"],
+        "global_guidelines": {
+            "guideline_adherence": ["Be polite", "Be kind"],
+        },
     }
 }
 
@@ -129,10 +131,43 @@ def test_global_guideline_adherence():
     expected_conf = {
         GENAI_CONFIG_NAME: {
             "metrics": ["guideline_adherence"],
-            "global_guidelines": ["Be polite", "Be kind"],
+            "global_guidelines": {
+                "guideline_adherence": ["Be polite", "Be kind"],
+            },
         }
     }
 
+    assert normalize_config(evaluation_config) == normalize_config(expected_conf)
+
+
+def test_multiple_global_guideline_adherence():
+    """Test passing multiple global guideline adherence scorers with different names."""
+    evaluation_config = {}
+
+    guideline = global_guideline_adherence(["Be polite", "Be kind"])  # w/ default name
+    english = global_guideline_adherence(
+        name="english",
+        guidelines=["The response must be in English"],
+    )
+    clarify = global_guideline_adherence(
+        name="clarify",
+        guidelines=["The response must be clear, coherent, and concise"],
+    )
+
+    scorers = [guideline, english, clarify]
+    for scorer in scorers:
+        evaluation_config = scorer.update_evaluation_config(evaluation_config)
+
+    expected_conf = {
+        GENAI_CONFIG_NAME: {
+            "metrics": ["guideline_adherence"],
+            "global_guidelines": {
+                "guideline_adherence": ["Be polite", "Be kind"],
+                "english": ["The response must be in English"],
+                "clarify": ["The response must be clear, coherent, and concise"],
+            },
+        }
+    }
     assert normalize_config(evaluation_config) == normalize_config(expected_conf)
 
 
@@ -150,8 +185,12 @@ def test_guideline_adherence_scorers(scorers):
 
     expected_conf = {
         GENAI_CONFIG_NAME: {
-            "metrics": ["guideline_adherence"],
-            "global_guidelines": ["Be polite", "Be kind"],
+            "metrics": [
+                "guideline_adherence",
+            ],
+            "global_guidelines": {
+                "guideline_adherence": ["Be polite", "Be kind"],
+            },
         }
     }
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15618?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15618/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15618/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15618
```

</p>
</details>

### What changes are proposed in this pull request?

Currently agent evaluation can accept multiple global guidelines as a dictionary format: https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/

```
global_guidelines = {
  "english": ["The response must be in English"],
  "clarity": ["The response must be clear, coherent, and concise"],
}

result = mlflow.evaluate(
    data=pd.DataFrame(examples),    # Your evaluation set
    # model=logged_model.model_uri, # If you have an MLFlow model. `retrieved_context` and `response` will be obtained from calling the model.
    model_type="databricks-agent",  # Enable Mosaic AI Agent Evaluation
    evaluator_config={
       "databricks-agent": {"global_guidelines": global_guidelines}
    }
)
```

On the other hand, the scorer implementation only takes in a single global guideline (`list[str]`). This PR updates the scorer logic so that users can specify multiple global guidelines like this.

```
        import mlflow
        from mlflow.genai.scorers import global_guideline_adherence

        # A single judge with multiple guidelines
        guideline = global_guideline_adherence(["Be polite", "Be kind"])

        # Create a judge with different names
        english = global_guideline_adherence(
            name="english_guidelines",
            guidelines=["The response must be in English"],
        )

        clarify = global_guideline_adherence(
            name="clarify_guidelines",
            guidelines=["The response must be clear, coherent, and concise"],
        )

        # Dataset
        eval_set = [
            {
                "inputs": "What is the capital of France?",
                "outputs": "The capital of France is Paris.",
            },
            {
                "inputs": "What is the capital of Germany?",
                "outputs": "The capital of Germany is Berlin.",
            },
        ]

        # Run evaluation
        mlflow.genai.evaluate(
            data=data,
            scorers=[guideline, english, clarify],
        )
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
