### PR TITLE
Fix dict->pandas conversion for GenAI eval API

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -14,6 +14,7 @@ from mlflow.models.evaluation.base import (
     _get_model_from_deployment_endpoint_uri,
     _is_model_deployment_endpoint_uri,
 )
+from mlflow.utils.uri import is_databricks_uri
 
 if TYPE_CHECKING:
     from genai.evaluation.utils import EvaluationDatasetTypes
@@ -102,7 +103,7 @@ def evaluate(
             "Please install it with `pip install databricks-agents`."
         )
 
-    if mlflow.get_tracking_uri() != "databricks":
+    if not is_databricks_uri(mlflow.get_tracking_uri()):
         raise ValueError(
             "The genai evaluation function is only supported on Databricks. "
             "Please set the tracking URI to Databricks."

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -51,7 +51,7 @@ def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame
                     "Every item in the list must have an 'inputs' key."
                 )
 
-        df = pd.DataFrame(data) if 1 < len(data) else pd.DataFrame(data[0])
+        df = pd.DataFrame(data)
     elif isinstance(data, pd.DataFrame):
         # Data is already a pd DataFrame, just copy it
         df = data.copy()

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -14,7 +14,6 @@ from mlflow.environment_variables import (
 
 _logger = logging.getLogger(__name__)
 
-
 @dataclass
 class Task:
     """A dataclass to represent a simple task."""

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -14,6 +14,7 @@ from mlflow.environment_variables import (
 
 _logger = logging.getLogger(__name__)
 
+
 @dataclass
 class Task:
     """A dataclass to represent a simple task."""

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -6,7 +6,6 @@ import pytest
 
 import mlflow
 from mlflow.genai.evaluation.utils import (
-    _convert_scorer_to_legacy_metric,
     _convert_to_legacy_eval_set,
 )
 from mlflow.genai.scorers import scorer
@@ -31,34 +30,62 @@ def spark():
         pytest.skip("Can't create a Spark session")
 
 
+@pytest.fixture(autouse=True)
+def spoof_tracking_uri_check():
+    # NB: The mlflow.genai.evaluate() API is only runnable when the tracking URI is set
+    # to Databricks. However, we cannot test against real Databricks server in CI, so
+    # we spoof the check by patching the is_databricks_uri() function.
+    with patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=True):
+        yield
+
+
 @pytest.fixture
-def sample_dict_data():
+def sample_dict_data_single():
     return [
         {
-            "inputs": [
-                "What is the difference between reduceByKey and groupByKey in Spark?",
-                {
-                    "messages": [
-                        {"role": "user", "content": "How can you minimize data shuffling in Spark?"}
-                    ]
-                },
-            ],
-            "outputs": [
-                {"choices": [{"message": {"content": "actual response for first question"}}]},
-                {"choices": [{"message": {"content": "actual response for second question"}}]},
-            ],
-            "expectations": [
-                "expected response for first question",
-                "expected response for second question",
-            ],
-        }
+            "inputs": "What is the difference between reduceByKey and groupByKey in Spark?",
+            "outputs": {"choices": [{"message": {"content": "response"}}]},
+            "expectations": "expected response for first question",
+        },
     ]
 
 
 @pytest.fixture
-def sample_pd_data(sample_dict_data):
+def sample_dict_data_multiple():
+    return [
+        {
+            "inputs": "What is the difference between reduceByKey and groupByKey in Spark?",
+            "outputs": {"choices": [{"message": {"content": "response"}}]},
+            "expectations": "expected response for first question",
+            # Additional columns required by the judges
+            "retrieved_context": [
+                {
+                    "content": "doc content 1",
+                    "doc_uri": "doc_uri_2_1",
+                },
+                {
+                    "content": "doc content 2.",
+                    "doc_uri": "doc_uri_6_extra",
+                },
+            ],
+        },
+        {
+            "inputs": {
+                "messages": [
+                    {"role": "user", "content": "How can you minimize data shuffling in Spark?"}
+                ]
+            },
+            "outputs": {"choices": [{"message": {"content": "response"}}]},
+            "expectations": "expected response for second question",
+            "retrieved_context": [],
+        },
+    ]
+
+
+@pytest.fixture
+def sample_pd_data(sample_dict_data_multiple):
     """Returns a pandas DataFrame with sample data"""
-    return pd.DataFrame(sample_dict_data[0])
+    return pd.DataFrame(sample_dict_data_multiple)
 
 
 @pytest.fixture
@@ -69,7 +96,7 @@ def sample_spark_data(sample_pd_data, spark):
 
 @pytest.mark.parametrize(
     "data_fixture",
-    ["sample_dict_data", "sample_pd_data", "sample_spark_data"],
+    ["sample_dict_data_single", "sample_dict_data_multiple", "sample_pd_data", "sample_spark_data"],
 )
 def test_convert_to_legacy_eval_set_has_no_errors(data_fixture, request):
     sample_data = request.getfixturevalue(data_fixture)
@@ -89,7 +116,7 @@ def test_convert_to_legacy_eval_set_has_no_errors(data_fixture, request):
 
 @pytest.mark.parametrize(
     "data_fixture",
-    ["sample_dict_data", "sample_pd_data", "sample_spark_data"],
+    ["sample_dict_data_single", "sample_dict_data_multiple", "sample_pd_data", "sample_spark_data"],
 )
 def test_scorer_receives_correct_data(data_fixture, request):
     sample_data = request.getfixturevalue(data_fixture)
@@ -97,68 +124,52 @@ def test_scorer_receives_correct_data(data_fixture, request):
     received_args = []
 
     @scorer
-    def dummy_scorer(inputs, outputs, expectations, trace):
+    def dummy_scorer(inputs, outputs, expectations):
         received_args.append(
             {
                 "inputs": inputs,
                 "outputs": outputs,
                 "expectations": expectations,
-                "trace": trace,
             }
         )
+        return 0
 
     with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        transformed_data = _convert_to_legacy_eval_set(sample_data)
-        legacy_metric = _convert_scorer_to_legacy_metric(dummy_scorer)
-        mlflow.evaluate(
-            data=transformed_data,
-            model_type="databricks-agent",
-            extra_metrics=[legacy_metric],
+        mlflow.genai.evaluate(
+            data=sample_data,
+            scorers=[dummy_scorer],
         )
 
-        expected_len = (
-            len(sample_data[0]["inputs"]) if isinstance(sample_data, list) else len(sample_data)
-        )
+        assert len(received_args) == len(sample_data)
+        assert set(received_args[0].keys()) == set({"inputs", "outputs", "expectations"})
 
-        assert len(received_args) == expected_len
-        assert set(received_args[0].keys()) == set({"inputs", "outputs", "expectations", "trace"})
-
-        all_inputs, all_outputs, all_expectations, all_traces = [], [], [], []
+        all_inputs, all_outputs, all_expectations = [], [], []
         for arg in received_args:
             all_inputs.append(arg["inputs"]["messages"][0]["content"])
             all_outputs.append(arg["outputs"]["choices"][0]["message"]["content"])
             all_expectations.append(arg["expectations"])
-            all_traces.extend(arg["trace"])
 
         expected_inputs = [
             "What is the difference between reduceByKey and groupByKey in Spark?",
             "How can you minimize data shuffling in Spark?",
-        ]
+        ][: len(sample_data)]
         expected_outputs = [
             "actual response for first question",
             "actual response for second question",
-        ]
+        ][: len(sample_data)]
         expected_expectations = [
             "expected response for first question",
             "expected response for second question",
-        ]
+        ][: len(sample_data)]
 
         assert set(all_inputs) == set(expected_inputs)
         assert set(all_outputs) == set(expected_outputs)
         assert set(all_expectations) == set(expected_expectations)
-        for trace in all_traces:
-            assert any(
-                expected_input in trace.info.request_preview for expected_input in expected_inputs
-            )
-            assert any(
-                expected_output in trace.info.response_preview
-                for expected_output in expected_outputs
-            )
 
 
 @pytest.mark.parametrize(
     "data_fixture",
-    ["sample_dict_data", "sample_pd_data", "sample_spark_data"],
+    ["sample_dict_data_single", "sample_dict_data_multiple", "sample_pd_data", "sample_spark_data"],
 )
 def test_predict_fn_receives_correct_data(data_fixture, request):
     sample_data = request.getfixturevalue(data_fixture)
@@ -170,21 +181,16 @@ def test_predict_fn_receives_correct_data(data_fixture, request):
         return inputs
 
     with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        transformed_data = _convert_to_legacy_eval_set(sample_data)
-        mlflow.evaluate(
-            model=predict_fn,
-            data=transformed_data,
-            model_type="databricks-agent",
+        mlflow.genai.evaluate(
+            predict_fn=predict_fn,
+            data=sample_data,
         )
-        expected_len = (
-            len(sample_data[0]["inputs"]) if isinstance(sample_data, list) else len(sample_data)
-        )
-        assert len(received_args) == expected_len
-        assert set(
-            {received_args[0]["messages"][0]["content"], received_args[1]["messages"][0]["content"]}
-        ) == set(
-            {
-                "What is the difference between reduceByKey and groupByKey in Spark?",
-                "How can you minimize data shuffling in Spark?",
-            }
-        )
+        received_args.pop(0)  # Remove the one-time prediction to check if a model is traced
+        assert len(received_args) == len(sample_data)
+        received_contents = [arg["messages"][0]["content"] for arg in received_args]
+        expected_contents = [
+            "What is the difference between reduceByKey and groupByKey in Spark?",
+            "How can you minimize data shuffling in Spark?",
+        ][: len(sample_data)]
+        # Using set because eval harness runs predict_fn in parallel
+        assert set(received_contents) == set(expected_contents)

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -44,7 +44,9 @@ def sample_dict_data_single():
     return [
         {
             "inputs": "What is the difference between reduceByKey and groupByKey in Spark?",
-            "outputs": {"choices": [{"message": {"content": "response"}}]},
+            "outputs": {
+                "choices": [{"message": {"content": "actual response for first question"}}]
+            },
             "expectations": "expected response for first question",
         },
     ]
@@ -55,7 +57,9 @@ def sample_dict_data_multiple():
     return [
         {
             "inputs": "What is the difference between reduceByKey and groupByKey in Spark?",
-            "outputs": {"choices": [{"message": {"content": "response"}}]},
+            "outputs": {
+                "choices": [{"message": {"content": "actual response for first question"}}]
+            },
             "expectations": "expected response for first question",
             # Additional columns required by the judges
             "retrieved_context": [
@@ -75,7 +79,9 @@ def sample_dict_data_multiple():
                     {"role": "user", "content": "How can you minimize data shuffling in Spark?"}
                 ]
             },
-            "outputs": {"choices": [{"message": {"content": "response"}}]},
+            "outputs": {
+                "choices": [{"message": {"content": "actual response for second question"}}]
+            },
             "expectations": "expected response for second question",
             "retrieved_context": [],
         },


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15620?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15620/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15620/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15620
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.genai.evaluate` API should accept a single dictionary

```
import mlflow
import pandas as pd
from mlflow.genai.scorers import relevance_to_query, safety

eval_set = [
    {
        "inputs": {"foo": "bar"}
        "outputs": "response from a model",
    }
]

mlflow.genai.evaluate(
    data=eval_set,
    scorers=[relevance_to_query(), safety()],
)
```

However, current implementation doesn't allow it. This PR fixes that. 
```
File ~/Workspace/mlflow/mlflow/genai/evaluation/utils.py:54, in _convert_to_legacy_eval_set(data)
     49         if "inputs" not in item:
     50             raise MlflowException.invalid_parameter_value(
     51                 "Every item in the list must have an 'inputs' key."
     52             )
---> 54     df = pd.DataFrame(data) if 1 < len(data) else pd.DataFrame(data[0])
     55 elif isinstance(data, pd.DataFrame):
     56     # Data is already a pd DataFrame, just copy it
     57     df = data.copy()
...

File ~/.pyenv/versions/3.10.12/lib/python3.10/site-packages/pandas/core/internals/construction.py:667, in _extract_index(data)
    664         raise ValueError("Per-column arrays must each be 1-dimensional")
    666 if not indexes and not raw_lengths:
--> 667     raise ValueError("If using all scalar values, you must pass an index")
    669 if have_series:
    670     index = union_indexes(indexes)

ValueError: If using all scalar values, you must pass an index
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
