### PR TITLE
Fix set active model during model loading

### DIFF
--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -5,12 +5,9 @@ import cloudpickle
 
 from mlflow.models import Model
 from mlflow.models.dependencies_schemas import _get_dependencies_schema_from_model
+from mlflow.models.model import _update_active_model_id_based_on_mlflow_model
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.tracking.fluent import (
-    _get_active_model_context,
-    _set_active_model_id,
-)
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import disable_autologging_globally
 from mlflow.utils.model_utils import (
@@ -48,17 +45,7 @@ def _load_model(model_uri, dst_path=None):
         loaded_wrapper = cloudpickle.load(f)
 
     _set_dependency_schema_to_tracer(local_model_path, loaded_wrapper.dspy_settings["callbacks"])
-    if (
-        mlflow_model.model_id
-        and (amc := _get_active_model_context())
-        # only set the active model if the model is not set by the user
-        and not amc.set_by_user
-        and amc.model_id != mlflow_model.model_id
-    ):
-        _set_active_model_id(model_id=mlflow_model.model_id)
-        _logger.info(
-            "Use `mlflow.set_active_model` to set the active model to a different one if needed."
-        )
+    _update_active_model_id_based_on_mlflow_model(mlflow_model)
     return loaded_wrapper
 
 

--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -9,7 +9,7 @@ from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.fluent import (
     _get_active_model_context,
-    _try_set_active_model_id,
+    _set_active_model_id,
 )
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import disable_autologging_globally
@@ -55,7 +55,7 @@ def _load_model(model_uri, dst_path=None):
         and not amc.set_by_user
         and amc.model_id != mlflow_model.model_id
     ):
-        _try_set_active_model_id(model_id=mlflow_model.model_id)
+        _set_active_model_id(model_id=mlflow_model.model_id)
         _logger.info(
             "Use `mlflow.set_active_model` to set the active model to a different one if needed."
         )

--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -9,7 +9,7 @@ from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.fluent import (
     _get_active_model_context,
-    _set_active_model,
+    _try_set_active_model_id,
 )
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import disable_autologging_globally
@@ -40,17 +40,6 @@ def _set_dependency_schema_to_tracer(model_path, callbacks):
 def _load_model(model_uri, dst_path=None):
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     mlflow_model = Model.load(local_model_path)
-    if (
-        mlflow_model.model_id
-        and (amc := _get_active_model_context())
-        # only set the active model if the model is not set by the user
-        and not amc.set_by_user
-        and amc.model_id != mlflow_model.model_id
-    ):
-        _set_active_model(model_id=mlflow_model.model_id)
-        _logger.info(
-            "Use `mlflow.set_active_model` to set the active model to a different one if needed."
-        )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name="dspy")
 
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
@@ -59,6 +48,17 @@ def _load_model(model_uri, dst_path=None):
         loaded_wrapper = cloudpickle.load(f)
 
     _set_dependency_schema_to_tracer(local_model_path, loaded_wrapper.dspy_settings["callbacks"])
+    if (
+        mlflow_model.model_id
+        and (amc := _get_active_model_context())
+        # only set the active model if the model is not set by the user
+        and not amc.set_by_user
+        and amc.model_id != mlflow_model.model_id
+    ):
+        _try_set_active_model_id(model_id=mlflow_model.model_id)
+        _logger.info(
+            "Use `mlflow.set_active_model` to set the active model to a different one if needed."
+        )
     return loaded_wrapper
 
 

--- a/mlflow/langchain/model.py
+++ b/mlflow/langchain/model.py
@@ -61,7 +61,7 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.fluent import (
     _get_active_model_context,
-    _try_set_active_model_id,
+    _set_active_model_id,
 )
 from mlflow.types.schema import ColSpec, DataType, Schema
 from mlflow.utils.annotations import experimental
@@ -891,7 +891,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
         and not amc.set_by_user
         and amc.model_id != mlflow_model.model_id
     ):
-        _try_set_active_model_id(model_id=mlflow_model.model_id)
+        _set_active_model_id(model_id=mlflow_model.model_id)
         logger.info(
             "Use `mlflow.set_active_model` to set the active model to a different one if needed."
         )

--- a/mlflow/langchain/model.py
+++ b/mlflow/langchain/model.py
@@ -47,7 +47,12 @@ from mlflow.models.dependencies_schemas import (
     _get_dependencies_schema_from_model,
     _get_dependencies_schemas,
 )
-from mlflow.models.model import MLMODEL_FILE_NAME, MODEL_CODE_PATH, MODEL_CONFIG
+from mlflow.models.model import (
+    MLMODEL_FILE_NAME,
+    MODEL_CODE_PATH,
+    MODEL_CONFIG,
+    _update_active_model_id_based_on_mlflow_model,
+)
 from mlflow.models.resources import DatabricksFunction, Resource, _ResourceBuilder
 from mlflow.models.signature import _infer_signature_from_input_example
 from mlflow.models.utils import (
@@ -59,10 +64,6 @@ from mlflow.pyfunc import FLAVOR_NAME as PYFUNC_FLAVOR_NAME
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.tracking.fluent import (
-    _get_active_model_context,
-    _set_active_model_id,
-)
 from mlflow.types.schema import ColSpec, DataType, Schema
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
@@ -884,17 +885,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
         model = _load_model(local_model_path, flavor_conf)
     # set active model after model loading since experiment ID might be set
     # in the model loading process
-    if (
-        mlflow_model.model_id
-        and (amc := _get_active_model_context())
-        # only set the active model if the model is not set by the user
-        and not amc.set_by_user
-        and amc.model_id != mlflow_model.model_id
-    ):
-        _set_active_model_id(model_id=mlflow_model.model_id)
-        logger.info(
-            "Use `mlflow.set_active_model` to set the active model to a different one if needed."
-        )
+    _update_active_model_id_based_on_mlflow_model(mlflow_model)
     return model
 
 

--- a/mlflow/llama_index/model.py
+++ b/mlflow/llama_index/model.py
@@ -24,7 +24,7 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.fluent import (
     _get_active_model_context,
-    _try_set_active_model_id,
+    _set_active_model_id,
 )
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
@@ -574,7 +574,7 @@ def load_model(model_uri, dst_path=None):
         and not amc.set_by_user
         and amc.model_id != mlflow_model.model_id
     ):
-        _try_set_active_model_id(model_id=mlflow_model.model_id)
+        _set_active_model_id(model_id=mlflow_model.model_id)
         _logger.info(
             "Use `mlflow.set_active_model` to set the active model to a different one if needed."
         )

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1406,14 +1406,9 @@ def _update_active_model_id_based_on_mlflow_model(mlflow_model: Model):
     This is useful for setting the active model ID when loading a model
     to ensure traces generated are associated with the loaded model.
     """
-    if (
-        mlflow_model.model_id
-        and (amc := _get_active_model_context())
-        # only set the active model if the model is not set by the user
-        and not amc.set_by_user
-        and amc.model_id != mlflow_model.model_id
-    ):
+    if mlflow_model.model_id is None:
+        return
+    amc = _get_active_model_context()
+    # only set the active model if the model is not set by the user
+    if amc.model_id != mlflow_model.model_id and not amc.set_by_user:
         _set_active_model_id(model_id=mlflow_model.model_id)
-        _logger.info(
-            "Use `mlflow.set_active_model` to set the active model to a different one if needed."
-        )

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -25,7 +25,7 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.fluent import (
     _get_active_model_context,
-    _set_active_model,
+    _try_set_active_model_id,
 )
 from mlflow.types import ColSpec, Schema, TensorSpec
 from mlflow.utils.annotations import experimental
@@ -554,7 +554,7 @@ def _load_model(path):
             and not amc.set_by_user
             and amc.model_id != mlflow_model.model_id
         ):
-            _set_active_model(model_id=mlflow_model.model_id)
+            _try_set_active_model_id(model_id=mlflow_model.model_id)
             _logger.info(
                 "Use `mlflow.set_active_model` to set the active model "
                 "to a different one if needed."

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -25,7 +25,7 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.fluent import (
     _get_active_model_context,
-    _try_set_active_model_id,
+    _set_active_model_id,
 )
 from mlflow.types import ColSpec, Schema, TensorSpec
 from mlflow.utils.annotations import experimental
@@ -554,7 +554,7 @@ def _load_model(path):
             and not amc.set_by_user
             and amc.model_id != mlflow_model.model_id
         ):
-            _try_set_active_model_id(model_id=mlflow_model.model_id)
+            _set_active_model_id(model_id=mlflow_model.model_id)
             _logger.info(
                 "Use `mlflow.set_active_model` to set the active model "
                 "to a different one if needed."

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -16,17 +16,13 @@ from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.environment_variables import MLFLOW_OPENAI_SECRET_SCOPE
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature
-from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.models.model import MLMODEL_FILE_NAME, _update_active_model_id_based_on_mlflow_model
 from mlflow.models.signature import _infer_signature_from_input_example
 from mlflow.models.utils import _save_example
 from mlflow.openai.constant import FLAVOR_NAME
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.tracking.fluent import (
-    _get_active_model_context,
-    _set_active_model_id,
-)
 from mlflow.types import ColSpec, Schema, TensorSpec
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import disable_autologging_globally
@@ -547,18 +543,7 @@ def _load_model(path):
     model_file_path = os.path.dirname(path)
     if os.path.exists(model_file_path):
         mlflow_model = Model.load(model_file_path)
-        if (
-            mlflow_model.model_id
-            and (amc := _get_active_model_context())
-            # only set the active model if the model is not set by the user
-            and not amc.set_by_user
-            and amc.model_id != mlflow_model.model_id
-        ):
-            _set_active_model_id(model_id=mlflow_model.model_id)
-            _logger.info(
-                "Use `mlflow.set_active_model` to set the active model "
-                "to a different one if needed."
-            )
+        _update_active_model_id_based_on_mlflow_model(mlflow_model)
     with open(path) as f:
         return yaml.safe_load(f)
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3277,13 +3277,12 @@ def set_active_model(*, name: Optional[str] = None, model_id: Optional[str] = No
         traces = mlflow.search_traces(model_id=mlflow.get_active_model_id(), return_type="list")
         assert len(traces) == 1
     """
-    active_model = _set_active_model(name=name, model_id=model_id)
-    active_model_ctx = _ACTIVE_MODEL_CONTEXT.get()
-    _ACTIVE_MODEL_CONTEXT.set(ActiveModelContext(active_model_ctx.model_id, set_by_user=True))
-    return active_model
+    return _set_active_model(name=name, model_id=model_id, set_by_user=True)
 
 
-def _set_active_model(*, name: Optional[str] = None, model_id: Optional[str] = None) -> ActiveModel:
+def _set_active_model(
+    *, name: Optional[str] = None, model_id: Optional[str] = None, set_by_user: bool = False
+) -> ActiveModel:
     if name is None and model_id is None:
         raise MlflowException.invalid_parameter_value(
             message="Either name or model_id must be provided",
@@ -3310,7 +3309,7 @@ def _set_active_model(*, name: Optional[str] = None, model_id: Optional[str] = N
             logged_model = mlflow.create_external_model(name=name)
         else:
             logged_model = logged_models[0]
-    return ActiveModel(logged_model=logged_model, set_by_user=False)
+    return ActiveModel(logged_model=logged_model, set_by_user=set_by_user)
 
 
 def _set_active_model_id(model_id: str, set_by_user: bool = False) -> None:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3313,34 +3313,17 @@ def _set_active_model(*, name: Optional[str] = None, model_id: Optional[str] = N
     return ActiveModel(logged_model=logged_model, set_by_user=False)
 
 
-def _set_active_model_id(model_id: str, set_by_user: bool) -> None:
+def _set_active_model_id(model_id: str, set_by_user: bool = False) -> None:
     """
     Set the active model ID in the active model context and update the
     corresponding environment variable. This should only be used when
     we know the LoggedModel with the model_id exists.
+    This function should be used inside MLflow to set the active model
+    while not blocking other code execution.
     """
     _ACTIVE_MODEL_CONTEXT.set(ActiveModelContext(model_id, set_by_user))
     _update_active_model_id_env_var(model_id)
     _logger.info(f"Active model set to model with ID: {model_id}")
-
-
-def _try_set_active_model_id(model_id):
-    """
-    Try to set the active model with the specified model ID. In databricks serving
-    environment, if users don't set current experiment ID correctly then MLflow may
-    not find the LoggedModel with the model_id.
-    This function should be used inside MLflow to set the active model while not blocking
-    other code execution.
-    """
-    _set_active_model_id(model_id=model_id, set_by_user=False)
-    try:
-        mlflow.get_logged_model(model_id)
-    except MlflowException as e:
-        _logger.warning(
-            f"Logged model with model_id {model_id} is not found, please "
-            "double check that you set the experiment ID correctly in the model "
-            f"or through environment variables. Error: {e}"
-        )
 
 
 def _get_active_model_context() -> ActiveModelContext:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3327,7 +3327,12 @@ def _set_active_model_id(model_id: str, set_by_user: bool = False) -> None:
     except Exception as e:
         _logger.warning(f"Failed to set active model ID to {model_id}, error: {e}")
     else:
-        _logger.info(f"Active model set to model with ID: {model_id}")
+        _logger.info(f"Active model is set to the logged model with ID: {model_id}")
+        if not set_by_user:
+            _logger.info(
+                "Use `mlflow.set_active_model` to set the active model "
+                "to a different one if needed."
+            )
 
 
 def _get_active_model_context() -> ActiveModelContext:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3321,9 +3321,13 @@ def _set_active_model_id(model_id: str, set_by_user: bool = False) -> None:
     This function should be used inside MLflow to set the active model
     while not blocking other code execution.
     """
-    _ACTIVE_MODEL_CONTEXT.set(ActiveModelContext(model_id, set_by_user))
-    _update_active_model_id_env_var(model_id)
-    _logger.info(f"Active model set to model with ID: {model_id}")
+    try:
+        _ACTIVE_MODEL_CONTEXT.set(ActiveModelContext(model_id, set_by_user))
+        _update_active_model_id_env_var(model_id)
+    except Exception as e:
+        _logger.warning(f"Failed to set active model ID to {model_id}, error: {e}")
+    else:
+        _logger.info(f"Active model set to model with ID: {model_id}")
 
 
 def _get_active_model_context() -> ActiveModelContext:

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -964,9 +964,9 @@ def test_model_loading_set_active_model_id_without_fetching_logged_model():
 
     model_info = mlflow.dspy.log_model(dspy_model, name="model")
 
-    with mock.patch("mlflow.get_logged_model", side_effect=Exception):
+    with mock.patch("mlflow.get_logged_model", side_effect=Exception("get_logged_model failed")):
         loaded_model = mlflow.dspy.load_model(model_info.model_uri)
-        loaded_model(model_info.model_id)
+    loaded_model(model_info.model_id)
 
     traces = get_traces()
     assert len(traces) == 1

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -952,3 +952,23 @@ def test_autolog_link_traces_active_model():
         model_id = json.loads(trace.data.request)["args"][0]
         assert model_id != model.model_id
         assert trace.info.request_metadata[SpanAttributeKey.MODEL_ID] == model.model_id
+
+
+@skip_when_testing_trace_sdk
+def test_model_loading_set_active_model_id_without_fetching_logged_model():
+    mlflow.dspy.autolog()
+    dspy.settings.configure(
+        lm=DummyLM([{"answer": "test output", "reasoning": "No more responses"}])
+    )
+    dspy_model = CoT()
+
+    model_info = mlflow.dspy.log_model(dspy_model, name="model")
+
+    with mock.patch("mlflow.get_logged_model", side_effect=Exception):
+        loaded_model = mlflow.dspy.load_model(model_info.model_uri)
+        loaded_model(model_info.model_id)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    model_id = json.loads(traces[0].data.request)["args"][0]
+    assert model_id == traces[0].info.request_metadata[SpanAttributeKey.MODEL_ID]

--- a/tests/llama_index/test_llama_index_autolog.py
+++ b/tests/llama_index/test_llama_index_autolog.py
@@ -347,9 +347,9 @@ def test_model_loading_set_active_model_id_without_fetching_logged_model():
         name="model",
         input_example={"topic": "Hello"},
     )
-    with mock.patch("mlflow.get_logged_model", side_effect=Exception):
+    with mock.patch("mlflow.get_logged_model", side_effect=Exception("get_logged_model failed")):
         loaded_workflow = mlflow.pyfunc.load_model(model_info.model_uri)
-        loaded_workflow.predict({"topic": f"Hello {model_info.model_id}"})
+    loaded_workflow.predict({"topic": f"Hello {model_info.model_id}"})
 
     traces = get_traces()
     assert len(traces) == 1

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -769,7 +769,7 @@ async def test_model_loading_set_active_model_id_without_fetching_logged_model(c
         messages=[{"role": "system", "content": "You are an MLflow expert."}],
     )
 
-    with mock.patch("mlflow.get_logged_model", side_effect=Exception):
+    with mock.patch("mlflow.get_logged_model", side_effect=Exception("get_logged_model failed")):
         model_dict = mlflow.openai.load_model(model_info.model_uri)
     resp = client.chat.completions.create(
         messages=[{"role": "user", "content": f"test {model_info.model_id}"}],

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -754,3 +754,34 @@ def test_autolog_link_traces_to_active_model(monkeypatch, mock_openai):
         assert trace.info.request_metadata[SpanAttributeKey.MODEL_ID] == model.model_id
         logged_model_id = span.inputs["input"][0]
         assert logged_model_id != model.model_id
+
+
+@skip_when_testing_trace_sdk
+@pytest.mark.asyncio
+async def test_model_loading_set_active_model_id_without_fetching_logged_model(client):
+    mlflow.openai.autolog()
+
+    model_info = mlflow.openai.log_model(
+        "gpt-4o-mini",
+        "chat.completions",
+        name="model",
+        temperature=0.9,
+        messages=[{"role": "system", "content": "You are an MLflow expert."}],
+    )
+
+    with mock.patch("mlflow.get_logged_model", side_effect=Exception):
+        model_dict = mlflow.openai.load_model(model_info.model_uri)
+    resp = client.chat.completions.create(
+        messages=[{"role": "user", "content": f"test {model_info.model_id}"}],
+        model=model_dict["model"],
+        temperature=model_dict["temperature"],
+    )
+    if client._is_async:
+        await resp
+
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+    model_id = traces[0].info.request_metadata[SpanAttributeKey.MODEL_ID]
+    assert model_id is not None
+    assert span.inputs["messages"][0]["content"] == f"test {model_id}"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15623?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15623/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15623/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15623/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
When MLflow internally sets the active_model_id inside model loading, we don't need to check if the model exists or not. Besides set_active_model shouldn't block model loading even if it fails, so we wrap it with try catch in this PR.
Also move the set_active_model at the end of model loading, since users might set experiment inside the model definition.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
