### PR TITLE
Use `mlflow@git+https://github.com/mlflow/mlflow.git` as an mlflow requirement

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -538,7 +538,8 @@ def _generate_mlflow_version_pinning() -> str:
     # and can't be installed from PyPI. We therefore subtract 1 from the micro version when running
     # tests.
     # TODO: Remove this hardcoded version once we released the stable 3.0.0 version.
-    return "mlflow==3.0.0rc1"  # f"mlflow=={version.major}.{version.minor}.{version.micro - 1}"
+    return "mlflow@git+https://github.com/mlflow/mlflow.git"
+    # return f"mlflow=={version.major}.{version.minor}.{version.micro - 1}"
 
 
 def _contains_mlflow_requirement(requirements):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15630?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15630/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15630/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15630/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

I encountered the following error while creating an endpoint from a model logged in MLflow 3.0.

```
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
[fjds7] [2025-05-08 12:03:26 +0000]     raise self._exception
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/site-packages/mlflowserving/scoring_server/__init__.py", line 211, in get_model_option_or_exit
[fjds7] [2025-05-08 12:03:26 +0000]     self.model = self.model_future.result()
[fjds7] [2025-05-08 12:03:26 +0000]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/concurrent/futures/_base.py", line 449, in result
[fjds7] [2025-05-08 12:03:26 +0000]     return self.__get_result()
[fjds7] [2025-05-08 12:03:26 +0000]            ^^^^^^^^^^^^^^^^^^^
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
[fjds7] [2025-05-08 12:03:26 +0000]     raise self._exception
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/concurrent/futures/thread.py", line 58, in run
[fjds7] [2025-05-08 12:03:26 +0000]     result = self.fn(*self.args, **self.kwargs)
[fjds7] [2025-05-08 12:03:26 +0000]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/site-packages/mlflowserving/scoring_server/__init__.py", line 131, in _load_model_closure
[fjds7] [2025-05-08 12:03:26 +0000]     model = load_model_fn(path)
[fjds7] [2025-05-08 12:03:26 +0000]             ^^^^^^^^^^^^^^^^^^^
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/site-packages/mlflow/tracing/provider.py", line 424, in wrapper
[fjds7] [2025-05-08 12:03:26 +0000]     is_func_called, result = True, f(*args, **kwargs)
[fjds7] [2025-05-08 12:03:26 +0000]                                    ^^^^^^^^^^^^^^^^^^
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/site-packages/mlflow/pyfunc/__init__.py", line 1169, in load_model
[fjds7] [2025-05-08 12:03:26 +0000]     model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
[fjds7] [2025-05-08 12:03:26 +0000]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/site-packages/mlflow/pyfunc/model.py", line 1090, in _load_pyfunc
[fjds7] [2025-05-08 12:03:26 +0000]     context, python_model, signature = _load_context_model_and_signature(model_path, model_config)
[fjds7] [2025-05-08 12:03:26 +0000]                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/site-packages/mlflow/pyfunc/model.py", line 1073, in _load_context_model_and_signature
[fjds7] [2025-05-08 12:03:26 +0000]     python_model = cloudpickle.load(f)
[fjds7] [2025-05-08 12:03:26 +0000]                    ^^^^^^^^^^^^^^^^^^^
[fjds7] [2025-05-08 12:03:26 +0000] AttributeError: Can't get attribute 'set_chat_attributes_special_case' on <module 'mlflow.tracing.utils' from '/opt/conda/envs/mlflow-env/lib/python3.11/site-packages/mlflow/tracing/utils/__init__.py'>
[fjds7] [2025-05-08 12:03:26 +0000] Exception ignored in:
[fjds7] [2025-05-08 12:03:26 +0000] <module 'threading' from '/opt/conda/envs/mlflow-env/lib/python3.11/threading.py'>
[fjds7] [2025-05-08 12:03:26 +0000] Traceback (most recent call last):
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/threading.py", line 1560, in _shutdown
[fjds7] [2025-05-08 12:03:26 +0000] atexit_call()
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/concurrent/futures/thread.py", line 31, in _python_exit
[fjds7] [2025-05-08 12:03:26 +0000] t.join()
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/threading.py", line 1119, in join
[fjds7] [2025-05-08 12:03:26 +0000] self._wait_for_tstate_lock()
[fjds7] [2025-05-08 12:03:26 +0000]   File "/opt/conda/envs/mlflow-env/lib/python3.11/threading.py", line 1139, in _wait_for_tstate_lock
[fjds7] [2025-05-08 12:03:26 +0000] if lock.acquire(block, timeout):
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
